### PR TITLE
feat: improve error messaging in `stylex.create`

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-validation-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-validation-create-test.js
@@ -114,7 +114,7 @@ describe('@stylexjs/babel-plugin', () => {
           const styles = stylex.create({
             dynamic: ({ color }) => ({
               color,
-            });
+            }),
           });
         `);
       }).toThrow(messages.ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS);
@@ -127,7 +127,7 @@ describe('@stylexjs/babel-plugin', () => {
           const styles = stylex.create({
             dynamic: (props = {}) => ({
               color: props.color,
-            });
+            }),
           });
         `);
       }).toThrow(messages.NO_DYNAMIC_STYLE_DEFAULT_PARAMETERS);
@@ -137,7 +137,7 @@ describe('@stylexjs/babel-plugin', () => {
           const styles = stylex.create({
             dynamic: (color = 'red') => ({
               color,
-            });
+            }),
           });
         `);
       }).toThrow(messages.NO_DYNAMIC_STYLE_DEFAULT_PARAMETERS);

--- a/packages/babel-plugin/__tests__/stylex-validation-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-validation-create-test.js
@@ -118,6 +118,16 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `);
       }).toThrow(messages.ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS);
+      expect(() => {
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            dynamic: (...rest) => ({
+              color: rest[0],
+            }),
+          });
+        `);
+      }).toThrow(messages.ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS);
     });
 
     test('dynamic style function arguments cannot have default parameters', () => {

--- a/packages/babel-plugin/__tests__/stylex-validation-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-validation-create-test.js
@@ -107,7 +107,27 @@ describe('@stylexjs/babel-plugin', () => {
       }).not.toThrow();
     });
 
-    test('dynamic style function parameters must be named', () => {
+    test('dynamic style function only accepts named parameters', () => {
+      expect(() => {
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            dynamic: (props = {}) => ({
+              color: props.color,
+            }),
+          });
+        `);
+      }).toThrow(messages.ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS);
+      expect(() => {
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            dynamic: (color = 'red') => ({
+              color,
+            }),
+          });
+        `);
+      }).toThrow(messages.ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS);
       expect(() => {
         transform(`
           import stylex from 'stylex';
@@ -128,29 +148,16 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `);
       }).toThrow(messages.ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS);
-    });
-
-    test('dynamic style function arguments cannot have default parameters', () => {
       expect(() => {
         transform(`
           import stylex from 'stylex';
           const styles = stylex.create({
-            dynamic: (props = {}) => ({
-              color: props.color,
+            dynamic: (backgroundColor) => ({
+              backgroundColor,
             }),
           });
         `);
-      }).toThrow(messages.NO_DYNAMIC_STYLE_DEFAULT_PARAMETERS);
-      expect(() => {
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({
-            dynamic: (color = 'red') => ({
-              color,
-            }),
-          });
-        `);
-      }).toThrow(messages.NO_DYNAMIC_STYLE_DEFAULT_PARAMETERS);
+      }).not.toThrow();
     });
 
     /* Properties */

--- a/packages/babel-plugin/__tests__/stylex-validation-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-validation-create-test.js
@@ -107,6 +107,42 @@ describe('@stylexjs/babel-plugin', () => {
       }).not.toThrow();
     });
 
+    test('dynamic style function parameters must be named', () => {
+      expect(() => {
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            dynamic: ({ color }) => ({
+              color,
+            });
+          });
+        `);
+      }).toThrow(messages.ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS);
+    });
+
+    test('dynamic style function arguments cannot have default parameters', () => {
+      expect(() => {
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            dynamic: (props = {}) => ({
+              color: props.color,
+            });
+          });
+        `);
+      }).toThrow(messages.NO_DYNAMIC_STYLE_DEFAULT_PARAMETERS);
+      expect(() => {
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            dynamic: (color = 'red') => ({
+              color,
+            });
+          });
+        `);
+      }).toThrow(messages.NO_DYNAMIC_STYLE_DEFAULT_PARAMETERS);
+    });
+
     /* Properties */
 
     test('properties must be a static value', () => {

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -113,6 +113,7 @@ export default function transformStyleXCreate(
       identifiers,
       memberExpressions,
     });
+
     if (!confident) {
       throw new Error(messages.NON_STATIC_VALUE);
     }

--- a/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
@@ -73,30 +73,14 @@ export function evaluateStyleXCreateArg(
     const allParams: Array<
       NodePath<t.Identifier | t.SpreadElement | t.Pattern>,
     > = fnPath.get('params');
+
+    validateDynamicStyleParams(allParams);
+
     const params: Array<t.Identifier> = allParams
       .filter((param): param is NodePath<t.Identifier> =>
         pathUtils.isIdentifier(param),
       )
       .map((param) => param.node);
-
-    if (
-      allParams.some(
-        (param) =>
-          pathUtils.isObjectPattern(param) || pathUtils.isRestElement(param),
-      )
-    ) {
-      throw new Error(
-        messages.ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS,
-      );
-    }
-
-    if (allParams.some((param) => pathUtils.isAssignmentPattern(param))) {
-      throw new Error(messages.NO_DYNAMIC_STYLE_DEFAULT_PARAMETERS);
-    }
-
-    if (params.length !== allParams.length) {
-      return { confident: false, deopt: valPath, value: null };
-    }
 
     const fnBody = fnPath.get('body');
     if (!pathUtils.isObjectExpression(fnBody)) {
@@ -262,4 +246,21 @@ function evaluateObjKey(
     confident: true,
     value: String(key),
   };
+}
+
+function validateDynamicStyleParams(
+  params: Array<NodePath<t.Identifier | t.SpreadElement | t.Pattern>>,
+) {
+  if (
+    params.some(
+      (param) =>
+        pathUtils.isObjectPattern(param) || pathUtils.isRestElement(param),
+    )
+  ) {
+    throw new Error(messages.ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS);
+  }
+
+  if (params.some((param) => pathUtils.isAssignmentPattern(param))) {
+    throw new Error(messages.NO_DYNAMIC_STYLE_DEFAULT_PARAMETERS);
+  }
 }

--- a/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
@@ -85,13 +85,7 @@ export function evaluateStyleXCreateArg(
       );
     }
 
-    if (
-      allParams.some(
-        (param) =>
-          pathUtils.isAssignmentPattern(param) &&
-          t.isIdentifier(param.node.left),
-      )
-    ) {
+    if (allParams.some((param) => pathUtils.isAssignmentPattern(param))) {
       throw new Error(messages.NO_DYNAMIC_STYLE_DEFAULT_PARAMETERS);
     }
 

--- a/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
@@ -251,16 +251,7 @@ function evaluateObjKey(
 function validateDynamicStyleParams(
   params: Array<NodePath<t.Identifier | t.SpreadElement | t.Pattern>>,
 ) {
-  if (
-    params.some(
-      (param) =>
-        pathUtils.isObjectPattern(param) || pathUtils.isRestElement(param),
-    )
-  ) {
+  if (params.some((param) => !pathUtils.isIdentifier(param))) {
     throw new Error(messages.ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS);
-  }
-
-  if (params.some((param) => pathUtils.isAssignmentPattern(param))) {
-    throw new Error(messages.NO_DYNAMIC_STYLE_DEFAULT_PARAMETERS);
   }
 }

--- a/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
@@ -79,7 +79,12 @@ export function evaluateStyleXCreateArg(
       )
       .map((param) => param.node);
 
-    if (allParams.some((param) => pathUtils.isObjectPattern(param))) {
+    if (
+      allParams.some(
+        (param) =>
+          pathUtils.isObjectPattern(param) || pathUtils.isRestElement(param),
+      )
+    ) {
       throw new Error(
         messages.ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS,
       );

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -2786,9 +2786,7 @@ const stylexValidStyles = {
                       node: param,
                       loc: param.loc,
                       message:
-                        param.type === 'AssignmentPattern'
-                          ? 'Dynamic Styles cannot have default parameters'
-                          : 'Dynamic Styles can only accept named parameters',
+                        'Dynamic Styles can only accept named parameters. Destructuring, spreading or default parameters are not allowed.',
                     });
                   });
               }

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -2786,7 +2786,9 @@ const stylexValidStyles = {
                       node: param,
                       loc: param.loc,
                       message:
-                        'Dynamic Styles can only accept named parameters',
+                        param.type === 'AssignmentPattern'
+                          ? 'Dynamic Styles cannot have default parameters'
+                          : 'Dynamic Styles can only accept named parameters',
                     });
                   });
               }

--- a/packages/shared/src/messages.js
+++ b/packages/shared/src/messages.js
@@ -58,3 +58,7 @@ export const NON_EXPORT_NAMED_DECLARATION =
   'The return value of stylex.defineVars() must be bound to a named export.';
 export const ANONYMOUS_THEME =
   'stylex.createTheme() must be bound to a named constant.';
+export const NO_DYNAMIC_STYLE_DEFAULT_PARAMETERS =
+  'Default parameters are not allowed in stylex.create() dynamic style functions';
+export const ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS =
+  'Only named parameters are allowed in stylex.create() dynamic style functions';

--- a/packages/shared/src/messages.js
+++ b/packages/shared/src/messages.js
@@ -58,7 +58,5 @@ export const NON_EXPORT_NAMED_DECLARATION =
   'The return value of stylex.defineVars() must be bound to a named export.';
 export const ANONYMOUS_THEME =
   'stylex.createTheme() must be bound to a named constant.';
-export const NO_DYNAMIC_STYLE_DEFAULT_PARAMETERS =
-  'Default parameters are not allowed in stylex.create() dynamic style functions';
 export const ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS =
-  'Only named parameters are allowed in stylex.create() dynamic style functions';
+  'Only named parameters are allowed in Dynamic Style functions. Destructuring, spreading or default values are not allowed.';


### PR DESCRIPTION
## What changed / motivation ?

This PR improves the error messaging for `stylex.create` dynamic values. In particular, it throws a more verbose error when consumers attempt to set default parameters or don't use named parameters. Previously, in both cases it would just throw `NON_STATIC_VALUE` error. I also improved the error message in `eslint-plugin`.

Let me know if the error messages themselves can be improved.

![image](https://github.com/facebook/stylex/assets/45975811/b2c8f39b-d3d3-4592-b0bf-b6c368223db3)


## Linked PR/Issues

Fixes #198 

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code