### PR TITLE
[ESLint] Add support for missing -webkit-scrollbar pseudo elements

### DIFF
--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -2212,6 +2212,14 @@ const pseudoElements = makeUnionRule(
   makeLiteralRule('::-webkit-search-cancel-button'),
   makeLiteralRule('::-webkit-search-results-button'),
   makeLiteralRule('::-webkit-search-results-decoration'),
+  // For Scrollbars in Webkit and Chromium
+  makeLiteralRule('::-webkit-scrollbar'),
+  makeLiteralRule('::-webkit-scrollbar-button'),
+  makeLiteralRule('::-webkit-scrollbar-thumb'),
+  makeLiteralRule('::-webkit-scrollbar-track'),
+  makeLiteralRule('::-webkit-scrollbar-track-piece'),
+  makeLiteralRule('::-webkit-scrollbar-corner'),
+  makeLiteralRule('::-webkit-resizer'),
 );
 
 const pseudoClassesAndAtRules = makeUnionRule(
@@ -2451,6 +2459,15 @@ const stylexValidStyles = {
               )(key, variables);
 
               if (ruleCheck !== undefined) {
+                if (keyName.startsWith('::')) {
+                  return context.report(
+                    ({
+                      node: style.value,
+                      loc: style.value.loc,
+                      message: `Unknown pseudo element "${keyName}"`,
+                    }: $ReadOnly<Rule.ReportDescriptor>),
+                  );
+                }
                 return context.report(
                   ({
                     node: style.value,


### PR DESCRIPTION
## What changed / motivation ?

Fixes #320 

Adds support for missing pseudo elements to the ESLint plugin.

Also, improve the error message when an unknown pseudo element is used.
