### PR TITLE
Update capitilisation of stylex to match documentation StyleX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# stylex &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebook/stylex/blob/main/LICENSE) [![npm version](https://img.shields.io/npm/v/@stylexjs/stylex.svg?style=flat)](https://www.npmjs.com/package/@stylexjs/stylex) [![Build Status](https://github.com/facebook/stylex/workflows/tests/badge.svg)](https://github.com/facebook/stylex/actions) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
+# StyleX &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebook/stylex/blob/main/LICENSE) [![npm version](https://img.shields.io/npm/v/@stylexjs/stylex.svg?style=flat)](https://www.npmjs.com/package/@stylexjs/stylex) [![Build Status](https://github.com/facebook/stylex/workflows/tests/badge.svg)](https://github.com/facebook/stylex/actions) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
 
 StyleX is a JavaScript library for defining styles for optimized user
 interfaces.
@@ -13,7 +13,7 @@ files. Start with
 
 ### Example
 
-Here is a simple example of stylex use:
+Here is a simple example of StyleX use:
 
 ```js
 import stylex from '@stylexjs/stylex';
@@ -32,7 +32,7 @@ const styleProps = stylex.apply(styles.root, styles.element);
 
 ## Development
 
-This is the development monorepo for stylex.
+This is the development monorepo for StyleX.
 
 ### Structure
 
@@ -40,7 +40,7 @@ This is the development monorepo for stylex.
   - Contains workflows used by GitHub Actions.
   - Contains issue templates and contribution guidelines.
 - `apps`
-  - Contains example apps using stylex and integration with build tools.
+  - Contains example apps using StyleX and integration with build tools.
 - `packages`
   - Contains the individual packages managed in the monorepo.
   - [babel-plugin](https://github.com/facebook/stylex/blob/main/packages/babel-plugin)


### PR DESCRIPTION
## What changed / motivation ?

Updated capitalisation in `README.md` file to match documentation website.

## Additional Context

I was trying to reference this project and wanted to quickly understand how this project should be capitalised. From what I can tell it should be `StyleX` so I wanted to make that clear in the README file.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code