### PR TITLE
Feat/bundle runtime

### DIFF
--- a/packages/babel-plugin/rollup.config.mjs
+++ b/packages/babel-plugin/rollup.config.mjs
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ *
  */
 
 import { nodeResolve } from '@rollup/plugin-node-resolve';

--- a/packages/stylex/.babelrc.js
+++ b/packages/stylex/.babelrc.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const BABEL_ENV = process.env['BABEL_ENV'];
+
 function makeHaste() {
   return {
     visitor: {
@@ -31,6 +33,7 @@ const presets = process.env['HASTE']
         {
           exclude: ['@babel/plugin-transform-typeof-symbol'],
           targets: 'defaults',
+          modules: BABEL_ENV === 'esm' ? false : 'cjs',
         },
       ],
       '@babel/preset-flow',

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -12,7 +12,7 @@
       "types": "./lib/stylex.d.ts"
     },
     "./lib/StyleXTypes": {
-      "import": "./lib/es/StyleXTypes.js",
+      "import": "./lib/StyleXTypes.js",
       "require": "./lib/StyleXTypes.js",
       "types": "./lib/StyleXTypes.d.ts"
     },

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -2,13 +2,27 @@
   "name": "@stylexjs/stylex",
   "version": "0.5.0-beta.1",
   "description": "A library for defining styles for optimized user interfaces.",
-  "main": "lib/stylex.js",
-  "types": "lib/stylex.d.ts",
+  "main": "./lib/stylex.js",
+  "module": "./lib/es/stylex.js",
+  "types": "./lib/stylex.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib/es/stylex.js",
+      "require": "./lib/stylex.js",
+      "types": "./lib/stylex.d.ts"
+    },
+    "./lib/StyleXTypes": "./lib/StyleXTypes.js",
+    "./lib/StyleXSheet": "./lib/StyleXSheet.js",
+    "./lib/stylex-inject": "./lib/stylex-inject.js",
+    "./package.json": "./package.json"
+  },
   "repository": "https://www.github.com/facebook/stylex",
   "license": "MIT",
   "scripts": {
     "prebuild": "gen-types -i src/ -o lib/",
-    "build": "babel src/ --out-dir lib/ --copy-files",
+    "build:cjs": "BABEL_ENV=cjs babel src/ --out-dir lib/ --copy-files",
+    "build:esm": "BABEL_ENV=esm babel src/ --out-dir lib/es --copy-files",
+    "build": "npm run build:cjs && npm run build:esm",
     "build-haste": "rewrite-imports -i src/ -o lib/",
     "test": "jest"
   },

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -11,9 +11,21 @@
       "require": "./lib/stylex.js",
       "types": "./lib/stylex.d.ts"
     },
-    "./lib/StyleXTypes": "./lib/StyleXTypes.js",
-    "./lib/StyleXSheet": "./lib/StyleXSheet.js",
-    "./lib/stylex-inject": "./lib/stylex-inject.js",
+    "./lib/StyleXTypes": {
+      "import": "./lib/es/StyleXTypes.js",
+      "require": "./lib/StyleXTypes.js",
+      "types": "./lib/StyleXTypes.d.ts"
+    },
+    "./lib/StyleXSheet": {
+      "import": "./lib/es/StyleXSheet.js",
+      "require": "./lib/StyleXSheet.js",
+      "types": "./lib/StyleXSheet.d.ts"
+    },
+    "./lib/stylex-inject": {
+      "import": "./lib/es/stylex-inject.js",
+      "require": "./lib/stylex-inject.js",
+      "types": "./lib/stylex-inject.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "repository": "https://www.github.com/facebook/stylex",
@@ -22,6 +34,7 @@
     "prebuild": "gen-types -i src/ -o lib/",
     "build:cjs": "BABEL_ENV=cjs babel src/ --out-dir lib/ --copy-files",
     "build:esm": "BABEL_ENV=esm babel src/ --out-dir lib/es --copy-files",
+    "postbuild:esm": "rollup -c ./rollup.config.mjs",
     "build": "npm run build:cjs && npm run build:esm",
     "build-haste": "rewrite-imports -i src/ -o lib/",
     "test": "jest"

--- a/packages/stylex/rollup.config.mjs
+++ b/packages/stylex/rollup.config.mjs
@@ -11,10 +11,14 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
 const config = {
-  input: './lib/stylex.js',
+  input: {
+    stylex: './lib/es/stylex.js',
+    StyleXSheet: './lib/es/StyleXSheet.js',
+  },
   output: {
-    file: './lib/stylex.js',
-    format: 'cjs',
+    dir: './lib/es/',
+    // file: './lib/es/stylex.js',
+    // format: 'cjs',
   },
   plugins: [nodeResolve(), commonjs()],
 };

--- a/packages/stylex/rollup.config.mjs
+++ b/packages/stylex/rollup.config.mjs
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+
+const config = {
+  input: './lib/stylex.js',
+  output: {
+    file: './lib/stylex.js',
+    format: 'cjs',
+  },
+  plugins: [nodeResolve(), commonjs()],
+};
+
+export default config;

--- a/packages/stylex/src/stylex.js
+++ b/packages/stylex/src/stylex.js
@@ -290,5 +290,5 @@ export function __monkey_patch__(
   }
 }
 
-export const stylex: IStyleX = _stylex;
+export const legacyMerge: IStyleX = _stylex;
 export default (_stylex: IStyleX);

--- a/packages/webpack-plugin/__tests__/index-test.js
+++ b/packages/webpack-plugin/__tests__/index-test.js
@@ -284,21 +284,60 @@ describe('webpack-plugin-stylex', () => {
           exports.ids = [179];
           exports.modules = {
 
-          /***/ "../../../stylex/lib/StyleXSheet.js":
-          /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+          /***/ "./index.js":
+          /***/ (() => {
 
 
+          // UNUSED EXPORTS: default
 
-          Object.defineProperty(exports, "__esModule", ({
-            value: true
-          }));
-          exports.styleSheet = exports.StyleXSheet = void 0;
-          var _invariant = _interopRequireDefault(__webpack_require__("../../../../node_modules/invariant/invariant.js"));
-          function _interopRequireDefault(obj) {
-            return obj && obj.__esModule ? obj : {
-              default: obj
-            };
+          ;// CONCATENATED MODULE: ../../../stylex/lib/es/StyleXSheet.js
+          function getDefaultExportFromCjs(x) {
+            return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
           }
+
+          /**
+           * Copyright (c) 2013-present, Facebook, Inc.
+           *
+           * This source code is licensed under the MIT license found in the
+           * LICENSE file in the root directory of this source tree.
+           */
+
+          /**
+           * Use invariant() to assert state which your program assumes to be true.
+           *
+           * Provide sprintf-style format (only %s is supported) and arguments
+           * to provide information about what broke and what you were
+           * expecting.
+           *
+           * The invariant message will be stripped in production, but the invariant
+           * will remain to ensure logic does not differ in production.
+           */
+
+          var NODE_ENV = "production";
+          var invariant = function (condition, format, a, b, c, d, e, f) {
+            if (NODE_ENV !== 'production') {
+              if (format === undefined) {
+                throw new Error('invariant requires an error message argument');
+              }
+            }
+            if (!condition) {
+              var error;
+              if (format === undefined) {
+                error = new Error('Minified exception occurred; use the non-minified dev environment ' + 'for the full error message and additional helpful warnings.');
+              } else {
+                var args = [a, b, c, d, e, f];
+                var argIndex = 0;
+                error = new Error(format.replace(/%s/g, function () {
+                  return args[argIndex++];
+                }));
+                error.name = 'Invariant Violation';
+              }
+              error.framesToPop = 1; // we don't care about invariant's own frame
+              throw error;
+            }
+          };
+          var invariant_1 = invariant;
+          var invariant$1 = /*@__PURE__*/getDefaultExportFromCjs(invariant_1);
           const LIGHT_MODE_CLASS_NAME = '__fb-light-mode';
           const DARK_MODE_CLASS_NAME = '__fb-dark-mode';
           function buildTheme(selector, theme) {
@@ -316,7 +355,7 @@ describe('webpack-plugin-stylex', () => {
             tag.setAttribute('type', 'text/css');
             tag.setAttribute('data-stylex', 'true');
             const head = document.head || document.getElementsByTagName('head')[0];
-            (0, _invariant.default)(head, 'expected head');
+            invariant$1(head, 'expected head');
             head.appendChild(tag);
             return tag;
           }
@@ -346,7 +385,7 @@ describe('webpack-plugin-stylex', () => {
               const {
                 tag
               } = this;
-              (0, _invariant.default)(tag != null, 'expected tag');
+              invariant$1(tag != null, 'expected tag');
               return tag;
             }
             getCSS() {
@@ -385,14 +424,14 @@ describe('webpack-plugin-stylex', () => {
             }
             delete(rule) {
               const index = this.rules.indexOf(rule);
-              (0, _invariant.default)(index >= 0, "Couldn't find the index for rule %s", rule);
+              invariant$1(index >= 0, "Couldn't find the index for rule %s", rule);
               this.rules.splice(index, 1);
               if (this.isHeadless()) {
                 return;
               }
               const tag = this.getTag();
               const sheet = tag.sheet;
-              (0, _invariant.default)(sheet, 'expected sheet');
+              invariant$1(sheet, 'expected sheet');
               sheet.deleteRule(index);
             }
             normalizeRule(rule) {
@@ -449,7 +488,6 @@ describe('webpack-plugin-stylex', () => {
               }
             }
           }
-          exports.StyleXSheet = StyleXSheet;
           function addAncestorSelector(selector, ancestorSelector) {
             if (!selector.startsWith('@')) {
               return \`\${ancestorSelector} \${selector}\`;
@@ -471,40 +509,18 @@ describe('webpack-plugin-stylex', () => {
             const afterCurly = selector.slice(lastOpenCurly);
             return \`\${beforeCurly}\${pseudo}\${afterCurly}\`;
           }
-          const styleSheet = exports.styleSheet = new StyleXSheet({
+          const styleSheet = new StyleXSheet({
             supportsVariables: true,
             rootTheme: {},
             rootDarkTheme: {}
           });
 
-          /***/ }),
+          ;// CONCATENATED MODULE: ../../../stylex/lib/es/stylex-inject.js
 
-          /***/ "../../../stylex/lib/stylex-inject.js":
-          /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
-
-          var __webpack_unused_export__;
-
-
-          __webpack_unused_export__ = ({
-            value: true
-          });
-          exports.Z = inject;
-          var _StyleXSheet = __webpack_require__("../../../stylex/lib/StyleXSheet.js");
           function inject(ltrRule, priority) {
             let rtlRule = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
-            _StyleXSheet.styleSheet.insert(ltrRule, priority, rtlRule);
+            styleSheet.insert(ltrRule, priority, rtlRule);
           }
-
-          /***/ }),
-
-          /***/ "./index.js":
-          /***/ ((__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) => {
-
-
-          // UNUSED EXPORTS: default
-
-          // EXTERNAL MODULE: ../../../stylex/lib/stylex-inject.js
-          var stylex_inject = __webpack_require__("../../../stylex/lib/stylex-inject.js");
           ;// CONCATENATED MODULE: external "stylex"
           const external_stylex_namespaceObject = stylex;
           ;// CONCATENATED MODULE: ./otherStyles.js
@@ -523,8 +539,8 @@ describe('webpack-plugin-stylex', () => {
 
 
 
-          (0,stylex_inject/* default */.Z)(".x1lliihq{display:block}", 3000);
-          (0,stylex_inject/* default */.Z)(".xh8yej3{width:100%}", 4000);
+          inject(".x1lliihq{display:block}", 3000);
+          inject(".xh8yej3{width:100%}", 4000);
           var styles = {
             bar: {
               "otherStyles__styles.bar": "otherStyles__styles.bar",
@@ -550,9 +566,9 @@ describe('webpack-plugin-stylex', () => {
 
 
 
-          (0,stylex_inject/* default */.Z)(".xt0psk2{display:inline}", 3000);
-          (0,stylex_inject/* default */.Z)(".x1egiwwb{height:500px}", 4000);
-          (0,stylex_inject/* default */.Z)(".x3hqpx7{width:50%}", 4000);
+          inject(".xt0psk2{display:inline}", 3000);
+          inject(".x1egiwwb{height:500px}", 4000);
+          inject(".x3hqpx7{width:50%}", 4000);
           const npmStyles_styles = {
             baz: {
               "npmStyles__styles.baz": "npmStyles__styles.baz",
@@ -579,14 +595,14 @@ describe('webpack-plugin-stylex', () => {
 
 
 
-          (0,stylex_inject/* default */.Z)("@keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}", 1);
+          inject("@keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}", 1);
           var fadeAnimation = "xgnty7z-B";
-          (0,stylex_inject/* default */.Z)(".xeuoslp{animation-name:xgnty7z-B}", 3000);
-          (0,stylex_inject/* default */.Z)(".x78zum5{display:flex}", 3000);
-          (0,stylex_inject/* default */.Z)(".x1hm9lzh{margin-inline-start:10px}", 3000);
-          (0,stylex_inject/* default */.Z)(".xlrshdv{margin-top:99px}", 4000);
-          (0,stylex_inject/* default */.Z)(".x1egiwwb{height:500px}", 4000);
-          (0,stylex_inject/* default */.Z)(".x1oz5o6v:hover{background:red}", 1130);
+          inject(".xeuoslp{animation-name:xgnty7z-B}", 3000);
+          inject(".x78zum5{display:flex}", 3000);
+          inject(".x1hm9lzh{margin-inline-start:10px}", 3000);
+          inject(".xlrshdv{margin-top:99px}", 4000);
+          inject(".x1egiwwb{height:500px}", 4000);
+          inject(".x1oz5o6v:hover{background:red}", 1130);
           var index_styles = {
             foo: {
               "index__styles.foo": "index__styles.foo",
@@ -614,64 +630,6 @@ describe('webpack-plugin-stylex', () => {
           function App() {
             return stylex(otherStyles.bar, index_styles.foo, npmStyles.baz);
           }
-
-          /***/ }),
-
-          /***/ "../../../../node_modules/invariant/invariant.js":
-          /***/ ((module) => {
-
-          /**
-           * Copyright (c) 2013-present, Facebook, Inc.
-           *
-           * This source code is licensed under the MIT license found in the
-           * LICENSE file in the root directory of this source tree.
-           */
-
-
-
-          /**
-           * Use invariant() to assert state which your program assumes to be true.
-           *
-           * Provide sprintf-style format (only %s is supported) and arguments
-           * to provide information about what broke and what you were
-           * expecting.
-           *
-           * The invariant message will be stripped in production, but the invariant
-           * will remain to ensure logic does not differ in production.
-           */
-
-          var NODE_ENV = "production";
-
-          var invariant = function(condition, format, a, b, c, d, e, f) {
-            if (NODE_ENV !== 'production') {
-              if (format === undefined) {
-                throw new Error('invariant requires an error message argument');
-              }
-            }
-
-            if (!condition) {
-              var error;
-              if (format === undefined) {
-                error = new Error(
-                  'Minified exception occurred; use the non-minified dev environment ' +
-                  'for the full error message and additional helpful warnings.'
-                );
-              } else {
-                var args = [a, b, c, d, e, f];
-                var argIndex = 0;
-                error = new Error(
-                  format.replace(/%s/g, function() { return args[argIndex++]; })
-                );
-                error.name = 'Invariant Violation';
-              }
-
-              error.framesToPop = 1; // we don't care about invariant's own frame
-              throw error;
-            }
-          };
-
-          module.exports = invariant;
-
 
           /***/ })
 


### PR DESCRIPTION
## What changed / motivation ?

This PR will change the build step for `@stylexjs/stylex` to prebundle dependencies. This will allow us to ship an ESM export for the runtime without waiting for `styleq` and `invariant` to updated first. This is somewhat urgent to solve an issue with Vite with `0.4.1` where the import for runtime injection isn't handled correctly.

We can remove this additional build step once the dependencies are updated.
