### PR TITLE
Docs: Improve code examples

### DIFF
--- a/apps/docs/docs/api/javascript/createTheme.mdx
+++ b/apps/docs/docs/api/javascript/createTheme.mdx
@@ -25,7 +25,7 @@ function createTheme(
 
 ```ts
 import * as stylex from '@stylexjs/stylex';
-import {colors} from './vars.stylex.js';
+import { colors } from './vars.stylex.js';
 
 const theme = stylex.createTheme(colors, {
   accentColor: 'red',

--- a/apps/docs/docs/api/javascript/defineVars.mdx
+++ b/apps/docs/docs/api/javascript/defineVars.mdx
@@ -25,7 +25,7 @@ You must define your variables as named exports in a `.stylex.js` (or
 ```tsx title="vars.stylex.js"
 import * as stylex from '@stylexjs/stylex';
 
-const colors = stylex.defineVars({
+export const colors = stylex.defineVars({
   accent: 'blue',
   background: 'white',
   line: 'gray',
@@ -38,7 +38,7 @@ You can then import and use these variables in any `stylex.create` call.
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';
-import {colors} from './vars.stylex.js';
+import { colors } from './vars.stylex.js';
 
 const styles = stylex.create({
   container: {


### PR DESCRIPTION
## What changed / motivation ?

| Before | After |
| - | - |
| ![stylexjs com_docs_learn_styling-ui_defining-styles_](https://github.com/facebook/stylex/assets/76220140/cc612461-c45c-4ec5-9083-081e082b4c4f) | ![localhost_3000_docs_api_javascript_defineVars_](https://github.com/facebook/stylex/assets/76220140/bfafbaae-7aa9-46ea-b85b-53f636f28479) |

Having it as `export const colors` just makes it clear that it should be exported. As for the other changes, nitpicks.

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code