### PR TITLE
docs: fix import in creating themes example

### DIFF
--- a/apps/docs/docs/learn/05-theming/03-creating-themes.mdx
+++ b/apps/docs/docs/learn/05-theming/03-creating-themes.mdx
@@ -24,7 +24,7 @@ Any variable group can be imported to create a theme like so:
 
 ```tsx title="themes.js"
 import * as stylex from '@stylexjs/stylex';
-import {colors, spacing} from './tokens.styles';
+import {colors, spacing} from './tokens.stylex';
 
 // A constant can be used to avoid repeating the media query
 const DARK = '@media (prefers-color-scheme: dark)';


### PR DESCRIPTION
## What changed / motivation?

Based on the example found on the [Using variables](https://github.com/facebook/stylex/blob/7ddea4976e6aecd9af56e37f758c65569e52505b/apps/docs/docs/learn/05-theming/02-using-variables.mdx#L60) page, I believe this other example is using an incorrect filename for the tokens import.

## Pre-flight checklist

- [X] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [X] Performed a self-review of my code