### PR TITLE
Chore: Export more types from Babel plugin

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -27,6 +27,8 @@ module.name_mapper='^@stylexjs\/shared$' -> '<PROJECT_ROOT>/packages/shared/src/
 module.name_mapper='^@stylexjs\/shared\/lib\/\([a-zA-Z0-9_\-]+\)$' -> '<PROJECT_ROOT>/packages/shared/src/\1'
 module.name_mapper='^@stylexjs/stylex$' -> '<PROJECT_ROOT>/packages/stylex/src/stylex.js'
 module.name_mapper='^@stylexjs/stylex\/lib\/\([a-zA-Z0-9_\-]+\)$' -> '<PROJECT_ROOT>/packages/stylex/src/\1'
+module.name_mapper='^@stylexjs/babel-plugin$' -> '<PROJECT_ROOT>/packages/babel-plugin/src/index.js'
+module.name_mapper='^@stylexjs/babel-plugin\/lib\/\([a-zA-Z0-9_\-]+\)$' -> '<PROJECT_ROOT>/packages/babel-plugin/src/\1'
 ; type-stubs
 module.system.node.resolve_dirname=flow_modules
 module.system.node.resolve_dirname=node_modules

--- a/apps/docs/docs/learn/05-theming/02-using-variables.mdx
+++ b/apps/docs/docs/learn/05-theming/02-using-variables.mdx
@@ -18,7 +18,7 @@ subject to change.
 
 :::
 
-Once [variables have been defined](../defining-variables), they can be imported
+Once [variables have been defined](./01-defining-variables.mdx), they can be imported
 and used to declare styles with `stylex.create`.
 
 Assume the following variables have been defined in a file called

--- a/apps/docs/docs/learn/05-theming/03-creating-themes.mdx
+++ b/apps/docs/docs/learn/05-theming/03-creating-themes.mdx
@@ -6,9 +6,6 @@
 sidebar_position: 3
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Creating themes
 
 :::danger

--- a/apps/rollup-example/rollup.config.mjs
+++ b/apps/rollup-example/rollup.config.mjs
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ *
  */
 
 import stylexPlugin from '@stylexjs/rollup-plugin';

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -10,6 +10,7 @@
 import * as t from '@babel/types';
 import type { NodePath } from '@babel/traverse';
 import type { PluginObj } from '@babel/core';
+import type { StyleXOptions } from './utils/state-manager';
 import StateManager from './utils/state-manager';
 import { readImportDeclarations, readRequires } from './visitors/imports';
 import transformStyleXCreate from './visitors/stylex-create';
@@ -24,6 +25,8 @@ import transformStylexProps from './visitors/stylex-props';
 import { skipStylexPropsChildren } from './visitors/stylex-props';
 
 const NAME = 'stylex';
+
+export type Options = StyleXOptions;
 
 /**
  * Entry point for the StyleX babel plugin.
@@ -139,6 +142,12 @@ export default function styleXTransform(): PluginObj<> {
   };
 }
 
+styleXTransform.withOptions = function stylexPluginWithOptions(
+  options: StyleXOptions,
+): [typeof styleXTransform, StyleXOptions] {
+  return [styleXTransform, options];
+};
+
 function isExported(path: null | NodePath<t.Node>): boolean {
   if (path == null || pathUtils.isProgram(path)) {
     return false;
@@ -167,7 +176,7 @@ function isExported(path: null | NodePath<t.Node>): boolean {
  *
  * End-users can choose to not use this function and use their own logic instead.
  */
-type Rule = [string, { ltr: string, rtl?: null | string }, number];
+export type Rule = [string, { ltr: string, rtl?: null | string }, number];
 function processStylexRules(
   rules: Array<Rule>,
   useLayers: boolean = false,

--- a/packages/babel-plugin/src/utils/state-manager.js
+++ b/packages/babel-plugin/src/utils/state-manager.js
@@ -36,7 +36,7 @@ type ModuleResolution =
       themeFileExtension?: string,
     };
 
-type StyleXOptions = {
+export type StyleXOptions = {
   ...RuntimeOptions,
   importSources: Array<string>,
   treeshakeCompensation?: boolean,


### PR DESCRIPTION
It should be possible to use a typed function to configure the Babel plugin,