### PR TITLE
Fix documentation typo

### DIFF
--- a/apps/docs/docs/api/configuration/babel-plugin.mdx
+++ b/apps/docs/docs/api/configuration/babel-plugin.mdx
@@ -147,7 +147,7 @@ unstable_moduleResolution: // Default: undefined
     }
 ```
 
-Strategy to use for resolving variables defined with `stylex.defineVars()`
+Strategy to use for resolving variables defined with `stylex.defineVars()`.
 This is required if you plan to use StyleX's theming APIs.
 
 **NOTE**: While theming APIs are stable, the shape of this configuration option


### PR DESCRIPTION
A period was missing at the end of a sentence. (babel plugin)
