### PR TITLE
fix: ESLint - Resolve local constant used as keys

### DIFF
--- a/apps/nextjs-example/app/Counter.tsx
+++ b/apps/nextjs-example/app/Counter.tsx
@@ -43,7 +43,7 @@ export default function Counter() {
   );
 }
 
-const DARK = '@media (prefers-color-scheme: dark)';
+const DARK = '@media (prefers-color-scheme: dark)' as const;
 
 const styles = stylex.create({
   container: {
@@ -69,7 +69,6 @@ const styles = stylex.create({
     backgroundColor: {
       default: colors.gray3,
       ':hover': colors.gray4,
-      // eslint-disable-next-line @stylexjs/valid-styles
       [DARK]: {
         default: colors.gray9,
         ':hover': colors.gray8,

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -43,6 +43,7 @@ import isAnimationName from './rules/isAnimationName';
 import isStylexDefineVarsToken from './rules/isStylexDefineVarsToken';
 import { borderSplitter } from './utils/split-css-value';
 import evaluate from './utils/evaluate';
+import resolveKey from './utils/resolveKey';
 
 export type Variables = $ReadOnlyMap<string, Expression | 'ARG'>;
 export type RuleCheck = (
@@ -2385,8 +2386,10 @@ const stylexValidStyles = {
           const keyName =
             key.type === 'Literal'
               ? key.value
-              : key.type === 'Identifier' && !style.computed
-                ? key.name
+              : key.type === 'Identifier'
+                ? !style.computed
+                  ? key.name
+                  : resolveKey(key, variables)
                 : null;
           if (isStylexDefineVarsToken(key, stylexDefineVarsTokenImports)) {
             return undefined;

--- a/packages/eslint-plugin/src/utils/resolveKey.js
+++ b/packages/eslint-plugin/src/utils/resolveKey.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type { Identifier } from 'estree';
+import type { Variables } from '../stylex-valid-styles';
+
+export default function resolveKey(
+  property: Identifier,
+  variables?: Variables,
+): ?string {
+  const name = property.name;
+  let existingVar = variables?.get(name);
+
+  while (existingVar != null) {
+    if (existingVar === 'ARG') {
+      return undefined;
+    }
+    if (existingVar.type === 'TSAsExpression') {
+      existingVar = existingVar.expression;
+    }
+    if (existingVar.type === 'TSSatisfiesExpression') {
+      existingVar = existingVar.expression;
+    }
+
+    if (existingVar.type === 'Literal') {
+      const value = existingVar.value;
+      if (typeof value === 'string') {
+        return value;
+      } else {
+        return undefined;
+      }
+    }
+    if (existingVar.type === 'Identifier') {
+      existingVar = variables?.get(existingVar.name);
+    } else {
+      return undefined;
+    }
+  }
+}


### PR DESCRIPTION
## What changed / motivation ?

In some edge-cases constants used as media queries weren't handled correctly by the ESLint plugin. Fix that.
