### PR TITLE
Fix: Validate options passed into the Babel plugin

### DIFF
--- a/apps/nextjs-example/app/globalTokens.stylex.ts
+++ b/apps/nextjs-example/app/globalTokens.stylex.ts
@@ -81,34 +81,17 @@ const INTERCEPT = {
   h1: Math.round(100 * (MIN_FONT.h1 - SLOPE.h1 * (MIN_WIDTH / 16))) / 100,
 };
 
+// prettier-ignore
 export const text = stylex.defineVars({
-  xxs: `clamp(${Math.min(MIN_FONT.xxs)}rem, calc(${INTERCEPT.xxs}rem + ${
-    Math.round(10000 * SLOPE.xxs) / 100
-  }vw), ${Math.max(MAX_FONT.xxs)}rem)`,
-  xs: `clamp(${Math.min(MIN_FONT.xs)}rem, calc(${INTERCEPT.xs}rem + ${
-    Math.round(10000 * SLOPE.xs) / 100
-  }vw), ${Math.max(MAX_FONT.xs)}rem)`,
-  sm: `clamp(${Math.min(MIN_FONT.sm)}rem, calc(${INTERCEPT.sm}rem + ${
-    Math.round(10000 * SLOPE.sm) / 100
-  }vw), ${Math.max(MAX_FONT.sm)}rem)`,
-  p: `clamp(${Math.min(MIN_FONT.p)}rem, calc(${INTERCEPT.p}rem + ${
-    Math.round(10000 * SLOPE.p) / 100
-  }vw), ${Math.max(MAX_FONT.p)}rem)`,
-  h5: `clamp(${Math.min(MIN_FONT.h5)}rem, calc(${INTERCEPT.h5}rem + ${
-    Math.round(10000 * SLOPE.h5) / 100
-  }vw), ${Math.max(MAX_FONT.h5)}rem)`,
-  h4: `clamp(${Math.min(MIN_FONT.h4)}rem, calc(${INTERCEPT.h4}rem + ${
-    Math.round(10000 * SLOPE.h4) / 100
-  }vw), ${Math.max(MAX_FONT.h4)}rem)`,
-  h3: `clamp(${Math.min(MIN_FONT.h3)}rem, calc(${INTERCEPT.h3}rem + ${
-    Math.round(10000 * SLOPE.h3) / 100
-  }vw), ${Math.max(MAX_FONT.h3)}rem)`,
-  h2: `clamp(${Math.min(MIN_FONT.h2)}rem, calc(${INTERCEPT.h2}rem + ${
-    Math.round(10000 * SLOPE.h2) / 100
-  }vw), ${Math.max(MAX_FONT.h2)}rem)`,
-  h1: `clamp(${Math.min(MIN_FONT.h1)}rem, calc(${INTERCEPT.h1}rem + ${
-    Math.round(10000 * SLOPE.h1) / 100
-  }vw), ${Math.max(MAX_FONT.h1)}rem)`,
+  xxs: `clamp(${ Math.min(MIN_FONT.xxs) }rem, calc(${ INTERCEPT.xxs }rem + ${ Math.round(10000 * SLOPE.xxs) / 100 }vw), ${ Math.max(MAX_FONT.xxs) }rem)`,
+  xs:  `clamp(${ Math.min(MIN_FONT.xs ) }rem, calc(${ INTERCEPT.xs  }rem + ${ Math.round(10000 * SLOPE.xs ) / 100 }vw), ${ Math.max(MAX_FONT.xs ) }rem)`,
+  sm:  `clamp(${ Math.min(MIN_FONT.sm ) }rem, calc(${ INTERCEPT.sm  }rem + ${ Math.round(10000 * SLOPE.sm ) / 100 }vw), ${ Math.max(MAX_FONT.sm ) }rem)`,
+  p:   `clamp(${ Math.min(MIN_FONT.p  ) }rem, calc(${ INTERCEPT.p   }rem + ${ Math.round(10000 * SLOPE.p  ) / 100 }vw), ${ Math.max(MAX_FONT.p  ) }rem)`,
+  h5:  `clamp(${ Math.min(MIN_FONT.h5 ) }rem, calc(${ INTERCEPT.h5  }rem + ${ Math.round(10000 * SLOPE.h5 ) / 100 }vw), ${ Math.max(MAX_FONT.h5 ) }rem)`,
+  h4:  `clamp(${ Math.min(MIN_FONT.h4 ) }rem, calc(${ INTERCEPT.h4  }rem + ${ Math.round(10000 * SLOPE.h4 ) / 100 }vw), ${ Math.max(MAX_FONT.h4 ) }rem)`,
+  h3:  `clamp(${ Math.min(MIN_FONT.h3 ) }rem, calc(${ INTERCEPT.h3  }rem + ${ Math.round(10000 * SLOPE.h3 ) / 100 }vw), ${ Math.max(MAX_FONT.h3 ) }rem)`,
+  h2:  `clamp(${ Math.min(MIN_FONT.h2 ) }rem, calc(${ INTERCEPT.h2  }rem + ${ Math.round(10000 * SLOPE.h2 ) / 100 }vw), ${ Math.max(MAX_FONT.h2 ) }rem)`,
+  h1:  `clamp(${ Math.min(MIN_FONT.h1 ) }rem, calc(${ INTERCEPT.h1  }rem + ${ Math.round(10000 * SLOPE.h1 ) / 100 }vw), ${ Math.max(MAX_FONT.h1 ) }rem)`,
 });
 
 /**
@@ -200,37 +183,19 @@ const INTERCEPT_SPACE = {
   xxxl: Math.round(4 * (MIN_SPACE.xxxl - SLOPE_SPACE.xxxl * MIN_WIDTH)) / 4,
   xxxxl: Math.round(4 * (MIN_SPACE.xxxxl - SLOPE_SPACE.xxxxl * MIN_WIDTH)) / 4,
 };
+
+// prettier-ignore
 export const spacing = stylex.defineVars({
-  xxxs: `clamp(${MIN_SPACE.xxxs}px, calc(${INTERCEPT_SPACE.xxxs}px - ${
-    Math.round(10000 * SLOPE_SPACE.xxxs) / 100
-  }vw), ${MAX_SPACE.xxxs}px)`,
-  xxs: `clamp(${MIN_SPACE.xxs}px, calc(${INTERCEPT_SPACE.xxs}px - ${
-    Math.round(10000 * SLOPE_SPACE.xxs) / 100
-  }vw), ${MAX_SPACE.xxs}px)`,
-  xs: `clamp(${MIN_SPACE.xs}px, calc(${INTERCEPT_SPACE.xs}px - ${
-    Math.round(10000 * SLOPE_SPACE.xs) / 100
-  }vw), ${MAX_SPACE.xs}px)`,
-  sm: `clamp(${MIN_SPACE.sm}px, calc(${INTERCEPT_SPACE.sm}px - ${
-    Math.round(10000 * SLOPE_SPACE.sm) / 100
-  }vw), ${MAX_SPACE.sm}px)`,
-  md: `clamp(${MIN_SPACE.md}px, calc(${INTERCEPT_SPACE.md}px - ${
-    Math.round(10000 * SLOPE_SPACE.md) / 100
-  }vw), ${MAX_SPACE.md}px)`,
-  lg: `clamp(${MIN_SPACE.lg}px, calc(${INTERCEPT_SPACE.lg}px - ${
-    Math.round(10000 * SLOPE_SPACE.lg) / 100
-  }vw), ${MAX_SPACE.lg}px)`,
-  xl: `clamp(${MIN_SPACE.xl}px, calc(${INTERCEPT_SPACE.xl}px - ${
-    Math.round(10000 * SLOPE_SPACE.xl) / 100
-  }vw), ${MAX_SPACE.xl}px)`,
-  xxl: `clamp(${MIN_SPACE.xxl}px, calc(${INTERCEPT_SPACE.xxl}px - ${
-    Math.round(10000 * SLOPE_SPACE.xxl) / 100
-  }vw), ${MAX_SPACE.xxl}px)`,
-  xxxl: `clamp(${MIN_SPACE.xxxl}px, calc(${INTERCEPT_SPACE.xxxl}px - ${
-    Math.round(10000 * SLOPE_SPACE.xxxl) / 100
-  }vw), ${MAX_SPACE.xxxl}px)`,
-  xxxxl: `clamp(${MIN_SPACE.xxxxl}px, calc(${INTERCEPT_SPACE.xxxxl}px - ${
-    Math.round(10000 * SLOPE_SPACE.xxxxl) / 100
-  }vw), ${MAX_SPACE.xxxxl}px)`,
+  xxxs:  `clamp(${MIN_SPACE.xxxs  }px, calc(${INTERCEPT_SPACE.xxxs  }px + ${ Math.round(10000 * SLOPE_SPACE.xxxs  ) / 100 }vw), ${MAX_SPACE.xxxs  }px)`,
+  xxs:   `clamp(${MIN_SPACE.xxs   }px, calc(${INTERCEPT_SPACE.xxs   }px + ${ Math.round(10000 * SLOPE_SPACE.xxs   ) / 100 }vw), ${MAX_SPACE.xxs   }px)`,
+  xs:    `clamp(${MIN_SPACE.xs    }px, calc(${INTERCEPT_SPACE.xs    }px + ${ Math.round(10000 * SLOPE_SPACE.xs    ) / 100 }vw), ${MAX_SPACE.xs    }px)`,
+  sm:    `clamp(${MIN_SPACE.sm    }px, calc(${INTERCEPT_SPACE.sm    }px + ${ Math.round(10000 * SLOPE_SPACE.sm    ) / 100 }vw), ${MAX_SPACE.sm    }px)`,
+  md:    `clamp(${MIN_SPACE.md    }px, calc(${INTERCEPT_SPACE.md    }px + ${ Math.round(10000 * SLOPE_SPACE.md    ) / 100 }vw), ${MAX_SPACE.md    }px)`,
+  lg:    `clamp(${MIN_SPACE.lg    }px, calc(${INTERCEPT_SPACE.lg    }px + ${ Math.round(10000 * SLOPE_SPACE.lg    ) / 100 }vw), ${MAX_SPACE.lg    }px)`,
+  xl:    `clamp(${MIN_SPACE.xl    }px, calc(${INTERCEPT_SPACE.xl    }px + ${ Math.round(10000 * SLOPE_SPACE.xl    ) / 100 }vw), ${MAX_SPACE.xl    }px)`,
+  xxl:   `clamp(${MIN_SPACE.xxl   }px, calc(${INTERCEPT_SPACE.xxl   }px + ${ Math.round(10000 * SLOPE_SPACE.xxl   ) / 100 }vw), ${MAX_SPACE.xxl   }px)`,
+  xxxl:  `clamp(${MIN_SPACE.xxxl  }px, calc(${INTERCEPT_SPACE.xxxl  }px + ${ Math.round(10000 * SLOPE_SPACE.xxxl  ) / 100 }vw), ${MAX_SPACE.xxxl  }px)`,
+  xxxxl: `clamp(${MIN_SPACE.xxxxl }px, calc(${INTERCEPT_SPACE.xxxxl }px + ${ Math.round(10000 * SLOPE_SPACE.xxxxl ) / 100 }vw), ${MAX_SPACE.xxxxl }px)`,
 });
 
 /**
@@ -240,10 +205,35 @@ const DARK_MODE = '@media (prefers-color-scheme: dark)';
 
 export const globalTokens = stylex.defineVars({
   maxWidth: `${MAX_WIDTH}px`,
-  fontMono:
-    'ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", monospace',
-  fontSans:
-    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+  fontMono: [
+    'ui-monospace',
+    'Menlo',
+    'Monaco',
+    '"Cascadia Mono"',
+    '"Segoe UI Mono"',
+    '"Roboto Mono"',
+    '"Oxygen Mono"',
+    '"Ubuntu Monospace"',
+    '"Source Code Pro"',
+    '"Fira Mono"',
+    '"Droid Sans Mono"',
+    '"Courier New"',
+    'monospace',
+  ].join(', '),
+  fontSans: [
+    '-apple-system',
+    'BlinkMacSystemFont',
+    '"Segoe UI"',
+    'Roboto',
+    '"Helvetica Neue"',
+    'Arial',
+    '"Noto Sans"',
+    'sans-serif',
+    '"Apple Color Emoji"',
+    '"Segoe UI Emoji"',
+    '"Segoe UI Symbol"',
+    '"Noto Color Emoji"',
+  ].join(', '),
 
   foregroundR: { default: '0', [DARK_MODE]: '255' },
   foregroundG: { default: '0', [DARK_MODE]: '255' },
@@ -274,14 +264,24 @@ export const globalTokens = stylex.defineVars({
   cardBorderB: { default: '135', [DARK_MODE]: '200' },
 
   primaryGlow: {
-    default:
-      'conic-gradient(from 180deg at 50% 50%, #16abff33 0deg, #0885ff33 55deg, #54d6ff33 120deg, #0071ff33 160deg, transparent 360deg)',
+    default: `conic-gradient(${[
+      'from 180deg at 50% 50%',
+      '#16abff33 0deg',
+      '#0885ff33 55deg',
+      '#54d6ff33 120deg',
+      '#0071ff33 160deg',
+      'transparent 360deg',
+    ].join(', ')})`,
     [DARK_MODE]: 'radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0))',
   },
   secondaryGlow: {
     default: 'radial-gradient(rgba(255, 255, 255, 1), rgba(255, 255, 255, 0))',
-    [DARK_MODE]:
-      'linear-gradient(to bottom right, rgba(1, 65, 255, 0), rgba(1, 65, 255, 0), rgba(1, 65, 255, 0.3))',
+    [DARK_MODE]: `linear-gradient(${[
+      'to bottom right',
+      'rgba(1, 65, 255, 0)',
+      'rgba(1, 65, 255, 0)',
+      'rgba(1, 65, 255, 0.3)',
+    ].join(', ')})`,
   },
 });
 

--- a/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
@@ -593,7 +593,7 @@ describe('@stylexjs/babel-plugin', () => {
           {
             dev: true,
             unstable_moduleResolution: {
-              type: 'commonjs',
+              type: 'commonJS',
               rootDir,
             },
             filename: '/stylex/packages/utils/NestedTheme.stylex.js',

--- a/packages/babel-plugin/__tests__/stylex-transform-override-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-override-vars-test.js
@@ -511,7 +511,7 @@ describe('@stylexjs/babel-plugin', () => {
           {
             dev: true,
             unstable_moduleResolution: {
-              type: 'commonjs',
+              type: 'commonJS',
               rootDir,
             },
             filename: '/stylex/packages/utils/NestedTheme.stylex.js',

--- a/packages/babel-plugin/flow_modules/@babel/core/index.js.flow
+++ b/packages/babel-plugin/flow_modules/@babel/core/index.js.flow
@@ -518,7 +518,7 @@ export interface BabelFile {
 export interface PluginPass {
   file: BabelFile;
   key: string;
-  opts: { [string]: mixed };
+  opts: { +[string]: mixed };
   cwd: string;
   filename: string | void;
   get(key: mixed): any;

--- a/packages/babel-plugin/src/utils/__tests__/state-manager.test.js
+++ b/packages/babel-plugin/src/utils/__tests__/state-manager.test.js
@@ -1,0 +1,281 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import StateManager from '../state-manager';
+
+const defaultConfig = {
+  file: ({ metadata: {} }: any),
+  key: 'key',
+  opts: {},
+  cwd: '/home/test/',
+  filename: '/home/test/main.js',
+  get(_key: mixed): any {},
+  set(_key: mixed, _value: mixed): void {},
+};
+
+const makeState = (opts: { ... }) =>
+  new StateManager({ ...defaultConfig, opts });
+
+describe('StateManager config parsing', () => {
+  let warnings = [];
+  beforeEach(() => {
+    warnings = [];
+    jest.spyOn(console, 'error').mockImplementation((...args) => {
+      warnings.push(args);
+    });
+  });
+
+  /* eslint-disable no-loop-func */
+  const booleanOptions = [
+    'dev',
+    'test',
+    'genConditionalClasses',
+    'useRemForFontSize',
+    'treeshakeCompensation',
+  ];
+  for (const opt of booleanOptions) {
+    it(`parses valid ${opt}`, () => {
+      // $FlowFixMe[invalid-computed-prop]
+      const stateManager = makeState({ [opt]: true });
+      expect(stateManager.options[opt]).toBe(true);
+
+      // $FlowFixMe[invalid-computed-prop]
+      const stateManager2 = makeState({ [opt]: false });
+      expect(stateManager2.options[opt]).toBe(false);
+
+      const stateManager3 = makeState({});
+      expect(stateManager3.options[opt]).toBe(false);
+
+      expect(warnings).toEqual([]);
+    });
+    it(`logs errors on invalid ${opt}`, () => {
+      // $FlowFixMe[invalid-computed-prop]
+      const stateManager = makeState({ [opt]: 'true' });
+      expect(stateManager.options[opt]).toBe(false);
+      expect(warnings).toEqual([
+        [
+          '[@stylexjs/babel-plugin]',
+          `Expected (options.${opt}) to be a boolean, but got \`"true"\`.`,
+        ],
+      ]);
+    });
+  }
+
+  it('parses valid runtimeInjection', () => {
+    let stateManager = makeState({ runtimeInjection: true });
+    expect(stateManager.options.runtimeInjection).toBe(
+      '@stylexjs/stylex/lib/stylex-inject',
+    );
+
+    stateManager = makeState({ dev: true });
+    expect(stateManager.options.runtimeInjection).toBe(
+      '@stylexjs/stylex/lib/stylex-inject',
+    );
+
+    stateManager = makeState({ runtimeInjection: 'true' });
+    expect(stateManager.options.runtimeInjection).toBe('true');
+
+    stateManager = makeState({ runtimeInjection: false });
+    expect(stateManager.options.runtimeInjection).toBeUndefined();
+
+    stateManager = makeState({});
+    expect(stateManager.options.runtimeInjection).toBeUndefined();
+
+    expect(warnings).toEqual([]);
+  });
+  it('logs errors on invalid runtimeInjection', () => {
+    const stateManager = makeState({ runtimeInjection: 1 });
+    expect(stateManager.options.runtimeInjection).toBeUndefined();
+    expect(warnings).toMatchInlineSnapshot(`
+      [
+        [
+          "[@stylexjs/babel-plugin]",
+          "Expected (options.runtimeInjection) to be one of
+      	- a boolean
+      	- a string
+      	- an object where:
+      But got: 1",
+        ],
+      ]
+    `);
+  });
+
+  it('parses valid classNamePrefix option', () => {
+    const stateManager = makeState({ classNamePrefix: 'test' });
+    expect(stateManager.options.classNamePrefix).toBe('test');
+
+    const stateManager2 = makeState({ classNamePrefix: '' });
+    expect(stateManager2.options.classNamePrefix).toBe('');
+
+    const stateManager3 = makeState({});
+    expect(stateManager3.options.classNamePrefix).toBe('x');
+
+    expect(warnings).toEqual([]);
+  });
+  it('logs errors on invalid classNamePrefix option', () => {
+    const stateManager = makeState({ classNamePrefix: 1 });
+    expect(stateManager.options.classNamePrefix).toBe('x');
+    expect(warnings).toMatchInlineSnapshot(`
+      [
+        [
+          "[@stylexjs/babel-plugin]",
+          "Expected (options.classNamePrefix) to be a string, but got \`1\`.",
+        ],
+      ]
+    `);
+  });
+
+  it('parses valid importSources option', () => {
+    let stateManager = makeState({ importSources: ['test'] });
+    expect(stateManager.options.importSources).toEqual([
+      '@stylexjs/stylex',
+      'stylex',
+      'test',
+    ]);
+
+    stateManager = makeState({ importSources: [] });
+    expect(stateManager.options.importSources).toEqual([
+      '@stylexjs/stylex',
+      'stylex',
+    ]);
+
+    stateManager = makeState({});
+    expect(stateManager.options.importSources).toEqual([
+      '@stylexjs/stylex',
+      'stylex',
+    ]);
+
+    expect(warnings).toEqual([]);
+  });
+  it('logs errors on invalid importSources option', () => {
+    const stateManager = makeState({ importSources: 1 });
+    expect(stateManager.options.importSources).toEqual([
+      '@stylexjs/stylex',
+      'stylex',
+    ]);
+    expect(warnings).toMatchInlineSnapshot(`
+      [
+        [
+          "[@stylexjs/babel-plugin]",
+          "Expected (options.importSources) to be an array, but got \`1\`.",
+        ],
+      ]
+    `);
+  });
+
+  it('parses valid styleResolution option', () => {
+    let stateManager = makeState({ styleResolution: 'application-order' });
+    expect(stateManager.options.styleResolution).toBe('application-order');
+
+    stateManager = makeState({ styleResolution: 'property-specificity' });
+    expect(stateManager.options.styleResolution).toBe('property-specificity');
+
+    stateManager = makeState({ styleResolution: 'legacy-expand-shorthands' });
+    expect(stateManager.options.styleResolution).toBe(
+      'legacy-expand-shorthands',
+    );
+
+    stateManager = makeState({});
+    expect(stateManager.options.styleResolution).toBe('application-order');
+
+    expect(warnings).toEqual([]);
+  });
+  it('logs errors on invalid styleResolution option', () => {
+    const stateManager = makeState({ styleResolution: 1 });
+    expect(stateManager.options.styleResolution).toBe('application-order');
+    expect(warnings).toMatchInlineSnapshot(`
+      [
+        [
+          "[@stylexjs/babel-plugin]",
+          "Expected (options.styleResolution) to be one of
+      	- the literal "application-order"
+      	- the literal "property-specificity"
+      	- the literal "legacy-expand-shorthands"
+      But got: 1",
+        ],
+      ]
+    `);
+  });
+
+  it('logs errors on invalid styleResolution option', () => {
+    const stateManager = makeState({ styleResolution: 'something-else' });
+    expect(stateManager.options.styleResolution).toBe('application-order');
+    expect(warnings).toMatchInlineSnapshot(`
+      [
+        [
+          "[@stylexjs/babel-plugin]",
+          "Expected (options.styleResolution) to be one of
+      	- the literal "application-order"
+      	- the literal "property-specificity"
+      	- the literal "legacy-expand-shorthands"
+      But got: "something-else"",
+        ],
+      ]
+    `);
+  });
+
+  it('parses valid unstable_moduleResolution option', () => {
+    let stateManager = makeState({
+      unstable_moduleResolution: { type: 'haste' },
+    });
+    expect(stateManager.options.unstable_moduleResolution).toEqual({
+      type: 'haste',
+    });
+
+    stateManager = makeState({
+      unstable_moduleResolution: { type: 'commonJS', rootDir: '/test/' },
+    });
+    expect(stateManager.options.unstable_moduleResolution).toEqual({
+      type: 'commonJS',
+      rootDir: '/test/',
+    });
+
+    expect(warnings).toEqual([]);
+  });
+  it('logs errors on commonJS unstable_moduleResolution without rootDir', () => {
+    const stateManager = makeState({
+      unstable_moduleResolution: { type: 'commonJS' },
+    });
+    expect(stateManager.options.unstable_moduleResolution).toBeNull();
+    expect(warnings).toMatchInlineSnapshot(`
+      [
+        [
+          "[@stylexjs/babel-plugin]",
+          "Expected (options.unstable_moduleResolution) to be one of
+      	- \`null\` or \`undefined\`
+      	- one of
+      		- an object where:
+      			- Expected "type": to be the literal "commonJS"
+      			- Expected "rootDir": to be a string
+      			- Expected "themeFileExtension": to be 	- 
+      				- one of
+      					- \`null\` or \`undefined\`
+      					- a string
+      			- {"type":"commonJS"}
+      		- an object where:
+      			- Expected "type": to be the literal "haste"
+      			- Expected "themeFileExtension": to be 	- 
+      				- one of
+      					- \`null\` or \`undefined\`
+      					- a string
+      			- {"type":"commonJS"}
+      		- an object where:
+      			- Expected "type": to be the literal "experimental_crossFileParsing"
+      			- Expected "rootDir": to be a string
+      			- Expected "themeFileExtension": to be 	- 
+      				- one of
+      					- \`null\` or \`undefined\`
+      					- a string
+      			- {"type":"commonJS"}
+      But got: {"type":"commonJS"}",
+        ],
+      ]
+    `);
+  });
+});

--- a/packages/babel-plugin/src/utils/validate.js
+++ b/packages/babel-plugin/src/utils/validate.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+// This is a small utility to validate the options passed to the plugin.
+// Think of this as a minimal version of `zod`.
+
+export const string =
+  (
+    message?: (name: string) => string = (name) =>
+      `Expected ${name} to be a string`,
+  ): ((val: mixed) => Error | string) =>
+  (value: mixed): Error | string => {
+    if (typeof value !== 'string') {
+      return new Error(message('string'));
+    }
+
+    return value;
+  };
+
+export const nullish =
+  (
+    message?: (name: string) => string = (name) =>
+      `Expected ${name} to be null or undefined`,
+  ): ((val: mixed) => ?Error) =>
+  (value: mixed): ?Error =>
+    value == null ? value : new Error(message('nullish'));
+
+export const boolean =
+  (
+    message?: (name: string) => string = (name) =>
+      `Expected ${name} to be a boolean`,
+  ): ((val: mixed) => Error | boolean) =>
+  (value: mixed): Error | boolean => {
+    if (typeof value !== 'boolean') {
+      return new Error(message('boolean'));
+    }
+
+    return value;
+  };
+
+export const number =
+  (
+    message?: (name: string) => string = (name) =>
+      `Expected ${name} to be a number`,
+  ): ((val: mixed) => Error | number) =>
+  (value: mixed): Error | number => {
+    if (typeof value !== 'number') {
+      return new Error(message('number'));
+    }
+
+    return value;
+  };
+
+export const literal =
+  <T: string | number | boolean>(
+    expected: T,
+    message?: (name: string) => string = (name) =>
+      `Expected ${name} to be ${String(expected)}`,
+  ): ((val: mixed) => Error | T) =>
+  (value: mixed): Error | T => {
+    if (value === expected) {
+      return expected;
+    }
+    const n: string = JSON.stringify(value) ?? String(value);
+    return new Error(message(n));
+  };

--- a/packages/babel-plugin/src/utils/validate.js
+++ b/packages/babel-plugin/src/utils/validate.js
@@ -10,63 +10,284 @@
 // This is a small utility to validate the options passed to the plugin.
 // Think of this as a minimal version of `zod`.
 
-export const string =
-  (
-    message?: (name: string) => string = (name) =>
-      `Expected ${name} to be a string`,
-  ): ((val: mixed) => Error | string) =>
-  (value: mixed): Error | string => {
+const defaultMessage =
+  (expected: string) =>
+  (value: mixed, name?: string): string =>
+    name
+      ? `Expected (${name}) to be ${expected}, but got \`${JSON.stringify(
+          (value: $FlowFixMe),
+        )}\`.`
+      : expected;
+
+const defaultUnionMessage =
+  (expected: string) =>
+  (value: mixed, name?: string): string =>
+    name ? `Expected (${name}) to be ${expected}` : expected;
+
+const defaultObjectMessage =
+  (expected: string) =>
+  (value: mixed, name?: string): string =>
+    name ? `Expected (${name}) to be ${expected} but:` : expected;
+
+const indent = (str: string): string =>
+  str
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('But got:'))
+    .map((line) =>
+      line.includes(', but got') ? line.replace(/, but got.+$/, '') : line,
+    )
+    .map((line) => (line.trim()[0] === '-' ? line : `- ${line}`))
+    .map((line) => `\n\t${line}`)
+    .join('');
+
+export type Check<+T> = (val: mixed, name?: string) => Error | T;
+export type InferCheckType<T> = T extends Check<infer U> ? U : empty;
+
+type Msg = (value: mixed, name?: string) => string;
+type PrimitiveChecker<+T> = (message?: Msg) => Check<T>;
+
+export const string: PrimitiveChecker<string> =
+  (message = defaultMessage('a string')) =>
+  (value, name) => {
     if (typeof value !== 'string') {
-      return new Error(message('string'));
+      return new Error(message(value, name));
     }
-
     return value;
   };
 
-export const nullish =
-  (
-    message?: (name: string) => string = (name) =>
-      `Expected ${name} to be null or undefined`,
-  ): ((val: mixed) => ?Error) =>
-  (value: mixed): ?Error =>
-    value == null ? value : new Error(message('nullish'));
+export const nullish: PrimitiveChecker<null | void> =
+  (message = defaultMessage('`null` or `undefined`')) =>
+  (value, name) =>
+    value == null ? value : new Error(message(value, name));
 
-export const boolean =
-  (
-    message?: (name: string) => string = (name) =>
-      `Expected ${name} to be a boolean`,
-  ): ((val: mixed) => Error | boolean) =>
-  (value: mixed): Error | boolean => {
+export const boolean: PrimitiveChecker<boolean> =
+  (message = defaultMessage('a boolean')) =>
+  (value, name) => {
     if (typeof value !== 'boolean') {
-      return new Error(message('boolean'));
+      return new Error(message(value, name));
     }
-
     return value;
   };
 
-export const number =
-  (
-    message?: (name: string) => string = (name) =>
-      `Expected ${name} to be a number`,
-  ): ((val: mixed) => Error | number) =>
-  (value: mixed): Error | number => {
+export const number: PrimitiveChecker<number> =
+  (message = defaultMessage('a number')) =>
+  (value, name) => {
     if (typeof value !== 'number') {
-      return new Error(message('number'));
+      return new Error(message(value, name));
     }
-
     return value;
   };
 
-export const literal =
-  <T: string | number | boolean>(
-    expected: T,
-    message?: (name: string) => string = (name) =>
-      `Expected ${name} to be ${String(expected)}`,
-  ): ((val: mixed) => Error | T) =>
-  (value: mixed): Error | T => {
+export const literal: <T: string | number | boolean>(
+  T,
+  msg?: Msg,
+) => Check<T> =
+  (
+    expected,
+    message = defaultMessage(`the literal ${JSON.stringify(expected)}`),
+  ) =>
+  (value, name) => {
     if (value === expected) {
       return expected;
     }
-    const n: string = JSON.stringify(value) ?? String(value);
-    return new Error(message(n));
+    return new Error(message(value, name));
   };
+
+export const array: <T>(Check<T>, msg?: Msg) => Check<$ReadOnlyArray<T>> =
+  <T>(
+    check: Check<T>,
+    message = defaultMessage('an array'),
+  ): Check<$ReadOnlyArray<T>> =>
+  (value: mixed, name?: string = 'array') => {
+    if (!Array.isArray(value)) {
+      return new Error(message(value, name));
+    }
+
+    const validated: $ReadOnlyArray<T | Error> = value.map((item, i) =>
+      check(item, name ? `${name}[${i}]` : undefined),
+    );
+
+    const errors = validated.filter(
+      (item): item is Error => item instanceof Error,
+    );
+
+    if (errors.length > 0) {
+      const errMessageList = errors
+        .map((item) => '\t' + item.message)
+        .join('\n');
+
+      return new Error(`Failed to validate ${name}:\n${errMessageList}`);
+    }
+
+    return validated.filter((item): item is T => !(item instanceof Error));
+  };
+
+type ObjOfChecks<T: { +[string]: Check<mixed> }> = $ReadOnly<{
+  [K in keyof T]: InferCheckType<T[K]>,
+}>;
+
+export const object: <T: { +[string]: Check<mixed> }>(
+  T,
+  msg?: Msg,
+) => Check<ObjOfChecks<T>> =
+  <T: { +[string]: Check<mixed> }>(
+    shape: T,
+    message = defaultMessage('an object where:'),
+  ): Check<ObjOfChecks<T>> =>
+  (value, name) => {
+    if (typeof value !== 'object' || value == null) {
+      return new Error(message(value, name));
+    }
+    // $FlowFixMe
+    const result: Partial<{ ...ObjOfChecks<T> }> = {};
+    for (const key in shape) {
+      const check = shape[key];
+      const item = check(value[key], name ? `${name}.${key}` : `obj.${key}`);
+      if (item instanceof Error) {
+        const objectDescription = Object.entries(shape)
+          .map(([key, check]) => {
+            let msg = (check(Symbol()): any).message;
+            if (msg.includes('\n')) {
+              msg = indent(indent(msg)).split('\n').slice(1).join('\n');
+            }
+            return `\t- Expected "${key}": to be ${msg}`;
+          })
+          .join('\n');
+
+        return new Error(
+          `${message(value, name)}\n${objectDescription}\nBut got: ${indent(
+            JSON.stringify((value: $FlowFixMe)),
+          )}`,
+        );
+      }
+      result[key] = item;
+    }
+    return result;
+  };
+
+export const objectOf: <T>(Check<T>, Msg) => Check<{ +[string]: T }> =
+  <T>(
+    check: Check<T>,
+    message = defaultObjectMessage('an object'),
+  ): Check<{ +[string]: T }> =>
+  (value, name) => {
+    if (typeof value !== 'object' || value == null) {
+      return new Error(message(value, name));
+    }
+    // $FlowFixMe
+    const result: { [string]: T } = {};
+    for (const key in value) {
+      const item = check(
+        value[key],
+        name ? `${name}.${key}` : `With the key '${key}':`,
+      );
+      if (item instanceof Error) {
+        return new Error(
+          `${message(value, name)}${indent(item.message)}\nBut got: ${indent(
+            JSON.stringify((value: $FlowFixMe)),
+          )}`,
+        );
+      }
+      result[key] = item;
+    }
+    return result;
+  };
+
+export const unionOf =
+  <A, B>(
+    a: Check<A>,
+    b: Check<B>,
+    message: Msg = defaultUnionMessage('one of'),
+  ): Check<A | B> =>
+  (value, name) => {
+    const resultA = a(value);
+    if (!(resultA instanceof Error)) {
+      return resultA;
+    }
+    const resultB = b(value);
+    if (!(resultB instanceof Error)) {
+      return resultB;
+    }
+    return new Error(
+      `${message(value, name)}${indent(resultA.message)}${indent(
+        resultB.message,
+      )}\nBut got: ${JSON.stringify((value: $FlowFixMe))}`,
+    );
+  };
+
+export const unionOf3 =
+  <A, B, C>(
+    a: Check<A>,
+    b: Check<B>,
+    c: Check<C>,
+    message: Msg = defaultUnionMessage('one of'),
+  ): Check<A | B | C> =>
+  (value, name) => {
+    const resultA = a(value);
+    if (!(resultA instanceof Error)) {
+      return resultA;
+    }
+    const resultB = b(value);
+    if (!(resultB instanceof Error)) {
+      return resultB;
+    }
+    const resultC = c(value);
+    if (!(resultC instanceof Error)) {
+      return resultC;
+    }
+    return new Error(
+      `${message(value, name)}${indent(resultA.message)}${indent(
+        resultB.message,
+      )}${indent(resultC.message)}\nBut got: ${JSON.stringify(
+        (value: $FlowFixMe),
+      )}`,
+    );
+  };
+
+export const unionOf4 =
+  <A, B, C, D>(
+    a: Check<A>,
+    b: Check<B>,
+    c: Check<C>,
+    d: Check<D>,
+    message: Msg = defaultUnionMessage('one of'),
+  ): Check<A | B | C | D> =>
+  (value, name) => {
+    const resultA = a(value);
+    if (!(resultA instanceof Error)) {
+      return resultA;
+    }
+    const resultB = b(value);
+    if (!(resultB instanceof Error)) {
+      return resultB;
+    }
+    const resultC = c(value);
+    if (!(resultC instanceof Error)) {
+      return resultC;
+    }
+    const resultD = d(value);
+    if (!(resultD instanceof Error)) {
+      return resultD;
+    }
+    return new Error(
+      `${message(value, name)}${indent(resultA.message)}${indent(
+        resultB.message,
+      )}${indent(resultC.message)}${indent(
+        resultD.message,
+      )}\nBut got: ${JSON.stringify((value: $FlowFixMe))}`,
+    );
+  };
+
+export const logAndDefault = <T>(
+  check: Check<T>,
+  value: mixed,
+  def: T,
+  name?: string,
+): T => {
+  const result = check(value, name);
+  if (result instanceof Error) {
+    console.error('[@stylexjs/babel-plugin]', result.message);
+    return def;
+  }
+  return result;
+};


### PR DESCRIPTION
## What changed / motivation ?

Improve the Babel plugin's `StateManager` to not use `$FlowFixMe` (`any`) and instead of validate the options passed in.

The code is very imperative at the moment and feels a bit hard to read and fragile. I'm looking into using a library like `zod` to clean this up.

