### PR TITLE
Fix:outlineOffset is not recognized by eslint-plugin, but cannot be set otherwise.

### DIFF
--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -1942,18 +1942,11 @@ const CSSProperties = {
   order: order,
   orphans: orphans,
   outline: outline,
-  outlineColor: showError(
-    "'outlineColor' is not supported yet. Please use 'outline' instead",
-  ),
-  outlineOffset: showError(
-    "'outlineOffset' is not supported yet. Please use 'outline' instead",
-  ),
-  outlineStyle: showError(
-    "'outlineStyle' is not supported yet. Please use 'outline' instead",
-  ),
-  outlineWidth: showError(
-    "'outlineWidth' is not supported yet. Please use 'outline' instead",
-  ),
+  outlineColor: outlineColor,
+  outlineOffset: width,
+  outlineStyle: outlineStyle, 
+  outlineWidth: width, 
+
   blockOverflow: overflow, // TODO - Add support to Babel Plugin
   inlineOverflow: overflow, // TODO - Add support to Babel Plugin
   overflow: overflow,


### PR DESCRIPTION
issue-:#135

## What changed / motivation ?

Added outlineOffset, outlineStyle and outlineWidth properties and set them to valid style types (width and outlineStyle).

Removed the showError calls for those properties and allowed them to be used.

Left outline as-is to still support shorthand outline property.

## Linked PR/Issues

Fixes #135