### PR TITLE
fix: rollup plugin add necessary deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31238,6 +31238,9 @@
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
+        "@babel/plugin-syntax-flow": "^7.18.6",
+        "@babel/plugin-syntax-jsx": "^7.14.5",
+        "@babel/plugin-syntax-typescript": "^7.14.5",
         "@stylexjs/babel-plugin": "0.3.0"
       },
       "devDependencies": {
@@ -36070,6 +36073,9 @@
       "version": "file:packages/rollup-plugin",
       "requires": {
         "@babel/core": "^7.16.0",
+        "@babel/plugin-syntax-flow": "^7.18.6",
+        "@babel/plugin-syntax-jsx": "^7.14.5",
+        "@babel/plugin-syntax-typescript": "^7.14.5",
         "@babel/preset-env": "^7.16.8",
         "@rollup/plugin-babel": "^6.0.0",
         "@rollup/plugin-commonjs": "^25.0.3",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -18,7 +18,10 @@
   },
   "dependencies": {
     "@babel/core": "^7.16.0",
-    "@stylexjs/babel-plugin": "0.3.0"
+    "@stylexjs/babel-plugin": "0.3.0",
+    "@babel/plugin-syntax-flow": "^7.18.6",
+    "@babel/plugin-syntax-jsx": "^7.14.5",
+    "@babel/plugin-syntax-typescript": "^7.14.5"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.8",


### PR DESCRIPTION
# Background

`@stylexjs/rollup-plugin` loose necessary dependencies, So this pull request add them.