### PR TITLE
chore: Add editor files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,14 @@ node_modules
 apps/docs/.stylex/*
 apps/rollup-example/.build
 apps/webpack-example/.build
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?


### PR DESCRIPTION
## What changed / motivation ?
Currently, there is no editor related ignore patterns inside gitignore. As we accept more contributions from the community, it may be helpful to add an ignore pattern for editor related dirs and files so that these are not accidentally committed to the PR.

## Linked PR/Issues
None

## Additional Context
None

## Pre-flight Checklist
- [x] I have read the [contributing guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] I have signed the contributing [agreement](https://code.facebook.com/cla)
- [ ] I have written unit tests where necessary (If it is a feature commit)
- [x] Performed a self-review of my code
- [x] Made sure PR title follows the conventional commit specification