### PR TITLE
Fix: Default useRemForFontSize to false

### DIFF
--- a/apps/docs/docs/api/configuration/babel-plugin.mdx
+++ b/apps/docs/docs/api/configuration/babel-plugin.mdx
@@ -58,7 +58,7 @@ Prefix to applied to every generated className.
 ### `useRemForFontSize`
 
 ```ts
-useRemForFontSize: boolean // Default: true
+useRemForFontSize: boolean // Default: false
 ```
 
 Should `px` values for `fontSize` be converted to `rem`?

--- a/packages/babel-plugin/__tests__/stylex-transform-value-normalize-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-value-normalize-test.js
@@ -20,7 +20,16 @@ function transform(source, opts = {}) {
     parserOpts: {
       flow: 'all',
     },
-    plugins: [[stylexPlugin, { runtimeInjection: true, ...opts }]],
+    plugins: [
+      [
+        stylexPlugin,
+        {
+          runtimeInjection: true,
+          useRemForFontSize: true,
+          ...opts,
+        },
+      ],
+    ],
   }).code;
 }
 

--- a/packages/babel-plugin/src/utils/state-manager.js
+++ b/packages/babel-plugin/src/utils/state-manager.js
@@ -88,7 +88,7 @@ export default class StateManager {
       definedStylexCSSVariables:
         (options: $FlowFixMe).definedStylexCSSVariables ?? {},
       genConditionalClasses: !!(options: $FlowFixMe).genConditionalClasses,
-      useRemForFontSize: (options: $FlowFixMe).useRemForFontSize ?? true,
+      useRemForFontSize: !!(options: $FlowFixMe).useRemForFontSize,
       styleResolution:
         (options: $FlowFixMe).styleResolution ?? 'application-order',
       unstable_moduleResolution:


### PR DESCRIPTION
As this transformation can be surprising, keep it off by default.