### PR TITLE
Fixed adding multiple style rules to the sheet with insertRule

### DIFF
--- a/packages/babel-plugin/src/visitors/stylex-define-vars.js
+++ b/packages/babel-plugin/src/visitors/stylex-define-vars.js
@@ -116,17 +116,21 @@ export default function transformStyleXDefineVars(
         state.injectImportInserted = injectName;
       }
 
-      statementPath.insertBefore(
-        t.expressionStatement(
-          t.callExpression(injectName, [
-            t.stringLiteral(css),
-            t.numericLiteral(0),
-          ]),
-        ),
-      );
+      css.forEach((rule) => {
+        statementPath.insertBefore(
+          t.expressionStatement(
+            t.callExpression(injectName, [
+              t.stringLiteral(rule),
+              t.numericLiteral(0),
+            ]),
+          ),
+        );
+      });
     }
 
-    state.addStyle([variablesObj.__themeName__, { ltr: css }, 0]);
+    css.forEach((rule) => {
+      state.addStyle([variablesObj.__themeName__, { ltr: rule }, 0]);
+    });
   }
 }
 

--- a/packages/babel-plugin/src/visitors/stylex-keyframes.js
+++ b/packages/babel-plugin/src/visitors/stylex-keyframes.js
@@ -107,18 +107,22 @@ export default function transformStyleXKeyframes(
         state.injectImportInserted = injectName;
       }
 
-      statementPath.insertBefore(
-        t.expressionStatement(
-          t.callExpression(injectName, [
-            t.stringLiteral(ltr),
-            t.numericLiteral(priority),
-            ...(rtl != null ? [t.stringLiteral(rtl)] : []),
-          ]),
-        ),
-      );
+      ltr.forEach((rule) => {
+        statementPath.insertBefore(
+          t.expressionStatement(
+            t.callExpression(injectName, [
+              t.stringLiteral(rule),
+              t.numericLiteral(priority),
+              ...(rtl != null ? [t.stringLiteral(rtl)] : []),
+            ]),
+          ),
+        );
+      });
     }
 
-    state.addStyle([animationName, { ltr, rtl }, priority]);
+    ltr.forEach((rule) => {
+      state.addStyle([animationName, { ltr: rule, rtl }, priority]);
+    });
   }
 }
 

--- a/packages/dev-runtime/src/index.js
+++ b/packages/dev-runtime/src/index.js
@@ -79,7 +79,10 @@ export default function inject({
     const [cssVarsObject, { css }] = shared.defineVars(variables, {
       themeName,
     });
-    insert(cssVarsObject.__themeName__, css, 0);
+
+    css.forEach((rule) => {
+      insert(cssVarsObject.__themeName__, rule, 0);
+    });
     // $FlowFixMe
     return cssVarsObject;
   };

--- a/packages/dev-runtime/src/index.js
+++ b/packages/dev-runtime/src/index.js
@@ -100,7 +100,10 @@ export default function inject({
       variablesOverride,
     );
     const styleKey = js[String(variablesTheme.__themeName__)];
-    insert(styleKey, css[styleKey].ltr, css[styleKey].priority);
+    css[styleKey].ltr.forEach((rule) => {
+      insert(styleKey, rule, css[styleKey].priority);
+    });
+
     // $FlowFixMe[incompatible-return]
     return js;
   };
@@ -112,7 +115,9 @@ export default function inject({
       (frames: $FlowFixMe),
       config,
     );
-    insert(animationName, ltr, priority, rtl);
+    ltr.forEach((rule) => {
+      insert(animationName, rule, priority, rtl);
+    });
     return animationName;
   };
   __monkey_patch__('keyframes', keyframes);

--- a/packages/dev-runtime/src/stylex-create.js
+++ b/packages/dev-runtime/src/stylex-create.js
@@ -124,7 +124,9 @@ function createWithFns<S: { ... }>(
   const [compiledStyles, injectedStyles] = create(stylesWithoutFns, config);
   for (const key in injectedStyles) {
     const { ltr, priority, rtl } = injectedStyles[key];
-    insert(key, ltr, priority, rtl);
+    ltr.forEach((rule) => {
+      insert(key, rule, priority, rtl);
+    });
   }
   spreadStyles(compiledStyles);
 

--- a/packages/shared/src/common-types.js
+++ b/packages/shared/src/common-types.js
@@ -22,7 +22,7 @@ export type PrimitiveRawStyles = $ReadOnly<{
 
 export type InjectableStyle = {
   +priority: number,
-  +ltr: string,
+  +ltr: [string, string],
   +rtl: null | string,
 };
 

--- a/packages/shared/src/stylex-create-theme.js
+++ b/packages/shared/src/stylex-create-theme.js
@@ -94,7 +94,10 @@ export default function styleXCreateTheme(
     { $$css: true, [themeVars.__themeName__]: overrideClassName },
     {
       [overrideClassName]: {
-        ltr: `.${overrideClassName}{${cssVariablesOverrideString}}${atRulesCss}`,
+        ltr: [
+          `.${overrideClassName}{${cssVariablesOverrideString}}`,
+          atRulesCss,
+        ],
         priority: 0.99,
         rtl: undefined,
       },

--- a/packages/shared/src/stylex-define-vars.js
+++ b/packages/shared/src/stylex-define-vars.js
@@ -29,7 +29,7 @@ export default function styleXDefineVars<
 >(
   variables: Vars,
   options: $ReadOnly<{ ...Partial<StyleXOptions>, themeName: string, ... }>,
-): [VarsObject<Vars>, { css: string }] {
+): [VarsObject<Vars>, { css: [string, string] }] {
   const {
     classNamePrefix,
     themeName,
@@ -63,7 +63,7 @@ function constructCssVariablesString(variables: {
     nameHash: string,
     value: string | { +default: string, +[string]: string },
   },
-}): string {
+}): [string, string] {
   const atRules: any = {};
 
   const varsString = objEntries(variables)
@@ -95,5 +95,6 @@ function constructCssVariablesString(variables: {
       return `${atRule}{:root{${varsArr.join('')}}}`;
     })
     .join('');
-  return `:root{${varsString}}${atRulesString || ''}`;
+
+  return [`:root{${varsString}}`, atRulesString];
 }


### PR DESCRIPTION
## What changed / motivation ?

Currently, as per the CSS specs, we cannot insert multiple css rules as a single string in the `insertRule` as it aborts with syntax error `SyntaxError: An invalid or illegal string was specified`. What I've done is just returned the css rules as an array instead of string and injected them with a separate AST syntax.

## Linked PR/Issues

Fixes [(issue)](https://github.com/facebook/stylex/issues/235)