### PR TITLE
Document Update: Add Spacing Definition to tokens.stylex.js

### DIFF
--- a/apps/docs/docs/learn/05-theming/02-using-variables.mdx
+++ b/apps/docs/docs/learn/05-theming/02-using-variables.mdx
@@ -40,6 +40,17 @@ export const colors = stylex.defineVars({
   fontFamily: 'system-ui, sans-serif',
   fontSize: '16px',
 });
+
+export const spacing = stylex.defineVars({
+  none: '0px',
+  xsmall: '4px',
+  small: '8px',
+  medium: '12px',
+  large: '20px',
+  xlarge: '32px',
+  xxlarge: '48px',
+  xxxlarge: '96px',
+});
 ```
 
 These styles can the imported and used like so:


### PR DESCRIPTION
## Summary

Documentation Enhancement: Complete Variable Examples with Spacing Definition

The code example in _components/MyComponent.js_ references `import {colors, spacing} from '../tokens.styles';` , which implies that both colors and spacing are defined within _tokens.styles.js_ . 

Without the spacing variable defined in _tokens.stylex.js_, this could lead to confusion for users trying to understand the complete implementation of StyleX variables. 

By including the spacing definition, it provides a more comprehensive example and aligns the documentation with the code, enhancing overall clarity and usability.