### PR TITLE
fix(@stylex/eslint-plugin): Change message when a property is disallowed

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -1238,8 +1238,7 @@ revert`,
       ],
       errors: [
         {
-          message: `grid value must be one of:
-grid properties disallowed for testing`,
+          message: 'Property grid is not allowed. grid properties disallowed for testing',
         },
       ],
     },
@@ -1265,8 +1264,7 @@ grid properties disallowed for testing`,
       ],
       errors: [
         {
-          message: `gridTemplateColumns value must be one of:
-grid properties disallowed for testing`,
+          message: 'Property gridTemplateColumns is not allowed. grid properties disallowed for testing',
         },
       ],
     },
@@ -1287,8 +1285,7 @@ grid properties disallowed for testing`,
       ],
       errors: [
         {
-          message: `grid value must be one of:
-This property is not supported in legacy StyleX resolution.`,
+          message: 'Property grid is not allowed. This property is not supported in legacy StyleX resolution.',
         },
       ],
     },

--- a/packages/eslint-plugin/src/rules/makeUnionRule.js
+++ b/packages/eslint-plugin/src/rules/makeUnionRule.js
@@ -23,6 +23,7 @@ export default function makeUnionRule(
     node: Expression | Pattern,
     variables?: Variables,
     prop?: Property,
+    key?: string,
   ): RuleResponse => {
     const failedRules = [];
     for (const _rule of rules) {
@@ -43,8 +44,10 @@ export default function makeUnionRule(
     const fixable = failedRules.filter((a) => a.suggest != null);
     fixable.sort((a, b) => (a.distance || Infinity) - (b.distance || Infinity));
 
+    const enumValues = failedRules.map((a) => a.message).join('\n')
+
     return {
-      message: failedRules.map((a) => a.message).join('\n'),
+      message: key ? `${key} value must be one of:\n${enumValues}` : enumValues,
       suggest: fixable[0] != null ? fixable[0].suggest : undefined,
     };
   };

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -50,6 +50,7 @@ export type RuleCheck = (
   node: $ReadOnly<Expression | Pattern>,
   variables?: Variables,
   prop?: $ReadOnly<Property>,
+  key?: string,
 ) => RuleResponse;
 export type RuleResponse = void | {
   message: string,
@@ -62,7 +63,7 @@ export type RuleResponse = void | {
 
 const showError =
   (message: string): RuleCheck =>
-  () => ({ message });
+  (_node, _variables, _props, key) => ({ message: key ? `Property ${key} is not allowed. ${message}` : message });
 
 const isStringOrNumber = makeUnionRule(isString, isNumber);
 
@@ -2624,14 +2625,14 @@ const stylexValidStyles = {
             }
           }
 
-          const check = ruleChecker(style.value, varsWithFnArgs, style);
+          const check = ruleChecker(style.value, varsWithFnArgs, style, key);
           if (check != null) {
             const { message, suggest } = check;
             return context.report(
               ({
                 node: style.value,
                 loc: style.value.loc,
-                message: `${key} value must be one of:\n${message}${
+                message: `${message}${
                   key === 'lineHeight'
                     ? '\nBe careful when fixing: lineHeight: 10px is not the same as lineHeight: 10'
                     : ''


### PR DESCRIPTION
## What changed / motivation ?

- Moved the logic that display the line `{key} value must be one of:\n` further down the codebase to be able to display a different message when a property is disallowed. 
- Add a `Property {key} is not allowed.` message.

This results in error messages more specific to the error its reporting.

This is a very naive attempt from my part to solve the problem with minimal changes and there might be more maintainable solutions.

Let me know if you think this is the right approach.

Also, feel free to suggest text for the error message.

## Linked PR/Issues

Fixes #282

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Tests where modified to reflect the changes:

Before:

```
grid value must be one of:
grid properties disallowed for testing
```

After:
```
Property grid is not allowed. grid properties disallowed for testing
```

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code