### PR TITLE
Chore: Added cleanup script for Next.js building

### DIFF
--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -7,7 +7,7 @@
     "predev": "npm run clean",
     "prebuild": "npm run clean",
     "dev": "next dev",
-    "build": "next build"
+    "build": "next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "scripts": {
     "predev": "rimraf .next",
+    "clean": "rimraf .next",
     "dev": "next dev",
-    "build": "next build",
+    "build": "npm run clean && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "predev": "rimraf .next",
     "clean": "rimraf .next",
+    "predev": "npm run clean",
+    "prebuild": "npm run clean",
     "dev": "next dev",
-    "build": "npm run clean && next build",
+    "build": "next build"
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
## What changed / motivation ?

I changed the package.json of the Next.js example to delete the .next directory before building the Next application.

## Linked PR/Issues

Fixes #109 (point 3 of the overview list)

## Additional Context

I didn't remove the predev script because it allows users to run the dev server with cleanup without building first. But I can remove it if desired.

Based on the cleanup script, this might work for this example, but might lead to longer build times if you start from scratch every time?

Shouldn't fail any tests since I only changed the package.json and the Next.js app build works accordingly.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Performed a self-review of my code