### PR TITLE
fix : add types to fontWeight

### DIFF
--- a/packages/stylex/src/StyleXCSSTypes.js
+++ b/packages/stylex/src/StyleXCSSTypes.js
@@ -337,7 +337,9 @@ type fontWeight =
   | 600
   | 700
   | 800
-  | 900;
+  | 900
+  | string
+  | number;
 type gap = number | string;
 type grid = gridTemplate | string;
 type gridArea = gridLine | string;


### PR DESCRIPTION
## What changed / motivation ?

This PR will adds `string and number` type in `fontWeight` types in `StyleXCSSTypes.js`  

## Linked PR/Issues
Fixes #124 

## Additional Context
Tested it
<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->
![image](https://github.com/facebook/stylex/assets/30369664/4bf8b090-285e-4397-950c-35a312ae6138)


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Performed a self-review of my code