### PR TITLE
fix: `stylex.create` types

### DIFF
--- a/packages/stylex/src/StyleXTypes.d.ts
+++ b/packages/stylex/src/StyleXTypes.d.ts
@@ -75,8 +75,8 @@ export type NestedCSSPropTypes = Partial<
 
 type UserAuthoredStyles = {
   [P in keyof CSSPropertiesWithExtras]?:
-    | CSSPropertiesWithExtras[P]
-    | { [key: string]: unknown };
+    | (CSSPropertiesWithExtras[P] | (string & {}))
+    | { [key: string]: CSSProperties[P] | (string & {}) };
 };
 export type StyleXSingleStyle = false | (null | undefined | NestedCSSPropTypes);
 // NOTE: `XStyle` has been deprecated in favor of `StaticStyles` and `StyleXStyles`.

--- a/packages/stylex/src/StyleXTypes.d.ts
+++ b/packages/stylex/src/StyleXTypes.d.ts
@@ -73,7 +73,11 @@ export type NestedCSSPropTypes = Partial<
   }>
 >;
 
-type UserAuthoredStyles = CSSPropertiesWithExtras | { [key: string]: unknown };
+type UserAuthoredStyles = {
+  [P in keyof CSSPropertiesWithExtras]?:
+    | CSSPropertiesWithExtras[P]
+    | { [key: string]: unknown };
+};
 export type StyleXSingleStyle = false | (null | undefined | NestedCSSPropTypes);
 // NOTE: `XStyle` has been deprecated in favor of `StaticStyles` and `StyleXStyles`.
 


### PR DESCRIPTION
## What changed / motivation ?

Can't get right types using Typescript or vanilla.js in current version. This pr is a fix.


## Linked PR/Issues

None.

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

![image](https://github.com/facebook/stylex/assets/52351095/52fdbb96-6203-4182-8cd0-f6b61cf41697)

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Performed a self-review of my code