### PR TITLE
Bug/overrides for token

### DIFF
--- a/packages/stylex/src/StyleXTypes.d.ts
+++ b/packages/stylex/src/StyleXTypes.d.ts
@@ -200,7 +200,7 @@ export type Theme<
 type OverridesForTokenType<Config extends { [key: string]: unknown }> = {
   [Key in keyof Config]:
     | Config[Key]
-    | { default: Config[Key]; [atRule: AtRuleStr]: Config[Key] };
+    | { default: Config[Key]; [atRule: string]: Config[Key] };
 };
 
 export type StyleX$CreateTheme = <

--- a/packages/stylex/src/StyleXTypes.js
+++ b/packages/stylex/src/StyleXTypes.js
@@ -177,11 +177,12 @@ export type Theme<
   [string]: StyleXClassNameFor<string, IDFromVarGroup<T>>,
 }>;
 
-export type OverridesForTokenType<Config: { +[string]: mixed }> = {
+export type OverridesForTokenType<Config extends { [key: string]: unknown }> = {
   [Key in keyof Config]:
     | Config[Key]
-    | { +default: Config[Key], +[string]: Config[Key] },
+    | { default: Config[Key]; [property: string]: Config[Key] };
 };
+
 
 export type StyleX$CreateTheme = <
   BaseTokens: VarGroup<{ +[string]: mixed }>,

--- a/packages/stylex/src/StyleXTypes.js
+++ b/packages/stylex/src/StyleXTypes.js
@@ -42,6 +42,7 @@ type CSSPropertiesWithExtras = $ReadOnly<{
   '::-webkit-search-cancel-button'?: CSSProperties,
   '::-webkit-search-results-button'?: CSSProperties,
   '::-webkit-search-results-decoration'?: CSSProperties,
+  
 }>;
 
 export type NestedCSSPropTypes = $ReadOnly<{


### PR DESCRIPTION
## What changed / motivation ?

The `OverridesForTokenType` type was updated to allow more flexibility when defining overrides in the `stylex.createTheme` function. The property names are no longer restricted to a specific type, providing greater flexibility for direct use of string literals.

## Linked PR/Issues

Fixes # (replace with the relevant issue number, if applicable)

## Additional Context

No additional context is necessary for this change.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code
