### PR TITLE
docs: Enable click event on full collapsible area

### DIFF
--- a/apps/docs/src/theme/MDXComponents/Details.js
+++ b/apps/docs/src/theme/MDXComponents/Details.js
@@ -22,7 +22,7 @@ export default function MDXDetails({
 }) {
   const [isOpen, setIsOpen] = useState(open);
 
-  const onToggle = (e) => {
+  const toggleDetails = (e) => {
     e.preventDefault();
     setIsOpen(!isOpen);
   };
@@ -44,7 +44,7 @@ export default function MDXDetails({
       <summary
         {...summaryProps}
         {...stylex.props(styles.summary)}
-        onClick={onToggle}
+        onClick={toggleDetails}
       />
       {children}
     </details>
@@ -73,16 +73,18 @@ const styles = stylex.create({
       ':is([open])': '90deg',
     },
     [tokens.summaryGap]: {
-      default: '0rem',
-      ':is([open])': '1rem',
+      default: '-1rem',
+      ':is([open])': '0rem',
     },
   },
   summary: {
     cursor: 'pointer',
     fontWeight: 'bold',
     listStyleType: 'none',
+    margin: '-1rem',
     marginBottom: tokens.summaryGap,
-    paddingInlineStart: '1.2rem',
+    paddingInlineStart: '2.2rem',
+    padding: '1rem',
     position: 'relative',
     // eslint-disable-next-line @stylexjs/valid-styles
     '::-webkit-details-marker': {
@@ -93,14 +95,13 @@ const styles = stylex.create({
     },
     '::before': {
       content: '',
-      marginRight: '0.5rem',
       borderWidth: '.4rem',
       borderStyle: 'solid',
       borderColor: 'transparent',
       borderInlineStartColor: 'var(--pink)',
       position: 'absolute',
-      top: '0.5rem',
-      insetInlineStart: '0.25rem',
+      top: '1.5rem',
+      insetInlineStart: '1.25rem',
       transform: `rotate(${tokens.arrowRotate})`,
       transformOrigin: '0.2rem 50%',
       transitionProperty: 'transform',

--- a/apps/docs/src/theme/MDXComponents/DetailsTokens.stylex.js
+++ b/apps/docs/src/theme/MDXComponents/DetailsTokens.stylex.js
@@ -11,5 +11,5 @@ import * as stylex from '@stylexjs/stylex';
 
 export const tokens = stylex.defineVars({
   arrowRotate: '0deg',
-  summaryGap: '0rem',
+  summaryGap: '-1rem',
 });


### PR DESCRIPTION
## What changed / motivation ?
It was a little annoying that the collapsible items on the current docs have a smaller hitbox than the entire size/area of the collapsible item. I saw that @nmn fixed the undesired click behavior on the same component [0e3cfb4](https://github.com/facebook/stylex/commit/0e3cfb4fcfd56a23a5af1a2dd9a561fa10f53eba) here. Just wanted to make the component more convenient and intuitive to use for future users. 

## Linked PR/Issues
None

## Additional Context
Before/After behavior. Tested with keyboard actions. ARIA labels not provided.

https://github.com/facebook/stylex/assets/15972898/38204d9f-7725-4c8f-937c-db28f4bac7d1


## Pre-flight Checklist
- [x] I have read the [contributing guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] I have signed the contributing [agreement](https://code.facebook.com/cla)
- [ ] I have written unit tests where necessary (If it is a feature commit)
- [x] Performed a self-review of my code
- [x] Made sure PR title follows the conventional commit specification