### PR TITLE
refactor: remove unused style variables 

### DIFF
--- a/apps/docs/docs/learn/05-theming/01-defining-variables.mdx
+++ b/apps/docs/docs/learn/05-theming/01-defining-variables.mdx
@@ -70,9 +70,6 @@ export const colors = stylex.defineVars({
   accent: {default: 'blue', [DARK]: 'lightblue'},
   background: {default: 'white', [DARK]: 'black'},
   lineColor: {default: 'gray', [DARK]: 'lightgray'},
-  borderRadius: '4px',
-  fontFamily: 'system-ui, sans-serif',
-  fontSize: '16px',
 });
 ```
 

--- a/apps/docs/docs/learn/05-theming/02-using-variables.mdx
+++ b/apps/docs/docs/learn/05-theming/02-using-variables.mdx
@@ -36,9 +36,6 @@ export const colors = stylex.defineVars({
   accent: {default: 'blue', [DARK]: 'lightblue'},
   background: {default: 'white', [DARK]: 'black'},
   lineColor: {default: 'gray', [DARK]: 'lightgray'},
-  borderRadius: '4px',
-  fontFamily: 'system-ui, sans-serif',
-  fontSize: '16px',
 });
 
 export const spacing = stylex.defineVars({


### PR DESCRIPTION
## What changed / motivation ?

- The code change in the commit involves the removal of some style variables from the colors object. The motivation behind this change is likely to simplify the codebase by removing unused or unnecessary style variables, which can contribute to cleaner and more maintainable code.

## Linked PR/Issues

Fixes [#231](https://github.com/facebook/stylex/issues/231)

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code