### PR TITLE
feat: support default values in dynamic style functions

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -1217,6 +1217,37 @@ describe('@stylexjs/babel-plugin', () => {
         };"
       `);
     });
+    test('transforms functions with nested dynamic values that have default params', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            default: (props = { color: 'red' }) => ({
+              ':hover': {
+                backgroundColor: props.color,
+                color: 'blue',
+              },
+            }),
+          });
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1vkaft9:hover{background-color:var(--b6ve2z,revert)}", 3130);
+        _inject(".x17z2mba:hover{color:blue}", 3130);
+        export const styles = {
+          default: (props = {
+            color: 'red'
+          }) => [{
+            ":hover_backgroundColor": "x1vkaft9",
+            ":hover_color": "x17z2mba",
+            $$css: true
+          }, {
+            "--b6ve2z": props.color != null ? props.color : "initial"
+          }]
+        };"
+      `);
+    });
     test('transforms mix of objects and functions', () => {
       expect(
         transform(`

--- a/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
@@ -73,8 +73,11 @@ export function evaluateStyleXCreateArg(
       NodePath<t.Identifier | t.SpreadElement | t.Pattern>,
     > = fnPath.get('params');
     const params: Array<t.Identifier | t.AssignmentPattern> = allParams
-      .filter((param): param is NodePath<t.Identifier | t.AssignmentPattern> =>
-        pathUtils.isIdentifier(param) || pathUtils.isAssignmentPattern(param),
+      .filter(
+        (param): param is NodePath<t.Identifier | t.AssignmentPattern> =>
+          pathUtils.isIdentifier(param) ||
+          (pathUtils.isAssignmentPattern(param) &&
+            t.isIdentifier(param.node.left)),
       )
       .map((param) => param.node);
     if (params.length !== allParams.length) {

--- a/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
@@ -31,7 +31,7 @@ export function evaluateStyleXCreateArg(
   deopt?: null | NodePath<>,
   fns?: {
     [string]: [
-      Array<t.Identifier>,
+      Array<t.Identifier | t.AssignmentPattern>,
       { +[string]: t.Expression | t.PatternLike },
     ],
   },
@@ -43,7 +43,7 @@ export function evaluateStyleXCreateArg(
   const value: { [string]: mixed } = {};
   const fns: {
     [string]: [
-      Array<t.Identifier>,
+      Array<t.Identifier | t.AssignmentPattern>,
       $ReadOnly<{ [string]: t.Expression | t.PatternLike }>,
     ],
   } = {};
@@ -72,9 +72,9 @@ export function evaluateStyleXCreateArg(
     const allParams: Array<
       NodePath<t.Identifier | t.SpreadElement | t.Pattern>,
     > = fnPath.get('params');
-    const params: Array<t.Identifier> = allParams
-      .filter((param): param is NodePath<t.Identifier> =>
-        pathUtils.isIdentifier(param),
+    const params: Array<t.Identifier | t.AssignmentPattern> = allParams
+      .filter((param): param is NodePath<t.Identifier | t.AssignmentPattern> =>
+        pathUtils.isIdentifier(param) || pathUtils.isAssignmentPattern(param),
       )
       .map((param) => param.node);
     if (params.length !== allParams.length) {


### PR DESCRIPTION
## What changed / motivation ?

This PR adds support for dynamic function parameter default values.

```
const styles = stylex.create({
  foo: (props = {}) => ({
    fontSize: props.size
  })
});
```

- [ ] Update the `eslint-plugin` accordingly
- [x] Add some tests

## Linked PR/Issues

Fixes #198 

## Additional Context

Currently, the default value assignment throws `NON_STATIC_VALUE` error and does not support assigning default value to the named parameter.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code