### PR TITLE
refactor(babel-plugin): remove unnecessary check

### DIFF
--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -66,10 +66,6 @@ export default function transformStyleXCreate(
     > = path.get('arguments');
     const firstArg = args[0];
 
-    if (!pathUtils.isObjectExpression(firstArg)) {
-      throw new Error(messages.ILLEGAL_ARGUMENT_LENGTH);
-    }
-
     // TODO: This should be removed soon since we should disallow spreads without
     // `stylex.include` in the future.
     // preProcessStyleArg(firstArg, state);


### PR DESCRIPTION
In `validateStyleXCreate`, we have checked whether the first argument is `ObjectExpression` or not. It seems that we don't need to check it again. Furthermore, the error message should be `messages.NON_OBJECT_FOR_STYLEX_CALL`