### PR TITLE
Enhancement: Add option to use CSS layers to all bundler plugins

### DIFF
--- a/apps/nextjs-example/next.config.js
+++ b/apps/nextjs-example/next.config.js
@@ -18,4 +18,5 @@ const rootDir = options.unstable_moduleResolution.rootDir ?? __dirname;
 
 module.exports = stylexPlugin({
   rootDir,
+  useCSSLayers: true,
 })({});

--- a/packages/nextjs-plugin/src/custom-webpack-plugin.js
+++ b/packages/nextjs-plugin/src/custom-webpack-plugin.js
@@ -37,7 +37,8 @@ type PluginOptions = $ReadOnly<{
     babelrc?: boolean,
   }>,
   filename?: string,
-  appendTo?: string | (string) => boolean
+  appendTo?: string | (string) => boolean,
+  useCSSLayers?: boolean,
 }>
 */
 
@@ -57,13 +58,11 @@ class StylexPlugin {
     stylexImports = ['stylex', '@stylexjs/stylex'],
     rootDir,
     babelConfig = {},
+    useCSSLayers = false,
   } /*: PluginOptions */ = {}) {
     this.dev = dev;
     this.appendTo = appendTo;
     this.filename = filename;
-    // if (filename.includes("stylex")) {
-    //   console.log("filename", filename);
-    // }
 
     this.babelConfig = {
       plugins: [],
@@ -87,6 +86,7 @@ class StylexPlugin {
         importSources: stylexImports,
       },
     ];
+    this.useCSSLayers = useCSSLayers;
   }
 
   apply(compiler) {
@@ -127,7 +127,10 @@ class StylexPlugin {
         const allRules = Object.keys(stylexRules)
           .map((filename) => stylexRules[filename])
           .flat();
-        return stylexBabelPlugin.processStylexRules(allRules);
+        return stylexBabelPlugin.processStylexRules(
+          allRules,
+          this.useCSSLayers,
+        );
       };
 
       if (this.appendTo) {

--- a/packages/nextjs-plugin/src/index.js
+++ b/packages/nextjs-plugin/src/index.js
@@ -12,7 +12,7 @@ const WebpackPluginStylex = require('./custom-webpack-plugin');
 let count = 0;
 
 module.exports =
-  ({ rootDir, filename = 'stylex-bundle.css' }) =>
+  ({ rootDir, filename = 'stylex-bundle.css', ...pluginOptions }) =>
   (nextConfig = {}) => {
     return {
       ...nextConfig,
@@ -56,6 +56,7 @@ module.exports =
           appendTo: (name) => name.endsWith('.css'),
           filename,
           dev,
+          ...pluginOptions,
         };
 
         const stylexPlugin = new WebpackPluginStylex(webpackPluginOptions);

--- a/packages/rollup-plugin/__tests__/index-test.js
+++ b/packages/rollup-plugin/__tests__/index-test.js
@@ -31,7 +31,7 @@ describe('rollup-plugin-stylex', () => {
           configFile: path.resolve(__dirname, '__fixtures__/.babelrc.json'),
           exclude: [/npmStyles\.js/],
         }),
-        stylexPlugin(options),
+        stylexPlugin({ useCSSLayers: true, ...options }),
       ],
     });
 

--- a/packages/rollup-plugin/src/index.js
+++ b/packages/rollup-plugin/src/index.js
@@ -24,6 +24,7 @@ module.exports = function stylexPlugin({
   fileName = 'stylex.css',
   babelConfig: { plugins = [], presets = [] } = {},
   stylexImports = ['stylex', '@stylexjs/stylex'],
+  useCSSLayers = false,
   ...options
 } = {}) {
   let stylexRules = {};
@@ -35,7 +36,10 @@ module.exports = function stylexPlugin({
     generateBundle() {
       const rules = Object.values(stylexRules).flat();
       if (rules.length > 0) {
-        const collectedCSS = stylexBabelPlugin.processStylexRules(rules, true);
+        const collectedCSS = stylexBabelPlugin.processStylexRules(
+          rules,
+          useCSSLayers,
+        );
         this.emitFile({
           fileName,
           source: collectedCSS,

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -36,7 +36,8 @@ type PluginOptions = $ReadOnly<{
     babelrc?: boolean,
   }>,
   filename?: string,
-  appendTo?: string | (string) => boolean
+  appendTo?: string | (string) => boolean,
+  useCSSLayers?: boolean,
 }>
 */
 
@@ -51,6 +52,7 @@ class StylexPlugin {
     stylexImports = ['stylex', '@stylexjs/stylex'],
     unstable_moduleResolution = { type: 'commonJS', rootDir: process.cwd() },
     babelConfig: { plugins = [], presets = [], babelrc = false } = {},
+    useCSSLayers = false,
     ...options
   } /*: PluginOptions */ = {}) {
     this.dev = dev;
@@ -67,6 +69,7 @@ class StylexPlugin {
         ...options,
       },
     ];
+    this.useCSSLayers = useCSSLayers;
   }
 
   apply(compiler) {
@@ -112,7 +115,10 @@ class StylexPlugin {
           )
           .map((filename) => stylexRules[filename])
           .flat();
-        return stylexBabelPlugin.processStylexRules(allRules);
+        return stylexBabelPlugin.processStylexRules(
+          allRules,
+          this.useCSSLayers,
+        );
       };
 
       if (this.appendTo) {


### PR DESCRIPTION
The function to generate CSS from extracted styles can use CSS `@layer` or polyfill using `:not(#\#)`. This PR adds an option to all existing bundler plugins to control this behaviour.