### PR TITLE
docs: Migrate docs pm to npm from yarn

### DIFF
--- a/apps/docs/.stylelintrc.js
+++ b/apps/docs/.stylelintrc.js
@@ -10,4 +10,5 @@ module.exports = {
   rules: {
     'docusaurus/copyright-header': true,
   },
+  ignoreFiles: ['**/build/**'],
 };

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -6,9 +6,8 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 
 - stylex actual package, and then the @stylexjs/babel-plugin plugin in node_modules
 
-In the project root directory (workspace)
 ```bash
-$ npm run build -w @stylexjs/stylex -w @stylexjs/shared -w @stylexjs/babel-plugin
+$ npm run build -w @stylexjs/stylex -w @stylexjs/shared -w @stylexjs/eslint-plugin -w @stylexjs/babel-plugin
 ```
 
 ### Installation

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -8,7 +8,7 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 
 In the project root directory (workspace)
 ```bash
-$ npm build -w @stylexjs/stylex && npm build -w @stylexjs/babel-plugin
+$ npm run build -w @stylexjs/stylex && npm run build -w @stylexjs/babel-plugin
 ```
 
 ### Installation

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -6,24 +6,29 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 
 - stylex actual package, and then the @stylexjs/babel-plugin plugin in node_modules
 
+In the project root directory (workspace)
+```bash
+$ npm build -w @stylexjs/stylex && npm build -w @stylexjs/babel-plugin
+```
+
 ### Installation
 
-```
-$ yarn
+```bash
+$ npm install 
 ```
 
 ### Local Development
 
-```
-$ yarn start
+```bash
+$ npm start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
 ### Build
 
-```
-$ yarn build
+```bash
+$ npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -32,14 +37,14 @@ This command generates static content into the `build` directory and can be serv
 
 Using SSH:
 
-```
-$ USE_SSH=true yarn deploy
+```bash
+$ USE_SSH=true npm run deploy
 ```
 
 Not using SSH:
 
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
+```bash
+$ GIT_USER=<Your GitHub username> npm run deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
@@ -48,6 +53,6 @@ If you are using GitHub pages for hosting, this command is a convenient way to b
 
 Some common defaults for linting/formatting have been set for you. If you integrate your project with an open source Continuous Integration system (e.g. Travis CI, CircleCI), you may check for issues using the following command.
 
-```
-$ yarn ci
+```bash
+$ npm run ci
 ```

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -8,7 +8,7 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 
 In the project root directory (workspace)
 ```bash
-$ npm run build -w @stylexjs/stylex && npm run build -w @stylexjs/babel-plugin
+$ npm run build -w @stylexjs/stylex -w @stylexjs/shared -w @stylexjs/babel-plugin
 ```
 
 ### Installation

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,7 +13,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "ci": "yarn lint && yarn format:diff",
+    "ci": "npm run lint && npm run format:diff",
     "lint": "eslint --cache \"**/*.js\" && stylelint \"**/*.css\"",
     "format": "prettier --config .prettierrc --write \"**/*.{js,jsx,ts,tsx,md,mdx}\"",
     "format:diff": "prettier --config .prettierrc --list-different \"**/*.{js,jsx,ts,tsx,md,mdx}\""


### PR DESCRIPTION
## What changed / motivation ?
I noticed that the project was mainly using npm, however, the docs app (website) was using yarn. I have edited the package.json to migrate yarn commands to npm and updated README to reflect the changes

## Linked PR/Issues
None

## Additional Context

- I would propose migrating to [pnpm](https://pnpm.io/pnpm-vs-npm)
- Also added documentation about building stylex packages to README
- **Important!**: It seems that stylelint fails due to a missing package `stylelint-copyright` and `lint & ci` commands seems to fail. Was not sure if this was expected behavior and if the linter is only ran on ci.
- Testing was done to make sure current behavior does not change
- Added `**/build/**` to stylelint (was not sure if this is a desired behavior)

## Pre-flight Checklist
- [x] I have read the [contributing guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] I have signed the contributing [agreement](https://code.facebook.com/cla)
- [ ] I have written unit tests where necessary (If it is a feature commit)
- [x] Performed a self-review of my code
- [x] Made sure PR title follows the conventional commit specification