### PR TITLE
fix : align footer content in center

### DIFF
--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -221,6 +221,10 @@ html[data-theme='dark'] .aa-DetachedSearchButton {
   --key-gradient: linear-gradient(-26.5deg, #565872, #31355b);
 }
 
+.footer{
+  text-align: center;
+}
+
 .footer .container {
   max-width: 960px;
 }


### PR DESCRIPTION
Issue No. #37 

Summary : This pull request fixes the footer alignment , it was skewed left before `text-align: center`

![image](https://github.com/facebook/stylex/assets/30369664/64cffab9-8601-4c98-82b4-e92975ef5bd1)
![image](https://github.com/facebook/stylex/assets/30369664/06666376-1721-4c9c-a703-d238e994b181)

After:
![image](https://github.com/facebook/stylex/assets/30369664/fbea75ca-48c4-4f37-b70e-6b33db979067)
