### PR TITLE
docs: fix typo in learn section

### DIFF
--- a/apps/docs/docs/learn/index.mdx
+++ b/apps/docs/docs/learn/index.mdx
@@ -148,7 +148,7 @@ challenges of particular use cases.
 ### Authoring UI in JavaScript
 
 StyleX is a CSS-in-JS library, which means that it is most useful when an app's UI is
-authored in Javascript. If an application uses a framework like React, Preact, Solid,
+authored in JavaScript. If an application uses a framework like React, Preact, Solid,
 lit-html, or Angular, using StyleX should be a good fit.
 
 Some frameworks, such as Svelte and Vue use custom file formats that are


### PR DESCRIPTION
There is a typo on word `Javascript`. It should be `JavaScript`.