### PR TITLE
Remove `React.MixedElement` from the typescript example

### DIFF
--- a/apps/docs/docs/learn/06-static-types.mdx
+++ b/apps/docs/docs/learn/06-static-types.mdx
@@ -28,7 +28,7 @@ type Props = {
   style?: StyleXStyles,
 };
 
-function MyComponent({style, ...otherProps}: Props): React.MixedElement {
+function MyComponent({style, ...otherProps}: Props) {
   return (
     <div
       {...stylex.props(localStyles.foo, localStyles.bar, style)}


### PR DESCRIPTION
AFAIK, `React.MixedElement` is not a valid type in Typescript 