### PR TITLE
Fix: Insert individual rules for runtimeInjection

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
@@ -205,7 +205,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
+        _inject("@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -284,7 +286,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
+        _inject("@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -380,7 +384,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
+        _inject("@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -388,7 +394,8 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(":root{--xcateir:white;--xmj7ivn:black;--x13gxjix:8;}@media (prefers-color-scheme: dark){:root{--xmj7ivn:white;}}", 0);
+        _inject(":root{--xcateir:white;--xmj7ivn:black;--x13gxjix:8;}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xmj7ivn:white;}}", 0);
         export const textInputTheme = {
           bgColor: "var(--xcateir)",
           labelColor: "var(--xmj7ivn)",
@@ -426,7 +433,9 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
         const RADIUS = 10;
-        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
+        _inject("@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -465,7 +474,9 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
         const color = 'blue';
-        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
+        _inject("@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -504,7 +515,9 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
         const name = 'light';
-        _inject(":root{--xgck17p:lightblue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        _inject(":root{--xgck17p:lightblue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
+        _inject("@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -543,7 +556,9 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
         const RADIUS = 2;
-        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:4;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}", 0);
+        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:4;--x4y59db:pink;}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
+        _inject("@media print{:root{--xgck17p:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -587,7 +602,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(":root{--x1sm8rlu:blue;--xxncinc:grey;--x4e1236:10;--xv9uic:pink;}@media (prefers-color-scheme: dark){:root{--x1sm8rlu:lightblue;--xxncinc:rgba(0, 0, 0, 0.8);}}@media print{:root{--x1sm8rlu:white;}}", 0);
+        _inject(":root{--x1sm8rlu:blue;--xxncinc:grey;--x4e1236:10;--xv9uic:pink;}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--x1sm8rlu:lightblue;--xxncinc:rgba(0, 0, 0, 0.8);}}", 0);
+        _inject("@media print{:root{--x1sm8rlu:white;}}", 0);
         export const buttonTheme = {
           bgColor: "var(--x1sm8rlu)",
           bgColorDisabled: "var(--xxncinc)",

--- a/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
@@ -206,8 +206,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
         _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
-        _inject("@media print{:root{--xgck17p:white;}}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -287,8 +287,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
         _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
-        _inject("@media print{:root{--xgck17p:white;}}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -385,8 +385,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
         _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
-        _inject("@media print{:root{--xgck17p:white;}}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -395,7 +395,7 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         _inject(":root{--xcateir:white;--xmj7ivn:black;--x13gxjix:8;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xmj7ivn:white;}}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xmj7ivn:white;}}", 0.1);
         export const textInputTheme = {
           bgColor: "var(--xcateir)",
           labelColor: "var(--xmj7ivn)",
@@ -434,8 +434,8 @@ describe('@stylexjs/babel-plugin', () => {
         import stylex from 'stylex';
         const RADIUS = 10;
         _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
-        _inject("@media print{:root{--xgck17p:white;}}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -475,8 +475,8 @@ describe('@stylexjs/babel-plugin', () => {
         import stylex from 'stylex';
         const color = 'blue';
         _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
-        _inject("@media print{:root{--xgck17p:white;}}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -516,8 +516,8 @@ describe('@stylexjs/babel-plugin', () => {
         import stylex from 'stylex';
         const name = 'light';
         _inject(":root{--xgck17p:lightblue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
-        _inject("@media print{:root{--xgck17p:white;}}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -557,8 +557,8 @@ describe('@stylexjs/babel-plugin', () => {
         import stylex from 'stylex';
         const RADIUS = 2;
         _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:4;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0);
-        _inject("@media print{:root{--xgck17p:white;}}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -603,8 +603,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
         _inject(":root{--x1sm8rlu:blue;--xxncinc:grey;--x4e1236:10;--xv9uic:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--x1sm8rlu:lightblue;--xxncinc:rgba(0, 0, 0, 0.8);}}", 0);
-        _inject("@media print{:root{--x1sm8rlu:white;}}", 0);
+        _inject("@media (prefers-color-scheme: dark){:root{--x1sm8rlu:lightblue;--xxncinc:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject("@media print{:root{--x1sm8rlu:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--x1sm8rlu)",
           bgColorDisabled: "var(--xxncinc)",

--- a/packages/babel-plugin/__tests__/stylex-transform-override-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-override-vars-test.js
@@ -122,9 +122,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
-        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
-        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -175,9 +175,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
-        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
-        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -237,9 +237,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
-        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
-        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -308,15 +308,15 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
-        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
-        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
           "TestTheme.stylex.js__buttonThemePositive": "TestTheme.stylex.js__buttonThemePositive"
         };
-        _inject(".xpsjjyf{--xgck17p:white;--xpegid5:black;--xrqfjmn:0px;}", 0.99);
+        _inject(".xpsjjyf{--xgck17p:white;--xpegid5:black;--xrqfjmn:0px;}", 0.8);
         const buttonThemeMonochromatic = {
           $$css: true,
           x568ih9: "xpsjjyf",
@@ -358,9 +358,9 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const RADIUS = 10;
-        _inject(".xrpt93l{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:10;--x4y59db:coral;}", 0.99);
-        _inject("@media (prefers-color-scheme: dark){.xrpt93l{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
-        _inject("@media print{.xrpt93l{--xgck17p:transparent;}}", 0.99);
+        _inject(".xrpt93l{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:10;--x4y59db:coral;}", 0.8);
+        _inject("@media (prefers-color-scheme: dark){.xrpt93l{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject("@media print{.xrpt93l{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xrpt93l",
@@ -402,9 +402,9 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const COLOR = 'coral';
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
-        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
-        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -446,9 +446,9 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const name = 'light';
-        _inject(".x1u43pop{--xgck17p:lightgreen;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
-        _inject("@media (prefers-color-scheme: dark){.x1u43pop{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
-        _inject("@media print{.x1u43pop{--xgck17p:transparent;}}", 0.99);
+        _inject(".x1u43pop{--xgck17p:lightgreen;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject("@media (prefers-color-scheme: dark){.x1u43pop{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject("@media print{.x1u43pop{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "x1u43pop",
@@ -490,9 +490,9 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const RADIUS = 2;
-        _inject(".x1ubmxd4{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4;--x4y59db:coral;}", 0.99);
-        _inject("@media (prefers-color-scheme: dark){.x1ubmxd4{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
-        _inject("@media print{.x1ubmxd4{--xgck17p:transparent;}}", 0.99);
+        _inject(".x1ubmxd4{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4;--x4y59db:coral;}", 0.8);
+        _inject("@media (prefers-color-scheme: dark){.x1ubmxd4{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject("@media print{.x1ubmxd4{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "x1ubmxd4",
@@ -527,9 +527,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
-        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
-        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",

--- a/packages/babel-plugin/__tests__/stylex-transform-override-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-override-vars-test.js
@@ -122,7 +122,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
+        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
+        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -173,7 +175,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
+        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
+        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -233,7 +237,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
+        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
+        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -302,7 +308,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
+        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
+        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -350,7 +358,9 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const RADIUS = 10;
-        _inject(".xrpt93l{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:10;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xrpt93l{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xrpt93l{--xgck17p:transparent;}}", 0.99);
+        _inject(".xrpt93l{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:10;--x4y59db:coral;}", 0.99);
+        _inject("@media (prefers-color-scheme: dark){.xrpt93l{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
+        _inject("@media print{.xrpt93l{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xrpt93l",
@@ -392,7 +402,9 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const COLOR = 'coral';
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
+        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
+        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -434,7 +446,9 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const name = 'light';
-        _inject(".x1u43pop{--xgck17p:lightgreen;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.x1u43pop{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.x1u43pop{--xgck17p:transparent;}}", 0.99);
+        _inject(".x1u43pop{--xgck17p:lightgreen;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
+        _inject("@media (prefers-color-scheme: dark){.x1u43pop{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
+        _inject("@media print{.x1u43pop{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "x1u43pop",
@@ -476,7 +490,9 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const RADIUS = 2;
-        _inject(".x1ubmxd4{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4;--x4y59db:coral;}@media (prefers-color-scheme: dark){.x1ubmxd4{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.x1ubmxd4{--xgck17p:transparent;}}", 0.99);
+        _inject(".x1ubmxd4{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4;--x4y59db:coral;}", 0.99);
+        _inject("@media (prefers-color-scheme: dark){.x1ubmxd4{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
+        _inject("@media print{.x1ubmxd4{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "x1ubmxd4",
@@ -511,7 +527,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
+        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.99);
+        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.99);
+        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.99);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",

--- a/packages/dev-runtime/__tests__/stylex-transform-create-theme-test.js
+++ b/packages/dev-runtime/__tests__/stylex-transform-create-theme-test.js
@@ -63,7 +63,23 @@ describe('Development Plugin Transformation', () => {
           [
             "xfmksyk",
             {
-              "ltr": ".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}",
+              "ltr": ".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}",
+              "rtl": undefined,
+            },
+            0.99,
+          ],
+          [
+            "xfmksyk-1lveb7",
+            {
+              "ltr": "@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}",
+              "rtl": undefined,
+            },
+            0.99,
+          ],
+          [
+            "xfmksyk-bdddrq",
+            {
+              "ltr": "@media print{.xfmksyk{--xgck17p:transparent;}}",
               "rtl": undefined,
             },
             0.99,

--- a/packages/dev-runtime/__tests__/stylex-transform-create-theme-test.js
+++ b/packages/dev-runtime/__tests__/stylex-transform-create-theme-test.js
@@ -66,7 +66,7 @@ describe('Development Plugin Transformation', () => {
               "ltr": ".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}",
               "rtl": undefined,
             },
-            0.99,
+            0.8,
           ],
           [
             "xfmksyk-1lveb7",
@@ -74,7 +74,7 @@ describe('Development Plugin Transformation', () => {
               "ltr": "@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}",
               "rtl": undefined,
             },
-            0.99,
+            0.9,
           ],
           [
             "xfmksyk-bdddrq",
@@ -82,7 +82,7 @@ describe('Development Plugin Transformation', () => {
               "ltr": "@media print{.xfmksyk{--xgck17p:transparent;}}",
               "rtl": undefined,
             },
-            0.99,
+            0.9,
           ],
         ]
       `);

--- a/packages/dev-runtime/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/dev-runtime/__tests__/stylex-transform-define-vars-test.js
@@ -64,7 +64,23 @@ describe('Development Plugin Transformation', () => {
           [
             "x1y709cs",
             {
-              "ltr": ":root{--x4ocsy0:blue;--x1hi3uh4:grey;--x1r1ahgb:10px;--xrbea40:pink;}@media (prefers-color-scheme: dark){:root{--x4ocsy0:lightblue;--x1hi3uh4:rgba(0, 0, 0, 0.8);}}@media print{:root{--x4ocsy0:white;}}",
+              "ltr": ":root{--x4ocsy0:blue;--x1hi3uh4:grey;--x1r1ahgb:10px;--xrbea40:pink;}",
+              "rtl": undefined,
+            },
+            0,
+          ],
+          [
+            "x1y709cs-1lveb7",
+            {
+              "ltr": "@media (prefers-color-scheme: dark){:root{--x4ocsy0:lightblue;--x1hi3uh4:rgba(0, 0, 0, 0.8);}}",
+              "rtl": undefined,
+            },
+            0,
+          ],
+          [
+            "x1y709cs-bdddrq",
+            {
+              "ltr": "@media print{:root{--x4ocsy0:white;}}",
               "rtl": undefined,
             },
             0,

--- a/packages/dev-runtime/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/dev-runtime/__tests__/stylex-transform-define-vars-test.js
@@ -75,7 +75,7 @@ describe('Development Plugin Transformation', () => {
               "ltr": "@media (prefers-color-scheme: dark){:root{--x4ocsy0:lightblue;--x1hi3uh4:rgba(0, 0, 0, 0.8);}}",
               "rtl": undefined,
             },
-            0,
+            0.1,
           ],
           [
             "x1y709cs-bdddrq",
@@ -83,7 +83,7 @@ describe('Development Plugin Transformation', () => {
               "ltr": "@media print{:root{--x4ocsy0:white;}}",
               "rtl": undefined,
             },
-            0,
+            0.1,
           ],
         ]
       `);

--- a/packages/dev-runtime/src/index.js
+++ b/packages/dev-runtime/src/index.js
@@ -76,10 +76,14 @@ export default function inject({
       themeName: themeNameUUID(),
     },
   ): VarGroup<DefaultTokens, ID> => {
-    const [cssVarsObject, { css }] = shared.defineVars(variables, {
+    const [cssVarsObject, injectedStyles] = shared.defineVars(variables, {
       themeName,
     });
-    insert(cssVarsObject.__themeName__, css, 0);
+
+    for (const [key, { ltr, priority }] of Object.entries(injectedStyles)) {
+      insert(key, ltr, priority);
+    }
+
     // $FlowFixMe
     return cssVarsObject;
   };
@@ -92,12 +96,14 @@ export default function inject({
     variablesTheme: BaseTokens,
     variablesOverride: OverridesForTokenType<TokensFromVarGroup<$FlowFixMe>>,
   ): Theme<BaseTokens, ID> => {
-    const [js, css] = shared.createTheme(
+    const [js, injectedStyles] = shared.createTheme(
       (variablesTheme: $FlowFixMe),
       variablesOverride,
     );
-    const styleKey = js[String(variablesTheme.__themeName__)];
-    insert(styleKey, css[styleKey].ltr, css[styleKey].priority);
+
+    for (const [key, { ltr, priority }] of Object.entries(injectedStyles)) {
+      insert(key, ltr, priority);
+    }
     // $FlowFixMe[incompatible-return]
     return js;
   };

--- a/packages/open-props/__tests__/__snapshots__/open-props-compile-test.js.snap
+++ b/packages/open-props/__tests__/__snapshots__/open-props-compile-test.js.snap
@@ -268,7 +268,7 @@ exports[`commonJS results of exported styles and variables animationNames.stylex
     {
       "ltr": "@media (prefers-color-scheme: dark){:root{--xwpxwog:x1xhkb8m-B;--x1f9mpsk:x18q36hy-B;}}",
     },
-    0,
+    0.1,
   ],
 ]
 `;
@@ -1821,7 +1821,7 @@ exports[`commonJS results of exported styles and variables highlights.stylex.js 
     {
       "ltr": "@media (prefers-color-scheme: dark){:root{--xgorgio:hsl(0 0% 100% / 20%);--x27iylq:0 0 0 10px hsl(0 0% 100% / 20%);}}",
     },
-    0,
+    0.1,
   ],
 ]
 `;
@@ -2136,7 +2136,7 @@ exports[`commonJS results of exported styles and variables shadows.stylex.js 2`]
       0 41px 33px -2px hsl(220 40% 2% / calc(25% + 6%)),
       0 100px 80px -2px hsl(220 40% 2% / calc(25% + 7%));--x11qlsbw:inset 0 0 0 1px hsl(220 40% 2% / calc(25% + 9%));--xa5ok5s:inset 0 1px 2px 0 hsl(220 40% 2% / calc(25% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x15xf9dp:inset 0 1px 4px 0 hsl(220 40% 2% / calc(25% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x1dicv20:inset 0 2px 8px 0 hsl(220 40% 2% / calc(25% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x1yks3sz:inset 0 2px 14px 0 hsl(220 40% 2% / calc(25% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;}}",
     },
-    0,
+    0.1,
   ],
 ]
 `;

--- a/packages/open-props/__tests__/__snapshots__/open-props-compile-test.js.snap
+++ b/packages/open-props/__tests__/__snapshots__/open-props-compile-test.js.snap
@@ -259,7 +259,14 @@ exports[`commonJS results of exported styles and variables animationNames.stylex
   [
     "x1p4jv38",
     {
-      "ltr": ":root{--xwgfw4z:x1wv65fh-B;--xwpxwog:x3cospo-B;--x1mrv0ld:x1mi9bte-B;--x1f9mpsk:xd93vs1-B;--x1dlahej:x1gdf4cp-B;--xchc88h:x1uvjygu-B;--x1wwe1u9:xyz4r9t-B;--xojb453:xyz4r9t-B;--x1erxhtw:x1qkfcoh-B;--x2p2omt:x1c1el34-B;--x1lyv700:x5q0om7-B;--x1dhg8ry:xiaildr-B;--x14d2ijb:x1pzz5b5-B;--x1r6uxce:x2i3tye-B;--x1o3zfci:x1f21ubi-B;--xhf4ud:xyj5ijk-B;--x7jv0fk:x1uh2x5g-B;--x1x4v7e3:xk6fz2t-B;--xg5no4m:x13kz0yu-B;--x7mxyyy:xtacmzc-B;--xs1cbdk:xmu8adp-B;--x1gf7j19:x1wtl5zh-B;}@media (prefers-color-scheme: dark){:root{--xwpxwog:x1xhkb8m-B;--x1f9mpsk:x18q36hy-B;}}",
+      "ltr": ":root{--xwgfw4z:x1wv65fh-B;--xwpxwog:x3cospo-B;--x1mrv0ld:x1mi9bte-B;--x1f9mpsk:xd93vs1-B;--x1dlahej:x1gdf4cp-B;--xchc88h:x1uvjygu-B;--x1wwe1u9:xyz4r9t-B;--xojb453:xyz4r9t-B;--x1erxhtw:x1qkfcoh-B;--x2p2omt:x1c1el34-B;--x1lyv700:x5q0om7-B;--x1dhg8ry:xiaildr-B;--x14d2ijb:x1pzz5b5-B;--x1r6uxce:x2i3tye-B;--x1o3zfci:x1f21ubi-B;--xhf4ud:xyj5ijk-B;--x7jv0fk:x1uh2x5g-B;--x1x4v7e3:xk6fz2t-B;--xg5no4m:x13kz0yu-B;--x7mxyyy:xtacmzc-B;--xs1cbdk:xmu8adp-B;--x1gf7j19:x1wtl5zh-B;}",
+    },
+    0,
+  ],
+  [
+    "x1p4jv38-1lveb7",
+    {
+      "ltr": "@media (prefers-color-scheme: dark){:root{--xwpxwog:x1xhkb8m-B;--x1f9mpsk:x18q36hy-B;}}",
     },
     0,
   ],
@@ -1805,7 +1812,14 @@ exports[`commonJS results of exported styles and variables highlights.stylex.js 
   [
     "xkkhulp",
     {
-      "ltr": ":root{--xmjqxfw:10px;--xgorgio:hsl(0 0% 0% / 20%);--x27iylq:0 0 0 10px hsl(0 0% 0% / 20%);}@media (prefers-color-scheme: dark){:root{--xgorgio:hsl(0 0% 100% / 20%);--x27iylq:0 0 0 10px hsl(0 0% 100% / 20%);}}",
+      "ltr": ":root{--xmjqxfw:10px;--xgorgio:hsl(0 0% 0% / 20%);--x27iylq:0 0 0 10px hsl(0 0% 0% / 20%);}",
+    },
+    0,
+  ],
+  [
+    "xkkhulp-1lveb7",
+    {
+      "ltr": "@media (prefers-color-scheme: dark){:root{--xgorgio:hsl(0 0% 100% / 20%);--x27iylq:0 0 0 10px hsl(0 0% 100% / 20%);}}",
     },
     0,
   ],
@@ -2087,7 +2101,14 @@ exports[`commonJS results of exported styles and variables shadows.stylex.js 2`]
       0 12px 10px -2px hsl(220 3% 15% / calc(1% + 4%)),
       0 22px 18px -2px hsl(220 3% 15% / calc(1% + 5%)),
       0 41px 33px -2px hsl(220 3% 15% / calc(1% + 6%)),
-      0 100px 80px -2px hsl(220 3% 15% / calc(1% + 7%));--x11qlsbw:inset 0 0 0 1px hsl(220 3% 15% / calc(1% + 9%));--xa5ok5s:inset 0 1px 2px 0 hsl(220 3% 15% / calc(1% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x15xf9dp:inset 0 1px 4px 0 hsl(220 3% 15% / calc(1% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x1dicv20:inset 0 2px 8px 0 hsl(220 3% 15% / calc(1% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x1yks3sz:inset 0 2px 14px 0 hsl(220 3% 15% / calc(1% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;}@media (prefers-color-scheme: dark){:root{--x1wj0zy1:0 1px 2px -1px hsl(220 40% 2% / calc(25% + 9%));--x1msc3j8:
+      0 100px 80px -2px hsl(220 3% 15% / calc(1% + 7%));--x11qlsbw:inset 0 0 0 1px hsl(220 3% 15% / calc(1% + 9%));--xa5ok5s:inset 0 1px 2px 0 hsl(220 3% 15% / calc(1% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x15xf9dp:inset 0 1px 4px 0 hsl(220 3% 15% / calc(1% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x1dicv20:inset 0 2px 8px 0 hsl(220 3% 15% / calc(1% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x1yks3sz:inset 0 2px 14px 0 hsl(220 3% 15% / calc(1% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;}",
+    },
+    0,
+  ],
+  [
+    "xtfhujy-1lveb7",
+    {
+      "ltr": "@media (prefers-color-scheme: dark){:root{--x1wj0zy1:0 1px 2px -1px hsl(220 40% 2% / calc(25% + 9%));--x1msc3j8:
     0 3px 5px -2px hsl(220 40% 2% / calc(25% + 3%)),
     0 7px 14px -5px hsl(220 40% 2% / calc(25% + 5%));--xmzq3gi:
     0 -1px 3px 0 hsl(220 40% 2% / calc(25% + 2%)),

--- a/packages/shared/__tests__/stylex-create-vars-test.js
+++ b/packages/shared/__tests__/stylex-create-vars-test.js
@@ -52,12 +52,12 @@ describe('stylex-create-vars test', () => {
         },
         "x568ih9-1lveb7": {
           "ltr": "@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}",
-          "priority": 0,
+          "priority": 0.1,
           "rtl": null,
         },
         "x568ih9-bdddrq": {
           "ltr": "@media print{:root{--xgck17p:white;}}",
-          "priority": 0,
+          "priority": 0.1,
           "rtl": null,
         },
       }

--- a/packages/shared/__tests__/stylex-create-vars-test.js
+++ b/packages/shared/__tests__/stylex-create-vars-test.js
@@ -43,8 +43,24 @@ describe('stylex-create-vars test', () => {
       fgColor: `var(--${classNamePrefix + createHash(`${themeName}.fgColor`)})`,
     });
 
-    expect(cssOutput).toEqual({
-      css: ':root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10px;--x4y59db:pink;}@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}@media print{:root{--xgck17p:white;}}',
-    });
+    expect(cssOutput).toMatchInlineSnapshot(`
+      {
+        "x568ih9": {
+          "ltr": ":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10px;--x4y59db:pink;}",
+          "priority": 0,
+          "rtl": null,
+        },
+        "x568ih9-1lveb7": {
+          "ltr": "@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}",
+          "priority": 0,
+          "rtl": null,
+        },
+        "x568ih9-bdddrq": {
+          "ltr": "@media print{:root{--xgck17p:white;}}",
+          "priority": 0,
+          "rtl": null,
+        },
+      }
+    `);
   });
 });

--- a/packages/shared/__tests__/stylex-override-vars-test.js
+++ b/packages/shared/__tests__/stylex-override-vars-test.js
@@ -42,7 +42,7 @@ describe('stylex-override-vars test', () => {
       .toMatchInlineSnapshot(`
       {
         "ltr": ".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}",
-        "priority": 0.99,
+        "priority": 0.8,
         "rtl": undefined,
       }
     `);

--- a/packages/shared/__tests__/stylex-override-vars-test.js
+++ b/packages/shared/__tests__/stylex-override-vars-test.js
@@ -41,7 +41,7 @@ describe('stylex-override-vars test', () => {
     expect(cssOutput[classNameOutput[defaultVars.__themeName__]])
       .toMatchInlineSnapshot(`
       {
-        "ltr": ".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}@media print{.xfmksyk{--xgck17p:transparent;}}",
+        "ltr": ".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}",
         "priority": 0.99,
         "rtl": undefined,
       }

--- a/packages/shared/src/stylex-create-theme.js
+++ b/packages/shared/src/stylex-create-theme.js
@@ -83,7 +83,7 @@ export default function styleXCreateTheme(
   const stylesToInject: { [string]: InjectableStyle } = {
     [overrideClassName]: {
       ltr: `.${overrideClassName}{${cssVariablesOverrideString}}`,
-      priority: 0.99,
+      priority: 0.8,
       rtl: undefined,
     },
   };
@@ -91,7 +91,7 @@ export default function styleXCreateTheme(
   for (const atRule of sortedAtRules) {
     stylesToInject[overrideClassName + '-' + createHash(atRule)] = {
       ltr: `${atRule}{.${overrideClassName}{${atRules[atRule].join('')}}}`,
-      priority: 0.99,
+      priority: 0.9,
       rtl: null,
     };
   }

--- a/packages/shared/src/stylex-create-theme.js
+++ b/packages/shared/src/stylex-create-theme.js
@@ -26,10 +26,7 @@ export default function styleXCreateTheme(
     );
   }
 
-  const { classNamePrefix } = {
-    ...defaultOptions,
-    ...options,
-  };
+  const { classNamePrefix } = { ...defaultOptions, ...options };
 
   // Sort the set of variables to get a consistent unique hash value
   const sortedKeys = Object.keys(variables).sort();
@@ -83,21 +80,24 @@ export default function styleXCreateTheme(
     classNamePrefix +
     createHash(cssVariablesOverrideString + atRulesStringForHash);
 
-  // Create a class name hash
-  const atRulesCss = sortedAtRules
-    .map((atRule) => {
-      return `${atRule}{.${overrideClassName}{${atRules[atRule].join('')}}}`;
-    })
-    .join('');
+  const stylesToInject: { [string]: InjectableStyle } = {
+    [overrideClassName]: {
+      ltr: `.${overrideClassName}{${cssVariablesOverrideString}}`,
+      priority: 0.99,
+      rtl: undefined,
+    },
+  };
+
+  for (const atRule of sortedAtRules) {
+    stylesToInject[overrideClassName + '-' + createHash(atRule)] = {
+      ltr: `${atRule}{.${overrideClassName}{${atRules[atRule].join('')}}}`,
+      priority: 0.99,
+      rtl: null,
+    };
+  }
 
   return [
     { $$css: true, [themeVars.__themeName__]: overrideClassName },
-    {
-      [overrideClassName]: {
-        ltr: `.${overrideClassName}{${cssVariablesOverrideString}}${atRulesCss}`,
-        priority: 0.99,
-        rtl: undefined,
-      },
-    },
+    stylesToInject,
   ];
 }

--- a/packages/shared/src/stylex-define-vars.js
+++ b/packages/shared/src/stylex-define-vars.js
@@ -92,7 +92,7 @@ function constructCssVariablesString(
     result[themeNameHash + suffix] = {
       ltr,
       rtl: null,
-      priority: 0,
+      priority: key === 'default' ? 0 : 0.1,
     };
   }
 

--- a/packages/shared/src/stylex-define-vars.js
+++ b/packages/shared/src/stylex-define-vars.js
@@ -7,33 +7,28 @@
  * @flow strict
  */
 
-import type { StyleXOptions } from './common-types';
+import type { InjectableStyle, StyleXOptions } from './common-types';
 
 import createHash from './hash';
 import { objEntries, objMap } from './utils/object-utils';
 import { defaultOptions } from './utils/default-options';
 
-type VarsObject<
-  Vars: { +[string]: string | { +default: string, +[string]: string } },
-> = $ReadOnly<{
+type VarsConfig = $ReadOnly<{
+  [string]: string | $ReadOnly<{ default: string, [string]: string }>,
+}>;
+
+type VarsObject<Vars: VarsConfig> = $ReadOnly<{
   ...$ObjMapConst<Vars, string>,
   __themeName__: string,
 }>;
 
 // Similar to `stylex.create` it takes an object of variables with their values
 // and returns a string after hashing it.
-export default function styleXDefineVars<
-  Vars: {
-    +[string]: string | { +default: string, +[string]: string },
-  },
->(
+export default function styleXDefineVars<Vars: VarsConfig>(
   variables: Vars,
   options: $ReadOnly<{ ...Partial<StyleXOptions>, themeName: string, ... }>,
-): [VarsObject<Vars>, { css: string }] {
-  const {
-    classNamePrefix,
-    themeName,
-  }: { ...StyleXOptions, themeName: string, ... } = {
+): [VarsObject<Vars>, { [string]: InjectableStyle }] {
+  const { classNamePrefix, themeName } = {
     ...defaultOptions,
     ...options,
   };
@@ -50,50 +45,56 @@ export default function styleXDefineVars<
     return `var(--${nameHash})`;
   });
 
-  const cssVariablesString = constructCssVariablesString(variablesMap);
+  const injectableStyles = constructCssVariablesString(
+    variablesMap,
+    themeNameHash,
+  );
 
   return [
     { ...themeVariablesObject, __themeName__: themeNameHash },
-    { css: cssVariablesString },
+    injectableStyles,
   ];
 }
 
-function constructCssVariablesString(variables: {
-  +[string]: {
-    nameHash: string,
-    value: string | { +default: string, +[string]: string },
-  },
-}): string {
-  const atRules: any = {};
+function constructCssVariablesString(
+  variables: { +[string]: { +nameHash: string, +value: VarsConfig[string] } },
+  themeNameHash: string,
+): { [string]: InjectableStyle } {
+  const ruleByAtRule: { [string]: Array<string> } = {};
 
-  const varsString = objEntries(variables)
-    .map(([key, { nameHash, value }]) => {
-      if (value !== null && typeof value === 'object') {
-        if (value.default === undefined) {
-          throw new Error(
-            'Default value is not defined for ' + key + ' variable.',
-          );
-        }
-        const definedVarString = `--${nameHash}:${value.default};`;
-        Object.keys(value).forEach((key) => {
-          if (key.startsWith('@')) {
-            const definedVarStringForAtRule = `--${nameHash}:${value[key]};`;
-            if (atRules[key] == null) {
-              atRules[key] = [definedVarStringForAtRule];
-            } else {
-              atRules[key].push(definedVarStringForAtRule);
-            }
-          }
-        });
-        return definedVarString;
+  for (const [key, { nameHash, value }] of objEntries(variables)) {
+    if (value !== null && typeof value === 'object') {
+      if (value.default === undefined) {
+        throw new Error(
+          'Default value is not defined for ' + key + ' variable.',
+        );
       }
-      return `--${nameHash}:${value};`;
-    })
-    .join('');
-  const atRulesString = objEntries(atRules)
-    .map(([atRule, varsArr]) => {
-      return `${atRule}{:root{${varsArr.join('')}}}`;
-    })
-    .join('');
-  return `:root{${varsString}}${atRulesString || ''}`;
+      const v = value;
+      for (const [key, value] of objEntries(v)) {
+        ruleByAtRule[key] ??= [];
+        ruleByAtRule[key].push(`--${nameHash}:${value};`);
+      }
+    } else {
+      ruleByAtRule.default ??= [];
+      ruleByAtRule.default.push(`--${nameHash}:${value};`);
+    }
+  }
+
+  const result: { [string]: InjectableStyle } = {};
+  for (const [key, value] of objEntries(ruleByAtRule)) {
+    const suffix = key === 'default' ? '' : `-${createHash(key)}`;
+
+    let ltr = `:root{${value.join('')}}`;
+    if (key !== 'default') {
+      ltr = `${key}{${ltr}}`;
+    }
+
+    result[themeNameHash + suffix] = {
+      ltr,
+      rtl: null,
+      priority: 0,
+    };
+  }
+
+  return result;
 }


### PR DESCRIPTION
## What changed / motivation ?

When defining variables with `defineVars` and `createTheme`, the generated CSS was generated as a single string. When `@` rules were used this string contained multiple CSS rules.

In development, when `runtimeInjection` is `true`, this would try to insert the whole string with the browser's `insertRule` API. This would error.

This PR, breaks up the generated CSS into individual rules that can be injected separately at runtime (when in development)

**NOTE:** This is a fix for development workflows. Everything already worked for production builds.

## Linked PR/Issues

#235 

## Additional Context

Test snapshots have been updated and I have verified that everything looks right.
