### PR TITLE
fix: strict report for stylex.create argument as object expression

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -360,6 +360,18 @@ eslintTester.run('stylex-valid-styles', rule.default, {
   ],
   invalid: [
     {
+      code: `
+        import stylex from 'stylex';
+        const styles = {default: {width: '30pt'}};
+        stylex.create(styles);
+      `,
+      errors: [
+        {
+          message: 'Styles must be represented as JavaScript objects',
+        },
+      ],
+    },
+    {
       code: "import stylex from 'stylex'; stylex.create({default: {textAlin: 'left'}});",
       errors: [
         {

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -2347,8 +2347,7 @@ const stylexValidStyles = {
         node &&
         node.type === 'CallExpression' &&
         isStylexCallee(node.callee) &&
-        node.arguments.length === 1 &&
-        node.arguments[0].type === 'ObjectExpression'
+        node.arguments.length === 1
       );
     }
 


### PR DESCRIPTION
## What changed / motivation ?

I have fixed to report when a value other than an `ObjectExpression` is specified as an argument for `stylex.create`.

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

![スクリーンショット 2023-12-13 0 58 04](https://github.com/facebook/stylex/assets/12913947/7f0c5e5b-222b-4548-846c-d9b63e3b7dd5)

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Performed a self-review of my code