### PR TITLE
Extract webpack plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7767,6 +7767,10 @@
       "resolved": "packages/eslint-plugin",
       "link": true
     },
+    "node_modules/@stylexjs/extract-webpack-plugin": {
+      "resolved": "packages/extract-webpack-plugin",
+      "link": true
+    },
     "node_modules/@stylexjs/nextjs-plugin": {
       "resolved": "packages/nextjs-plugin",
       "link": true
@@ -12790,6 +12794,13 @@
       "version": "3.1.3",
       "license": "MIT"
     },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/fast-glob": {
       "version": "3.2.12",
       "license": "MIT",
@@ -14954,6 +14965,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.18"
       }
     },
     "node_modules/iconv-lite": {
@@ -19480,6 +19500,43 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ=="
     },
+    "node_modules/json-joy": {
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/json-joy/-/json-joy-9.9.1.tgz",
+      "integrity": "sha512-/d7th2nbQRBQ/nqTkBe6KjjvDciSwn9UICmndwk3Ed/Bk9AqkTRm4PnLVfXG4DKbT0rEY0nKnwE7NqZlqKE6kg==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^5.0.2",
+        "hyperdyperid": "^1.2.0"
+      },
+      "bin": {
+        "jj": "bin/jj.js",
+        "json-pack": "bin/json-pack.js",
+        "json-pack-test": "bin/json-pack-test.js",
+        "json-patch": "bin/json-patch.js",
+        "json-patch-test": "bin/json-patch-test.js",
+        "json-pointer": "bin/json-pointer.js",
+        "json-pointer-test": "bin/json-pointer-test.js",
+        "json-unpack": "bin/json-unpack.js"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "quill-delta": "^5",
+        "rxjs": "7",
+        "tslib": "2"
+      }
+    },
+    "node_modules/json-joy/node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "license": "MIT"
@@ -19661,6 +19718,13 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/lodash.curry": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
@@ -19674,6 +19738,13 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
       "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -22238,6 +22309,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/randombytes": {
@@ -28923,6 +29009,18 @@
       "version": "0.2.0",
       "license": "MIT"
     },
+    "node_modules/thingies": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.15.0.tgz",
+      "integrity": "sha512-ZSJlvEpD8QllYim0VSGlbAoob/iPrTWNlV/m8ltizMvMmzzU2gVJvHfH9ijLstyciWF70ZiQXqz+BCXWJq+ZQw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "tslib": "^2"
+      }
+    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -31107,6 +31205,70 @@
         "micromatch": "^4.0.5"
       }
     },
+    "packages/extract-webpack-plugin": {
+      "name": "@stylexjs/extract-webpack-plugin",
+      "version": "0.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.15.5",
+        "@babel/plugin-syntax-flow": "^7.18.6",
+        "@babel/plugin-syntax-jsx": "^7.14.5",
+        "@babel/plugin-syntax-typescript": "^7.14.5",
+        "@stylexjs/babel-plugin": "0.3.0",
+        "webpack": "^5.88.2"
+      },
+      "devDependencies": {
+        "@babel/preset-env": "^7.16.8",
+        "@stylexjs/stylex": "0.3.0",
+        "babel-loader": "^8.2.2",
+        "html-webpack-plugin": "^5.5.4",
+        "memfs": "4.2.0",
+        "webpack-cli": "^5.1.4"
+      }
+    },
+    "packages/extract-webpack-plugin/node_modules/html-webpack-plugin": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.4.tgz",
+      "integrity": "sha512-3wNSaVVxdxcu0jd4FpQFoICdqgxs4zIQQvj+2yQKFfBOnLETQ6X5CDWdeasuGlSsooFlMkEioWDTqBv1wvw5Iw==",
+      "dev": true,
+      "dependencies": {
+        "@types/html-minifier-terser": "^6.0.0",
+        "html-minifier-terser": "^6.0.2",
+        "lodash": "^4.17.21",
+        "pretty-error": "^4.0.0",
+        "tapable": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/html-webpack-plugin"
+      },
+      "peerDependencies": {
+        "webpack": "^5.20.0"
+      }
+    },
+    "packages/extract-webpack-plugin/node_modules/memfs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.2.0.tgz",
+      "integrity": "sha512-V5/xE+zl6+soWxlBjiVTQSkfXybTwhEBj2I8sK9LaS5lcZsTuhRftakrcRpDY7Ycac2NTK/VzEtpKMp+gpymrQ==",
+      "dev": true,
+      "dependencies": {
+        "json-joy": "^9.2.0",
+        "thingies": "^1.11.1"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
     "packages/nextjs-plugin": {
       "name": "@stylexjs/nextjs-plugin",
       "version": "0.3.0",
@@ -31202,6 +31364,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -31217,6 +31380,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -31232,6 +31396,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31247,6 +31412,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31262,6 +31428,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31277,6 +31444,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31292,6 +31460,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -31307,6 +31476,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -31322,6 +31492,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -36119,6 +36290,48 @@
         "micromatch": "^4.0.5"
       }
     },
+    "@stylexjs/extract-webpack-plugin": {
+      "version": "file:packages/extract-webpack-plugin",
+      "requires": {
+        "@babel/core": "^7.15.5",
+        "@babel/plugin-syntax-flow": "^7.18.6",
+        "@babel/plugin-syntax-jsx": "^7.14.5",
+        "@babel/plugin-syntax-typescript": "^7.14.5",
+        "@babel/preset-env": "^7.16.8",
+        "@stylexjs/babel-plugin": "0.3.0",
+        "@stylexjs/stylex": "0.3.0",
+        "babel-loader": "^8.2.2",
+        "html-webpack-plugin": "*",
+        "memfs": "4.2.0",
+        "webpack": "^5.88.2",
+        "webpack-cli": "^5.1.4"
+      },
+      "dependencies": {
+        "html-webpack-plugin": {
+          "version": "5.5.4",
+          "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.4.tgz",
+          "integrity": "sha512-3wNSaVVxdxcu0jd4FpQFoICdqgxs4zIQQvj+2yQKFfBOnLETQ6X5CDWdeasuGlSsooFlMkEioWDTqBv1wvw5Iw==",
+          "dev": true,
+          "requires": {
+            "@types/html-minifier-terser": "^6.0.0",
+            "html-minifier-terser": "^6.0.2",
+            "lodash": "^4.17.21",
+            "pretty-error": "^4.0.0",
+            "tapable": "^2.0.0"
+          }
+        },
+        "memfs": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.2.0.tgz",
+          "integrity": "sha512-V5/xE+zl6+soWxlBjiVTQSkfXybTwhEBj2I8sK9LaS5lcZsTuhRftakrcRpDY7Ycac2NTK/VzEtpKMp+gpymrQ==",
+          "dev": true,
+          "requires": {
+            "json-joy": "^9.2.0",
+            "thingies": "^1.11.1"
+          }
+        }
+      }
+    },
     "@stylexjs/nextjs-plugin": {
       "version": "file:packages/nextjs-plugin",
       "requires": {
@@ -40282,6 +40495,13 @@
     "fast-deep-equal": {
       "version": "3.1.3"
     },
+    "fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "peer": true
+    },
     "fast-glob": {
       "version": "3.2.12",
       "requires": {
@@ -41795,6 +42015,12 @@
     },
     "human-signals": {
       "version": "2.1.0"
+    },
+    "hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -44964,6 +45190,24 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ=="
     },
+    "json-joy": {
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/json-joy/-/json-joy-9.9.1.tgz",
+      "integrity": "sha512-/d7th2nbQRBQ/nqTkBe6KjjvDciSwn9UICmndwk3Ed/Bk9AqkTRm4PnLVfXG4DKbT0rEY0nKnwE7NqZlqKE6kg==",
+      "dev": true,
+      "requires": {
+        "arg": "^5.0.2",
+        "hyperdyperid": "^1.2.0"
+      },
+      "dependencies": {
+        "arg": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+          "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+          "dev": true
+        }
+      }
+    },
     "json-parse-even-better-errors": {
       "version": "2.3.1"
     },
@@ -45090,6 +45334,13 @@
     "lodash": {
       "version": "4.17.21"
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "peer": true
+    },
     "lodash.curry": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
@@ -45102,6 +45353,13 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
       "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true,
+      "peer": true
     },
     "lodash.memoize": {
       "version": "4.1.2"
@@ -47365,6 +47623,18 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
+    },
+    "quill-delta": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -52083,6 +52353,13 @@
     "text-table": {
       "version": "0.2.0"
     },
+    "thingies": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.15.0.tgz",
+      "integrity": "sha512-ZSJlvEpD8QllYim0VSGlbAoob/iPrTWNlV/m8ltizMvMmzzU2gVJvHfH9ijLstyciWF70ZiQXqz+BCXWJq+ZQw==",
+      "dev": true,
+      "requires": {}
+    },
     "thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -53532,60 +53809,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
       "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
-    },
-    "@next/swc-darwin-arm64": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.1.tgz",
-      "integrity": "sha512-JyxnGCS4qT67hdOKQ0CkgFTp+PXub5W1wsGvIq98TNbF3YEIN7iDekYhYsZzc8Ov0pWEsghQt+tANdidITCLaw==",
-      "optional": true
-    },
-    "@next/swc-darwin-x64": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.1.tgz",
-      "integrity": "sha512-625Z7bb5AyIzswF9hvfZWa+HTwFZw+Jn3lOBNZB87lUS0iuCYDHqk3ujuHCkiyPtSC0xFBtYDLcrZ11mF/ap3w==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-gnu": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.1.tgz",
-      "integrity": "sha512-iVpn3KG3DprFXzVHM09kvb//4CNNXBQ9NB/pTm8LO+vnnnaObnzFdS5KM+w1okwa32xH0g8EvZIhoB3fI3mS1g==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-musl": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.1.tgz",
-      "integrity": "sha512-mVsGyMxTLWZXyD5sen6kGOTYVOO67lZjLApIj/JsTEEohDDt1im2nkspzfV5MvhfS7diDw6Rp/xvAQaWZTv1Ww==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-gnu": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.1.tgz",
-      "integrity": "sha512-wMqf90uDWN001NqCM/auRl3+qVVeKfjJdT9XW+RMIOf+rhUzadmYJu++tp2y+hUbb6GTRhT+VjQzcgg/QTD9NQ==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-musl": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.1.tgz",
-      "integrity": "sha512-ol1X1e24w4j4QwdeNjfX0f+Nza25n+ymY0T2frTyalVczUmzkVD7QGgPTZMHfR1aLrO69hBs0G3QBYaj22J5GQ==",
-      "optional": true
-    },
-    "@next/swc-win32-arm64-msvc": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.1.tgz",
-      "integrity": "sha512-WEmTEeWs6yRUEnUlahTgvZteh5RJc4sEjCQIodJlZZ5/VJwVP8p2L7l6VhzQhT4h7KvLx/Ed4UViBdne6zpIsw==",
-      "optional": true
-    },
-    "@next/swc-win32-ia32-msvc": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.1.tgz",
-      "integrity": "sha512-oFpHphN4ygAgZUKjzga7SoH2VGbEJXZa/KL8bHCAwCjDWle6R1SpiGOdUdA8EJ9YsG1TYWpzY6FTbUA+iAJeww==",
-      "optional": true
-    },
-    "@next/swc-win32-x64-msvc": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.1.tgz",
-      "integrity": "sha512-FFp3nOJ/5qSpeWT0BZQ+YE1pSMk4IMpkME/1DwKBwhg4mJLB9L+6EXuJi4JEwaJdl5iN+UUlmUD3IsR1kx5fAg==",
-      "optional": true
     }
   }
 }

--- a/packages/extract-webpack-plugin/README.md
+++ b/packages/extract-webpack-plugin/README.md
@@ -1,0 +1,67 @@
+# @stylexjs/extract-webpack-plugin
+
+
+## Documentation Website
+[https://stylexjs.com](https://stylexjs.com)
+
+## Installation
+
+Install the package by using:
+```bash
+npm install --save-dev @stylexjs/extract-webpack-plugin
+```
+
+or with yarn:
+
+```bash
+yarn add --dev @stylexjs/extract-webpack-plugin
+```
+
+Add the following to your `webpack.config.js`
+```javascript
+const StylexPlugin = require('@stylexjs/extract-webpack-plugin');
+const path = require('path');
+
+const config = (env, argv) => ({
+  entry: {
+    main: './src/index.js',
+  },
+  output: {
+    path: path.resolve(__dirname, '.build'),
+    filename: '[name].js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: 'babel-loader',
+      },
+    ],
+  },
+  plugins: [
+    // Ensure that the stylex plugin is used before Babel
+    new StylexPlugin({
+      filename: '[name].[contenthash].css',
+      // get webpack mode and set value for dev
+      dev: argv.mode === 'development',
+      // Use statically generated CSS files and not runtime injected CSS.
+      // Even in development.
+      runtimeInjection: false,
+      // optional. default: 'x'
+      classNamePrefix: 'x',
+      // Required for CSS variable support
+      unstable_moduleResolution: {
+        // type: 'commonJS' | 'haste'
+        // default: 'commonJS'
+        type: 'commonJS',
+        // The absolute path to the root directory of your project
+        rootDir: __dirname,
+      },
+    }),
+  ],
+  cache: true,
+});
+
+module.exports = config;
+```

--- a/packages/extract-webpack-plugin/__tests__/__fixtures__/.babelrc.json
+++ b/packages/extract-webpack-plugin/__tests__/__fixtures__/.babelrc.json
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "ie": 11
+        }
+      }
+    ]
+  ]
+}

--- a/packages/extract-webpack-plugin/__tests__/__fixtures__/index.html
+++ b/packages/extract-webpack-plugin/__tests__/__fixtures__/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport"
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Main page</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/packages/extract-webpack-plugin/__tests__/__fixtures__/index.js
+++ b/packages/extract-webpack-plugin/__tests__/__fixtures__/index.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+import stylex from 'stylex';
+import otherStyles from './otherStyles';
+import npmStyles from './npmStyles';
+
+const fadeAnimation = stylex.keyframes({
+  '0%': {
+    opacity: 0.25,
+  },
+  '100%': {
+    opacity: 1,
+  },
+});
+
+const styles = stylex.create({
+  foo: {
+    animationName: fadeAnimation,
+    display: 'flex',
+    marginStart: 10,
+    marginBlockStart: 99,
+    height: 500,
+    ':hover': {
+      background: 'red',
+    },
+  },
+});
+
+export default function App() {
+  return stylex(otherStyles.bar, styles.foo, npmStyles.baz);
+}

--- a/packages/extract-webpack-plugin/__tests__/__fixtures__/npmStyles.js
+++ b/packages/extract-webpack-plugin/__tests__/__fixtures__/npmStyles.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+// npmStyles.js
+
+'use strict';
+
+import stylex from 'stylex';
+
+const styles = stylex.create({
+  baz: {
+    display: 'inline',
+    height: 500,
+    width: '50%',
+  },
+});
+
+export default styles;

--- a/packages/extract-webpack-plugin/__tests__/__fixtures__/other.html
+++ b/packages/extract-webpack-plugin/__tests__/__fixtures__/other.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport"
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Other page</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/packages/extract-webpack-plugin/__tests__/__fixtures__/other.js
+++ b/packages/extract-webpack-plugin/__tests__/__fixtures__/other.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+import stylex from 'stylex';
+import otherStyles from './otherStyles';
+
+const fadeAnimation = stylex.keyframes({
+  '0%': {
+    opacity: 0.25,
+  },
+  '100%': {
+    opacity: 1,
+  },
+});
+
+const styles = stylex.create({
+  foo: {
+    animationName: fadeAnimation,
+    display: 'flex',
+    marginStart: 10,
+    marginBlockStart: 99,
+    height: 500,
+    ':hover': {
+      background: 'red',
+    },
+  },
+});
+
+export default function App() {
+  return stylex(otherStyles, styles.foo);
+}

--- a/packages/extract-webpack-plugin/__tests__/__fixtures__/otherStyles.js
+++ b/packages/extract-webpack-plugin/__tests__/__fixtures__/otherStyles.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+// otherStyles.js
+
+'use strict';
+
+import stylex from 'stylex';
+
+const styles = stylex.create({
+  bar: {
+    display: 'block',
+    width: '100%',
+  },
+});
+
+export default styles;

--- a/packages/extract-webpack-plugin/__tests__/__fixtures__/webpack.config.js
+++ b/packages/extract-webpack-plugin/__tests__/__fixtures__/webpack.config.js
@@ -32,7 +32,16 @@ module.exports = {
     new StylexPlugin({
       filename: '[name].[contenthash].css'
     }),
-    new HtmlWebpackPlugin()
+    new HtmlWebpackPlugin({
+      filename: 'index.html',
+      template: path.resolve(__dirname,'index.html'),
+      excludeChunks: ['other']
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'other.html',
+      template: path.resolve(__dirname,'other.html'),
+      excludeChunks: ['main']
+    })
   ],
   devtool: false, //'cheap-source-map',
   externals: {

--- a/packages/extract-webpack-plugin/__tests__/__fixtures__/webpack.config.js
+++ b/packages/extract-webpack-plugin/__tests__/__fixtures__/webpack.config.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+const path = require('path');
+const StylexPlugin = require('../../src/index');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  context: __dirname,
+  entry: {
+    main: path.resolve(__dirname, './index.js'),
+    other: path.resolve(__dirname, './other.js')
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: [/node_modules/, path.resolve(__dirname, './npmStyles.js')],
+        use: {
+          loader: require.resolve('babel-loader'),
+        },
+      },
+    ],
+  },
+  plugins: [
+    new StylexPlugin({
+      filename: '[name].[contenthash].css'
+    }),
+    new HtmlWebpackPlugin()
+  ],
+  devtool: false, //'cheap-source-map',
+  externals: {
+    // Remove stylex runtime from bundle
+    stylex: 'stylex',
+  },
+  mode: process.env.NODE_ENV ?? 'production',
+  output: {
+    path: path.resolve(__dirname, 'build'),
+  },
+  optimization: {
+    // Keep output readable
+    minimize: false,
+    // Remove webpack runtime from bundle
+    runtimeChunk: 'single',
+  },
+  target: 'node',
+};

--- a/packages/extract-webpack-plugin/__tests__/index-test.js
+++ b/packages/extract-webpack-plugin/__tests__/index-test.js
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+const memfs = require('memfs');
+const path = require('path');
+const StylexPlugin = require('../src/index');
+const webpack = require('webpack');
+
+/**
+ * Webpack compiler factory
+ */
+function createCompiler(entry, pluginOptions = {}, config = {}) {
+  const stylexPlugin = new StylexPlugin(pluginOptions);
+  const fullConfig = {
+    context: path.resolve(__dirname, './__fixtures__'),
+    entry: Object.entries(entry).reduce((prev,[k,v]) => {
+      return {...prev,[k]:path.resolve(__dirname, './__fixtures__', v)}
+    },{}),
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          exclude: [
+            /node_modules/,
+            path.resolve(__dirname, './__fixtures__/npmStyles.js'),
+          ],
+          use: {
+            loader: require.resolve('babel-loader'),
+          },
+        },
+      ],
+    },
+    plugins: [stylexPlugin],
+    devtool: false, //'cheap-source-map',
+    externals: [
+      'stylex',
+      '@stylexjs/stylex',
+      // '@stylexjs/stylex/lib/stylex-inject',
+    ],
+    mode: 'production',
+    output: {
+      path: path.resolve(__dirname, '__builds__'),
+    },
+    optimization: {
+      // Keep output readable
+      minimize: false,
+      // Keep module IDs from changing between test runs
+      // and failing the snapshot comparison
+      moduleIds: 'named',
+      // Remove webpack runtime from bundle
+      runtimeChunk: 'single',
+    },
+    target: 'node',
+    ...config,
+  };
+
+  const compiler = webpack(fullConfig);
+
+  if (!config.outputFileSystem) {
+    // Use in-memory file system
+    compiler.outputFileSystem = memfs.createFsFromVolume(new memfs.Volume());
+  }
+
+  return compiler;
+}
+
+function getTargetFile(asset) {
+  let targetFile = asset;
+  const queryStringIdx = targetFile.indexOf('?');
+  if (queryStringIdx >= 0) {
+    targetFile = targetFile.substr(0, queryStringIdx);
+  }
+  return targetFile;
+}
+
+/**
+ * Read assets in the webpack output
+ */
+function readAsset(asset, compiler, stats) {
+  const usedFs = compiler.outputFileSystem;
+  const outputPath = stats.compilation.outputOptions.path;
+  const targetFile = getTargetFile(asset);
+  try {
+    return usedFs.readFileSync(path.join(outputPath, targetFile)).toString();
+  } catch (error) {
+    return error.toString();
+  }
+}
+
+function assetExists(asset, compiler, stats) {
+  const usedFs = compiler.outputFileSystem;
+  const outputPath = stats.compilation.outputOptions.path;
+  const targetFile = getTargetFile(asset);
+  return usedFs.existsSync(path.join(outputPath, targetFile));
+}
+
+describe('extract-webpack-plugin', () => {
+  it('extracts CSS and removes stylex.inject calls', (done) => {
+    const compiler = createCompiler({main: 'index.js', other: 'other.js'});
+    compiler.run((error, stats) => {
+      expect(error).toBe(null);
+
+      const mainCSS = readAsset('main.css', compiler, stats);
+      const mainJS = readAsset('main.js', compiler, stats);
+      const otherCSS = readAsset('other.css', compiler, stats);
+      const otherJS = readAsset('other.js', compiler, stats);
+
+      expect(mainCSS).toMatchInlineSnapshot(`
+        "@keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}
+        .x1oz5o6v:hover:not(#\\#):not(#\\#){background:red}
+        .xeuoslp:not(#\\#):not(#\\#):not(#\\#){animation-name:xgnty7z-B}
+        .x1lliihq:not(#\\#):not(#\\#):not(#\\#){display:block}
+        .x78zum5:not(#\\#):not(#\\#):not(#\\#){display:flex}
+        .xt0psk2:not(#\\#):not(#\\#):not(#\\#){display:inline}
+        .x1hm9lzh:not(#\\#):not(#\\#):not(#\\#){margin-inline-start:10px}
+        .x1egiwwb:not(#\\#):not(#\\#):not(#\\#):not(#\\#){height:500px}
+        .xlrshdv:not(#\\#):not(#\\#):not(#\\#):not(#\\#){margin-top:99px}
+        .xh8yej3:not(#\\#):not(#\\#):not(#\\#):not(#\\#){width:100%}
+        .x3hqpx7:not(#\\#):not(#\\#):not(#\\#):not(#\\#){width:50%}"
+      `);
+
+      expect(otherCSS).toMatchInlineSnapshot(`
+        "@keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}
+        .x1oz5o6v:hover:not(#\\#):not(#\\#){background:red}
+        .xeuoslp:not(#\\#):not(#\\#):not(#\\#){animation-name:xgnty7z-B}
+        .x1lliihq:not(#\\#):not(#\\#):not(#\\#){display:block}
+        .x78zum5:not(#\\#):not(#\\#):not(#\\#){display:flex}
+        .x1hm9lzh:not(#\\#):not(#\\#):not(#\\#){margin-inline-start:10px}
+        .x1egiwwb:not(#\\#):not(#\\#):not(#\\#):not(#\\#){height:500px}
+        .xlrshdv:not(#\\#):not(#\\#):not(#\\#):not(#\\#){margin-top:99px}
+        .xh8yej3:not(#\\#):not(#\\#):not(#\\#):not(#\\#){width:100%}"
+      `);
+
+      expect(mainJS).not.toContain('/lib/stylex-inject.js');
+      expect(otherJS).not.toContain('/lib/stylex-inject.js');
+
+      done();
+    });
+  });
+
+  it('supports [name], [contenthash] in output filename', async () => {
+    const compiler = createCompiler({
+      main: 'index.js',
+      other: 'other.js'
+    }, {
+      filename: '[name].[contenthash].css',
+    });
+    return new Promise((resolve, reject) => {
+      compiler.run((error, stats) => {
+        try {
+          expect(error).toBe(null);
+          expect(assetExists('main.09fffeec3686166d4767.css', compiler, stats),).toBe(true);
+          expect(assetExists('other.8896b6b37d6834340ed1.css', compiler, stats),).toBe(true);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+
+  describe('when in dev mode', () => {
+    it('preserves stylex.inject calls and does not extract CSS', (done) => {
+      const compiler = createCompiler({
+        main: 'index.js',
+        other: 'other.js'
+      }, { dev: true });
+      compiler.run((error, stats) => {
+        expect(error).toBe(null);
+
+        const mainJS = readAsset('main.js', compiler, stats);
+        const otherJS = readAsset('other.js', compiler, stats);
+
+        expect(assetExists('main.css', compiler, stats)).toEqual(false);
+        expect(assetExists('other.css', compiler, stats)).toEqual(false);
+
+        expect(mainJS).toContain('/lib/stylex-inject.js');
+        expect(otherJS).toContain('/lib/stylex-inject.js');
+
+        done();
+      });
+    });
+  });
+});

--- a/packages/extract-webpack-plugin/package.json
+++ b/packages/extract-webpack-plugin/package.json
@@ -29,9 +29,10 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.8",
-    "babel-loader": "^8.2.2",
-    "memfs": "4.2.0",
     "@stylexjs/stylex": "0.3.0",
+    "babel-loader": "^8.2.2",
+    "html-webpack-plugin": "^5.5.4",
+    "memfs": "4.2.0",
     "webpack-cli": "^5.1.4"
   }
 }

--- a/packages/extract-webpack-plugin/package.json
+++ b/packages/extract-webpack-plugin/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@stylexjs/extract-webpack-plugin",
+  "version": "0.3.0",
+  "description": "StyleX extraction webpack plugin",
+  "main": "src/index.js",
+  "repository": "https://www.github.com/facebook/stylex",
+  "license": "MIT",
+  "scripts": {
+    "fixtures:webpack": "webpack build --config __tests__/__fixtures__/webpack.config.js",
+    "fixtures:webpack:watch": "NODE_ENV=development webpack build --watch --config __tests__/__fixtures__/webpack.config.js",
+    "build": "webpack build --config __tests__/__fixtures__/webpack.config.js",
+    "test": "jest"
+  },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "__builds__",
+      "/__fixtures__/"
+    ],
+    "testEnvironment": "node"
+  },
+  "dependencies": {
+    "@babel/core": "^7.15.5",
+    "@babel/plugin-syntax-flow": "^7.18.6",
+    "@babel/plugin-syntax-jsx": "^7.14.5",
+    "@babel/plugin-syntax-typescript": "^7.14.5",
+    "@stylexjs/babel-plugin": "0.3.0",
+    "webpack": "^5.88.2"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.16.8",
+    "babel-loader": "^8.2.2",
+    "memfs": "4.2.0",
+    "@stylexjs/stylex": "0.3.0",
+    "webpack-cli": "^5.1.4"
+  }
+}

--- a/packages/extract-webpack-plugin/src/index.js
+++ b/packages/extract-webpack-plugin/src/index.js
@@ -1,0 +1,237 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+const babel = require('@babel/core');
+const path = require('path');
+const stylexBabelPlugin = require('@stylexjs/babel-plugin');
+const webpack = require('webpack');
+const flowSyntaxPlugin = require('@babel/plugin-syntax-flow');
+const jsxSyntaxPlugin = require('@babel/plugin-syntax-jsx');
+const typescriptSyntaxPlugin = require('@babel/plugin-syntax-typescript');
+const fs = require('fs/promises');
+
+const { NormalModule } = webpack;
+
+const PLUGIN_NAME = 'stylex';
+const MODULE_TYPE = 'css/stylex'
+
+const IS_DEV_ENV =
+  process.env.NODE_ENV === 'development' ||
+  process.env.BABEL_ENV === 'development';
+
+const { RawSource } = webpack.sources;
+
+/*::
+type PluginOptions = $ReadOnly<{
+  dev?: boolean,
+  stylexImports?: $ReadOnlyArray<string>,
+  babelConfig?: $ReadOnly<{
+    plugins?: $ReadOnlyArray<mixed>,
+    presets?: $ReadOnlyArray<mixed>,
+    babelrc?: boolean,
+  }>,
+  filename?: string,
+  useCSSLayers?: boolean,
+}>
+*/
+
+class StylexPlugin {
+  stylexRules = {};
+
+  constructor({
+    dev = IS_DEV_ENV,
+    filename =  '[name].css',
+    chunkFilename = '[id].css',
+    stylexImports = ['stylex', '@stylexjs/stylex'],
+    unstable_moduleResolution = { type: 'commonJS', rootDir: process.cwd() },
+    babelConfig: { plugins = [], presets = [], babelrc = false } = {},
+    useCSSLayers = false,
+    ...options
+  } /*: PluginOptions */ = {}) {
+    this.dev = dev;
+    this.filename = filename;
+    this.chunkFilename = chunkFilename;
+    this.babelConfig = { plugins, presets, babelrc };
+    this.stylexImports = stylexImports;
+    this.babelPlugin = [
+      stylexBabelPlugin,
+      {
+        dev,
+        unstable_moduleResolution,
+        importSources: stylexImports,
+        ...options,
+      },
+    ];
+    this.useCSSLayers = useCSSLayers;
+  }
+
+  apply(compiler) {
+    compiler.hooks.make.tap(PLUGIN_NAME, (compilation) => {
+      // Apply loader to JS modules.
+      NormalModule.getCompilationHooks(compilation).loader.tap(
+        PLUGIN_NAME,
+        (loaderContext, module) => {
+          if (
+            // JavaScript (and Flow) modules
+            /\.jsx?/.test(path.extname(module.resource)) ||
+            // TypeScript modules
+            /\.tsx?/.test(path.extname(module.resource))
+          ) {
+            // It might make sense to use .push() here instead of .unshift()
+            // Webpack usually runs loaders in reverse order and we want to ideally run
+            // our loader before anything else.
+            module.loaders.unshift({
+              loader: path.resolve(__dirname, 'loader.js'),
+              options: { stylexPlugin: this },
+            });
+          }
+        },
+      );
+
+      const getChunkModules = (chunk, chunkGraph) => {
+        return typeof chunkGraph !== 'undefined'
+          ? chunkGraph.getChunkModulesIterable(chunk)
+          : chunk.modulesIterable;
+      }
+
+      const getStyleXRules = (modules) => {
+        const { stylexRules } = this;
+        if (Object.keys(stylexRules).length === 0) {
+          return null;
+        }
+
+        if(modules.length === 0){
+          return;
+        }
+
+        const filesInLastRun = [...modules.values()].reduce((prev, m) => {
+          if(m.modules){
+            return [...prev, ...m.modules.map(cm =>cm.resource)]
+          }
+          return [...prev, m.resource];
+        },[]).filter(Boolean);
+
+        // Take styles for the modules that were included in the last compilation.
+        const allRules = Object.keys(stylexRules)
+          .filter((filename) => filesInLastRun.includes(filename))
+          .map((filename) => stylexRules[filename])
+          .flat();
+
+        return stylexBabelPlugin.processStylexRules(
+          allRules,
+          this.useCSSLayers,
+        );
+      };
+
+      compilation.hooks.renderManifest.tap(
+        PLUGIN_NAME,
+        (result, { chunk }) => {
+          if(this.dev){
+            return;
+          }
+
+          const { chunkGraph } = compilation;
+          const { HotUpdateChunk } = webpack;
+
+          // We don't need hot update chunks for css
+          // We will use the real asset instead to update
+          if (chunk instanceof HotUpdateChunk) {
+            return;
+          }
+
+          const modules = getChunkModules(chunk, chunkGraph);
+          const collectedCSS = getStyleXRules(modules, chunk);
+
+          const filenameTemplate =
+            (
+              chunk.canBeInitial()
+                ? this.filename
+                : this.chunkFilename
+            );
+
+          if (collectedCSS.length > 0) {
+            result.push({
+              render: () => new RawSource(collectedCSS),
+              filenameTemplate,
+              pathOptions: {
+                chunk,
+                contentHashType: MODULE_TYPE,
+              },
+              identifier: `${PLUGIN_NAME}.${chunk.id}`,
+              hash: chunk.contentHash[MODULE_TYPE],
+            });
+          }
+        }
+      );
+
+      compilation.hooks.contentHash.tap(PLUGIN_NAME, (chunk) => {
+        if(this.dev){
+          return;
+        }
+
+        const { outputOptions, chunkGraph } = compilation;
+        const modules = getChunkModules(chunk, chunkGraph);
+
+        if (modules) {
+          const { hashFunction, hashDigest, hashDigestLength } = outputOptions;
+          const { createHash } = compiler.webpack.util;
+          const hash = createHash((hashFunction));
+
+          for (const m of modules) {
+            hash.update(chunkGraph.getModuleHash(m, chunk.runtime));
+          }
+
+          // eslint-disable-next-line no-param-reassign
+          chunk.contentHash[MODULE_TYPE] = (hash.digest(hashDigest)).substring(0, hashDigestLength);
+        }
+      });
+    });
+  }
+
+  // This function is not called by Webpack directly.
+  // Instead, `NormalModule.getCompilationHooks` is used to inject a loader
+  // for JS modules. The loader than calls this function.
+  async transformCode(inputCode, filename, logger) {
+    if (
+      this.stylexImports.some((importName) => inputCode.includes(importName))
+    ) {
+      const originalSource = this.babelConfig.babelrc
+        ? await fs.readFile(filename, 'utf8')
+        : inputCode;
+      const { code, map, metadata } = await babel.transformAsync(
+        originalSource,
+        {
+          babelrc: this.babelConfig.babelrc,
+          filename,
+          // Use TypeScript syntax plugin if the filename ends with `.ts` or `.tsx`
+          // and use the Flow syntax plugin otherwise.
+          plugins: [
+            ...this.babelConfig.plugins,
+            /\.jsx?/.test(path.extname(filename))
+              ? flowSyntaxPlugin
+              : typescriptSyntaxPlugin,
+            jsxSyntaxPlugin,
+            this.babelPlugin,
+          ],
+          presets: this.babelConfig.presets,
+        },
+      );
+      if (metadata.stylex != null && metadata.stylex.length > 0) {
+        this.stylexRules[filename] = metadata.stylex;
+        logger.debug(`Read stylex styles from ${filename}:`, metadata.stylex);
+      }
+      if (!this.babelConfig.babelrc) {
+        return { code, map };
+      }
+    }
+    return { code: inputCode };
+  }
+}
+
+module.exports = StylexPlugin;

--- a/packages/extract-webpack-plugin/src/loader.js
+++ b/packages/extract-webpack-plugin/src/loader.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+const PLUGIN_NAME = 'stylex';
+
+module.exports = function stylexLoader(inputCode) {
+  const callback = this.async();
+  const { stylexPlugin } = this.getOptions();
+  const logger = this._compiler.getInfrastructureLogger(PLUGIN_NAME);
+
+  stylexPlugin.transformCode(inputCode, this.resourcePath, logger).then(
+    ({ code, map }) => {
+      callback(null, code, map);
+    },
+    (error) => {
+      callback(error);
+    },
+  );
+};


### PR DESCRIPTION
## What changed / motivation ?

This PR to add a new webpack plugin that propose a new approach to extract StyleX styles and create css file for each webpack entry. The new plugin can help resolve some limitions of current plugin:
- It allows collect and create css file for each webpack entry instead of create a single css file for all entries like current webpack plugin.
- It support use [name], [contenthash] in filename.
- By use this new plugin with `html-webpack-plugin, the css files auto inject to HTML.

I created a new plugin instead of modify the current plugin because I see the approach are difference. But I'm happy to bring and merge the changes to current plugin if needed.

## Linked PR/Issues

Fixes #197, #132, and #105

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code