### PR TITLE
Fix: The object position can also be in percentages or pixel values.

### DIFF
--- a/packages/stylex/src/StyleXCSSTypes.js
+++ b/packages/stylex/src/StyleXCSSTypes.js
@@ -475,7 +475,7 @@ type MsOverflowStyle =
   | 'scrollbar'
   | '-ms-autohiding-scrollbar';
 type objectFit = 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
-type objectPosition = string;
+type objectPosition = string | number ;
 type opacity = number;
 type order = number;
 type orphans = number;


### PR DESCRIPTION
## Object postion

We can use pixels and percentages in values as well. I have seen the only string we can use in numbers as well.