### PR TITLE
Fix: Fix specificity of styles injected at runtime

### DIFF
--- a/apps/nextjs-example/.babelrc.js
+++ b/apps/nextjs-example/.babelrc.js
@@ -7,7 +7,6 @@ module.exports = {
       '@stylexjs/babel-plugin',
       {
         dev: process.env.NODE_ENV === 'development',
-        runtimeInjection: false,
         genConditionalClasses: true,
         treeshakeCompensation: true,
         unstable_moduleResolution: {

--- a/apps/nextjs-example/app/Card.tsx
+++ b/apps/nextjs-example/app/Card.tsx
@@ -7,7 +7,7 @@
  *
  */
 
-import stylex from '@stylexjs/stylex';
+import * as stylex from '@stylexjs/stylex';
 import { globalTokens as $, spacing, text } from './globalTokens.stylex';
 import { colors } from '@stylexjs/open-props/lib/colors.stylex';
 import { tokens } from './CardTokens.stylex';

--- a/apps/nextjs-example/app/Counter.tsx
+++ b/apps/nextjs-example/app/Counter.tsx
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import { spacing, text, globalTokens as $ } from './globalTokens.stylex';
+import { colors } from '@stylexjs/open-props/lib/colors.stylex';
+import { useState } from 'react';
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div {...stylex.props(styles.container)}>
+      <button
+        {...stylex.props(styles.button)}
+        onClick={() => setCount((c) => c - 1)}
+      >
+        -
+      </button>
+      <div
+        {...stylex.props(
+          styles.count,
+          Math.abs(count) > 99 && styles.largeNumber,
+        )}
+      >
+        {count}
+      </div>
+      <button
+        {...stylex.props(styles.button)}
+        onClick={() => setCount((c) => c + 1)}
+      >
+        +
+      </button>
+    </div>
+  );
+}
+
+const DARK = '@media (prefers-color-scheme: dark)';
+
+const styles = stylex.create({
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    borderRadius: spacing.md,
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: colors.blue7,
+    padding: spacing.xxxs,
+    fontFamily: $.fontSans,
+    gap: spacing.xs,
+  },
+  button: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '6rem',
+    aspectRatio: 1,
+    color: colors.blue7,
+    backgroundColor: {
+      default: colors.gray3,
+      ':hover': colors.gray4,
+      // eslint-disable-next-line @stylexjs/valid-styles
+      [DARK]: {
+        default: colors.gray9,
+        ':hover': colors.gray8,
+      },
+    },
+    borderWidth: 0,
+    borderStyle: 'none',
+    borderRadius: spacing.xs,
+    padding: spacing.xs,
+    margin: spacing.xs,
+    cursor: 'pointer',
+    fontSize: text.h2,
+    transform: {
+      default: null,
+      ':hover': 'scale(1.025)',
+      ':active': 'scale(0.975)',
+    },
+  },
+  count: {
+    fontSize: text.h2,
+    fontWeight: 100,
+    color: colors.lime7,
+    minWidth: '6rem',
+    textAlign: 'center',
+    fontFamily: $.fontMono,
+  },
+  largeNumber: {
+    fontSize: text.h3,
+  },
+});

--- a/apps/nextjs-example/app/page.tsx
+++ b/apps/nextjs-example/app/page.tsx
@@ -15,6 +15,7 @@ import {
   text,
   scales,
 } from './globalTokens.stylex';
+import Counter from './Counter';
 
 const HOMEPAGE = 'https://stylexjs.com';
 
@@ -31,6 +32,7 @@ export default function Home() {
         <h1 {...stylex.props(style.h1)}>
           Next.js App Dir<span {...stylex.props(style.emoji)}>♥️</span>️StyleX
         </h1>
+        <Counter />
       </div>
 
       <div {...stylex.props(style.grid)}>
@@ -89,8 +91,10 @@ const style = stylex.create({
   hero: {
     flexGrow: 1,
     display: 'flex',
+    flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
+    gap: spacing.xl,
   },
   h1: {
     fontSize: text.h1,

--- a/apps/nextjs-example/next.config.js
+++ b/apps/nextjs-example/next.config.js
@@ -19,4 +19,6 @@ const rootDir = options.unstable_moduleResolution.rootDir ?? __dirname;
 module.exports = stylexPlugin({
   rootDir,
   useCSSLayers: true,
-})({});
+})({
+  transpilePackages: ['@stylexjs/open-props'],
+});

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -401,7 +401,7 @@ function addSpecificityLevel(selector: string, index: number): string {
   if (selector.startsWith('@keyframes')) {
     return selector;
   }
-  const pseudo = Array.from({ length: index + 1 })
+  const pseudo = Array.from({ length: index })
     .map(() => ':not(#\\#)')
     .join('');
 


### PR DESCRIPTION
## What changed / motivation ?

Update the logic for runtime injection to:
1. Log errors when encountered. Currently they're silently ignored
2. Insert styles defensively. Currently, one failure causes many further insertions to fail.
3. Use the `:not(#/#)` selector to bump specificity for consistency.

Also, updated the NextJS example to include a Counter which is a Client Component.

## Linked PR/Issues

This should fix usage in NextJS `pages` directory.

## Additional Context

<img width="1038" alt="image" src="https://github.com/facebook/stylex/assets/3582514/ea9d2e29-5d0b-4255-9b62-b8c7515b1fd3">
