### PR TITLE
Fix Typo in Themes Docs

### DIFF
--- a/apps/docs/docs/learn/05-theming/03-creating-themes.mdx
+++ b/apps/docs/docs/learn/05-theming/03-creating-themes.mdx
@@ -20,7 +20,7 @@ the values of those variables for specific UI sub-trees.
 
 ## Creating Themes
 
-Any variable group can imported to create a theme like so:
+Any variable group can be imported to create a theme like so:
 
 ```tsx title="themes.js"
 import * as stylex from '@stylexjs/stylex';


### PR DESCRIPTION
Add missing "be".