### PR TITLE
Fix: Typo in "Readability & Maintainability Over Terseness" Section

### DIFF
--- a/apps/docs/docs/learn/02-thinking-in-stylex.mdx
+++ b/apps/docs/docs/learn/02-thinking-in-stylex.mdx
@@ -326,7 +326,7 @@ for convenience.)_
 
 We also enforce that styles are authored in objects separate from the HTML
 elements where they are used. We made this decision to help with the readability
-of HTML markup and for appropriatelu named styles to indicate their purpose. For
+of HTML markup and for appropriately named styles to indicate their purpose. For
 example, using a name like `styles.active` emphasizes *why* styles are being applied
 without having to dig through *what* styles are being applied.
 


### PR DESCRIPTION
While reviewing the documentation, I noticed a small typographical error in the "Readability & Maintainability Over Terseness" section. The word "appropriatelu" appears to be a typo and should be corrected to "appropriately".

This minor correction will improve the readability of the documentation and avoid any potential confusion for readers.

Thank you for considering this fix. I look forward to your feedback.