### PR TITLE
Altered eslint error message for outlineOffset

### DIFF
--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -1945,9 +1945,7 @@ const CSSProperties = {
   outlineColor: showError(
     "'outlineColor' is not supported yet. Please use 'outline' instead",
   ),
-  outlineOffset: showError(
-    "'outlineOffset' is not supported yet. Please use 'outline' instead",
-  ),
+  outlineOffset: showError("'outlineOffset' is not supported yet."),
   outlineStyle: showError(
     "'outlineStyle' is not supported yet. Please use 'outline' instead",
   ),


### PR DESCRIPTION
while outlineOffset is not supported, still eslint error was promoting to use 'outline' instead, and 'outlineOffset' is not one of the shorthand property of outline, in css.

## Linked PR/Issues

Fixes # #135 

## Additional Context

altered the eslint error message, so that it does not mis guides the user to use outline. 


## Pre-flight checklist

- [* ] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [ *] Performed a self-review of my code