### PR TITLE
Fixed typo in 02-using-styles.mdx page

### DIFF
--- a/apps/docs/docs/learn/04-styling-ui/02-using-styles.mdx
+++ b/apps/docs/docs/learn/04-styling-ui/02-using-styles.mdx
@@ -23,7 +23,7 @@ use them conditionally, or even compose styles across module boundaries.
 
 ## Merging styles
 
-The `stylex.props` function can take a list of styles and merges them in a
+The `stylex.props` function can take a list of styles and merge them in a
 deterministic way, where “the last style applied always wins”.
 
 Consider that a couple of style objects are defined as so:
@@ -69,7 +69,7 @@ The actual implementation is optimized for performance.
 
 Styles can be applied conditionally at runtime by using common JavaScript
 patterns such as ternary expressions and the `&&` operator. `stylex.props`
-ignores falsy values such as `null`, `undefined` or `false`.
+ignores falsy values such as `null`, `undefined` or `false` and empty objects.
 
 ```tsx
 <div

--- a/apps/docs/docs/learn/04-styling-ui/02-using-styles.mdx
+++ b/apps/docs/docs/learn/04-styling-ui/02-using-styles.mdx
@@ -69,7 +69,7 @@ The actual implementation is optimized for performance.
 
 Styles can be applied conditionally at runtime by using common JavaScript
 patterns such as ternary expressions and the `&&` operator. `stylex.props`
-ignores falsy values such as `null`, `undefined` or `false` and empty objects.
+ignores falsy values such as `null`, `undefined` or `false`.
 
 ```tsx
 <div


### PR DESCRIPTION

## What changed / motivation ?

1. - What: Fixed a little typo in [Merging styles](https://stylexjs.com/docs/learn/styling-ui/using-styles/#merging-styles) section
    - Why: Typos can be distracting and lead to confusion, this change will help avoiding it.

2. - What: Clarified that props function also ignores empty objects
    - Why: It's important to understand how the props function handles the logic for devs who will use this function throughout their apps and this change will ensure devs are aware of this scenario.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Performed a self-review of my code