### PR TITLE
docs: Fixing a typo on props.mdx page, fixed the issue of not copying to clipboard and added 16 to the comment on 06-static-types.mdx

### DIFF
--- a/apps/docs/docs/api/javascript/props.mdx
+++ b/apps/docs/docs/api/javascript/props.mdx
@@ -9,7 +9,7 @@ sidebar_position: 2
 # `stylex.props`
 
 Takes an StyleX style or array of StyleX styles, and returns a props object.
-Values can be also be `null`, `undefined`, or `false`.
+Values can also be `null`, `undefined`, or `false`.
 
 The return value should be onto an element to apply the styles directly.
 

--- a/apps/docs/docs/learn/06-static-types.mdx
+++ b/apps/docs/docs/learn/06-static-types.mdx
@@ -157,7 +157,7 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 type Props = {
   ...
   // Only accept styles for marginTop and nothing else.
-  // The value for marginTop can only be 0, 4, or 8.
+  // The value for marginTop can only be 0, 4, 8 or 16.
   style?: StyleXStyles<{
     marginTop: 0 | 4 | 8 | 16
   }>,
@@ -173,7 +173,7 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 type Props = $ReadOnly<{
   ...
   // Only accept styles for marginTop and nothing else.
-  // The value for marginTop can only be 0, 4, or 8.
+  // The value for marginTop can only be 0, 4, 8 or 16.
   style?: StyleXStyles<{
     marginTop: 0 | 4 | 8 | 16
   }>,


### PR DESCRIPTION
## What changed / motivation ?

In this commit, I addressed a typographical error found on the props.mdx page, ensuring accuracy and clarity in the documentation.

Fix for the issue of not copying to the clipboard mentioned in issue #121 , has been proposed with this pull request.

Additionally, I added the number "16" to a comment in the 06-static-types.mdx file to provide context and enhance the comprehensibility of the code. This change aims to improve the overall quality and understanding of the static types section.

These modifications contribute to a more polished and user-friendly documentation experience.

## Linked PR/Issues

## Additional Context

- The typo fix in the props.mdx page is crucial for maintaining precision in the documentation, particularly in conveying information about component properties.
- The Copy to ClipBoard option not working properly  #121 for Installation Command has been fixed with this pr
- The addition of the number "16" to a comment in the 06-static-types.mdx file serves to provide context and improve the clarity of the associated code. This change aligns with efforts to enhance code readability and understanding.

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

## Pre-flight checklist

- [X] I have read the contributing guidelines
      [Contribution Guidelines](../CONTRIBUTING.md)
- [X] Performed a self-review of my code