### PR TITLE
fix: cta section responsive issue

### DIFF
--- a/apps/docs/components/CtaButton.js
+++ b/apps/docs/components/CtaButton.js
@@ -25,6 +25,8 @@ export default function CtaButton({children, color, to}) {
   );
 }
 
+const CTA_BREAK = '@media (max-width: 390px)';
+
 const styles = stylex.create({
   base: {
     display: 'flex',
@@ -43,7 +45,10 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
     backgroundColor: 'var(--fg1)',
     paddingBlock: '0.75rem',
-    paddingInline: '2rem',
+    paddingInline: {
+      default: '2rem',
+      [CTA_BREAK]: '1.5rem',
+    },
     boxShadow: {
       default: '0 0 2px rgba(0,0,0,0.35)',
       ':hover': '0 0 10px rgba(0,0,0,0.75)',

--- a/apps/docs/components/CtaButton.js
+++ b/apps/docs/components/CtaButton.js
@@ -24,7 +24,6 @@ export default function CtaButton({children, color, to}) {
     </Link>
   );
 }
-
 const styles = stylex.create({
   base: {
     display: 'flex',
@@ -44,7 +43,6 @@ const styles = stylex.create({
     backgroundColor: 'var(--fg1)',
     paddingBlock: '0.75rem',
     paddingInline: '2rem',
-      
     boxShadow: {
       default: '0 0 2px rgba(0,0,0,0.35)',
       ':hover': '0 0 10px rgba(0,0,0,0.75)',

--- a/apps/docs/components/CtaButton.js
+++ b/apps/docs/components/CtaButton.js
@@ -25,8 +25,6 @@ export default function CtaButton({children, color, to}) {
   );
 }
 
-const CTA_BREAK = '@media (max-width: 390px)';
-
 const styles = stylex.create({
   base: {
     display: 'flex',
@@ -45,10 +43,8 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
     backgroundColor: 'var(--fg1)',
     paddingBlock: '0.75rem',
-    paddingInline: {
-      default: '2rem',
-      [CTA_BREAK]: '1.5rem',
-    },
+    paddingInline: '2rem',
+      
     boxShadow: {
       default: '0 0 2px rgba(0,0,0,0.35)',
       ':hover': '0 0 10px rgba(0,0,0,0.75)',

--- a/apps/docs/src/pages/index.js
+++ b/apps/docs/src/pages/index.js
@@ -59,7 +59,7 @@ export default function Home() {
   );
 }
 
-const CTA_BREAK = '@media (max-width: 360px)';
+const CTA_BREAK = '@media (max-width: 385px)';
 
 const styles = stylex.create({
   main: {


### PR DESCRIPTION
## What changed / motivation ?
FIX: CTA section's responsive issue fixed

## Additional Context
### Issue was:
When screen size is around 370-380px the CTA section touches the edge which is not looks good (Please check the attached screenshot)

### Changes I made:
- There was several options to fix it. I just reduced the padding-x of those button when screen size is less then 390px

### Before:
![cta-before](https://github.com/facebook/stylex/assets/48852166/1b0aacaa-8106-484d-958d-abb3a4a84ac7)

### After: 
![cta-after](https://github.com/facebook/stylex/assets/48852166/cb23dada-fed8-4522-8f0a-283f99ee6989)

### Notes for Reviewers:
Hope you are going great. 
Please check my changes and if you have suggestions or need any modification please let me know. 

Thank you for your time and consideration!

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Performed a self-review of my code