### PR TITLE
Enhancement: Add option to process arbitrary named exports

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-call-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-call-test.js
@@ -1246,6 +1246,46 @@ describe('@stylexjs/babel-plugin', () => {
         "x1e2nbdu";"
       `);
     });
+    test('Named import from custom source', () => {
+      expect(
+        transform(
+          `
+          import {css as stylex} from 'custom-stylex-path';
+          const styles = stylex.create({
+            red: {
+              color: 'red',
+            }
+          });
+          stylex(styles.red);
+        `,
+          { importSources: [{ from: 'custom-stylex-path', as: 'css' }] },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import { css as stylex } from 'custom-stylex-path';
+        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "x1e2nbdu";"
+      `);
+    });
+    test('Named import with other name from custom source', () => {
+      expect(
+        transform(
+          `
+          import {css} from 'custom-stylex-path';
+          const styles = css.create({
+            red: {
+              color: 'red',
+            }
+          });
+          css(styles.red);
+        `,
+          { importSources: [{ from: 'custom-stylex-path', as: 'css' }] },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import { css } from 'custom-stylex-path';
+        css.inject(".x1e2nbdu{color:red}", 3000);
+        "x1e2nbdu";"
+      `);
+    });
   });
   describe('Specific edge-case bugs', () => {
     test('Basic stylex call', () => {

--- a/packages/babel-plugin/src/utils/state-manager.js
+++ b/packages/babel-plugin/src/utils/state-manager.js
@@ -38,7 +38,9 @@ type ModuleResolution =
 
 export type StyleXOptions = {
   ...RuntimeOptions,
-  importSources: Array<string>,
+  importSources: $ReadOnlyArray<
+    string | $ReadOnly<{ from: string, as: string }>,
+  >,
   treeshakeCompensation?: boolean,
   genConditionalClasses: boolean,
   unstable_moduleResolution: void | ModuleResolution,
@@ -84,7 +86,11 @@ export default class StateManager {
       runtimeInjection:
         (options: $FlowFixMe).runtimeInjection ?? !!(options: $FlowFixMe).dev,
       classNamePrefix: (options: $FlowFixMe).classNamePrefix ?? 'x',
-      importSources: (options: $FlowFixMe).importSources ?? [name, 'stylex'],
+      importSources: [
+        name,
+        'stylex',
+        ...((options: $FlowFixMe).importSources ?? []),
+      ],
       definedStylexCSSVariables:
         (options: $FlowFixMe).definedStylexCSSVariables ?? {},
       genConditionalClasses: !!(options: $FlowFixMe).genConditionalClasses,
@@ -108,6 +114,21 @@ export default class StateManager {
       return [...this.importPaths][0];
     }
     return '@stylexjs/stylex';
+  }
+
+  get importSources(): $ReadOnlyArray<string> {
+    return this.options.importSources.map((source) =>
+      typeof source === 'string' ? source : source.from,
+    );
+  }
+
+  importAs(source: string): null | string {
+    for (const importSource of this.options.importSources) {
+      if (typeof importSource !== 'string' && importSource.from === source) {
+        return importSource.as;
+      }
+    }
+    return null;
   }
 
   get canReferenceTheme(): boolean {

--- a/packages/babel-plugin/src/visitors/imports.js
+++ b/packages/babel-plugin/src/visitors/imports.js
@@ -20,66 +20,64 @@ export function readImportDeclarations(
   if (node?.importKind === 'type' || node?.importKind === 'typeof') {
     return;
   }
-  if (state.options.importSources.includes(node.source.value)) {
-    state.importPaths.add(node.source.value);
+  const sourcePath = node.source.value;
+  if (state.importSources.includes(sourcePath)) {
     for (const specifier of node.specifiers) {
-      if (specifier.type === 'ImportDefaultSpecifier') {
+      if (
+        specifier.type === 'ImportDefaultSpecifier' &&
+        state.importAs(sourcePath) === null
+      ) {
+        state.importPaths.add(sourcePath);
         state.stylexImport.add(specifier.local.name);
       }
-      if (specifier.type === 'ImportNamespaceSpecifier') {
+      if (
+        specifier.type === 'ImportNamespaceSpecifier' &&
+        state.importAs(sourcePath) === null
+      ) {
+        state.importPaths.add(sourcePath);
         state.stylexImport.add(specifier.local.name);
       }
       if (specifier.type === 'ImportSpecifier') {
-        if (specifier.imported.type === 'Identifier') {
-          if (specifier.imported.name === 'create') {
-            state.stylexCreateImport.add(specifier.local.name);
+        if (
+          specifier.imported.type === 'Identifier' ||
+          specifier.imported.type === 'StringLiteral'
+        ) {
+          const importedName =
+            specifier.imported.type === 'Identifier'
+              ? specifier.imported.name
+              : specifier.imported.value;
+          const localName = specifier.local.name;
+
+          if (state.importAs(sourcePath) === importedName) {
+            state.importPaths.add(sourcePath);
+            state.stylexImport.add(localName);
           }
-          if (specifier.imported.name === 'props') {
-            state.stylexPropsImport.add(specifier.local.name);
-          }
-          if (specifier.imported.name === 'keyframes') {
-            state.stylexKeyframesImport.add(specifier.local.name);
-          }
-          if (specifier.imported.name === 'include') {
-            state.stylexIncludeImport.add(specifier.local.name);
-          }
-          if (specifier.imported.name === 'firstThatWorks') {
-            state.stylexFirstThatWorksImport.add(specifier.local.name);
-          }
-          if (specifier.imported.name === 'defineVars') {
-            state.stylexDefineVarsImport.add(specifier.local.name);
-          }
-          if (specifier.imported.name === 'createTheme') {
-            state.stylexCreateThemeImport.add(specifier.local.name);
-          }
-          if (specifier.imported.name === 'types') {
-            state.stylexTypesImport.add(specifier.local.name);
-          }
-        }
-        if (specifier.imported.type === 'StringLiteral') {
-          if (specifier.imported.value === 'create') {
-            state.stylexCreateImport.add(specifier.local.name);
-          }
-          if (specifier.imported.value === 'props') {
-            state.stylexPropsImport.add(specifier.local.name);
-          }
-          if (specifier.imported.value === 'keyframes') {
-            state.stylexKeyframesImport.add(specifier.local.name);
-          }
-          if (specifier.imported.value === 'include') {
-            state.stylexIncludeImport.add(specifier.local.name);
-          }
-          if (specifier.imported.value === 'firstThatWorks') {
-            state.stylexFirstThatWorksImport.add(specifier.local.name);
-          }
-          if (specifier.imported.value === 'defineVars') {
-            state.stylexDefineVarsImport.add(specifier.local.name);
-          }
-          if (specifier.imported.value === 'createTheme') {
-            state.stylexCreateThemeImport.add(specifier.local.name);
-          }
-          if (specifier.imported.value === 'types  ') {
-            state.stylexTypesImport.add(specifier.local.name);
+          if (state.importAs(sourcePath) === null) {
+            state.importPaths.add(sourcePath);
+            if (importedName === 'create') {
+              state.stylexCreateImport.add(localName);
+            }
+            if (importedName === 'props') {
+              state.stylexPropsImport.add(localName);
+            }
+            if (importedName === 'keyframes') {
+              state.stylexKeyframesImport.add(localName);
+            }
+            if (importedName === 'include') {
+              state.stylexIncludeImport.add(localName);
+            }
+            if (importedName === 'firstThatWorks') {
+              state.stylexFirstThatWorksImport.add(localName);
+            }
+            if (importedName === 'defineVars') {
+              state.stylexDefineVarsImport.add(localName);
+            }
+            if (importedName === 'createTheme') {
+              state.stylexCreateThemeImport.add(localName);
+            }
+            if (importedName === 'types') {
+              state.stylexTypesImport.add(localName);
+            }
           }
         }
       }
@@ -101,10 +99,14 @@ export function readRequires(
     init.callee?.name === 'require' &&
     init.arguments?.length === 1 &&
     init.arguments?.[0].type === 'StringLiteral' &&
-    state.options.importSources.includes(init.arguments[0].value)
+    state.importSources.includes(init.arguments[0].value)
   ) {
     const importPath = init.arguments[0].value;
-    importPath != null && state.importPaths.add(importPath);
+    if (importPath == null) {
+      console.log('importPath is null');
+      return;
+    }
+    state.importPaths.add(importPath);
     if (node.id.type === 'Identifier') {
       state.stylexImport.add(node.id.name);
     }

--- a/packages/babel-plugin/src/visitors/imports.js
+++ b/packages/babel-plugin/src/visitors/imports.js
@@ -103,7 +103,7 @@ export function readRequires(
   ) {
     const importPath = init.arguments[0].value;
     if (importPath == null) {
-      console.log('importPath is null');
+      // Impossible.
       return;
     }
     state.importPaths.add(importPath);


### PR DESCRIPTION
## What changed / motivation ?

By default you import stylex from the `@stylexjs/stylex` package and the compiler detects and compiles that. It has also been possible to set up custom import paths for custom aliases. However, so far it was expected that you'd still use `import * as <name>` from a custom source.

This PR adds the ability to mark `stylex` to be a named export from a custom path. This lets enables the following pattern:

```ts
import {html, css} from 'browser';

const styles = css.create({
  foo: {...}
});

css.props(styles.foo);
```

This will enable larger UI frameworks to incorporate StyleX within their own API.

## Additional Context

Added a couple of tests which are passes as expected.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Performed a self-review of my code