### PR TITLE
fix : dark theme inconsistency

### DIFF
--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -93,6 +93,14 @@ html[data-theme='dark']:root {
   --aa-muted-color-rgb: 146, 138, 255;
   --aa-primary-color-rgb: 146, 138, 255;
 
+  --aa-background-color-rgb: 21,24,42;
+  --aa-selected-color-rgb: 146,138,255;
+  --aa-selected-color-alpha: 0.25;
+  --aa-description-highlight-background-color-rgb: 0 255 255;
+  --aa-description-highlight-background-color-alpha: 0.25;
+  --aa-panel-shadow: inset 1px 1px 0 0 #2c2e40,0 3px 8px 0 #000309;
+  --aa-scrollbar-track-background-color-rgb: 44,46,64;
+
   --ifm-color-scheme: dark;
   --ifm-color-emphasis-0: var(--ifm-color-gray-1000);
   --ifm-color-emphasis-100: var(--ifm-color-gray-900);


### PR DESCRIPTION
## What changed / motivation ?
`docusaurus` dark theme variables were not applied , so instead we can use that dark theme related variables in custom css (not more than 6 variables and it solve the problem without needing to specify properties for the panel and search buttons.

## Linked PR/Issues

Fixes #149 

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->
![chrome-capture-2023-12-13 (1)](https://github.com/facebook/stylex/assets/30369664/386bc877-02e9-442a-a098-dfd993b69c69)

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Performed a self-review of my code