### PR TITLE
Bump GitHub workflow actions to latest versions

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -7,7 +7,7 @@ jobs:
     name: runtime-size
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: necolas/compressed-size-action@master
         with:
           name: 'runtime library'
@@ -19,7 +19,7 @@ jobs:
     name: bundle-size
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: necolas/compressed-size-action@master
         with:
           name: 'e2e bundles'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - run: npm install
@@ -21,8 +21,8 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - run: npm install
@@ -31,8 +31,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - run: npm install
@@ -42,8 +42,8 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - run: npm install


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions, thus avoiding deprecation warnings as seen [here](https://github.com/facebook/stylex/actions/runs/7320001293).

- [x] I have read the [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code