### PR TITLE
docs: increase contrast in home CTA and search

### DIFF
--- a/apps/docs/components/CtaButton.js
+++ b/apps/docs/components/CtaButton.js
@@ -61,8 +61,8 @@ const styles = stylex.create({
   },
   pink: {
     color: {
-      default: 'white',
-      ':hover': 'white',
+      default: 'black',
+      ':hover': 'black',
     },
     backgroundColor: 'hsl(var(--pink-h), var(--pink-s), var(--pink-l))',
     boxShadow: {

--- a/apps/docs/components/CtaButton.js
+++ b/apps/docs/components/CtaButton.js
@@ -61,8 +61,8 @@ const styles = stylex.create({
   },
   pink: {
     color: {
-      default: 'black',
-      ':hover': 'black',
+      default: 'white',
+      ':hover': 'white',
     },
     backgroundColor: 'hsl(var(--pink-h), var(--pink-s), var(--pink-l))',
     boxShadow: {

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -201,7 +201,7 @@ article .theme-doc-markdown.markdown {
 }
 
 .aa-DetachedSearchButtonPlaceholder {
-  color: var(--ifm-color-content);
+  color: rgba(var(--aa-input-border-color-rgb));
 }
 
 .aa-FooterSearchCredit {

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -200,6 +200,10 @@ article .theme-doc-markdown.markdown {
   border: 1px solid rgba(128, 126, 163, 0.8);
 }
 
+.aa-DetachedSearchButtonPlaceholder {
+  color: var(--ifm-color-content);
+}
+
 .aa-FooterSearchCredit {
   font-size: 0.5rem;
 }


### PR DESCRIPTION
Addresses the issue #76 

Changed contrast color for both CTA and search placeholder texts.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/facebook/stylex/assets/45975811/0afcb27a-1cdc-47e6-8776-8737289be438) | ![image](https://github.com/facebook/stylex/assets/45975811/98e571a0-4b69-4570-b411-09777654db2f) |

Passes the lighthouse test:
![image](https://github.com/facebook/stylex/assets/45975811/7315f62c-b0a7-4717-a625-d84f93861cd4)



