### PR TITLE
Support replacement tokens in the webpack filename

### DIFF
--- a/packages/webpack-plugin/__tests__/index-test.js
+++ b/packages/webpack-plugin/__tests__/index-test.js
@@ -245,6 +245,25 @@ describe('webpack-plugin-stylex', () => {
     });
   });
 
+  it('supports [contenthash] in output filename', async () => {
+    const compiler = createCompiler('index.js', {
+      filename: 'stylex.[contenthash].css',
+    });
+    return new Promise((resolve, reject) => {
+      compiler.run((error, stats) => {
+        try {
+          expect(error).toBe(null);
+          expect(
+            assetExists('stylex.09fffeec3686166d4767.css', compiler, stats),
+          ).toBe(true);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+
   describe('when in dev mode', () => {
     it('preserves stylex.inject calls and does not extract CSS', (done) => {
       const compiler = createCompiler('index.js', { dev: true });


### PR DESCRIPTION


## What changed / motivation ?

Webpack only supports token replacement for chunks and modules, not plain assets. Instead, teach the plugin to do token replacement the same way that webpack does it for supported types.

## Linked PR/Issues

Fixes #105 

## Pre-flight checklist

- [X] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [X] Performed a self-review of my code