### PR TITLE
fix: creating `keyframes` inside `defineVars`

### DIFF
--- a/apps/docs/docs/api/javascript/createTheme.mdx
+++ b/apps/docs/docs/api/javascript/createTheme.mdx
@@ -25,7 +25,7 @@ function createTheme(
 
 ```ts
 import * as stylex from '@stylexjs/stylex';
-import {colors} from './vars.stylex.js';
+import { colors } from './vars.stylex.js';
 
 const theme = stylex.createTheme(colors, {
   accentColor: 'red',

--- a/apps/docs/docs/api/javascript/defineVars.mdx
+++ b/apps/docs/docs/api/javascript/defineVars.mdx
@@ -25,7 +25,7 @@ You must define your variables as named exports in a `.stylex.js` (or
 ```tsx title="vars.stylex.js"
 import * as stylex from '@stylexjs/stylex';
 
-const colors = stylex.defineVars({
+export const colors = stylex.defineVars({
   accent: 'blue',
   background: 'white',
   line: 'gray',
@@ -38,7 +38,7 @@ You can then import and use these variables in any `stylex.create` call.
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';
-import {colors} from './vars.stylex.js';
+import { colors } from './vars.stylex.js';
 
 const styles = stylex.create({
   container: {

--- a/packages/babel-plugin/__tests__/stylex-validation-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-validation-define-vars-test.js
@@ -130,8 +130,8 @@ describe('@stylexjs/babel-plugin', () => {
               '100%': { opacity: 1}
             }),
           });
-        `)
-      }).not.toThrow()
+        `);
+      }).not.toThrow();
       // not static
       expect(() => {
         transform(`

--- a/packages/babel-plugin/__tests__/stylex-validation-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-validation-define-vars-test.js
@@ -120,7 +120,7 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `);
       }).not.toThrow();
-      // keyframe
+      // keyframes
       expect(() => {
         transform(`
           import stylex from 'stylex';

--- a/packages/babel-plugin/__tests__/stylex-validation-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-validation-define-vars-test.js
@@ -101,7 +101,7 @@ describe('@stylexjs/babel-plugin', () => {
 
     /* Values */
 
-    test('values must be static number or string in stylex.defineVars()', () => {
+    test('values must be static number, string or keyframe in stylex.defineVars()', () => {
       // number
       expect(() => {
         transform(`
@@ -120,6 +120,18 @@ describe('@stylexjs/babel-plugin', () => {
           });
         `);
       }).not.toThrow();
+      // keyframe
+      expect(() => {
+        transform(`
+          import stylex from 'stylex';
+          export const styles = stylex.defineVars({
+            fadeIn: stylex.keyframes({
+              '0%': { opacity: 0 },
+              '100%': { opacity: 1}
+            }),
+          });
+        `)
+      }).not.toThrow()
       // not static
       expect(() => {
         transform(`

--- a/packages/babel-plugin/__tests__/stylex-validation-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-validation-define-vars-test.js
@@ -101,7 +101,7 @@ describe('@stylexjs/babel-plugin', () => {
 
     /* Values */
 
-    test('values must be static number, string or keyframe in stylex.defineVars()', () => {
+    test('values must be static number or string, or keyframes in stylex.defineVars()', () => {
       // number
       expect(() => {
         transform(`

--- a/packages/babel-plugin/src/visitors/stylex-define-vars.js
+++ b/packages/babel-plugin/src/visitors/stylex-define-vars.js
@@ -16,7 +16,7 @@ import {
   messages,
   utils,
   keyframes as stylexKeyframes,
-  type InjectableStyle
+  type InjectableStyle,
 } from '@stylexjs/shared';
 import { convertObjectToAST } from '../utils/js-to-ast';
 import { evaluate, type FunctionConfig } from '../utils/evaluate-path';
@@ -72,7 +72,7 @@ export default function transformStyleXDefineVars(
       >,
     > = callExpressionPath.get('arguments');
     const firstArg = args[0];
- 
+
     const injectedKeyframes: { [animationName: string]: InjectableStyle } = {};
 
     // eslint-disable-next-line no-inner-declarations
@@ -92,15 +92,15 @@ export default function transformStyleXDefineVars(
     const identifiers: FunctionConfig['identifiers'] = {};
     const memberExpressions: FunctionConfig['memberExpressions'] = {};
     state.stylexKeyframesImport.forEach((name) => {
-      identifiers[name] = { fn: keyframes }
-    })
+      identifiers[name] = { fn: keyframes };
+    });
     state.stylexImport.forEach((name) => {
       if (memberExpressions[name] === undefined) {
-        memberExpressions[name] = {}
+        memberExpressions[name] = {};
       }
 
-      memberExpressions[name].keyframes = { fn: keyframes }
-    })
+      memberExpressions[name].keyframes = { fn: keyframes };
+    });
 
     const { confident, value } = evaluate(firstArg, state, {
       identifiers,
@@ -120,15 +120,18 @@ export default function transformStyleXDefineVars(
 
     const exportName = varId.name;
 
-    const [variablesObj, injectedStylesSansKeyframes] = stylexDefineVars(value, {
-      ...state.options,
-      themeName: utils.genFileBasedIdentifier({ fileName, exportName }),
-    });
+    const [variablesObj, injectedStylesSansKeyframes] = stylexDefineVars(
+      value,
+      {
+        ...state.options,
+        themeName: utils.genFileBasedIdentifier({ fileName, exportName }),
+      },
+    );
 
     const injectedStyles = {
       ...injectedKeyframes,
-      ...injectedStylesSansKeyframes
-    }
+      ...injectedStylesSansKeyframes,
+    };
 
     // This should be a transformed variables object
     callExpressionPath.replaceWith(convertObjectToAST(variablesObj));

--- a/packages/babel-plugin/src/visitors/stylex-define-vars.js
+++ b/packages/babel-plugin/src/visitors/stylex-define-vars.js
@@ -15,6 +15,8 @@ import {
   defineVars as stylexDefineVars,
   messages,
   utils,
+  keyframes as stylexKeyframes,
+  type InjectableStyle
 } from '@stylexjs/shared';
 import { convertObjectToAST } from '../utils/js-to-ast';
 import { evaluate, type FunctionConfig } from '../utils/evaluate-path';
@@ -70,9 +72,35 @@ export default function transformStyleXDefineVars(
       >,
     > = callExpressionPath.get('arguments');
     const firstArg = args[0];
+ 
+    const injectedKeyframes: { [animationName: string]: InjectableStyle } = {};
+
+    // eslint-disable-next-line no-inner-declarations
+    function keyframes<
+      Obj: {
+        +[key: string]: { +[k: string]: string | number },
+      },
+    >(animation: Obj): string {
+      const [animationName, injectedStyle] = stylexKeyframes(
+        animation,
+        state.options,
+      );
+      injectedKeyframes[animationName] = injectedStyle;
+      return animationName;
+    }
 
     const identifiers: FunctionConfig['identifiers'] = {};
     const memberExpressions: FunctionConfig['memberExpressions'] = {};
+    state.stylexKeyframesImport.forEach((name) => {
+      identifiers[name] = { fn: keyframes }
+    })
+    state.stylexImport.forEach((name) => {
+      if (memberExpressions[name] === undefined) {
+        memberExpressions[name] = {}
+      }
+
+      memberExpressions[name].keyframes = { fn: keyframes }
+    })
 
     const { confident, value } = evaluate(firstArg, state, {
       identifiers,
@@ -92,10 +120,15 @@ export default function transformStyleXDefineVars(
 
     const exportName = varId.name;
 
-    const [variablesObj, injectedStyles] = stylexDefineVars(value, {
+    const [variablesObj, injectedStylesSansKeyframes] = stylexDefineVars(value, {
       ...state.options,
       themeName: utils.genFileBasedIdentifier({ fileName, exportName }),
     });
+
+    const injectedStyles = {
+      ...injectedKeyframes,
+      ...injectedStylesSansKeyframes
+    }
 
     // This should be a transformed variables object
     callExpressionPath.replaceWith(convertObjectToAST(variablesObj));


### PR DESCRIPTION
## What changed / motivation ?

This PR fixes the bug, where consumers cannot create `keyframes` directly inside `defineVars`.

```
export const vars = stylex.defineVars({
  fadeIn: stylex.keyframes({
    '0%': { opacity: 0 },
    '100%': { opacity: 1},
  }),
});
```

## Linked PR/Issues

Fixes #291 

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code