### PR TITLE
Fix: CSS layer order in Next.js app

### DIFF
--- a/apps/nextjs-example/app/globals.css
+++ b/apps/nextjs-example/app/globals.css
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-* {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
+@layer reset {
+  * {
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+  }
 }


### PR DESCRIPTION
## What changed / motivation ?

The nextJS example didn't have margins or paddings because the reset styles overriding all StyleX styles. (because of `@CSS layers`).

Fixed this by putting the reset styles in a CSS Layer themselves.

## Additional Context

<img width="1566" alt="image" src="https://github.com/facebook/stylex/assets/3582514/68d4e1bc-1be4-4491-a715-9818a839ccd3">

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Performed a self-review of my code