### PR TITLE
feat: Remove style rules that are not needed

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
@@ -1111,10 +1111,6 @@ describe('@stylexjs/babel-plugin', () => {
             foo: {
               color: "x1e2nbdu",
               $$css: true
-            },
-            bar: {
-              backgroundColor: "x1t391ir",
-              $$css: true
             }
           };"
         `);

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -95,13 +95,71 @@ function styleXTransform(): PluginObj<> {
             },
           });
 
-          const varsToKeep = new Set(
+          const varsToKeep: { [string]: true | Array<string> } = {};
+          for (const [varName, namespaceName] of state.styleVarsToKeep) {
+            if (varsToKeep[varName] === true) {
+              continue;
+            }
+            if (varsToKeep[varName] == null) {
+              varsToKeep[varName] =
+                namespaceName === true ? true : [namespaceName];
+            } else if (Array.isArray(varsToKeep[varName])) {
+              if (namespaceName === true) {
+                varsToKeep[varName] = true;
+              } else {
+                varsToKeep[varName].push(namespaceName);
+              }
+            }
+          }
+
+          const varsToKeepOld = new Set(
             [...state.styleVarsToKeep.values()].map(
               ([varName, _namespaceName]) => varName,
             ),
           );
           state.styleVars.forEach((path, varName) => {
-            if (!varsToKeep.has(varName) && !isExported(path)) {
+            if (isExported(path)) {
+              return;
+            }
+
+            if (varsToKeep[varName] === true) {
+              return;
+            }
+
+            const namespacesToKeep: Array<string> = varsToKeep[varName];
+
+            if (namespacesToKeep == null) {
+              path.remove();
+              return;
+            }
+
+            if (pathUtils.isVariableDeclarator(path)) {
+              const init = path.get('init');
+              if (init != null && pathUtils.isObjectExpression(init)) {
+                for (const prop of init.get('properties')) {
+                  if (pathUtils.isObjectProperty(prop)) {
+                    const key = prop.get('key').node;
+                    const keyAsString =
+                      key.type === 'Identifier'
+                        ? key.name
+                        : key.type === 'StringLiteral'
+                          ? key.value
+                          : key.type === 'NumericLiteral'
+                            ? String(key.value)
+                            : null;
+
+                    if (
+                      keyAsString != null &&
+                      !namespacesToKeep.includes(keyAsString)
+                    ) {
+                      prop.remove();
+                    }
+                  }
+                }
+              }
+            }
+
+            if (!varsToKeepOld.has(varName) && !isExported(path)) {
               path.remove();
             }
           });
@@ -126,14 +184,20 @@ function styleXTransform(): PluginObj<> {
             if (pathUtils.isMemberExpression(parentPath)) {
               const { property, computed } = parentPath.node;
               if (property.type === 'Identifier' && !computed) {
-                state.markComposedNamespace([name, property.name]);
+                state.markComposedNamespace([name, property.name, true]);
+              } else if (property.type === 'StringLiteral' && computed) {
+                state.markComposedNamespace([name, property.value, true]);
+              } else if (property.type === 'NumericLiteral' && computed) {
+                state.markComposedNamespace([
+                  name,
+                  String(property.value),
+                  true,
+                ]);
+              } else {
+                state.markComposedNamespace([name, true, true]);
               }
-              if (property.type === 'StringLiteral' && computed) {
-                state.markComposedNamespace([name, property.value]);
-              }
-              state.markComposedNamespace([name, null]);
             } else {
-              state.markComposedNamespace([name, null]);
+              state.markComposedNamespace([name, true, true]);
             }
           }
         }

--- a/packages/babel-plugin/src/utils/state-manager.js
+++ b/packages/babel-plugin/src/utils/state-manager.js
@@ -79,7 +79,8 @@ export default class StateManager {
   +styleVars: Map<string, NodePath<>> = new Map();
 
   // resuls of `stylex.create` calls that should be kept
-  +styleVarsToKeep: Set<[string, null | string]> = new Set();
+  +styleVarsToKeep: Set<[string, true | string, true | Array<string>]> =
+    new Set();
 
   inStyleXCreate: boolean = false;
 
@@ -256,7 +257,9 @@ export default class StateManager {
     this.metadata.stylex.push(style);
   }
 
-  markComposedNamespace(memberExpression: [string, null | string]): void {
+  markComposedNamespace(
+    memberExpression: [string, true | string, true | Array<string>],
+  ): void {
     this.styleVarsToKeep.add(memberExpression);
   }
 }


### PR DESCRIPTION
## What changed / motivation ?

At a high-level, the StyleX compiler works in the following steps:
1. All the function calls other than `stylex()` and `stylex.props()` are compiled down. `stylex.create` calls are replaced by object expressions that map keys to classNames.
2. We try to precompute `stylex()` and `stylex.props()` calls. Replacing them string constants if possible.
3. If all references to the compiled styles from step 1 are removed, we can remove the object entirely.

This PR improves the dead-code elimination from step 3. Now, when there are dynamic references that exist after compilation to style objects, only the style objects that are needed are kept, and other style rules within the same variable declaration can be removed.

TLDR; Extra sub-objects are removed from the compiled code.

## Additional Context

A couple of snapshots have been updated as a result of this change and I've added an additional test to demonstrate the change.

## Next Step

The style objects contain many properties with the value `null` in order to override previous styles. We should be able to remove all of these keys when a style object *only* occurs as the first argument of `stylex()` or `stylex.props()`.

Further, the second argument only needs to `null`-out properties that existed on previous style objects as arguments on the same function call and so on.

The metadata for doing this is already being collected in this PR. A follow-up PR will actually remove the `null` properties.
