### PR TITLE
Update index.mdx to use valid css color

### DIFF
--- a/apps/docs/docs/learn/index.mdx
+++ b/apps/docs/docs/learn/index.mdx
@@ -102,7 +102,7 @@ const styles = stylex.create({
 
 const colorStyles = stylex.create({
   red: {
-    backgroundColor: 'lightred',
+    backgroundColor: 'red',
     borderColor: 'darkred',
   },
   green: {


### PR DESCRIPTION
For some reason or another (despite the fact "palegoldenrod" is a color) "lightred" does not appear to be a valid CSS color. 

https://www.w3.org/wiki/CSS/Properties/color/keywords

## What changed / motivation ?

I was trying the intro and the background didn't change to light red.

## Linked PR/Issues

Didn't make an issue.

## Additional Context

No.

## Pre-flight checklist

- [X] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [X] Performed a self-review of my code