### PR TITLE
Perf: Remove runtime injection from runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31133,6 +31133,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
+        "@babel/helper-module-imports": "^7.22.15",
         "@stylexjs/shared": "0.3.0"
       },
       "devDependencies": {
@@ -31295,6 +31296,7 @@
         "@stylexjs/babel-plugin": "0.3.0"
       },
       "devDependencies": {
+        "@babel/cli": "^7.23.0",
         "@babel/preset-env": "^7.16.8",
         "@rollup/plugin-babel": "^6.0.0",
         "@rollup/plugin-commonjs": "^25.0.3",
@@ -35999,6 +36001,7 @@
     "@stylexjs/babel-plugin": {
       "version": "file:packages/babel-plugin",
       "requires": {
+        "@babel/helper-module-imports": "^7.22.15",
         "@stylexjs/shared": "0.3.0",
         "ts-node": "^10.8.1"
       }
@@ -36123,6 +36126,7 @@
     "@stylexjs/rollup-plugin": {
       "version": "file:packages/rollup-plugin",
       "requires": {
+        "@babel/cli": "^7.23.0",
         "@babel/core": "^7.16.0",
         "@babel/plugin-syntax-flow": "^7.18.6",
         "@babel/plugin-syntax-jsx": "^7.14.5",

--- a/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
@@ -65,10 +65,11 @@ describe('Evaluation of imported values works based on configuration', () => {
       );
       expect(transformation.code).toContain(expectedVarName);
       expect(transformation.code).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         import 'otherFile.stylex';
         import { MyTheme } from 'otherFile.stylex';
-        stylex.inject(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
+        _inject(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
         "__hashed_var__1r7rkhg";"
       `);
       expect(transformation.metadata.stylex).toMatchInlineSnapshot(`
@@ -103,10 +104,11 @@ describe('Evaluation of imported values works based on configuration', () => {
       );
       expect(transformation.code).toContain(expectedVarName);
       expect(transformation.code).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         import 'otherFile.stylex.js';
         import { MyTheme } from 'otherFile.stylex.js';
-        stylex.inject(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
+        _inject(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
         "__hashed_var__1r7rkhg";"
       `);
       expect(transformation.metadata.stylex).toMatchInlineSnapshot(`
@@ -141,10 +143,11 @@ describe('Evaluation of imported values works based on configuration', () => {
       );
       expect(transformation.code).toContain(expectedVarName);
       expect(transformation.code).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         import 'otherFile.stylex.js';
         import { MyTheme as mt } from 'otherFile.stylex.js';
-        stylex.inject(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
+        _inject(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
         "__hashed_var__1r7rkhg";"
       `);
       expect(transformation.metadata.stylex).toMatchInlineSnapshot(`

--- a/packages/babel-plugin/__tests__/stylex-transform-call-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-call-test.js
@@ -51,8 +51,9 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.red);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
     });
@@ -72,9 +73,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles[0], styles[1]);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x1t391ir{background-color:blue}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
         "x1e2nbdu x1t391ir";"
       `);
     });
@@ -94,9 +96,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles[0], styles[1]);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x1t391ir{background-color:blue}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
         "x1e2nbdu x1t391ir";"
       `);
     });
@@ -116,10 +119,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles[0], styles[1]);
         `),
       ).toMatchInlineSnapshot(`
-        "import { create } from '@stylexjs/stylex';
-        import __stylex__ from "@stylexjs/stylex";
-        __stylex__.inject(".x1e2nbdu{color:red}", 3000);
-        __stylex__.inject(".x1t391ir{background-color:blue}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import { create } from '@stylexjs/stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
         const styles = {
           "0": {
             color: "x1e2nbdu",
@@ -146,8 +149,9 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles['default']);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
     });
@@ -169,9 +173,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.default, otherStyles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x1t391ir{background-color:blue}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
         "x1e2nbdu x1t391ir";"
       `);
     });
@@ -188,8 +193,9 @@ describe('@stylexjs/babel-plugin', () => {
           }
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         const a = function () {
           return "x1e2nbdu";
         };"
@@ -212,9 +218,10 @@ describe('@stylexjs/babel-plugin', () => {
           const foo = styles;
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x1t391ir{background-color:blue}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
         const styles = {
           foo: {
             color: "x1e2nbdu",
@@ -245,8 +252,9 @@ describe('@stylexjs/babel-plugin', () => {
           }
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         export default function MyExportDefault() {
           return "x1e2nbdu";
         }
@@ -268,8 +276,9 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.foo);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x14odnwx{padding:5px}", 1000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14odnwx{padding:5px}", 1000);
         "x14odnwx";"
       `);
     });
@@ -286,8 +295,9 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.foo);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x14odnwx{padding:5px}", 1000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14odnwx{padding:5px}", 1000);
         export const styles = {
           foo: {
             padding: "x14odnwx",
@@ -319,9 +329,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x17z2mba:hover{color:blue}", 3130);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x17z2mba:hover{color:blue}", 3130);
         "x1e2nbdu x17z2mba";"
       `);
     });
@@ -341,9 +352,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x17z2mba:hover{color:blue}", 3130);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x17z2mba:hover{color:blue}", 3130);
         "x1e2nbdu x17z2mba";"
       `);
     });
@@ -366,10 +378,11 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-        stylex.inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
         "xrkmrrc xc445zv x1ssfqz5";"
       `);
     });
@@ -390,10 +403,11 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-        stylex.inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
         "xrkmrrc xc445zv x1ssfqz5";"
       `);
     });
@@ -416,10 +430,11 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-        stylex.inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+        _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
         "xrkmrrc x6m3b6q x6um648";"
       `);
     });
@@ -440,10 +455,11 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-        stylex.inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+        _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
         "xrkmrrc x6m3b6q x6um648";"
       `);
     });
@@ -467,9 +483,10 @@ describe('@stylexjs/babel-plugin', () => {
             { genConditionalClasses: true },
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".xrkmrrc{background-color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".xrkmrrc{background-color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           ({
             0: "xrkmrrc",
             1: "xrkmrrc xju2f9n"
@@ -494,9 +511,10 @@ describe('@stylexjs/babel-plugin', () => {
             `,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".xrkmrrc{background-color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".xrkmrrc{background-color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           const styles = {
             default: {
               backgroundColor: "xrkmrrc",
@@ -527,9 +545,10 @@ describe('@stylexjs/babel-plugin', () => {
             stylex(styles.blue, styles.red);
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           "xju2f9n";
           "x1e2nbdu";"
         `);
@@ -551,8 +570,9 @@ describe('@stylexjs/babel-plugin', () => {
             stylex(styles.revert, styles.red);
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
           "";
           "x1e2nbdu";"
         `);
@@ -576,11 +596,12 @@ describe('@stylexjs/babel-plugin', () => {
             stylex(styles.foo, styles.bar);
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x14odnwx{padding:5px}", 1000);
-          stylex.inject(".x2vl965{padding-inline-end:10px}", 3000);
-          stylex.inject(".x1i3ajwb{padding:2px}", 1000);
-          stylex.inject(".xe2zdcy{padding-inline-start:10px}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x14odnwx{padding:5px}", 1000);
+          _inject(".x2vl965{padding-inline-end:10px}", 3000);
+          _inject(".x1i3ajwb{padding:2px}", 1000);
+          _inject(".xe2zdcy{padding-inline-start:10px}", 3000);
           "x2vl965 x1i3ajwb xe2zdcy";"
         `);
       });
@@ -603,10 +624,11 @@ describe('@stylexjs/babel-plugin', () => {
             stylex(styles.foo, styles.bar);
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x14odnwx{padding:5px}", 1000);
-          stylex.inject(".x2vl965{padding-inline-end:10px}", 3000);
-          stylex.inject(".x1i3ajwb{padding:2px}", 1000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x14odnwx{padding:5px}", 1000);
+          _inject(".x2vl965{padding-inline-end:10px}", 3000);
+          _inject(".x1i3ajwb{padding:2px}", 1000);
           "x2vl965 x1i3ajwb";"
         `);
       });
@@ -629,9 +651,10 @@ describe('@stylexjs/babel-plugin', () => {
             { genConditionalClasses: true },
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           ({
             0: "x1e2nbdu",
             1: "xju2f9n"
@@ -656,9 +679,10 @@ describe('@stylexjs/babel-plugin', () => {
             `,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           const styles = {
             red: {
               color: "x1e2nbdu",
@@ -691,8 +715,9 @@ describe('@stylexjs/babel-plugin', () => {
             { genConditionalClasses: true },
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
           ({
             0: "x1e2nbdu",
             1: ""
@@ -717,8 +742,9 @@ describe('@stylexjs/babel-plugin', () => {
             `,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
           const styles = {
             red: {
               color: "x1e2nbdu",
@@ -755,8 +781,9 @@ describe('@stylexjs/babel-plugin', () => {
             options,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
           "FooBar__styles.default x1e2nbdu";"
         `);
       });
@@ -786,9 +813,10 @@ describe('@stylexjs/babel-plugin', () => {
             options,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".x1t391ir{background-color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".x1t391ir{background-color:blue}", 3000);
           ({
             0: "FooBar__styles.default x1e2nbdu",
             1: "FooBar__styles.default x1e2nbdu FooBar__otherStyles.default x1t391ir"
@@ -820,8 +848,9 @@ describe('@stylexjs/babel-plugin', () => {
             options,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
               "FooBar__styles.default": "FooBar__styles.default",
@@ -829,7 +858,7 @@ describe('@stylexjs/babel-plugin', () => {
               $$css: true
             }
           };
-          stylex.inject(".x1t391ir{background-color:blue}", 3000);
+          _inject(".x1t391ir{background-color:blue}", 3000);
           const otherStyles = {
             default: {
               "FooBar__otherStyles.default": "FooBar__otherStyles.default",
@@ -865,9 +894,10 @@ describe('@stylexjs/babel-plugin', () => {
             options,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           ({
             0: "FooBar__styles.default x1e2nbdu",
             1: "FooBar__styles.default FooBar__styles.active xju2f9n"
@@ -898,9 +928,10 @@ describe('@stylexjs/babel-plugin', () => {
             options,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           const styles = {
             default: {
               "FooBar__styles.default": "FooBar__styles.default",
@@ -934,9 +965,10 @@ describe('@stylexjs/babel-plugin', () => {
             stylex(styles[variant]);
           `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x1t391ir{background-color:blue}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
         const styles = {
           "0": {
             color: "x1e2nbdu",
@@ -962,8 +994,9 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.default, props);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         const styles = {
           default: {
             color: "x1e2nbdu",
@@ -991,9 +1024,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x17z2mba:hover{color:blue}", 3130);
-        stylex.inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x17z2mba:hover{color:blue}", 3130);
+        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         export const styles = {
           default: {
             ":hover_color": "x17z2mba",
@@ -1022,9 +1056,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x17z2mba:hover{color:blue}", 3130);
-        stylex.inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x17z2mba:hover{color:blue}", 3130);
+        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         export const styles = {
           default: {
             color: "x17z2mba",
@@ -1052,10 +1087,11 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
           stylex(styles[variant]);
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".x1t391ir{background-color:blue}", 3000);
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".x1t391ir{background-color:blue}", 3000);
           const styles = {
             "0": {
               color: "x1e2nbdu",
@@ -1095,7 +1131,8 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
           function MyComponent() {
             return <>
                             <div className={"x1e2nbdu"} />
@@ -1104,8 +1141,8 @@ describe('@stylexjs/babel-plugin', () => {
                             <div className={"x1e2nbdu x1t391ir"} />
                           </>;
           }
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".x1t391ir{background-color:blue}", 3000);
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".x1t391ir{background-color:blue}", 3000);
           const styles = {
             foo: {
               color: "x1e2nbdu",
@@ -1130,9 +1167,10 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
           stylex(styles.default, props);
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
               color: "x1e2nbdu",
@@ -1157,12 +1195,13 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
           stylex(styles.default, props);
-          stylex.inject(".x16gpukw{border-top:5px solid blue}", 2000);
-          stylex.inject(".x13nwy86{border-left:5px solid blue}", 2000);
-          stylex.inject(".x2ekbea{border-right:5px solid blue}", 2000);
-          stylex.inject(".x1o3008b{border-bottom:5px solid blue}", 2000);
+          _inject(".x16gpukw{border-top:5px solid blue}", 2000);
+          _inject(".x13nwy86{border-left:5px solid blue}", 2000);
+          _inject(".x2ekbea{border-right:5px solid blue}", 2000);
+          _inject(".x1o3008b{border-bottom:5px solid blue}", 2000);
           const styles = {
             default: {
               borderTop: "x16gpukw",
@@ -1210,10 +1249,11 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
           "x17z2mba xc445zv";
-          stylex.inject(".x17z2mba:hover{color:blue}", 3130);
-          stylex.inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+          _inject(".x17z2mba:hover{color:blue}", 3130);
+          _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
           export const styles = {
             default: {
               ":hover_color": "x17z2mba",
@@ -1241,8 +1281,9 @@ describe('@stylexjs/babel-plugin', () => {
           { importSources: ['custom-stylex-path'] },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'custom-stylex-path';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'custom-stylex-path';
+        _inject(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
     });
@@ -1261,8 +1302,9 @@ describe('@stylexjs/babel-plugin', () => {
           { importSources: [{ from: 'custom-stylex-path', as: 'css' }] },
         ),
       ).toMatchInlineSnapshot(`
-        "import { css as stylex } from 'custom-stylex-path';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import { css as stylex } from 'custom-stylex-path';
+        _inject(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
     });
@@ -1281,8 +1323,9 @@ describe('@stylexjs/babel-plugin', () => {
           { importSources: [{ from: 'custom-stylex-path', as: 'css' }] },
         ),
       ).toMatchInlineSnapshot(`
-        "import { css } from 'custom-stylex-path';
-        css.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import { css } from 'custom-stylex-path';
+        _inject(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
     });
@@ -1328,19 +1371,20 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, genConditionalClasses: true },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from '@stylexjs/stylex';
-        stylex.inject(".x9f619{box-sizing:border-box}", 3000);
-        stylex.inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        stylex.inject(".x1fdo2jl{grid-area:content}", 1000);
-        stylex.inject(".xrvj5dj{display:grid}", 3000);
-        stylex.inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        stylex.inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        stylex.inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        stylex.inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        stylex.inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        stylex.inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        stylex.inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        stylex.inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from '@stylexjs/stylex';
+        _inject(".x9f619{box-sizing:border-box}", 3000);
+        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject(".x1fdo2jl{grid-area:content}", 1000);
+        _inject(".xrvj5dj{display:grid}", 3000);
+        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         export const styles = {
           sidebar: {
             "UnknownFile__styles.sidebar": "UnknownFile__styles.sidebar",
@@ -1435,19 +1479,20 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from '@stylexjs/stylex';
-        stylex.inject(".x9f619{box-sizing:border-box}", 3000);
-        stylex.inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        stylex.inject(".x1fdo2jl{grid-area:content}", 1000);
-        stylex.inject(".xrvj5dj{display:grid}", 3000);
-        stylex.inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        stylex.inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        stylex.inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        stylex.inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        stylex.inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        stylex.inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        stylex.inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        stylex.inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from '@stylexjs/stylex';
+        _inject(".x9f619{box-sizing:border-box}", 3000);
+        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject(".x1fdo2jl{grid-area:content}", 1000);
+        _inject(".xrvj5dj{display:grid}", 3000);
+        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         export const styles = {
           sidebar: {
             "UnknownFile__styles.sidebar": "UnknownFile__styles.sidebar",
@@ -1541,19 +1586,20 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, genConditionalClasses: true },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from '@stylexjs/stylex';
-        stylex.inject(".x9f619{box-sizing:border-box}", 3000);
-        stylex.inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        stylex.inject(".x1fdo2jl{grid-area:content}", 1000);
-        stylex.inject(".xrvj5dj{display:grid}", 3000);
-        stylex.inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        stylex.inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        stylex.inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        stylex.inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        stylex.inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        stylex.inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        stylex.inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        stylex.inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from '@stylexjs/stylex';
+        _inject(".x9f619{box-sizing:border-box}", 3000);
+        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject(".x1fdo2jl{grid-area:content}", 1000);
+        _inject(".xrvj5dj{display:grid}", 3000);
+        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         const complex = {
           0: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4",
           4: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x",

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -39,9 +39,10 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject(".xju2f9n{color:blue}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject(".xju2f9n{color:blue}", 3000);"
       `);
     });
 
@@ -57,9 +58,10 @@ describe('@stylexjs/babel-plugin', () => {
            });
          `),
       ).toMatchInlineSnapshot(`
-        "import * as foo from 'stylex';
-        foo.inject(".xrkmrrc{background-color:red}", 3000);
-        foo.inject(".xju2f9n{color:blue}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import * as foo from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject(".xju2f9n{color:blue}", 3000);"
       `);
     });
 
@@ -75,10 +77,10 @@ describe('@stylexjs/babel-plugin', () => {
            });
          `),
       ).toMatchInlineSnapshot(`
-        "import { create } from 'stylex';
-        import __stylex__ from "stylex";
-        __stylex__.inject(".xrkmrrc{background-color:red}", 3000);
-        __stylex__.inject(".xju2f9n{color:blue}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import { create } from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject(".xju2f9n{color:blue}", 3000);"
       `);
     });
 
@@ -93,8 +95,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xgau0yw{--background-color:red}", 1);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xgau0yw{--background-color:red}", 1);"
       `);
     });
 
@@ -109,8 +112,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x13tgbkp{--final-color:var(--background-color)}", 1);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x13tgbkp{--final-color:var(--background-color)}", 1);"
       `);
     });
 
@@ -128,9 +132,10 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject(".xju2f9n{color:blue}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject(".xju2f9n{color:blue}", 3000);"
       `);
     });
 
@@ -145,8 +150,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xd71okc{content:attr(some-attribute)}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xd71okc{content:attr(some-attribute)}", 3000);"
       `);
     });
 
@@ -171,8 +177,9 @@ describe('@stylexjs/babel-plugin', () => {
       expect(camelCased).toEqual(kebabCased);
 
       expect(camelCased).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1cfch2b{transition-property:margin-top}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1cfch2b{transition-property:margin-top}", 3000);"
       `);
     });
 
@@ -187,8 +194,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x17389it{transition-property:--foo}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x17389it{transition-property:--foo}", 3000);"
       `);
     });
 
@@ -206,9 +214,10 @@ describe('@stylexjs/babel-plugin', () => {
            });
          `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1gykpug:hover{background-color:red}", 3130);
-        stylex.inject(".x17z2mba:hover{color:blue}", 3130);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1gykpug:hover{background-color:red}", 3130);
+        _inject(".x17z2mba:hover{color:blue}", 3130);"
       `);
     });
 
@@ -228,9 +237,10 @@ describe('@stylexjs/babel-plugin', () => {
            });
          `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1gykpug:hover{background-color:red}", 3130);
-        stylex.inject(".x17z2mba:hover{color:blue}", 3130);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1gykpug:hover{background-color:red}", 3130);
+        _inject(".x17z2mba:hover{color:blue}", 3130);"
       `);
     });
 
@@ -245,8 +255,9 @@ describe('@stylexjs/babel-plugin', () => {
            });
          `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1ruww2u{position:sticky;position:fixed}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1ruww2u{position:sticky;position:fixed}", 3000);"
       `);
     });
 
@@ -264,9 +275,10 @@ describe('@stylexjs/babel-plugin', () => {
            });
          `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xixxii4{position:fixed}", 3000);
-        stylex.inject("@media (min-width: 768px){.x1vazst0.x1vazst0{position:sticky;position:fixed}}", 3200);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xixxii4{position:fixed}", 3000);
+        _inject("@media (min-width: 768px){.x1vazst0.x1vazst0{position:sticky;position:fixed}}", 3200);"
       `);
     });
 
@@ -282,8 +294,9 @@ describe('@stylexjs/babel-plugin', () => {
            });
          `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x87ps6o{user-select:none}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x87ps6o{user-select:none}", 3000);"
       `);
     });
 
@@ -301,10 +314,11 @@ describe('@stylexjs/babel-plugin', () => {
            });
          `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xb3r6kr{overflow:hidden}", 2000);
-        stylex.inject(".xbsl7fq{border-style:dashed}", 2000);
-        stylex.inject(".xmkeg23{border-width:1px}", 2000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xb3r6kr{overflow:hidden}", 2000);
+        _inject(".xbsl7fq{border-style:dashed}", 2000);
+        _inject(".xmkeg23{border-width:1px}", 2000);"
       `);
     });
 
@@ -361,8 +375,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x15oojuh{position:fixed;position:sticky}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x15oojuh{position:fixed;position:sticky}", 3000);
         export const styles = {
           foo: {
             position: "x15oojuh",
@@ -383,8 +398,9 @@ describe('@stylexjs/babel-plugin', () => {
            });
          `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xxnfx33{box-shadow:0 2px 4px var(--shadow-1)}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xxnfx33{box-shadow:0 2px 4px var(--shadow-1)}", 3000);"
       `);
     });
 
@@ -404,9 +420,10 @@ describe('@stylexjs/babel-plugin', () => {
             });
          `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x19iys6w:invalpwdijad{background-color:red}", 3040);
-          stylex.inject(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x19iys6w:invalpwdijad{background-color:red}", 3040);
+          _inject(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
         `);
       });
 
@@ -432,11 +449,12 @@ describe('@stylexjs/babel-plugin', () => {
             });
          `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x17z2mba:hover{color:blue}", 3130);
-          stylex.inject(".x96fq8s:active{color:red}", 3170);
-          stylex.inject(".x1wvtd7d:focus{color:yellow}", 3150);
-          stylex.inject(".x126ychx:nth-child(2n){color:purple}", 3060);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x17z2mba:hover{color:blue}", 3130);
+          _inject(".x96fq8s:active{color:red}", 3170);
+          _inject(".x1wvtd7d:focus{color:yellow}", 3150);
+          _inject(".x126ychx:nth-child(2n){color:purple}", 3060);"
         `);
       });
 
@@ -453,8 +471,9 @@ describe('@stylexjs/babel-plugin', () => {
             });
          `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
         `);
       });
     });
@@ -473,9 +492,10 @@ describe('@stylexjs/babel-plugin', () => {
             });
          `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x19iys6w:invalpwdijad{background-color:red}", 3040);
-          stylex.inject(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x19iys6w:invalpwdijad{background-color:red}", 3040);
+          _inject(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
         `);
       });
 
@@ -495,11 +515,12 @@ describe('@stylexjs/babel-plugin', () => {
             });
          `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x17z2mba:hover{color:blue}", 3130);
-          stylex.inject(".x96fq8s:active{color:red}", 3170);
-          stylex.inject(".x1wvtd7d:focus{color:yellow}", 3150);
-          stylex.inject(".x126ychx:nth-child(2n){color:purple}", 3060);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x17z2mba:hover{color:blue}", 3130);
+          _inject(".x96fq8s:active{color:red}", 3170);
+          _inject(".x1wvtd7d:focus{color:yellow}", 3150);
+          _inject(".x126ychx:nth-child(2n){color:purple}", 3060);"
         `);
       });
 
@@ -516,8 +537,9 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
         `);
       });
     });
@@ -540,9 +562,10 @@ describe('@stylexjs/babel-plugin', () => {
              });
            `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x16oeupf::before{color:red}", 8000);
-          stylex.inject(".xdaarc3::after{color:blue}", 8000);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x16oeupf::before{color:red}", 8000);
+          _inject(".xdaarc3::after{color:blue}", 8000);"
         `);
       });
 
@@ -559,8 +582,9 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x6yu8oj::placeholder{color:gray}", 8000);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x6yu8oj::placeholder{color:gray}", 8000);"
         `);
       });
 
@@ -577,8 +601,9 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1en94km::-webkit-slider-thumb, .x1en94km::-moz-range-thumb, .x1en94km::-ms-thumb{width:16px}", 9000);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1en94km::-webkit-slider-thumb, .x1en94km::-moz-range-thumb, .x1en94km::-ms-thumb{width:16px}", 9000);"
         `);
       });
     });
@@ -601,10 +626,11 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".xrkmrrc{background-color:red}", 3000);
-          stylex.inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-          stylex.inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".xrkmrrc{background-color:red}", 3000);
+          _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+          _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);"
         `);
       });
 
@@ -625,10 +651,11 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".xrkmrrc{background-color:red}", 3000);
-          stylex.inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-          stylex.inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".xrkmrrc{background-color:red}", 3000);
+          _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+          _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);"
         `);
       });
     });
@@ -649,10 +676,11 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".xrkmrrc{background-color:red}", 3000);
-          stylex.inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-          stylex.inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".xrkmrrc{background-color:red}", 3000);
+          _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+          _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);"
         `);
       });
 
@@ -671,10 +699,11 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".xrkmrrc{background-color:red}", 3000);
-          stylex.inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-          stylex.inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".xrkmrrc{background-color:red}", 3000);
+          _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+          _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);"
         `);
       });
     });
@@ -714,22 +743,23 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         const borderRadius = 2;
-        stylex.inject(".xe4njm9{margin:calc((100% - 50px) * .5) 20px 0}", 1000);
-        stylex.inject(".xs4buau{border-color:red blue}", 2000);
-        stylex.inject(".xbsl7fq{border-style:dashed}", 2000);
-        stylex.inject(".xn43iik{border-width:0 0 2px 0}", 2000);
-        stylex.inject(".xmkeg23{border-width:1px}", 2000);
-        stylex.inject(".xa309fb{border-bottom-width:5px}", 4000);
-        stylex.inject(".x1y0btm7{border-style:solid}", 2000);
-        stylex.inject(".x1q0q8m5{border-bottom-style:solid}", 4000);
-        stylex.inject(".x1lh7sze{border-color:var(--divider)}", 2000);
-        stylex.inject(".xud65wk{border-bottom-color:red}", 4000);
-        stylex.inject(".x12oqio5{border-radius:4px}", 2000);
-        stylex.inject(".x1lmef92{padding:calc((100% - 50px) * .5) var(--rightpadding,20px)}", 1000);
-        stylex.inject(".xexx8yu{padding-top:0}", 4000);
-        stylex.inject(".x1bg2uv5{border-color:green}", 2000);"
+        _inject(".xe4njm9{margin:calc((100% - 50px) * .5) 20px 0}", 1000);
+        _inject(".xs4buau{border-color:red blue}", 2000);
+        _inject(".xbsl7fq{border-style:dashed}", 2000);
+        _inject(".xn43iik{border-width:0 0 2px 0}", 2000);
+        _inject(".xmkeg23{border-width:1px}", 2000);
+        _inject(".xa309fb{border-bottom-width:5px}", 4000);
+        _inject(".x1y0btm7{border-style:solid}", 2000);
+        _inject(".x1q0q8m5{border-bottom-style:solid}", 4000);
+        _inject(".x1lh7sze{border-color:var(--divider)}", 2000);
+        _inject(".xud65wk{border-bottom-color:red}", 4000);
+        _inject(".x12oqio5{border-radius:4px}", 2000);
+        _inject(".x1lmef92{padding:calc((100% - 50px) * .5) var(--rightpadding,20px)}", 1000);
+        _inject(".xexx8yu{padding-top:0}", 4000);
+        _inject(".x1bg2uv5{border-color:green}", 2000);"
       `);
     });
 
@@ -753,13 +783,14 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.default, styles.override);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         const borderRadius = 2;
-        stylex.inject(".x1ok221b{margin-top:5px}", 4000);
-        stylex.inject(".x1sa5p1d{margin-inline-end:10px}", 3000);
-        stylex.inject(".x1fqp7bg{margin-bottom:15px}", 4000);
-        stylex.inject(".xqsn43r{margin-inline-start:20px}", 3000);
-        stylex.inject(".x1ghz6dp{margin:0}", 1000);
+        _inject(".x1ok221b{margin-top:5px}", 4000);
+        _inject(".x1sa5p1d{margin-inline-end:10px}", 3000);
+        _inject(".x1fqp7bg{margin-bottom:15px}", 4000);
+        _inject(".xqsn43r{margin-inline-start:20px}", 3000);
+        _inject(".x1ghz6dp{margin:0}", 1000);
         "x1ghz6dp";"
       `);
     });
@@ -1053,9 +1084,10 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject(".x19dipnz{color:var(--color,revert)}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject(".x19dipnz{color:var(--color,revert)}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
@@ -1080,9 +1112,10 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject(".x17fnjtu{width:var(--width,revert)}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject(".x17fnjtu{width:var(--width,revert)}", 4000);
         export const styles = {
           default: width => [{
             backgroundColor: "xrkmrrc",
@@ -1110,10 +1143,11 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject(".x19dipnz{color:var(--color,revert)}", 3000);
-        stylex.inject(".x1mqxbix{color:black}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject(".x1mqxbix{color:black}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
@@ -1141,8 +1175,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
         export const styles = {
           default: bgColor => [{
             "--background-color": "xyv4n8w",
@@ -1167,9 +1202,10 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1gykpug:hover{background-color:red}", 3130);
-        stylex.inject(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1gykpug:hover{background-color:red}", 3130);
+        _inject(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
         export const styles = {
           default: color => [{
             ":hover_backgroundColor": "x1gykpug",
@@ -1196,10 +1232,11 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject(".x19dipnz{color:var(--color,revert)}", 3000);
-        stylex.inject(".x1mqxbix{color:black}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject(".x1mqxbix{color:black}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
@@ -1227,8 +1264,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
         export const styles = {
           default: bgColor => [{
             "--background-color": "xyv4n8w",
@@ -1253,9 +1291,10 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1gykpug:hover{background-color:red}", 3130);
-        stylex.inject(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1gykpug:hover{background-color:red}", 3130);
+        _inject(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
         export const styles = {
           default: color => [{
             ":hover_backgroundColor": "x1gykpug",

--- a/packages/babel-plugin/__tests__/stylex-transform-create-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-vars-test.js
@@ -16,7 +16,6 @@ const stylexPlugin = require('../src/index');
 
 const classNamePrefix = 'x';
 const defaultOpts = {
-  stylexSheetName: '<>',
   unstable_moduleResolution: { type: 'haste' },
   classNamePrefix,
 };
@@ -204,8 +203,9 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, ...defaultOpts },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -282,8 +282,9 @@ describe('@stylexjs/babel-plugin', () => {
           },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -377,8 +378,9 @@ describe('@stylexjs/babel-plugin', () => {
           },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -386,7 +388,7 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        stylex.inject(":root{--xcateir:white;--xmj7ivn:black;--x13gxjix:8;}@media (prefers-color-scheme: dark){:root{--xmj7ivn:white;}}", 0);
+        _inject(":root{--xcateir:white;--xmj7ivn:black;--x13gxjix:8;}@media (prefers-color-scheme: dark){:root{--xmj7ivn:white;}}", 0);
         export const textInputTheme = {
           bgColor: "var(--xcateir)",
           labelColor: "var(--xmj7ivn)",
@@ -421,9 +423,10 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, ...defaultOpts },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         const RADIUS = 10;
-        stylex.inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -459,9 +462,10 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, ...defaultOpts },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         const color = 'blue';
-        stylex.inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -497,9 +501,10 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, ...defaultOpts },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         const name = 'light';
-        stylex.inject(":root{--xgck17p:lightblue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        _inject(":root{--xgck17p:lightblue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -535,9 +540,10 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, ...defaultOpts },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         const RADIUS = 2;
-        stylex.inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:4;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:4;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -579,8 +585,9 @@ describe('@stylexjs/babel-plugin', () => {
           },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(":root{--x1sm8rlu:blue;--xxncinc:grey;--x4e1236:10;--xv9uic:pink;}@media (prefers-color-scheme: dark){:root{--x1sm8rlu:lightblue;--xxncinc:rgba(0, 0, 0, 0.8);}}@media print{:root{--x1sm8rlu:white;}}", 0);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(":root{--x1sm8rlu:blue;--xxncinc:grey;--x4e1236:10;--xv9uic:pink;}@media (prefers-color-scheme: dark){:root{--x1sm8rlu:lightblue;--xxncinc:rgba(0, 0, 0, 0.8);}}@media print{:root{--x1sm8rlu:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--x1sm8rlu)",
           bgColorDisabled: "var(--xxncinc)",

--- a/packages/babel-plugin/__tests__/stylex-transform-import-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-import-test.js
@@ -64,8 +64,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         export const styles = {
           foo: {
             color: "x1e2nbdu",
@@ -105,8 +106,9 @@ describe('@stylexjs/babel-plugin', () => {
           export {styles}
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         const styles = {
           foo: {
             color: "x1e2nbdu",
@@ -128,8 +130,9 @@ describe('@stylexjs/babel-plugin', () => {
           }));
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         export default {
           foo: {
             color: "x1e2nbdu",
@@ -151,8 +154,9 @@ describe('@stylexjs/babel-plugin', () => {
           module.export = styles;
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         const styles = {
           foo: {
             color: "x1e2nbdu",
@@ -180,10 +184,11 @@ describe('@stylexjs/babel-plugin', () => {
           styles;
         `),
       ).toMatchInlineSnapshot(`
-        "import foobar from 'stylex';
-        foobar.inject(".xrkmrrc{background-color:red}", 3000);
-        foobar.inject(".xju2f9n{color:blue}", 3000);
-        foobar.inject(".x14odnwx{padding:5px}", 1000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import foobar from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject(".xju2f9n{color:blue}", 3000);
+        _inject(".x14odnwx{padding:5px}", 1000);
         const styles = {
           default: {
             backgroundColor: "xrkmrrc",
@@ -217,10 +222,11 @@ describe('@stylexjs/babel-plugin', () => {
           styles;
         `),
       ).toMatchInlineSnapshot(`
-        "import * as foobar from 'stylex';
-        foobar.inject(".xrkmrrc{background-color:red}", 3000);
-        foobar.inject(".xju2f9n{color:blue}", 3000);
-        foobar.inject(".x14odnwx{padding:5px}", 1000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import * as foobar from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject(".xju2f9n{color:blue}", 3000);
+        _inject(".x14odnwx{padding:5px}", 1000);
         const styles = {
           default: {
             backgroundColor: "xrkmrrc",
@@ -254,11 +260,11 @@ describe('@stylexjs/babel-plugin', () => {
           styles;
         `),
       ).toMatchInlineSnapshot(`
-        "import { create } from 'stylex';
-        import __stylex__ from "stylex";
-        __stylex__.inject(".xrkmrrc{background-color:red}", 3000);
-        __stylex__.inject(".xju2f9n{color:blue}", 3000);
-        __stylex__.inject(".x14odnwx{padding:5px}", 1000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import { create } from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject(".xju2f9n{color:blue}", 3000);
+        _inject(".x14odnwx{padding:5px}", 1000);
         const styles = {
           default: {
             backgroundColor: "xrkmrrc",
@@ -292,11 +298,11 @@ describe('@stylexjs/babel-plugin', () => {
           styles;
         `),
       ).toMatchInlineSnapshot(`
-        "import { create as css } from 'stylex';
-        import __stylex__ from "stylex";
-        __stylex__.inject(".xrkmrrc{background-color:red}", 3000);
-        __stylex__.inject(".xju2f9n{color:blue}", 3000);
-        __stylex__.inject(".x14odnwx{padding:5px}", 1000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import { create as css } from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject(".xju2f9n{color:blue}", 3000);
+        _inject(".x14odnwx{padding:5px}", 1000);
         const styles = {
           default: {
             backgroundColor: "xrkmrrc",

--- a/packages/babel-plugin/__tests__/stylex-transform-keyframes-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-keyframes-test.js
@@ -41,8 +41,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
         const name = "xbopttm-B";"
       `);
     });
@@ -62,8 +63,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import * as stylex from 'stylex';
-        stylex.inject("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import * as stylex from 'stylex';
+        _inject("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
         const name = "xbopttm-B";"
       `);
     });
@@ -83,9 +85,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import { keyframes } from 'stylex';
-        import __stylex__ from "stylex";
-        __stylex__.inject("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import { keyframes } from 'stylex';
+        _inject("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
         const name = "xbopttm-B";"
       `);
     });
@@ -110,10 +112,11 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject("@keyframes x3zqmp-B{from{background-color:blue;}to{background-color:red;}}", 1);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject("@keyframes x3zqmp-B{from{background-color:blue;}to{background-color:red;}}", 1);
         const name = "x3zqmp-B";
-        stylex.inject(".x1qs41r0{animation:3s x3zqmp-B}", 1000);"
+        _inject(".x1qs41r0{animation:3s x3zqmp-B}", 1000);"
       `);
     });
 
@@ -136,9 +139,10 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject("@keyframes x3zqmp-B{from{background-color:blue;}to{background-color:red;}}", 1);
-        stylex.inject(".xcoz2pf{animation-name:x3zqmp-B}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject("@keyframes x3zqmp-B{from{background-color:blue;}to{background-color:red;}}", 1);
+        _inject(".xcoz2pf{animation-name:x3zqmp-B}", 3000);"
       `);
     });
 
@@ -163,10 +167,11 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject("@keyframes x1jkcf39-B{from{inset-inline-start:0;}to{inset-inline-start:500px;}}", 1);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject("@keyframes x1jkcf39-B{from{inset-inline-start:0;}to{inset-inline-start:500px;}}", 1);
         const name = "x1jkcf39-B";
-        stylex.inject(".x1vfi257{animation-name:x1jkcf39-B}", 3000);
+        _inject(".x1vfi257{animation-name:x1jkcf39-B}", 3000);
         export const styles = {
           root: {
             animationName: "x1vfi257",

--- a/packages/babel-plugin/__tests__/stylex-transform-legacy-shorthands-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-legacy-shorthands-test.js
@@ -51,11 +51,12 @@ describe('Legacy-shorthand-expansion resolution', () => {
           stylex(styles.foo);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x123j3cw{padding-top:5px}", 4000);
-        stylex.inject(".x1mpkggp{padding-right:5px}", 3000, ".x1mpkggp{padding-left:5px}");
-        stylex.inject(".xs9asl8{padding-bottom:5px}", 4000);
-        stylex.inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x123j3cw{padding-top:5px}", 4000);
+        _inject(".x1mpkggp{padding-right:5px}", 3000, ".x1mpkggp{padding-left:5px}");
+        _inject(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
         export const styles = {
           foo: {
             paddingTop: "x123j3cw",
@@ -86,15 +87,16 @@ describe('Legacy-shorthand-expansion resolution', () => {
           stylex(styles.foo, styles.bar);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x123j3cw{padding-top:5px}", 4000);
-        stylex.inject(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
-        stylex.inject(".xs9asl8{padding-bottom:5px}", 4000);
-        stylex.inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
-        stylex.inject(".x1nn3v0j{padding-top:2px}", 4000);
-        stylex.inject(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
-        stylex.inject(".x1120s5i{padding-bottom:2px}", 4000);
-        stylex.inject(".x1sln4lm{padding-left:10px}", 3000, ".x1sln4lm{padding-right:10px}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x123j3cw{padding-top:5px}", 4000);
+        _inject(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
+        _inject(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject(".x1nn3v0j{padding-top:2px}", 4000);
+        _inject(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
+        _inject(".x1120s5i{padding-bottom:2px}", 4000);
+        _inject(".x1sln4lm{padding-left:10px}", 3000, ".x1sln4lm{padding-right:10px}");
         "x1nn3v0j xg83lxy x1120s5i x1sln4lm";"
       `);
     });
@@ -116,14 +118,15 @@ describe('Legacy-shorthand-expansion resolution', () => {
           stylex(styles.foo, styles.bar);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x123j3cw{padding-top:5px}", 4000);
-        stylex.inject(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
-        stylex.inject(".xs9asl8{padding-bottom:5px}", 4000);
-        stylex.inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
-        stylex.inject(".x1nn3v0j{padding-top:2px}", 4000);
-        stylex.inject(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
-        stylex.inject(".x1120s5i{padding-bottom:2px}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x123j3cw{padding-top:5px}", 4000);
+        _inject(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
+        _inject(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject(".x1nn3v0j{padding-top:2px}", 4000);
+        _inject(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
+        _inject(".x1120s5i{padding-bottom:2px}", 4000);
         "x1nn3v0j xg83lxy x1120s5i";"
       `);
     });
@@ -141,9 +144,10 @@ describe('Legacy-shorthand-expansion resolution', () => {
           stylex(styles.foo);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
-        stylex.inject(".x1mpkggp{padding-right:5px}", 3000, ".x1mpkggp{padding-left:5px}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject(".x1mpkggp{padding-right:5px}", 3000, ".x1mpkggp{padding-left:5px}");
         export const styles = {
           foo: {
             paddingStart: "x1t2a60a",
@@ -174,15 +178,16 @@ describe('Legacy-shorthand-expansion resolution', () => {
           stylex(styles.foo, styles.bar);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x123j3cw{padding-top:5px}", 4000);
-        stylex.inject(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
-        stylex.inject(".xs9asl8{padding-bottom:5px}", 4000);
-        stylex.inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
-        stylex.inject(".x1nn3v0j{padding-top:2px}", 4000);
-        stylex.inject(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
-        stylex.inject(".x1120s5i{padding-bottom:2px}", 4000);
-        stylex.inject(".x1sln4lm{padding-left:10px}", 3000, ".x1sln4lm{padding-right:10px}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x123j3cw{padding-top:5px}", 4000);
+        _inject(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
+        _inject(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject(".x1nn3v0j{padding-top:2px}", 4000);
+        _inject(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
+        _inject(".x1120s5i{padding-bottom:2px}", 4000);
+        _inject(".x1sln4lm{padding-left:10px}", 3000, ".x1sln4lm{padding-right:10px}");
         "x1nn3v0j xg83lxy x1120s5i x1sln4lm";"
       `);
     });
@@ -204,14 +209,15 @@ describe('Legacy-shorthand-expansion resolution', () => {
           stylex(styles.foo, styles.bar);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x123j3cw{padding-top:5px}", 4000);
-        stylex.inject(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
-        stylex.inject(".xs9asl8{padding-bottom:5px}", 4000);
-        stylex.inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
-        stylex.inject(".x1nn3v0j{padding-top:2px}", 4000);
-        stylex.inject(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
-        stylex.inject(".x1120s5i{padding-bottom:2px}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x123j3cw{padding-top:5px}", 4000);
+        _inject(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
+        _inject(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject(".x1nn3v0j{padding-top:2px}", 4000);
+        _inject(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
+        _inject(".x1120s5i{padding-bottom:2px}", 4000);
         "x1nn3v0j xg83lxy x1120s5i";"
       `);
     });

--- a/packages/babel-plugin/__tests__/stylex-transform-logical-properties-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-logical-properties-test.js
@@ -40,8 +40,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1lkbs04{border-block-color:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1lkbs04{border-block-color:0}", 3000);
         const classnames = "x1lkbs04";"
       `);
     });
@@ -54,8 +55,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x4q076{border-top-color:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x4q076{border-top-color:0}", 3000);
         const classnames = "x4q076";"
       `);
     });
@@ -68,8 +70,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1ylptbq{border-bottom-color:0}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1ylptbq{border-bottom-color:0}", 4000);
         const classnames = "x1ylptbq";"
       `);
     });
@@ -82,8 +85,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1v09clb{border-inline-color:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1v09clb{border-inline-color:0}", 2000);
         const classnames = "x1v09clb";"
       `);
     });
@@ -96,8 +100,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1t19a1o{border-inline-start-color:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1t19a1o{border-inline-start-color:0}", 3000);
         const classnames = "x1t19a1o";"
       `);
     });
@@ -110,8 +115,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x14mj1wy{border-inline-end-color:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14mj1wy{border-inline-end-color:0}", 3000);
         const classnames = "x14mj1wy";"
       `);
     });
@@ -126,8 +132,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x7mea6a{border-block-style:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x7mea6a{border-block-style:0}", 3000);
         const classnames = "x7mea6a";"
       `);
     });
@@ -140,8 +147,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1d917x0{border-top-style:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1d917x0{border-top-style:0}", 3000);
         const classnames = "x1d917x0";"
       `);
     });
@@ -154,8 +162,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1nmap2y{border-bottom-style:0}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1nmap2y{border-bottom-style:0}", 4000);
         const classnames = "x1nmap2y";"
       `);
     });
@@ -168,8 +177,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xt8kkye{border-inline-style:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xt8kkye{border-inline-style:0}", 2000);
         const classnames = "xt8kkye";"
       `);
     });
@@ -182,8 +192,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xl8mozw{border-inline-start-style:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xl8mozw{border-inline-start-style:0}", 3000);
         const classnames = "xl8mozw";"
       `);
     });
@@ -196,8 +207,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x10o505a{border-inline-end-style:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x10o505a{border-inline-end-style:0}", 3000);
         const classnames = "x10o505a";"
       `);
     });
@@ -212,8 +224,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1616tdu{border-block-width:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1616tdu{border-block-width:0}", 3000);
         const classnames = "x1616tdu";"
       `);
     });
@@ -226,8 +239,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x972fbf{border-top-width:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x972fbf{border-top-width:0}", 3000);
         const classnames = "x972fbf";"
       `);
     });
@@ -240,8 +254,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1qhh985{border-bottom-width:0}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1qhh985{border-bottom-width:0}", 4000);
         const classnames = "x1qhh985";"
       `);
     });
@@ -254,8 +269,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xuxrje7{border-inline-width:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xuxrje7{border-inline-width:0}", 2000);
         const classnames = "xuxrje7";"
       `);
     });
@@ -268,8 +284,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x14e42zd{border-inline-start-width:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14e42zd{border-inline-start-width:0}", 3000);
         const classnames = "x14e42zd";"
       `);
     });
@@ -282,8 +299,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x10w94by{border-inline-end-width:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x10w94by{border-inline-end-width:0}", 3000);
         const classnames = "x10w94by";"
       `);
     });
@@ -298,8 +316,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x13vifvy{top:0}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x13vifvy{top:0}", 4000);
         const classnames = "x13vifvy";"
       `);
     });
@@ -312,8 +331,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x10no89f{inset-block:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x10no89f{inset-block:0}", 2000);
         const classnames = "x10no89f";"
       `);
     });
@@ -326,8 +346,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1ey2m1c{bottom:0}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1ey2m1c{bottom:0}", 4000);
         const classnames = "x1ey2m1c";"
       `);
     });
@@ -340,8 +361,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x13vifvy{top:0}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x13vifvy{top:0}", 4000);
         const classnames = "x13vifvy";"
       `);
     });
@@ -354,8 +376,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x17y0mx6{inset-inline:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x17y0mx6{inset-inline:0}", 2000);
         const classnames = "x17y0mx6";"
       `);
     });
@@ -368,8 +391,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xtijo5x{inset-inline-end:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xtijo5x{inset-inline-end:0}", 3000);
         const classnames = "xtijo5x";"
       `);
     });
@@ -382,8 +406,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1o0tod{inset-inline-start:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1o0tod{inset-inline-start:0}", 3000);
         const classnames = "x1o0tod";"
       `);
     });
@@ -398,8 +423,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x10im51j{margin-block:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x10im51j{margin-block:0}", 2000);
         const classnames = "x10im51j";"
       `);
     });
@@ -412,8 +438,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xat24cr{margin-bottom:0}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xat24cr{margin-bottom:0}", 4000);
         const classnames = "xat24cr";"
       `);
     });
@@ -426,8 +453,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xdj266r{margin-top:0}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xdj266r{margin-top:0}", 4000);
         const classnames = "xdj266r";"
       `);
     });
@@ -440,8 +468,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrxpjvj{margin-inline:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrxpjvj{margin-inline:0}", 2000);
         const classnames = "xrxpjvj";"
       `);
     });
@@ -454,8 +483,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x14z9mp{margin-inline-end:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14z9mp{margin-inline-end:0}", 3000);
         const classnames = "x14z9mp";"
       `);
     });
@@ -468,8 +498,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1lziwak{margin-inline-start:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1lziwak{margin-inline-start:0}", 3000);
         const classnames = "x1lziwak";"
       `);
     });
@@ -484,8 +515,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xt970qd{padding-block:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xt970qd{padding-block:0}", 2000);
         const classnames = "xt970qd";"
       `);
     });
@@ -498,8 +530,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x18d9i69{padding-bottom:0}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x18d9i69{padding-bottom:0}", 4000);
         const classnames = "x18d9i69";"
       `);
     });
@@ -512,8 +545,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xexx8yu{padding-top:0}", 4000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xexx8yu{padding-top:0}", 4000);
         const classnames = "xexx8yu";"
       `);
     });
@@ -526,8 +560,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xnjsko4{padding-inline:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xnjsko4{padding-inline:0}", 2000);
         const classnames = "xnjsko4";"
       `);
     });
@@ -540,8 +575,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xyri2b{padding-inline-end:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xyri2b{padding-inline-end:0}", 3000);
         const classnames = "xyri2b";"
       `);
     });
@@ -554,8 +590,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1c1uobl{padding-inline-start:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1c1uobl{padding-inline-start:0}", 3000);
         const classnames = "x1c1uobl";"
       `);
     });
@@ -572,8 +609,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xceh6e4{inset-inline-end:5px}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xceh6e4{inset-inline-end:5px}", 3000);
         const classnames = "xceh6e4";"
       `);
     });
@@ -586,8 +624,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x14z9mp{margin-inline-end:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14z9mp{margin-inline-end:0}", 3000);
         const classnames = "x14z9mp";"
       `);
     });
@@ -600,8 +639,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrxpjvj{margin-inline:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrxpjvj{margin-inline:0}", 2000);
         const classnames = "xrxpjvj";"
       `);
     });
@@ -614,8 +654,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1lziwak{margin-inline-start:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1lziwak{margin-inline-start:0}", 3000);
         const classnames = "x1lziwak";"
       `);
     });
@@ -628,8 +669,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x10im51j{margin-block:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x10im51j{margin-block:0}", 2000);
         const classnames = "x10im51j";"
       `);
     });
@@ -642,8 +684,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xyri2b{padding-inline-end:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xyri2b{padding-inline-end:0}", 3000);
         const classnames = "xyri2b";"
       `);
     });
@@ -656,8 +699,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xnjsko4{padding-inline:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xnjsko4{padding-inline:0}", 2000);
         const classnames = "xnjsko4";"
       `);
     });
@@ -670,8 +714,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1c1uobl{padding-inline-start:0}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1c1uobl{padding-inline-start:0}", 3000);
         const classnames = "x1c1uobl";"
       `);
     });
@@ -684,8 +729,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xt970qd{padding-block:0}", 2000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xt970qd{padding-block:0}", 2000);
         const classnames = "xt970qd";"
       `);
     });
@@ -698,8 +744,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1fb7gu6{inset-inline-start:5px}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1fb7gu6{inset-inline-start:5px}", 3000);
         const classnames = "x1fb7gu6";"
       `);
     });
@@ -720,8 +767,9 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.four);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xi71r3n{margin:1 2 3 4}", 1000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xi71r3n{margin:1 2 3 4}", 1000);
         "xi71r3n";"
       `);
     });

--- a/packages/babel-plugin/__tests__/stylex-transform-logical-values-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-logical-values-test.js
@@ -42,8 +42,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xof8tvn{clear:inline-end}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xof8tvn{clear:inline-end}", 3000);
         const classnames = "xof8tvn";"
       `);
     });
@@ -56,8 +57,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x18lmvvi{clear:inline-start}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x18lmvvi{clear:inline-start}", 3000);
         const classnames = "x18lmvvi";"
       `);
     });
@@ -70,8 +72,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1h0q493{float:inline-end}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1h0q493{float:inline-end}", 3000);
         const classnames = "x1h0q493";"
       `);
     });
@@ -84,8 +87,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1kmio9f{float:inline-start}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1kmio9f{float:inline-start}", 3000);
         const classnames = "x1kmio9f";"
       `);
     });
@@ -98,8 +102,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xp4054r{text-align:right}", 3000, ".xp4054r{text-align:left}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xp4054r{text-align:right}", 3000, ".xp4054r{text-align:left}");
         const classnames = "xp4054r";"
       `);
     });
@@ -112,8 +117,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1yc453h{text-align:left}", 3000, ".x1yc453h{text-align:right}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1yc453h{text-align:left}", 3000, ".x1yc453h{text-align:right}");
         const classnames = "x1yc453h";"
       `);
     });
@@ -130,8 +136,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xodj72a{clear:right}", 3000, ".xodj72a{clear:left}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xodj72a{clear:right}", 3000, ".xodj72a{clear:left}");
         const classnames = "xodj72a";"
       `);
     });
@@ -144,8 +151,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x390i0x{clear:left}", 3000, ".x390i0x{clear:right}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x390i0x{clear:left}", 3000, ".x390i0x{clear:right}");
         const classnames = "x390i0x";"
       `);
     });
@@ -158,8 +166,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1guec7k{float:right}", 3000, ".x1guec7k{float:left}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1guec7k{float:right}", 3000, ".x1guec7k{float:left}");
         const classnames = "x1guec7k";"
       `);
     });
@@ -172,8 +181,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrbpyxo{float:left}", 3000, ".xrbpyxo{float:right}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrbpyxo{float:left}", 3000, ".xrbpyxo{float:right}");
         const classnames = "xrbpyxo";"
       `);
     });
@@ -190,8 +200,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x14mnfz1{cursor:e-resize}", 3000, ".x14mnfz1{cursor:w-resize}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14mnfz1{cursor:e-resize}", 3000, ".x14mnfz1{cursor:w-resize}");
         const classnames = "x14mnfz1";"
       `);
     });
@@ -204,8 +215,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x14isd7o{cursor:w-resize}", 3000, ".x14isd7o{cursor:e-resize}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14isd7o{cursor:w-resize}", 3000, ".x14isd7o{cursor:e-resize}");
         const classnames = "x14isd7o";"
       `);
     });
@@ -218,8 +230,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xc7edbc{cursor:ne-resize}", 3000, ".xc7edbc{cursor:nw-resize}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xc7edbc{cursor:ne-resize}", 3000, ".xc7edbc{cursor:nw-resize}");
         const classnames = "xc7edbc";"
       `);
     });
@@ -232,8 +245,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrpsa6j{cursor:nw-resize}", 3000, ".xrpsa6j{cursor:ne-resize}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrpsa6j{cursor:nw-resize}", 3000, ".xrpsa6j{cursor:ne-resize}");
         const classnames = "xrpsa6j";"
       `);
     });
@@ -246,8 +260,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xp35lg9{cursor:se-resize}", 3000, ".xp35lg9{cursor:sw-resize}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xp35lg9{cursor:se-resize}", 3000, ".xp35lg9{cursor:sw-resize}");
         const classnames = "xp35lg9";"
       `);
     });
@@ -260,8 +275,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1egwzy8{cursor:sw-resize}", 3000, ".x1egwzy8{cursor:se-resize}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1egwzy8{cursor:sw-resize}", 3000, ".x1egwzy8{cursor:se-resize}");
         const classnames = "x1egwzy8";"
       `);
     });
@@ -279,8 +295,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x13xdq3h{animation-name:ignore}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x13xdq3h{animation-name:ignore}", 3000);
         const classnames = "x13xdq3h";"
       `);
     });
@@ -293,8 +310,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xl0ducr{background-position:top right}", 2000, ".xl0ducr{background-position:top left}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xl0ducr{background-position:top right}", 2000, ".xl0ducr{background-position:top left}");
         const classnames = "xl0ducr";"
       `);
       expect(
@@ -304,8 +322,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xgg80n4{background-position:top left}", 2000, ".xgg80n4{background-position:top right}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xgg80n4{background-position:top left}", 2000, ".xgg80n4{background-position:top right}");
         const classnames = "xgg80n4";"
       `);
     });
@@ -318,8 +337,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1gnnqk1{box-shadow:none}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1gnnqk1{box-shadow:none}", 3000);
         const classnames = "x1gnnqk1";"
       `);
       expect(
@@ -329,8 +349,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xtgyqtp{box-shadow:1px 1px #000}", 3000, ".xtgyqtp{box-shadow:-1px 1px #000}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xtgyqtp{box-shadow:1px 1px #000}", 3000, ".xtgyqtp{box-shadow:-1px 1px #000}");
         const classnames = "xtgyqtp";"
       `);
       expect(
@@ -340,8 +361,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1d2r41h{box-shadow:-1px -1px #000}", 3000, ".x1d2r41h{box-shadow:1px -1px #000}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1d2r41h{box-shadow:-1px -1px #000}", 3000, ".x1d2r41h{box-shadow:1px -1px #000}");
         const classnames = "x1d2r41h";"
       `);
       expect(
@@ -351,8 +373,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1x0mpz7{box-shadow:inset 1px 1px #000}", 3000, ".x1x0mpz7{box-shadow:inset -1px 1px #000}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1x0mpz7{box-shadow:inset 1px 1px #000}", 3000, ".x1x0mpz7{box-shadow:inset -1px 1px #000}");
         const classnames = "x1x0mpz7";"
       `);
       expect(
@@ -362,8 +385,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1fumi7f{box-shadow:1px 1px 1px 1px #000}", 3000, ".x1fumi7f{box-shadow:-1px 1px 1px 1px #000}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1fumi7f{box-shadow:1px 1px 1px 1px #000}", 3000, ".x1fumi7f{box-shadow:-1px 1px 1px 1px #000}");
         const classnames = "x1fumi7f";"
       `);
       expect(
@@ -373,8 +397,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1fs23zf{box-shadow:inset 1px 1px 1px 1px #000}", 3000, ".x1fs23zf{box-shadow:inset -1px 1px 1px 1px #000}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1fs23zf{box-shadow:inset 1px 1px 1px 1px #000}", 3000, ".x1fs23zf{box-shadow:inset -1px 1px 1px 1px #000}");
         const classnames = "x1fs23zf";"
       `);
       expect(
@@ -384,8 +409,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xtgmjod{box-shadow:2px 2px 2px 2px red,inset 1px 1px 1px 1px #000}", 3000, ".xtgmjod{box-shadow:-2px 2px 2px 2px red, inset -1px 1px 1px 1px #000}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xtgmjod{box-shadow:2px 2px 2px 2px red,inset 1px 1px 1px 1px #000}", 3000, ".xtgmjod{box-shadow:-2px 2px 2px 2px red, inset -1px 1px 1px 1px #000}");
         const classnames = "xtgmjod";"
       `);
     });
@@ -398,8 +424,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x19pm5ym{text-shadow:none}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x19pm5ym{text-shadow:none}", 3000);
         const classnames = "x19pm5ym";"
       `);
       expect(
@@ -409,8 +436,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x12y90mb{text-shadow:1px 1px #000}", 3000, ".x12y90mb{text-shadow:-1px 1px #000}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x12y90mb{text-shadow:1px 1px #000}", 3000, ".x12y90mb{text-shadow:-1px 1px #000}");
         const classnames = "x12y90mb";"
       `);
       expect(
@@ -420,8 +448,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1l3mtsg{text-shadow:-1px -1px #000}", 3000, ".x1l3mtsg{text-shadow:1px -1px #000}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1l3mtsg{text-shadow:-1px -1px #000}", 3000, ".x1l3mtsg{text-shadow:1px -1px #000}");
         const classnames = "x1l3mtsg";"
       `);
       expect(
@@ -431,8 +460,9 @@ describe('@stylexjs/babel-plugin', () => {
           const classnames = stylex(styles.x);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x67hq7l{text-shadow:1px 1px 1px #000}", 3000, ".x67hq7l{text-shadow:-1px 1px 1px #000}");
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x67hq7l{text-shadow:1px 1px 1px #000}", 3000, ".x67hq7l{text-shadow:-1px 1px 1px #000}");
         const classnames = "x67hq7l";"
       `);
     });

--- a/packages/babel-plugin/__tests__/stylex-transform-override-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-override-vars-test.js
@@ -113,7 +113,8 @@ describe('@stylexjs/babel-plugin', () => {
         { dev: true, ...defaultOpts },
       );
       expect(output1).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -121,7 +122,7 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        stylex.inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -163,7 +164,8 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, ...defaultOpts },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -171,7 +173,7 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        stylex.inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -222,7 +224,8 @@ describe('@stylexjs/babel-plugin', () => {
           },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -230,7 +233,7 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        stylex.inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -290,7 +293,8 @@ describe('@stylexjs/babel-plugin', () => {
           },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -298,13 +302,13 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        stylex.inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
           "TestTheme.stylex.js__buttonThemePositive": "TestTheme.stylex.js__buttonThemePositive"
         };
-        stylex.inject(".xpsjjyf{--xgck17p:white;--xpegid5:black;--xrqfjmn:0px;}", 0.99);
+        _inject(".xpsjjyf{--xgck17p:white;--xpegid5:black;--xrqfjmn:0px;}", 0.99);
         const buttonThemeMonochromatic = {
           $$css: true,
           x568ih9: "xpsjjyf",
@@ -336,7 +340,8 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, ...defaultOpts },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -345,7 +350,7 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const RADIUS = 10;
-        stylex.inject(".xrpt93l{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:10;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xrpt93l{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xrpt93l{--xgck17p:transparent;}}", 0.99);
+        _inject(".xrpt93l{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:10;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xrpt93l{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xrpt93l{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xrpt93l",
@@ -377,7 +382,8 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, ...defaultOpts },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -386,7 +392,7 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const COLOR = 'coral';
-        stylex.inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -418,7 +424,8 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, ...defaultOpts },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -427,7 +434,7 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const name = 'light';
-        stylex.inject(".x1u43pop{--xgck17p:lightgreen;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.x1u43pop{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.x1u43pop{--xgck17p:transparent;}}", 0.99);
+        _inject(".x1u43pop{--xgck17p:lightgreen;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.x1u43pop{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.x1u43pop{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "x1u43pop",
@@ -459,7 +466,8 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, ...defaultOpts },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -468,7 +476,7 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const RADIUS = 2;
-        stylex.inject(".x1ubmxd4{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4;--x4y59db:coral;}@media (prefers-color-scheme: dark){.x1ubmxd4{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.x1ubmxd4{--xgck17p:transparent;}}", 0.99);
+        _inject(".x1ubmxd4{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4;--x4y59db:coral;}@media (prefers-color-scheme: dark){.x1ubmxd4{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.x1ubmxd4{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "x1ubmxd4",
@@ -494,7 +502,8 @@ describe('@stylexjs/babel-plugin', () => {
           },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -502,7 +511,7 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        stylex.inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",

--- a/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
@@ -51,8 +51,9 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props(styles.red);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         ({
           className: "x1e2nbdu"
         });"
@@ -74,9 +75,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props([styles[0], styles[1]]);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x1t391ir{background-color:blue}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
         ({
           className: "x1e2nbdu x1t391ir"
         });"
@@ -98,9 +100,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props([styles[0], styles[1]]);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x1t391ir{background-color:blue}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
         ({
           className: "x1e2nbdu x1t391ir"
         });"
@@ -119,8 +122,9 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props(styles['default']);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         ({
           className: "x1e2nbdu"
         });"
@@ -144,10 +148,10 @@ describe('@stylexjs/babel-plugin', () => {
           props([styles.default, otherStyles.default]);
         `),
       ).toMatchInlineSnapshot(`
-        "import { create, props } from 'stylex';
-        import __stylex__ from "stylex";
-        __stylex__.inject(".x1e2nbdu{color:red}", 3000);
-        __stylex__.inject(".x1t391ir{background-color:blue}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import { create, props } from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
         ({
           className: "x1e2nbdu x1t391ir"
         });"
@@ -166,8 +170,9 @@ describe('@stylexjs/babel-plugin', () => {
           }
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         const a = function () {
           return {
             className: "x1e2nbdu"
@@ -192,9 +197,10 @@ describe('@stylexjs/babel-plugin', () => {
           const foo = styles;
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x1t391ir{background-color:blue}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
         const styles = {
           foo: {
             color: "x1e2nbdu",
@@ -227,8 +233,9 @@ describe('@stylexjs/babel-plugin', () => {
           }
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         export default function MyExportDefault() {
           return {
             className: "x1e2nbdu"
@@ -254,8 +261,9 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props(styles.foo);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x14odnwx{padding:5px}", 1000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14odnwx{padding:5px}", 1000);
         ({
           className: "x14odnwx"
         });"
@@ -274,8 +282,9 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props([styles.foo]);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x14odnwx{padding:5px}", 1000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14odnwx{padding:5px}", 1000);
         export const styles = {
           foo: {
             padding: "x14odnwx",
@@ -309,9 +318,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x17z2mba:hover{color:blue}", 3130);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x17z2mba:hover{color:blue}", 3130);
         ({
           className: "x1e2nbdu x17z2mba"
         });"
@@ -333,9 +343,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import * as stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x17z2mba:hover{color:blue}", 3130);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import * as stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x17z2mba:hover{color:blue}", 3130);
         ({
           className: "x1e2nbdu x17z2mba"
         });"
@@ -360,10 +371,11 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-        stylex.inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
         ({
           className: "xrkmrrc xc445zv x1ssfqz5"
         });"
@@ -386,10 +398,11 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-        stylex.inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
         ({
           className: "xrkmrrc xc445zv x1ssfqz5"
         });"
@@ -414,10 +427,11 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-        stylex.inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+        _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
         ({
           className: "xrkmrrc x6m3b6q x6um648"
         });"
@@ -440,10 +454,11 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xrkmrrc{background-color:red}", 3000);
-        stylex.inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-        stylex.inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+        _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
         ({
           className: "xrkmrrc x6m3b6q x6um648"
         });"
@@ -469,9 +484,10 @@ describe('@stylexjs/babel-plugin', () => {
             { genConditionalClasses: true },
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".xrkmrrc{background-color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".xrkmrrc{background-color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           ({
             0: {
               className: "xrkmrrc"
@@ -500,9 +516,10 @@ describe('@stylexjs/babel-plugin', () => {
             `,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".xrkmrrc{background-color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".xrkmrrc{background-color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           const styles = {
             default: {
               backgroundColor: "xrkmrrc",
@@ -533,9 +550,10 @@ describe('@stylexjs/babel-plugin', () => {
             stylex.props([styles.blue, styles.red]);
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           ({
             className: "xju2f9n"
           });
@@ -561,8 +579,9 @@ describe('@stylexjs/babel-plugin', () => {
             stylex.props([styles.revert, styles.red]);
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
           ({});
           ({
             className: "x1e2nbdu"
@@ -588,11 +607,12 @@ describe('@stylexjs/babel-plugin', () => {
             stylex.props([styles.foo, styles.bar]);
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x14odnwx{padding:5px}", 1000);
-          stylex.inject(".x2vl965{padding-inline-end:10px}", 3000);
-          stylex.inject(".x1i3ajwb{padding:2px}", 1000);
-          stylex.inject(".xe2zdcy{padding-inline-start:10px}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x14odnwx{padding:5px}", 1000);
+          _inject(".x2vl965{padding-inline-end:10px}", 3000);
+          _inject(".x1i3ajwb{padding:2px}", 1000);
+          _inject(".xe2zdcy{padding-inline-start:10px}", 3000);
           ({
             className: "x2vl965 x1i3ajwb xe2zdcy"
           });"
@@ -617,10 +637,11 @@ describe('@stylexjs/babel-plugin', () => {
             stylex.props([styles.foo, styles.bar]);
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x14odnwx{padding:5px}", 1000);
-          stylex.inject(".x2vl965{padding-inline-end:10px}", 3000);
-          stylex.inject(".x1i3ajwb{padding:2px}", 1000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x14odnwx{padding:5px}", 1000);
+          _inject(".x2vl965{padding-inline-end:10px}", 3000);
+          _inject(".x1i3ajwb{padding:2px}", 1000);
           ({
             className: "x2vl965 x1i3ajwb"
           });"
@@ -645,9 +666,10 @@ describe('@stylexjs/babel-plugin', () => {
             { genConditionalClasses: true },
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           ({
             0: {
               className: "x1e2nbdu"
@@ -676,9 +698,10 @@ describe('@stylexjs/babel-plugin', () => {
             `,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           const styles = {
             red: {
               color: "x1e2nbdu",
@@ -711,8 +734,9 @@ describe('@stylexjs/babel-plugin', () => {
             { genConditionalClasses: true },
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
           ({
             0: {
               className: "x1e2nbdu"
@@ -739,8 +763,9 @@ describe('@stylexjs/babel-plugin', () => {
             `,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
           const styles = {
             red: {
               color: "x1e2nbdu",
@@ -777,8 +802,9 @@ describe('@stylexjs/babel-plugin', () => {
             options,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
           ({
             className: "FooBar__styles.default x1e2nbdu"
           });"
@@ -810,9 +836,10 @@ describe('@stylexjs/babel-plugin', () => {
             options,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".x1t391ir{background-color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".x1t391ir{background-color:blue}", 3000);
           ({
             0: {
               className: "FooBar__styles.default x1e2nbdu"
@@ -848,8 +875,9 @@ describe('@stylexjs/babel-plugin', () => {
             options,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
               "FooBar__styles.default": "FooBar__styles.default",
@@ -857,7 +885,7 @@ describe('@stylexjs/babel-plugin', () => {
               $$css: true
             }
           };
-          stylex.inject(".x1t391ir{background-color:blue}", 3000);
+          _inject(".x1t391ir{background-color:blue}", 3000);
           const otherStyles = {
             default: {
               "FooBar__otherStyles.default": "FooBar__otherStyles.default",
@@ -893,9 +921,10 @@ describe('@stylexjs/babel-plugin', () => {
             options,
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".xju2f9n{color:blue}", 3000);
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
           ({
             0: {
               className: "FooBar__styles.default x1e2nbdu"
@@ -924,9 +953,10 @@ describe('@stylexjs/babel-plugin', () => {
             stylex.props(styles[variant]);
           `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
-        stylex.inject(".x1t391ir{background-color:blue}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
         const styles = {
           "0": {
             color: "x1e2nbdu",
@@ -952,8 +982,9 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props([styles.default, props]);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
         const styles = {
           default: {
             color: "x1e2nbdu",
@@ -981,9 +1012,10 @@ describe('@stylexjs/babel-plugin', () => {
           stylex.props(styles.default);
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x17z2mba:hover{color:blue}", 3130);
-        stylex.inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x17z2mba:hover{color:blue}", 3130);
+        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         export const styles = {
           default: {
             ":hover_color": "x17z2mba",
@@ -1013,10 +1045,11 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
           stylex.props(styles[variant]);
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".x1t391ir{background-color:blue}", 3000);
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".x1t391ir{background-color:blue}", 3000);
           const styles = {
             "0": {
               color: "x1e2nbdu",
@@ -1056,7 +1089,8 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
           function MyComponent() {
             return <>
                             <div {...{
@@ -1071,8 +1105,8 @@ describe('@stylexjs/babel-plugin', () => {
               }} />
                           </>;
           }
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
-          stylex.inject(".x1t391ir{background-color:blue}", 3000);
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".x1t391ir{background-color:blue}", 3000);
           const styles = {
             foo: {
               color: "x1e2nbdu",
@@ -1097,9 +1131,10 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
           stylex.props([styles.default, props]);
-          stylex.inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
               color: "x1e2nbdu",
@@ -1126,12 +1161,13 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
           ({
             className: "x17z2mba xc445zv"
           });
-          stylex.inject(".x17z2mba:hover{color:blue}", 3130);
-          stylex.inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+          _inject(".x17z2mba:hover{color:blue}", 3130);
+          _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
           export const styles = {
             default: {
               ":hover_color": "x17z2mba",
@@ -1159,8 +1195,9 @@ describe('@stylexjs/babel-plugin', () => {
           { importSources: ['custom-stylex-path'] },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'custom-stylex-path';
-        stylex.inject(".x1e2nbdu{color:red}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'custom-stylex-path';
+        _inject(".x1e2nbdu{color:red}", 3000);
         ({
           className: "x1e2nbdu"
         });"
@@ -1208,19 +1245,20 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, genConditionalClasses: true },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from '@stylexjs/stylex';
-        stylex.inject(".x9f619{box-sizing:border-box}", 3000);
-        stylex.inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        stylex.inject(".x1fdo2jl{grid-area:content}", 1000);
-        stylex.inject(".xrvj5dj{display:grid}", 3000);
-        stylex.inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        stylex.inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        stylex.inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        stylex.inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        stylex.inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        stylex.inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        stylex.inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        stylex.inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from '@stylexjs/stylex';
+        _inject(".x9f619{box-sizing:border-box}", 3000);
+        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject(".x1fdo2jl{grid-area:content}", 1000);
+        _inject(".xrvj5dj{display:grid}", 3000);
+        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         export const styles = {
           sidebar: {
             "UnknownFile__styles.sidebar": "UnknownFile__styles.sidebar",
@@ -1321,19 +1359,20 @@ describe('@stylexjs/babel-plugin', () => {
           { dev: true, genConditionalClasses: true },
         ),
       ).toMatchInlineSnapshot(`
-        "import stylex from '@stylexjs/stylex';
-        stylex.inject(".x9f619{box-sizing:border-box}", 3000);
-        stylex.inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        stylex.inject(".x1fdo2jl{grid-area:content}", 1000);
-        stylex.inject(".xrvj5dj{display:grid}", 3000);
-        stylex.inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        stylex.inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        stylex.inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        stylex.inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        stylex.inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        stylex.inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        stylex.inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        stylex.inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from '@stylexjs/stylex';
+        _inject(".x9f619{box-sizing:border-box}", 3000);
+        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject(".x1fdo2jl{grid-area:content}", 1000);
+        _inject(".xrvj5dj{display:grid}", 3000);
+        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         const complex = {
           0: {
             className: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"

--- a/packages/babel-plugin/__tests__/stylex-transform-value-normalize-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-value-normalize-test.js
@@ -50,8 +50,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x18qx21s{transform:rotate(10deg) translate3d(0,0,0)}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x18qx21s{transform:rotate(10deg) translate3d(0,0,0)}", 3000);"
       `);
       expect(
         transform(`
@@ -59,8 +60,9 @@ describe('@stylexjs/babel-plugin', () => {
           const styles = stylex.create({ x: { color: 'rgba( 1, 222,  33 , 0.5)' } });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xe1l9yr{color:rgba(1,222,33,.5)}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xe1l9yr{color:rgba(1,222,33,.5)}", 3000);"
       `);
     });
 
@@ -74,9 +76,10 @@ describe('@stylexjs/babel-plugin', () => {
           } });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1ghz6dp{margin:0}", 1000);
-        stylex.inject(".xgsvwom{margin-left:1px}", 4000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1ghz6dp{margin:0}", 1000);
+        _inject(".xgsvwom{margin-left:1px}", 4000);"
       `);
     });
 
@@ -87,8 +90,9 @@ describe('@stylexjs/babel-plugin', () => {
           const styles = stylex.create({ x: { transitionDuration: '500ms' } });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1wsgiic{transition-duration:.5s}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1wsgiic{transition-duration:.5s}", 3000);"
       `);
     });
 
@@ -103,8 +107,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1jpfit1{transform:0deg}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1jpfit1{transform:0deg}", 3000);"
       `);
     });
 
@@ -115,8 +120,9 @@ describe('@stylexjs/babel-plugin', () => {
           const styles = stylex.create({ x: { width: 'calc((100% + 3% -   100px) / 7)' } });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1hauit9{width:calc((100% + 3% - 100px) / 7)}", 4000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1hauit9{width:calc((100% + 3% - 100px) / 7)}", 4000);"
       `);
     });
 
@@ -130,9 +136,10 @@ describe('@stylexjs/babel-plugin', () => {
           } });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xpvlhck{transition-duration:.01s}", 3000);
-        stylex.inject(".xxziih7{transition-timing-function:cubic-bezier(.08,.52,.52,1)}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xpvlhck{transition-duration:.01s}", 3000);
+        _inject(".xxziih7{transition-timing-function:cubic-bezier(.08,.52,.52,1)}", 3000);"
       `);
     });
 
@@ -143,8 +150,9 @@ describe('@stylexjs/babel-plugin', () => {
           const styles = stylex.create({ x: { quotes: "''" } });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x169joja{quotes:\\"\\"}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x169joja{quotes:\\"\\"}", 3000);"
       `);
     });
 
@@ -159,10 +167,11 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xsa3hc2{transition-duration:1.234s}", 3000);
-        stylex.inject(".xpvlhck{transition-duration:.01s}", 3000);
-        stylex.inject(".xjd9b36{transition-duration:1ms}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xsa3hc2{transition-duration:1.234s}", 3000);
+        _inject(".xpvlhck{transition-duration:.01s}", 3000);
+        _inject(".xjd9b36{transition-duration:1ms}", 3000);"
       `);
     });
 
@@ -184,13 +193,14 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1egiwwb{height:500px}", 4000);
-        stylex.inject(".x1oin6zd{margin:10px}", 1000);
-        stylex.inject(".xvue9z{width:500px}", 4000);
-        stylex.inject(".xk50ysn{font-weight:500}", 3000);
-        stylex.inject(".x1evy7pa{line-height:1.5}", 3000);
-        stylex.inject(".xbyyjgo{opacity:.5}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1egiwwb{height:500px}", 4000);
+        _inject(".x1oin6zd{margin:10px}", 1000);
+        _inject(".xvue9z{width:500px}", 4000);
+        _inject(".xk50ysn{font-weight:500}", 3000);
+        _inject(".x1evy7pa{line-height:1.5}", 3000);
+        _inject(".xbyyjgo{opacity:.5}", 3000);"
       `);
     });
 
@@ -201,8 +211,9 @@ describe('@stylexjs/babel-plugin', () => {
           const styles = stylex.create({ x: { height: 100 / 3 } });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x1vvwc6p{height:33.3333px}", 4000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1vvwc6p{height:33.3333px}", 4000);"
       `);
     });
 
@@ -223,10 +234,11 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".x14axycx{content:\\"\\"}", 3000);
-        stylex.inject(".xmmpjw1{content:\\"next\\"}", 3000);
-        stylex.inject(".x12vzfr8{content:\\"prev\\"}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14axycx{content:\\"\\"}", 3000);
+        _inject(".xmmpjw1{content:\\"next\\"}", 3000);
+        _inject(".x12vzfr8{content:\\"prev\\"}", 3000);"
       `);
     });
 
@@ -237,8 +249,9 @@ describe('@stylexjs/babel-plugin', () => {
           const styles = stylex.create({ x: { color: 'red !important' } });
         `),
       ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        stylex.inject(".xzw3067{color:red!important}", 3000);"
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xzw3067{color:red!important}", 3000);"
       `);
     });
   });
@@ -265,11 +278,12 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".xngnso2{font-size:1.5rem}", 3000);
-          stylex.inject(".x1c3i2sq{font-size:1.125rem}", 3000);
-          stylex.inject(".x1603h9y{font-size:1.25rem}", 3000);
-          stylex.inject(".x1qlqyl8{font-size:inherit}", 3000);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".xngnso2{font-size:1.5rem}", 3000);
+          _inject(".x1c3i2sq{font-size:1.125rem}", 3000);
+          _inject(".x1603h9y{font-size:1.25rem}", 3000);
+          _inject(".x1qlqyl8{font-size:inherit}", 3000);"
         `);
       });
 
@@ -284,8 +298,9 @@ describe('@stylexjs/babel-plugin', () => {
             });
           `),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x37c5sx{font-size:calc(100% - 1.5rem)}", 3000);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x37c5sx{font-size:calc(100% - 1.5rem)}", 3000);"
         `);
       });
     });
@@ -313,11 +328,12 @@ describe('@stylexjs/babel-plugin', () => {
             { useRemForFontSize: false },
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1pvqxga{font-size:24px}", 3000);
-          stylex.inject(".xosj86m{font-size:18px}", 3000);
-          stylex.inject(".x1603h9y{font-size:1.25rem}", 3000);
-          stylex.inject(".x1qlqyl8{font-size:inherit}", 3000);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1pvqxga{font-size:24px}", 3000);
+          _inject(".xosj86m{font-size:18px}", 3000);
+          _inject(".x1603h9y{font-size:1.25rem}", 3000);
+          _inject(".x1qlqyl8{font-size:inherit}", 3000);"
         `);
       });
 
@@ -335,8 +351,9 @@ describe('@stylexjs/babel-plugin', () => {
             { useRemForFontSize: false },
           ),
         ).toMatchInlineSnapshot(`
-          "import stylex from 'stylex';
-          stylex.inject(".x1upkca{font-size:calc(100% - 24px)}", 3000);"
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1upkca{font-size:calc(100% - 24px)}", 3000);"
         `);
       });
     });

--- a/packages/babel-plugin/__tests__/stylex-transform-variable-removal-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-variable-removal-test.js
@@ -37,9 +37,10 @@ describe('[optimization] Removes `styles` variable when not needed', () => {
       styles;
     `);
     expect(result.code).toMatchInlineSnapshot(`
-      "import stylex from 'stylex';
-      stylex.inject(".xrkmrrc{background-color:red}", 3000);
-      stylex.inject(".xju2f9n{color:blue}", 3000);
+      "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+      import stylex from 'stylex';
+      _inject(".xrkmrrc{background-color:red}", 3000);
+      _inject(".xju2f9n{color:blue}", 3000);
       const styles = {
         default: {
           backgroundColor: "xrkmrrc",
@@ -85,9 +86,10 @@ describe('[optimization] Removes `styles` variable when not needed', () => {
       });
     `);
     expect(result.code).toMatchInlineSnapshot(`
-      "import stylex from 'stylex';
-      stylex.inject(".xrkmrrc{background-color:red}", 3000);
-      stylex.inject(".xju2f9n{color:blue}", 3000);"
+      "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+      import stylex from 'stylex';
+      _inject(".xrkmrrc{background-color:red}", 3000);
+      _inject(".xju2f9n{color:blue}", 3000);"
     `);
     expect(result.metadata).toMatchInlineSnapshot(`
       {

--- a/packages/babel-plugin/flow_modules/@babel/helper-module-imports/index.js.flow
+++ b/packages/babel-plugin/flow_modules/@babel/helper-module-imports/index.js.flow
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import * as t from '../types';
+import type { NodePath } from '@babel/traverse';
+
+export type ImportOptions = $ReadOnly<{
+  /**
+   * The module being referenced.
+   */
+  importedSource: string | null,
+  /**
+   * The type of module being imported:
+   *
+   *  * 'es6'      - An ES6 module.
+   *  * 'commonjs' - A CommonJS module. (Default)
+   */
+  importedType: 'es6' | 'commonjs',
+  /**
+   * The type of interop behavior for namespace/default/named when loading
+   * CommonJS modules.
+   *
+   * ## 'babel' (Default)
+   *
+   * Load using Babel's interop.
+   *
+   * If '.__esModule' is true, treat as 'compiled', else:
+   *
+   * * Namespace: A copy of the module.exports with .default
+   *     populated by the module.exports object.
+   * * Default: The module.exports value.
+   * * Named: The .named property of module.exports.
+   *
+   * The 'ensureLiveReference' has no effect on the liveness of these.
+   *
+   * ## 'compiled'
+   *
+   * Assume the module is ES6 compiled to CommonJS. Useful to avoid injecting
+   * interop logic if you are confident that the module is a certain format.
+   *
+   * * Namespace: The root module.exports object.
+   * * Default: The .default property of the namespace.
+   * * Named: The .named property of the namespace.
+   *
+   * Will return erroneous results if the imported module is _not_ compiled
+   * from ES6 with Babel.
+   *
+   * ## 'uncompiled'
+   *
+   * Assume the module is _not_ ES6 compiled to CommonJS. Used a simplified
+   * access pattern that doesn't require additional function calls.
+   *
+   * Will return erroneous results if the imported module _is_ compiled
+   * from ES6 with Babel.
+   *
+   * * Namespace: The module.exports object.
+   * * Default: The module.exports object.
+   * * Named: The .named property of module.exports.
+   */
+  importedInterop: 'babel' | 'node' | 'compiled' | 'uncompiled',
+  /**
+   * The type of CommonJS interop included in the environment that will be
+   * loading the output code.
+   *
+   *  * 'babel' - CommonJS modules load with Babel's interop. (Default)
+   *  * 'node'  - CommonJS modules load with Node's interop.
+   *
+   * See descriptions in 'importedInterop' for more details.
+   */
+  importingInterop: 'babel' | 'node',
+  /**
+   * Define whether we explicitly care that the import be a live reference.
+   * Only applies when importing default and named imports, not the namespace.
+   *
+   *  * true  - Force imported values to be live references.
+   *  * false - No particular requirements. Keeps the code simplest. (Default)
+   */
+  ensureLiveReference: boolean,
+  /**
+   * Define if we explicitly care that the result not be a property reference.
+   *
+   *  * true  - Force calls to exclude context. Useful if the value is going to
+   *            be used as function callee.
+   *  * false - No particular requirements for context of the access. (Default)
+   */
+  ensureNoContext: boolean,
+  /**
+   * Define whether the import should be loaded before or after the existing imports.
+   * "after" is only allowed inside ECMAScript modules, since it's not possible to
+   * reliably pick the location _after_ require() calls but _before_ other code in CJS.
+   */
+  importPosition: 'before' | 'after',
+
+  nameHint?: string,
+  blockHoist?: number,
+}>;
+
+declare export function addDefault(
+  path: NodePath<>,
+  importedSource: string,
+  opts?: Partial<ImportOptions>,
+): t.Identifier;
+
+/**
+ * add a named import to the program path of given path
+ *
+ * @param path The starting path to find a program path
+ * @param name The name of the generated binding. Babel will prefix it with `_`
+ * @param importedSource The source of the import
+ * @param [opts]
+ * @returns If opts.ensureNoContext is true, returns a SequenceExpression,
+ *   else if opts.ensureLiveReference is true, returns a MemberExpression, else returns an Identifier
+ */
+declare export const addNamed: (
+  path: NodePath<>,
+  name: string,
+  importedSource: string,
+  opts?: Omit<
+    Partial<ImportOptions>,
+    'ensureLiveReference' | 'ensureNoContext',
+  >,
+) => t.Identifier;
+
+// declare export function addNamed(
+//     path: NodePath<>,
+//     name: string,
+//     importedSource: string,
+//     opts?: Omit<Partial<ImportOptions>, "ensureLiveReference"> & {
+//         ensureLiveReference: true;
+//     },
+// ): t.MemberExpression;
+// declare export function addNamed(
+//     path: NodePath,
+//     name: string,
+//     importedSource: string,
+//     opts?: Omit<Partial<ImportOptions>, "ensureNoContext"> & {
+//         ensureNoContext: true;
+//     },
+// ): t.SequenceExpression;
+
+declare export function addNamespace(
+  path: NodePath<>,
+  importedSource: string,
+  opts?: Partial<ImportOptions>,
+): t.Identifier;
+
+// declare export function addSideEffect(
+//   path: NodePath<>,
+//   importedSource: string,
+//   opts?: Partial<ImportOptions>,
+// ): void;
+
+declare export function isModule(path: NodePath<t.Program>): boolean;
+
+// declare export class ImportInjector {
+//   constructor(
+//     path: NodePath<>,
+//     importedSource?: string,
+//     opts?: Partial<ImportOptions>,
+//   ): ImportInjector;
+
+//   addDefault(
+//     importedSourceIn: string,
+//     opts: Partial<ImportOptions>,
+//   ): t.Identifier;
+//   addNamed(
+//     importName: string,
+//     importedSourceIn: string,
+//     opts: Partial<ImportOptions>,
+//   ): t.Identifier;
+//   addNamespace(
+//     importedSourceIn: string,
+//     opts: Partial<ImportOptions>,
+//   ): t.Identifier;
+//   addSideEffect(importedSourceIn: string, opts: Partial<ImportOptions>): void;
+// }

--- a/packages/babel-plugin/flow_modules/@babel/traverse/index.js.flow
+++ b/packages/babel-plugin/flow_modules/@babel/traverse/index.js.flow
@@ -3,6 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
  * @flow strict
  */
 
@@ -307,8 +308,8 @@ declare export class NodePath<+T: Node = Node> {
   type: T extends null | void
     ? void
     : T extends Node
-    ? T['type']
-    : string | void;
+      ? T['type']
+      : string | void;
 
   typeAnnotation: { ... };
 
@@ -996,7 +997,7 @@ export type NodePathResult<T: Node | $ReadOnlyArray<Node>> =
   T extends $ReadOnlyArray<infer TNode>
     ? $ReadOnlyArray<NodePath<TNode>>
     : T extends null | void
-    ? void
-    : T extends Node
-    ? NodePath<T>
-    : T;
+      ? void
+      : T extends Node
+        ? NodePath<T>
+        : T;

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -12,6 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@babel/helper-module-imports": "^7.22.15",
     "@stylexjs/shared": "0.3.0"
   },
   "peerDependencies": {

--- a/packages/babel-plugin/src/visitors/stylex-create-theme.js
+++ b/packages/babel-plugin/src/visitors/stylex-create-theme.js
@@ -9,6 +9,7 @@
 
 import * as t from '@babel/types';
 import type { NodePath } from '@babel/traverse';
+import { addDefault, addNamed } from '@babel/helper-module-imports';
 import StateManager from '../utils/state-manager';
 import { createTheme as stylexCreateTheme, messages } from '@stylexjs/shared';
 import { convertObjectToAST } from '../utils/js-to-ast';
@@ -107,36 +108,28 @@ export default function transformStyleXCreateTheme(
     // This should be a transformed variables object
     callExpressionPath.replaceWith(convertObjectToAST(overridesObj));
 
-    if (state.runtimeInjection) {
-      // We know that the top level parent path is an variable declarator
-      const statementPath: ?NodePath<> = variableDeclaratorPath.parentPath;
+    const statementPath: ?NodePath<> = variableDeclaratorPath.parentPath;
 
-      let stylexName: string;
-      state.stylexImport.forEach((importName) => {
-        stylexName = importName;
-      });
-      if (stylexName == null) {
-        stylexName = '__stylex__';
-        statementPath?.insertBefore(
-          t.importDeclaration(
-            [t.importDefaultSpecifier(t.identifier(stylexName))],
-            t.stringLiteral(state.importPathString),
-          ),
-        );
+    if (state.runtimeInjection != null && statementPath != null) {
+      let injectName: t.Identifier;
+      if (state.injectImportInserted != null) {
+        injectName = state.injectImportInserted;
+      } else {
+        const { from, as } = state.runtimeInjection;
+        injectName =
+          as != null
+            ? addNamed(statementPath, as, from, { nameHint: 'inject' })
+            : addDefault(statementPath, from, { nameHint: 'inject' });
+
+        state.injectImportInserted = injectName;
       }
 
       statementPath?.insertBefore(
         t.expressionStatement(
-          t.callExpression(
-            t.memberExpression(
-              t.identifier(stylexName),
-              t.identifier('inject'),
-            ),
-            [
-              t.stringLiteral(css[styleKey].ltr),
-              t.numericLiteral(css[styleKey].priority),
-            ],
-          ),
+          t.callExpression(injectName, [
+            t.stringLiteral(css[styleKey].ltr),
+            t.numericLiteral(css[styleKey].priority),
+          ]),
         ),
       );
     }

--- a/packages/babel-plugin/src/visitors/stylex-keyframes.js
+++ b/packages/babel-plugin/src/visitors/stylex-keyframes.js
@@ -79,13 +79,7 @@ export default function transformStyleXKeyframes(
 
     const statementPath: ?NodePath<t.Statement> = path.getStatementParent();
 
-    if (
-      // TODO: remove this check and traverse up to find a top level statment
-      statementPath != null &&
-      state.runtimeInjection != null
-    ) {
-      // We know that the parent path is a variable declaration
-
+    if (statementPath != null && state.runtimeInjection != null) {
       let injectName: t.Identifier;
       if (state.injectImportInserted != null) {
         injectName = state.injectImportInserted;

--- a/packages/rollup-plugin/__tests__/index-test.js
+++ b/packages/rollup-plugin/__tests__/index-test.js
@@ -21,7 +21,11 @@ describe('rollup-plugin-stylex', () => {
     // Configure a rollup bundle
     const bundle = await rollup.rollup({
       // Remove stylex runtime from bundle
-      external: ['stylex'],
+      external: [
+        'stylex',
+        '@stylexjs/stylex',
+        '@stylexjs/stylex/lib/stylex-inject',
+      ],
       input: path.resolve(__dirname, '__fixtures__/index.js'),
       plugins: [
         nodeResolve(),
@@ -169,7 +173,8 @@ describe('rollup-plugin-stylex', () => {
       expect(css).toBeUndefined();
 
       expect(js).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import _inject from '@stylexjs/stylex/lib/stylex-inject';
+        import stylex from 'stylex';
 
         /**
          * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -180,8 +185,8 @@ describe('rollup-plugin-stylex', () => {
          *
          */
 
-        stylex.inject(".x1lliihq{display:block}", 3000);
-        stylex.inject(".xh8yej3{width:100%}", 4000);
+        _inject(".x1lliihq{display:block}", 3000);
+        _inject(".xh8yej3{width:100%}", 4000);
         var styles$2 = {
           bar: {
             "otherStyles__styles.bar": "otherStyles__styles.bar",
@@ -200,9 +205,9 @@ describe('rollup-plugin-stylex', () => {
          *
          */
 
-        stylex.inject(".xt0psk2{display:inline}", 3000);
-        stylex.inject(".x1egiwwb{height:500px}", 4000);
-        stylex.inject(".x3hqpx7{width:50%}", 4000);
+        _inject(".xt0psk2{display:inline}", 3000);
+        _inject(".x1egiwwb{height:500px}", 4000);
+        _inject(".x3hqpx7{width:50%}", 4000);
         const styles$1 = {
           baz: {
             "npmStyles__styles.baz": "npmStyles__styles.baz",
@@ -222,13 +227,13 @@ describe('rollup-plugin-stylex', () => {
          *
          */
 
-        stylex.inject("@keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}", 1);
-        stylex.inject(".xeuoslp{animation-name:xgnty7z-B}", 3000);
-        stylex.inject(".x78zum5{display:flex}", 3000);
-        stylex.inject(".x1hm9lzh{margin-inline-start:10px}", 3000);
-        stylex.inject(".xlrshdv{margin-top:99px}", 4000);
-        stylex.inject(".x1egiwwb{height:500px}", 4000);
-        stylex.inject(".x1oz5o6v:hover{background:red}", 1130);
+        _inject("@keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}", 1);
+        _inject(".xeuoslp{animation-name:xgnty7z-B}", 3000);
+        _inject(".x78zum5{display:flex}", 3000);
+        _inject(".x1hm9lzh{margin-inline-start:10px}", 3000);
+        _inject(".xlrshdv{margin-top:99px}", 4000);
+        _inject(".x1egiwwb{height:500px}", 4000);
+        _inject(".x1oz5o6v:hover{background:red}", 1130);
         var styles = {
           foo: {
             "index__styles.foo": "index__styles.foo",

--- a/packages/shared/src/common-types.js
+++ b/packages/shared/src/common-types.js
@@ -41,11 +41,10 @@ export type FlatCompiledStyles = $ReadOnly<{
   $$css: true,
 }>;
 
-export type StyleXOptions = {
+export type StyleXOptions = $ReadOnly<{
   dev: boolean,
   test: boolean,
   useRemForFontSize: boolean,
-  runtimeInjection: boolean,
   classNamePrefix: string,
   definedStylexCSSVariables?: { [key: string]: mixed },
   styleResolution:
@@ -56,7 +55,7 @@ export type StyleXOptions = {
     // This is not recommended, and will be removed in a future version.
     | 'legacy-expand-shorthands',
   ...
-};
+}>;
 
 export type MutableCompiledNamespaces = {
   [key: string]: FlatCompiledStyles,

--- a/packages/shared/src/utils/default-options.js
+++ b/packages/shared/src/utils/default-options.js
@@ -24,7 +24,6 @@ import type { StyleXOptions } from '../common-types';
 
 export const defaultOptions: StyleXOptions = {
   dev: false,
-  runtimeInjection: false,
   useRemForFontSize: true,
   test: false,
   classNamePrefix: 'x',

--- a/packages/stylex/__tests__/stylex-test.js
+++ b/packages/stylex/__tests__/stylex-test.js
@@ -15,7 +15,7 @@ import stylex from '../src/stylex';
 // TODO: priorities need testing
 test('stylex.inject', () => {
   const prevCount = styleSheet.getRuleCount();
-  stylex.inject('hey {}', 0);
+  styleSheet.inject('hey {}', 0);
   expect(styleSheet.getRuleCount()).toBeGreaterThan(prevCount);
 });
 

--- a/packages/stylex/src/stylex.js
+++ b/packages/stylex/src/stylex.js
@@ -32,7 +32,6 @@ export type {
   StaticStylesWithout,
 } from './StyleXTypes';
 
-import injectStyle from './stylex-inject';
 import { styleq } from 'styleq';
 
 type Cache = WeakMap<
@@ -235,8 +234,6 @@ export const firstThatWorks = <T: string | number>(
   throw new Error('stylex.firstThatWorks should never be called.');
 };
 
-export const inject: typeof injectStyle = injectStyle;
-
 function _stylex(
   ...styles: $ReadOnlyArray<StyleXArray<?CompiledStyles | boolean>>
 ): string {
@@ -250,7 +247,6 @@ _stylex.createTheme = createTheme;
 _stylex.include = include;
 _stylex.keyframes = keyframes;
 _stylex.firstThatWorks = firstThatWorks;
-_stylex.inject = inject;
 _stylex.types = types;
 
 type IStyleX = {
@@ -274,7 +270,6 @@ type IStyleX = {
   firstThatWorks: <T: string | number>(
     ...v: $ReadOnlyArray<T>
   ) => $ReadOnlyArray<T>,
-  inject: (ltrRule: string, priority: number, rtlRule: ?string) => void,
   keyframes: (keyframes: Keyframes) => string,
   __customProperties?: { [string]: mixed },
   ...


### PR DESCRIPTION
## What changed / motivation ?

The `inject` function has been removed from the main export of `@stylex/stylex`. Now the inject function can only be used by manually importing `@stylex/stylex/lib/stylex-inject`.

The Babel plugin has similarly been updated to import the `inject` function from the new location when `runtimeInjection` is turned on.

Also, `runtimeInjection` now accepts a string or `{from: string, as: string}` object to be able to override the `inject` function module location.

## Additional Context

<img width="490" alt="image" src="https://github.com/facebook/stylex/assets/3582514/4c8c98dd-13c7-4cfa-9475-16a1b5797dcf">

Tests have been updated to reflect the changes. The updated snapshots will show what has changed.

NOTE: The Webpack plugin is currently inlining the `stylex-inject` module in the generated code in the snapshot test. Trying to configure Webpack to not do that is causing strange errors.

## Pre-flight checklist

- [x] Performed a self-review of my code