### PR TITLE
feat: Add stylex.attrs for frameworks that expect 'class' over 'className'

### DIFF
--- a/apps/docs/docs/api/index.mdx
+++ b/apps/docs/docs/api/index.mdx
@@ -18,6 +18,7 @@ sidebar_position: 1
 
 - [`stylex.create()`](./javascript/create.mdx)
 - [`stylex.props()`](./javascript/props.mdx)
+- [`stylex.attrs()`](./javascript/attrs.mdx)
 - [`stylex.keyframes()`](./javascript/keyframes.mdx)
 - [`stylex.firstThatWorks()`](./javascript/firstThatWorks.mdx)
 - [`stylex.defineVars()`](./javascript/defineVars.mdx)

--- a/apps/docs/docs/api/javascript/attrs.mdx
+++ b/apps/docs/docs/api/javascript/attrs.mdx
@@ -3,27 +3,27 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-sidebar_position: 2
+sidebar_position: 3
 ---
 
-# `stylex.props`
+# `stylex.attrs`
+
+:::info
+
+Just like [`stylex.props`](./props.mdx) but the return object uses `class` instead of `className`,
+and converts `style` to a string.
+
+:::
 
 Takes an StyleX style or array of StyleX styles, and returns a props object.
 Values can also be `null`, `undefined`, or `false`.
 
 The return value should be onto an element to apply the styles directly.
 
-:::tip For Solid, Svelte, Qwik, Vue, & others: `stylex.attrs`
-
-For frameworks that expect `class` instead of `className`, use [`style.attrs`](./attrs.mdx) instead.
-The usage is otherwise identical to `stylex.props`.
-
-:::
-
 ```ts
-function props(styles: StyleXStyles | StyleXStyles[]): {
-  className: string;
-  style: {[key: string]: string};
+function attrs(styles: StyleXStyles | StyleXStyles[]): {
+  class?: string;
+  style?: string;
 };
 ```
 
@@ -47,7 +47,7 @@ const styles = stylex.create({
 });
 
 <div
-  {...stylex.props(
+  {...stylex.attrs(
     styles.root,
     condition && styles.conditional,
     props.style,

--- a/apps/docs/docs/api/javascript/createTheme.mdx
+++ b/apps/docs/docs/api/javascript/createTheme.mdx
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # `stylex.createTheme`

--- a/apps/docs/docs/api/javascript/defineVars.mdx
+++ b/apps/docs/docs/api/javascript/defineVars.mdx
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # `stylex.defineVars`

--- a/apps/docs/docs/api/javascript/firstThatWorks.mdx
+++ b/apps/docs/docs/api/javascript/firstThatWorks.mdx
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # `stylex.firstThatWorks`

--- a/apps/docs/docs/api/javascript/keyframes.mdx
+++ b/apps/docs/docs/api/javascript/keyframes.mdx
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # `stylex.keyframes`

--- a/apps/docs/docs/learn/04-styling-ui/02-using-styles.mdx
+++ b/apps/docs/docs/learn/04-styling-ui/02-using-styles.mdx
@@ -9,7 +9,7 @@ sidebar_position: 2
 # Using styles
 
 Once styles have been defined, they can be converted to props that can be spread
-on HTML elements using the `stylex.props` function. The `stylex.props` function
+on HTML elements using the [`stylex.props`](../../api/javascript/props.mdx) function. The `stylex.props` function
 sets the appropriate `className` prop on the HTML element and, when using
 [dynamic styles](/docs/learn/styling-ui/defining-styles/#dynamic-styles), the
 `style` prop.
@@ -20,6 +20,16 @@ sets the appropriate `className` prop on the HTML element and, when using
 
 While this is the simplest case, it is trivial to merge multiple style objects,
 use them conditionally, or even compose styles across module boundaries.
+
+:::tip For Solid, Svelte, Qwik, Vue, & others: `stylex.attrs`
+
+For frameworks that expect `class` instead of `className`, use [`style.attrs`](../../api/javascript/attrs.mdx) instead.
+The usage is otherwise identical to `stylex.props`.
+
+`stylex.attrs` also converts any `style` value to a string, which is useful for
+server-side rendering and frameworks that don't accept objects for `style`.
+
+:::
 
 ## Merging styles
 

--- a/packages/babel-plugin/__tests__/stylex-transform-stylex-attrs-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-stylex-attrs-test.js
@@ -1,0 +1,1403 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+jest.autoMockOff();
+
+const { transformSync } = require('@babel/core');
+const stylexPlugin = require('../src/index');
+const jsx = require('@babel/plugin-syntax-jsx');
+
+function transform(source, opts = {}) {
+  return transformSync(source, {
+    filename: opts.filename,
+    parserOpts: {
+      flow: 'all',
+    },
+    plugins: [jsx, [stylexPlugin, { ...opts, runtimeInjection: true }]],
+  }).code;
+}
+
+describe('@stylexjs/babel-plugin', () => {
+  describe('[transform] stylex.attrs() call', () => {
+    test('empty stylex.attrs call', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          stylex.attrs();
+        `),
+      ).toMatchInlineSnapshot(`
+        "import stylex from 'stylex';
+        ({});"
+      `);
+    });
+
+    test('basic stylex call', () => {
+      expect(
+        transform(`
+          import * as stylex from 'stylex';
+          const styles = stylex.create({
+            red: {
+              color: 'red',
+            }
+          });
+          stylex.attrs(styles.red);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import * as stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        ({
+          class: "x1e2nbdu"
+        });"
+      `);
+    });
+
+    test('stylex call with number', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            0: {
+              color: 'red',
+            },
+            1: {
+              backgroundColor: 'blue',
+            }
+          });
+          stylex.attrs([styles[0], styles[1]]);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
+        ({
+          class: "x1e2nbdu x1t391ir"
+        });"
+      `);
+    });
+
+    test('stylex call with computed number', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            [0]: {
+              color: 'red',
+            },
+            [1]: {
+              backgroundColor: 'blue',
+            }
+          });
+          stylex.attrs([styles[0], styles[1]]);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
+        ({
+          class: "x1e2nbdu x1t391ir"
+        });"
+      `);
+    });
+
+    test('stylex call with computed string', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            'default': {
+              color: 'red',
+            }
+          });
+          stylex.attrs(styles['default']);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        ({
+          class: "x1e2nbdu"
+        });"
+      `);
+    });
+
+    test('stylex call with multiple namespaces', () => {
+      expect(
+        transform(`
+          import {create, attrs} from 'stylex';
+          const styles = create({
+            default: {
+              color: 'red',
+            },
+          });
+          const otherStyles = create({
+            default: {
+              backgroundColor: 'blue',
+            }
+          });
+          attrs([styles.default, otherStyles.default]);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import { create, attrs } from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
+        ({
+          class: "x1e2nbdu x1t391ir"
+        });"
+      `);
+    });
+
+    test('stylex call within variable declarations', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: { color: 'red' }
+          });
+          const a = function() {
+            return stylex.attrs(styles.foo);
+          }
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        const a = function () {
+          return {
+            class: "x1e2nbdu"
+          };
+        };"
+      `);
+    });
+
+    test('stylex call with styles variable assignment', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              color: 'red',
+            },
+            bar: {
+              backgroundColor: 'blue',
+            }
+          });
+          stylex.attrs([styles.foo, styles.bar]);
+          const foo = styles;
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
+        const styles = {
+          foo: {
+            color: "x1e2nbdu",
+            $$css: true
+          },
+          bar: {
+            backgroundColor: "x1t391ir",
+            $$css: true
+          }
+        };
+        ({
+          class: "x1e2nbdu x1t391ir"
+        });
+        const foo = styles;"
+      `);
+    });
+
+    test('stylex call within export declarations', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: { color: 'red' }
+          });
+          export default function MyExportDefault() {
+            return stylex.attrs(styles.foo);
+          }
+          export function MyExport() {
+            return stylex.attrs(styles.foo);
+          }
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        export default function MyExportDefault() {
+          return {
+            class: "x1e2nbdu"
+          };
+        }
+        export function MyExport() {
+          return {
+            class: "x1e2nbdu"
+          };
+        }"
+      `);
+    });
+
+    test('stylex call with short-form properties', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              padding: 5
+            }
+          });
+          stylex.attrs(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14odnwx{padding:5px}", 1000);
+        ({
+          class: "x14odnwx"
+        });"
+      `);
+    });
+
+    test('stylex call with exported short-form properties', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            foo: {
+              padding: 5
+            }
+          });
+          stylex.attrs([styles.foo]);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x14odnwx{padding:5px}", 1000);
+        export const styles = {
+          foo: {
+            padding: "x14odnwx",
+            paddingInline: null,
+            paddingStart: null,
+            paddingLeft: null,
+            paddingEnd: null,
+            paddingRight: null,
+            paddingBlock: null,
+            paddingTop: null,
+            paddingBottom: null,
+            $$css: true
+          }
+        };
+        ({
+          class: "x14odnwx"
+        });"
+      `);
+    });
+
+    test('stylex call using styles with pseudo selectors', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            default: {
+              color: 'red',
+              ':hover': {
+                color: 'blue',
+              }
+            }
+          });
+          stylex.attrs(styles.default);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x17z2mba:hover{color:blue}", 3130);
+        ({
+          class: "x1e2nbdu x17z2mba"
+        });"
+      `);
+    });
+
+    test('stylex call using styles with pseudo selectors within property', () => {
+      expect(
+        transform(`
+          import * as stylex from 'stylex';
+          const styles = stylex.create({
+            default: {
+              color: {
+                default: 'red',
+                ':hover': 'blue',
+              }
+            }
+          });
+          stylex.attrs(styles.default);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import * as stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x17z2mba:hover{color:blue}", 3130);
+        ({
+          class: "x1e2nbdu x17z2mba"
+        });"
+      `);
+    });
+
+    test('stylex call using styles with Media Queries', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            default: {
+              backgroundColor: 'red',
+              '@media (min-width: 1000px)': {
+                backgroundColor: 'blue',
+              },
+              '@media (min-width: 2000px)': {
+                backgroundColor: 'purple',
+              },
+            },
+          });
+          stylex.attrs(styles.default);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+        ({
+          class: "xrkmrrc xc445zv x1ssfqz5"
+        });"
+      `);
+    });
+
+    test('stylex call using styles with Media Queries within property', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            default: {
+              backgroundColor: {
+                default:'red',
+                '@media (min-width: 1000px)': 'blue',
+                '@media (min-width: 2000px)': 'purple',
+              },
+            },
+          });
+          stylex.attrs(styles.default);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+        ({
+          class: "xrkmrrc xc445zv x1ssfqz5"
+        });"
+      `);
+    });
+
+    test('stylex call using styles with Support Queries', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            default: {
+              backgroundColor: 'red',
+              '@supports (hover: hover)': {
+                backgroundColor: 'blue',
+              },
+              '@supports not (hover: hover)': {
+                backgroundColor: 'purple',
+              },
+            },
+          });
+          stylex.attrs(styles.default);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+        _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+        ({
+          class: "xrkmrrc x6m3b6q x6um648"
+        });"
+      `);
+    });
+
+    test('stylex call using styles with Support Queries within property', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            default: {
+              backgroundColor: {
+                default:'red',
+                '@supports (hover: hover)': 'blue',
+                '@supports not (hover: hover)': 'purple',
+              },
+            },
+          });
+          stylex.attrs(styles.default);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".xrkmrrc{background-color:red}", 3000);
+        _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+        _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+        ({
+          class: "xrkmrrc x6m3b6q x6um648"
+        });"
+      `);
+    });
+
+    describe('with conditional styles and collisions', () => {
+      test('stylex call with conditions', () => {
+        expect(
+          transform(
+            `
+            import stylex from 'stylex';
+            const styles = stylex.create({
+              default: {
+                backgroundColor: 'red',
+              },
+              active: {
+                color: 'blue',
+              }
+            });
+            stylex.attrs([styles.default, isActive && styles.active]);
+          `,
+            { genConditionalClasses: true },
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".xrkmrrc{background-color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
+          ({
+            0: {
+              class: "xrkmrrc"
+            },
+            1: {
+              class: "xrkmrrc xju2f9n"
+            }
+          })[!!isActive << 0];"
+        `);
+      });
+
+      test('stylex call with conditions - skip conditional', () => {
+        expect(
+          transform(
+            `
+            import stylex from 'stylex';
+            const styles = stylex.create({
+              default: {
+                backgroundColor: 'red',
+              },
+              active: {
+                color: 'blue',
+              }
+            });
+            stylex.attrs([styles.default, isActive && styles.active]);
+            `,
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".xrkmrrc{background-color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
+          const styles = {
+            default: {
+              backgroundColor: "xrkmrrc",
+              $$css: true
+            },
+            active: {
+              color: "xju2f9n",
+              $$css: true
+            }
+          };
+          stylex.attrs([styles.default, isActive && styles.active]);"
+        `);
+      });
+
+      test('stylex call with property collisions', () => {
+        expect(
+          transform(`
+            import stylex from 'stylex';
+            const styles = stylex.create({
+              red: {
+                color: 'red',
+              },
+              blue: {
+                color: 'blue',
+              }
+            });
+            stylex.attrs([styles.red, styles.blue]);
+            stylex.attrs([styles.blue, styles.red]);
+          `),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
+          ({
+            class: "xju2f9n"
+          });
+          ({
+            class: "x1e2nbdu"
+          });"
+        `);
+      });
+
+      test('stylex call with reverting by null', () => {
+        expect(
+          transform(`
+            import stylex from 'stylex';
+            const styles = stylex.create({
+              red: {
+                color: 'red',
+              },
+              revert: {
+                color: null,
+              }
+            });
+            stylex.attrs([styles.red, styles.revert]);
+            stylex.attrs([styles.revert, styles.red]);
+          `),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          ({});
+          ({
+            class: "x1e2nbdu"
+          });"
+        `);
+      });
+
+      test('stylex call with short-form property collisions', () => {
+        expect(
+          transform(`
+            import stylex from 'stylex';
+            const styles = stylex.create({
+              foo: {
+                padding: 5,
+                paddingEnd: 10,
+              },
+  
+              bar: {
+                padding: 2,
+                paddingStart: 10,
+              },
+            });
+            stylex.attrs([styles.foo, styles.bar]);
+          `),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x14odnwx{padding:5px}", 1000);
+          _inject(".x2vl965{padding-inline-end:10px}", 3000);
+          _inject(".x1i3ajwb{padding:2px}", 1000);
+          _inject(".xe2zdcy{padding-inline-start:10px}", 3000);
+          ({
+            class: "x2vl965 x1i3ajwb xe2zdcy"
+          });"
+        `);
+      });
+
+      test('stylex call with short-form property collisions with null', () => {
+        expect(
+          transform(`
+            import stylex from 'stylex';
+            const styles = stylex.create({
+              foo: {
+                padding: 5,
+                paddingEnd: 10,
+              },
+  
+              bar: {
+                padding: 2,
+                paddingStart: null,
+              },
+            });
+            stylex.attrs([styles.foo, styles.bar]);
+          `),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x14odnwx{padding:5px}", 1000);
+          _inject(".x2vl965{padding-inline-end:10px}", 3000);
+          _inject(".x1i3ajwb{padding:2px}", 1000);
+          ({
+            class: "x2vl965 x1i3ajwb"
+          });"
+        `);
+      });
+
+      test('stylex call with conditions and collisions', () => {
+        expect(
+          transform(
+            `
+            import stylex from 'stylex';
+            const styles = stylex.create({
+              red: {
+                color: 'red',
+              },
+              blue: {
+                color: 'blue',
+              }
+            });
+            stylex.attrs([styles.red, isActive && styles.blue]);
+          `,
+            { genConditionalClasses: true },
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
+          ({
+            0: {
+              class: "x1e2nbdu"
+            },
+            1: {
+              class: "xju2f9n"
+            }
+          })[!!isActive << 0];"
+        `);
+      });
+
+      test('stylex call with conditions and collisions - skip conditional', () => {
+        expect(
+          transform(
+            `
+            import stylex from 'stylex';
+            const styles = stylex.create({
+              red: {
+                color: 'red',
+              },
+              blue: {
+                color: 'blue',
+              }
+            });
+            stylex.attrs([styles.red, isActive && styles.blue]);
+            `,
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
+          const styles = {
+            red: {
+              color: "x1e2nbdu",
+              $$css: true
+            },
+            blue: {
+              color: "xju2f9n",
+              $$css: true
+            }
+          };
+          stylex.attrs([styles.red, isActive && styles.blue]);"
+        `);
+      });
+
+      test('stylex call with conditions and null collisions', () => {
+        expect(
+          transform(
+            `
+            import stylex from 'stylex';
+            const styles = stylex.create({
+              red: {
+                color: 'red',
+              },
+              blue: {
+                color: null,
+              }
+            });
+            stylex.attrs([styles.red, isActive && styles.blue]);
+          `,
+            { genConditionalClasses: true },
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          ({
+            0: {
+              class: "x1e2nbdu"
+            },
+            1: {}
+          })[!!isActive << 0];"
+        `);
+      });
+
+      test('stylex call with conditions and null collisions - skip conditional', () => {
+        expect(
+          transform(
+            `
+            import stylex from 'stylex';
+            const styles = stylex.create({
+              red: {
+                color: 'red',
+              },
+              blue: {
+                color: null,
+              }
+            });
+            stylex.attrs([styles.red, isActive && styles.blue]);
+            `,
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          const styles = {
+            red: {
+              color: "x1e2nbdu",
+              $$css: true
+            },
+            blue: {
+              color: null,
+              $$css: true
+            }
+          };
+          stylex.attrs([styles.red, isActive && styles.blue]);"
+        `);
+      });
+    });
+
+    // COMPOSITION
+    describe('with plugin options', () => {
+      test('stylex call produces dev class names', () => {
+        const options = {
+          filename: '/html/js/FooBar.react.js',
+          dev: true,
+        };
+        expect(
+          transform(
+            `
+              import stylex from 'stylex';
+              const styles = stylex.create({
+                default: {
+                  color: 'red',
+                },
+              });
+              stylex.attrs(styles.default);
+            `,
+            options,
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          ({
+            class: "FooBar__styles.default x1e2nbdu"
+          });"
+        `);
+      });
+
+      test('stylex call produces dev class name with conditions', () => {
+        const options = {
+          filename: '/html/js/FooBar.react.js',
+          dev: true,
+          genConditionalClasses: true,
+        };
+        expect(
+          transform(
+            `
+              import stylex from 'stylex';
+              const styles = stylex.create({
+                default: {
+                  color: 'red',
+                },
+              });
+              const otherStyles = stylex.create({
+                default: {
+                  backgroundColor: 'blue',
+                }
+              });
+              stylex.attrs([styles.default, isActive && otherStyles.default]);
+          `,
+            options,
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".x1t391ir{background-color:blue}", 3000);
+          ({
+            0: {
+              class: "FooBar__styles.default x1e2nbdu"
+            },
+            1: {
+              class: "FooBar__styles.default x1e2nbdu FooBar__otherStyles.default x1t391ir"
+            }
+          })[!!isActive << 0];"
+        `);
+      });
+
+      test('stylex call produces dev class name with conditions - skip conditional', () => {
+        const options = {
+          filename: '/html/js/FooBar.react.js',
+          dev: true,
+        };
+        expect(
+          transform(
+            `
+              import stylex from 'stylex';
+              const styles = stylex.create({
+                default: {
+                  color: 'red',
+                },
+              });
+              const otherStyles = stylex.create({
+                default: {
+                  backgroundColor: 'blue',
+                }
+              });
+              stylex.attrs([styles.default, isActive && otherStyles.default]);
+          `,
+            options,
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          const styles = {
+            default: {
+              "FooBar__styles.default": "FooBar__styles.default",
+              color: "x1e2nbdu",
+              $$css: true
+            }
+          };
+          _inject(".x1t391ir{background-color:blue}", 3000);
+          const otherStyles = {
+            default: {
+              "FooBar__otherStyles.default": "FooBar__otherStyles.default",
+              backgroundColor: "x1t391ir",
+              $$css: true
+            }
+          };
+          stylex.attrs([styles.default, isActive && otherStyles.default]);"
+        `);
+      });
+
+      test('stylex call produces dev class name with collisions', () => {
+        const options = {
+          filename: '/html/js/FooBar.react.js',
+          dev: true,
+          genConditionalClasses: true,
+        };
+
+        expect(
+          transform(
+            `
+              import stylex from 'stylex';
+              const styles = stylex.create({
+                default: {
+                  color: 'red',
+                },
+                active: {
+                  color: 'blue',
+                }
+              });
+              stylex.attrs([styles.default, isActive && styles.active]);
+          `,
+            options,
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".xju2f9n{color:blue}", 3000);
+          ({
+            0: {
+              class: "FooBar__styles.default x1e2nbdu"
+            },
+            1: {
+              class: "FooBar__styles.default FooBar__styles.active xju2f9n"
+            }
+          })[!!isActive << 0];"
+        `);
+      });
+    });
+  });
+  describe('Keep stylex.create when needed', () => {
+    test('stylex call with computed key access', () => {
+      expect(
+        transform(`
+            import stylex from 'stylex';
+            const styles = stylex.create({
+              [0]: {
+                color: 'red',
+              },
+              [1]: {
+                backgroundColor: 'blue',
+              }
+            });
+            stylex.attrs(styles[variant]);
+          `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        _inject(".x1t391ir{background-color:blue}", 3000);
+        const styles = {
+          "0": {
+            color: "x1e2nbdu",
+            $$css: true
+          },
+          "1": {
+            backgroundColor: "x1t391ir",
+            $$css: true
+          }
+        };
+        stylex.attrs(styles[variant]);"
+      `);
+    });
+    test('stylex call with composition of external styles', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            default: {
+              color: 'red',
+            },
+          });
+          stylex.attrs([styles.default, props]);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        const styles = {
+          default: {
+            color: "x1e2nbdu",
+            $$css: true
+          }
+        };
+        stylex.attrs([styles.default, props]);"
+      `);
+    });
+
+    test('stylex call using exported styles with pseudo selectors, and queries', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            default: {
+              ':hover': {
+                color: 'blue',
+              },
+              '@media (min-width: 1000px)': {
+                backgroundColor: 'blue',
+              },
+            }
+          });
+          stylex.attrs(styles.default);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        _inject(".x17z2mba:hover{color:blue}", 3130);
+        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        export const styles = {
+          default: {
+            ":hover_color": "x17z2mba",
+            "@media (min-width: 1000px)_backgroundColor": "xc445zv",
+            $$css: true
+          }
+        };
+        ({
+          class: "x17z2mba xc445zv"
+        });"
+      `);
+    });
+
+    describe('even when stylex calls come first', () => {
+      test('stylex call with computed key access', () => {
+        expect(
+          transform(`
+            import stylex from 'stylex';
+            stylex.attrs(styles[variant]);
+            const styles = stylex.create({
+              [0]: {
+                color: 'red',
+              },
+              [1]: {
+                backgroundColor: 'blue',
+              }
+            });
+          `),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          stylex.attrs(styles[variant]);
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".x1t391ir{background-color:blue}", 3000);
+          const styles = {
+            "0": {
+              color: "x1e2nbdu",
+              $$css: true
+            },
+            "1": {
+              backgroundColor: "x1t391ir",
+              $$css: true
+            }
+          };"
+        `);
+      });
+
+      test('stylex call with mixed access', () => {
+        expect(
+          transform(`
+            import stylex from 'stylex';
+            
+            function MyComponent() {
+              return (
+                <>
+                  <div {...stylex.attrs(styles.foo)} />
+                  <div {...stylex.attrs(styles.bar)} />
+                  <CustomComponent xstyle={styles.foo} />
+                  <div {...stylex.attrs([styles.foo, styles.bar])} />
+                </>
+              );
+            }
+
+            const styles = stylex.create({
+              foo: {
+                color: 'red',
+              },
+              bar: {
+                backgroundColor: 'blue',
+              }
+            });
+          `),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          function MyComponent() {
+            return <>
+                            <div {...{
+                class: "x1e2nbdu"
+              }} />
+                            <div {...{
+                class: "x1t391ir"
+              }} />
+                            <CustomComponent xstyle={styles.foo} />
+                            <div {...{
+                class: "x1e2nbdu x1t391ir"
+              }} />
+                          </>;
+          }
+          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject(".x1t391ir{background-color:blue}", 3000);
+          const styles = {
+            foo: {
+              color: "x1e2nbdu",
+              $$css: true
+            }
+          };"
+        `);
+      });
+      test('stylex call with composition of external styles', () => {
+        expect(
+          transform(`
+            import stylex from 'stylex';
+            stylex.attrs([styles.default, props]);
+            const styles = stylex.create({
+              default: {
+                color: 'red',
+              },
+            });
+          `),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          stylex.attrs([styles.default, props]);
+          _inject(".x1e2nbdu{color:red}", 3000);
+          const styles = {
+            default: {
+              color: "x1e2nbdu",
+              $$css: true
+            }
+          };"
+        `);
+      });
+
+      test('stylex call using exported styles with pseudo selectors, and queries', () => {
+        expect(
+          transform(`
+            import stylex from 'stylex';
+            stylex.attrs(styles.default);
+            export const styles = stylex.create({
+              default: {
+                ':hover': {
+                  color: 'blue',
+                },
+                '@media (min-width: 1000px)': {
+                  backgroundColor: 'blue',
+                },
+              }
+            });
+          `),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          import stylex from 'stylex';
+          ({
+            class: "x17z2mba xc445zv"
+          });
+          _inject(".x17z2mba:hover{color:blue}", 3130);
+          _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+          export const styles = {
+            default: {
+              ":hover_color": "x17z2mba",
+              "@media (min-width: 1000px)_backgroundColor": "xc445zv",
+              $$css: true
+            }
+          };"
+        `);
+      });
+    });
+  });
+  describe('Setting custom import paths', () => {
+    test('Basic stylex call', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'custom-stylex-path';
+          const styles = stylex.create({
+            red: {
+              color: 'red',
+            }
+          });
+          stylex.attrs(styles.red);
+        `,
+          { importSources: ['custom-stylex-path'] },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'custom-stylex-path';
+        _inject(".x1e2nbdu{color:red}", 3000);
+        ({
+          class: "x1e2nbdu"
+        });"
+      `);
+    });
+  });
+  describe('Specific edge-case bugs', () => {
+    test('Basic stylex call', () => {
+      expect(
+        transform(
+          `
+          import stylex from '@stylexjs/stylex';
+          export const styles = stylex.create({
+            sidebar: {
+              boxSizing: 'border-box',
+              gridArea: 'sidebar',
+            },
+            content: {
+              gridArea: 'content',
+            },
+            root: {
+              display: 'grid',
+              gridTemplateRows: '100%',
+              gridTemplateAreas: '"content"',
+            },
+            withSidebar: {
+              gridTemplateColumns: 'auto minmax(0, 1fr)',
+              gridTemplateRows: '100%',
+              gridTemplateAreas: '"sidebar content"',
+              '@media (max-width: 640px)': {
+                gridTemplateRows: 'minmax(0, 1fr) auto',
+                gridTemplateAreas: '"content" "sidebar"',
+                gridTemplateColumns: '100%',
+              },
+            },
+            noSidebar: {
+              gridTemplateColumns: 'minmax(0, 1fr)',
+            },
+          });
+          stylex.attrs([
+            styles.root,
+            sidebar == null ? styles.noSidebar : styles.withSidebar,
+          ]);
+        `,
+          { dev: true, genConditionalClasses: true },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from '@stylexjs/stylex';
+        _inject(".x9f619{box-sizing:border-box}", 3000);
+        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject(".x1fdo2jl{grid-area:content}", 1000);
+        _inject(".xrvj5dj{display:grid}", 3000);
+        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        export const styles = {
+          sidebar: {
+            "UnknownFile__styles.sidebar": "UnknownFile__styles.sidebar",
+            boxSizing: "x9f619",
+            gridArea: "x1yc5d2u",
+            gridRow: null,
+            gridRowStart: null,
+            gridRowEnd: null,
+            gridColumn: null,
+            gridColumnStart: null,
+            gridColumnEnd: null,
+            $$css: true
+          },
+          content: {
+            "UnknownFile__styles.content": "UnknownFile__styles.content",
+            gridArea: "x1fdo2jl",
+            gridRow: null,
+            gridRowStart: null,
+            gridRowEnd: null,
+            gridColumn: null,
+            gridColumnStart: null,
+            gridColumnEnd: null,
+            $$css: true
+          },
+          root: {
+            "UnknownFile__styles.root": "UnknownFile__styles.root",
+            display: "xrvj5dj",
+            gridTemplateRows: "x7k18q3",
+            gridTemplateAreas: "x5gp9wm",
+            $$css: true
+          },
+          withSidebar: {
+            "UnknownFile__styles.withSidebar": "UnknownFile__styles.withSidebar",
+            gridTemplateColumns: "x1rkzygb",
+            gridTemplateRows: "x7k18q3",
+            gridTemplateAreas: "x17lh93j",
+            "@media (max-width: 640px)_gridTemplateRows": "xmr4b4k",
+            "@media (max-width: 640px)_gridTemplateAreas": "xesbpuc",
+            "@media (max-width: 640px)_gridTemplateColumns": "x15nfgh4",
+            $$css: true
+          },
+          noSidebar: {
+            "UnknownFile__styles.noSidebar": "UnknownFile__styles.noSidebar",
+            gridTemplateColumns: "x1mkdm3x",
+            $$css: true
+          }
+        };
+        ({
+          0: {
+            class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
+          },
+          1: {
+            class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x"
+          }
+        })[!!(sidebar == null) << 0];"
+      `);
+    });
+
+    test('Basic stylex call', () => {
+      expect(
+        transform(
+          `
+          import stylex from '@stylexjs/stylex';
+          const styles = stylex.create({
+            sidebar: {
+              boxSizing: 'border-box',
+              gridArea: 'sidebar',
+            },
+            content: {
+              gridArea: 'content',
+            },
+            root: {
+              display: 'grid',
+              gridTemplateRows: '100%',
+              gridTemplateAreas: '"content"',
+            },
+            withSidebar: {
+              gridTemplateColumns: 'auto minmax(0, 1fr)',
+              gridTemplateRows: '100%',
+              gridTemplateAreas: '"sidebar content"',
+              '@media (max-width: 640px)': {
+                gridTemplateRows: 'minmax(0, 1fr) auto',
+                gridTemplateAreas: '"content" "sidebar"',
+                gridTemplateColumns: '100%',
+              },
+            },
+            noSidebar: {
+              gridTemplateColumns: 'minmax(0, 1fr)',
+            },
+          });
+          const complex = stylex.attrs([
+            styles.root,
+            sidebar == null && !isSidebar ? styles.noSidebar : styles.withSidebar,
+            isSidebar && styles.sidebar,
+            isContent && styles.content,
+          ]);
+        `,
+          { dev: true, genConditionalClasses: true },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from '@stylexjs/stylex';
+        _inject(".x9f619{box-sizing:border-box}", 3000);
+        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject(".x1fdo2jl{grid-area:content}", 1000);
+        _inject(".xrvj5dj{display:grid}", 3000);
+        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        const complex = {
+          0: {
+            class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
+          },
+          4: {
+            class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x"
+          },
+          2: {
+            class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 UnknownFile__styles.sidebar x9f619 x1yc5d2u"
+          },
+          6: {
+            class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x UnknownFile__styles.sidebar x9f619 x1yc5d2u"
+          },
+          1: {
+            class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 UnknownFile__styles.content x1fdo2jl"
+          },
+          5: {
+            class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x UnknownFile__styles.content x1fdo2jl"
+          },
+          3: {
+            class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 UnknownFile__styles.sidebar x9f619 UnknownFile__styles.content x1fdo2jl"
+          },
+          7: {
+            class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x UnknownFile__styles.sidebar x9f619 UnknownFile__styles.content x1fdo2jl"
+          }
+        }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];"
+      `);
+    });
+  });
+});

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -23,6 +23,9 @@ import transformStylexCall, {
 import * as pathUtils from './babel-path-utils';
 import transformStylexProps from './visitors/stylex-props';
 import { skipStylexPropsChildren } from './visitors/stylex-props';
+import transformStylexAttrs, {
+  skipStylexAttrsChildren,
+} from './visitors/stylex-attrs';
 
 const NAME = 'stylex';
 
@@ -92,6 +95,7 @@ function styleXTransform(): PluginObj<> {
             CallExpression(path: NodePath<t.CallExpression>) {
               transformStylexCall(path, state);
               transformStylexProps(path, state);
+              transformStylexAttrs(path, state);
             },
           });
 
@@ -218,6 +222,7 @@ function styleXTransform(): PluginObj<> {
         // should be kept.
         skipStylexMergeChildren(path, state);
         skipStylexPropsChildren(path, state);
+        skipStylexAttrsChildren(path, state);
       },
 
       Identifier(path: NodePath<t.Identifier>) {

--- a/packages/babel-plugin/src/utils/state-manager.js
+++ b/packages/babel-plugin/src/utils/state-manager.js
@@ -104,6 +104,7 @@ export default class StateManager {
   +importPaths: Set<string> = new Set();
   +stylexImport: Set<string> = new Set();
   +stylexPropsImport: Set<string> = new Set();
+  +stylexAttrsImport: Set<string> = new Set();
   +stylexCreateImport: Set<string> = new Set();
   +stylexIncludeImport: Set<string> = new Set();
   +stylexFirstThatWorksImport: Set<string> = new Set();

--- a/packages/babel-plugin/src/visitors/imports.js
+++ b/packages/babel-plugin/src/visitors/imports.js
@@ -60,6 +60,9 @@ export function readImportDeclarations(
             if (importedName === 'props') {
               state.stylexPropsImport.add(localName);
             }
+            if (importedName === 'attrs') {
+              state.stylexAttrsImport.add(localName);
+            }
             if (importedName === 'keyframes') {
               state.stylexKeyframesImport.add(localName);
             }
@@ -123,6 +126,9 @@ export function readRequires(
           }
           if (prop.key.name === 'props') {
             state.stylexPropsImport.add(value.name);
+          }
+          if (prop.key.name === 'attrs') {
+            state.stylexAttrsImport.add(value.name);
           }
           if (prop.key.name === 'keyframes') {
             state.stylexKeyframesImport.add(value.name);

--- a/packages/babel-plugin/src/visitors/stylex-attrs.js
+++ b/packages/babel-plugin/src/visitors/stylex-attrs.js
@@ -1,0 +1,358 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type { NodePath } from '@babel/traverse';
+
+import * as t from '@babel/types';
+import StateManager from '../utils/state-manager';
+import { attrs } from '@stylexjs/stylex';
+
+import { IncludedStyles } from '@stylexjs/shared';
+import { convertObjectToAST } from '../utils/js-to-ast';
+import { evaluate } from '../utils/evaluate-path';
+import * as babelPathUtils from '../babel-path-utils';
+
+type ClassNameValue = string | null | boolean | NonStringClassNameValue;
+type NonStringClassNameValue = [t.Expression, ClassNameValue, ClassNameValue];
+
+type StyleObject = {
+  [key: string]: string | null | boolean | IncludedStyles,
+};
+
+type ConditionalStyle = [t.Expression, ?StyleObject, ?StyleObject];
+type ResolvedArg = ?StyleObject | ConditionalStyle;
+type ResolvedArgs = Array<ResolvedArg>;
+
+export function skipStylexAttrsChildren(
+  path: NodePath<t.CallExpression>,
+  state: StateManager,
+) {
+  if (
+    !isCalleeIdentifier(path, state) &&
+    !isCalleeMemberExpression(path, state)
+  ) {
+    return;
+  }
+  path.skip();
+}
+
+// If a `stylex()` call uses styles that are all locally defined,
+// This function is able to pre-compute that into a single string or
+// a single expression of strings and ternary expressions.
+export default function transformStylexAttrs(
+  path: NodePath<t.CallExpression>,
+  state: StateManager,
+) {
+  const { node } = path;
+
+  if (
+    !isCalleeIdentifier(path, state) &&
+    !isCalleeMemberExpression(path, state)
+  ) {
+    return;
+  }
+
+  let bailOut = false;
+  let conditional = 0;
+
+  const args = node.arguments.flatMap((arg) =>
+    arg.type === 'ArrayExpression' ? arg.elements : [arg],
+  );
+
+  let currentIndex = -1;
+  let bailOutIndex: ?number = null;
+
+  const resolvedArgs: ResolvedArgs = [];
+  for (const arg of args) {
+    currentIndex++;
+    switch (arg.type) {
+      case 'MemberExpression': {
+        const resolved = parseNullableStyle(arg, state);
+        if (resolved === 'other') {
+          bailOutIndex = currentIndex;
+          bailOut = true;
+        } else {
+          resolvedArgs.push(resolved);
+        }
+        break;
+      }
+      case 'ConditionalExpression': {
+        const { test, consequent, alternate } = arg;
+        const primary = parseNullableStyle(consequent, state);
+        const fallback = parseNullableStyle(alternate, state);
+        if (primary === 'other' || fallback === 'other') {
+          bailOutIndex = currentIndex;
+          bailOut = true;
+        } else {
+          resolvedArgs.push([test, primary, fallback]);
+          conditional++;
+        }
+        break;
+      }
+      case 'LogicalExpression': {
+        if (arg.operator !== '&&') {
+          bailOutIndex = currentIndex;
+          bailOut = true;
+          break;
+        }
+        const { left, right } = arg;
+        const leftResolved = parseNullableStyle(left, state);
+        const rightResolved = parseNullableStyle(right, state);
+        if (leftResolved !== 'other' || rightResolved === 'other') {
+          bailOutIndex = currentIndex;
+          bailOut = true;
+        } else {
+          resolvedArgs.push([left, rightResolved, null]);
+          conditional++;
+        }
+        break;
+      }
+      default:
+        bailOutIndex = currentIndex;
+        bailOut = true;
+        break;
+    }
+    if (conditional > 4) {
+      bailOut = true;
+    }
+    if (bailOut) {
+      break;
+    }
+  }
+  if (!state.options.genConditionalClasses && conditional) {
+    bailOut = true;
+  }
+  if (bailOut) {
+    const argumentPaths = path.get('arguments');
+
+    let nonNullProps: Array<string> | true = [];
+
+    let index = -1;
+    for (const argPath of argumentPaths) {
+      index++;
+      // eslint-disable-next-line no-loop-func, no-inner-declarations
+      function MemberExpression(path: NodePath<t.MemberExpression>) {
+        const object = path.get('object').node;
+        const property = path.get('property').node;
+        const computed = path.node.computed;
+        let objName: string | null = null;
+        let propName: number | string | null = null;
+        if (object.type === 'Identifier' && state.styleMap.has(object.name)) {
+          objName = object.name;
+
+          if (property.type === 'Identifier' && !computed) {
+            propName = property.name;
+          }
+          if (
+            (property.type === 'StringLiteral' ||
+              property.type === 'NumericLiteral') &&
+            computed
+          ) {
+            propName = property.value;
+          }
+        }
+        let styleNonNullProps: true | Array<string> = [];
+        if (bailOutIndex != null && index > bailOutIndex) {
+          nonNullProps = true;
+          styleNonNullProps = true;
+        }
+        if (nonNullProps === true) {
+          styleNonNullProps = true;
+        } else {
+          const { confident, value: styleValue } = evaluate(path, state);
+          if (!confident) {
+            nonNullProps = true;
+            styleNonNullProps = true;
+          } else {
+            styleNonNullProps =
+              nonNullProps === true ? true : [...nonNullProps];
+            if (nonNullProps !== true) {
+              nonNullProps = [
+                ...nonNullProps,
+                ...Object.keys(styleValue).filter(
+                  (key) => styleValue[key] !== null,
+                ),
+              ];
+            }
+          }
+        }
+
+        if (objName != null) {
+          state.styleVarsToKeep.add([
+            objName,
+            propName != null ? String(propName) : true,
+            styleNonNullProps,
+          ]);
+        }
+      }
+
+      if (babelPathUtils.isMemberExpression(argPath)) {
+        MemberExpression(argPath);
+      } else {
+        argPath.traverse({
+          MemberExpression,
+        });
+      }
+    }
+  } else {
+    path.skip();
+    // convert resolvedStyles to a string + ternary expressions
+    // We no longer need the keys, so we can just use the values.
+    const stringExpression = makeStringExpression(resolvedArgs);
+    path.replaceWith(stringExpression);
+  }
+}
+
+// Looks for Null or locally defined style namespaces.
+// Otherwise it returns the string "other"
+// Which is used as an indicator to bail out of this optimization.
+function parseNullableStyle(
+  node: t.Expression,
+  state: StateManager,
+): null | StyleObject | 'other' {
+  if (
+    t.isNullLiteral(node) ||
+    (t.isIdentifier(node) && node.name === 'undefined')
+  ) {
+    return null;
+  }
+
+  if (t.isMemberExpression(node)) {
+    const { object, property, computed: computed } = node;
+    let objName = null;
+    let propName: null | number | string = null;
+    if (
+      object.type === 'Identifier' &&
+      state.styleMap.has(object.name) &&
+      property.type === 'Identifier' &&
+      !computed
+    ) {
+      objName = object.name;
+      propName = property.name;
+    }
+    if (
+      object.type === 'Identifier' &&
+      state.styleMap.has(object.name) &&
+      (property.type === 'StringLiteral' ||
+        property.type === 'NumericLiteral') &&
+      computed
+    ) {
+      objName = object.name;
+      propName = property.value;
+    }
+
+    if (objName != null && propName != null) {
+      const style = state.styleMap.get(objName);
+      if (style != null && style[String(propName)] != null) {
+        // $FlowFixMe
+        return style[String(propName)];
+      }
+    }
+  }
+
+  return 'other';
+}
+
+function makeStringExpression(values: ResolvedArgs): t.Expression {
+  const conditions = values
+    .filter((v: ResolvedArg): v is ConditionalStyle => Array.isArray(v))
+    .map((v: ConditionalStyle) => v[0]);
+
+  if (conditions.length === 0) {
+    const result = attrs((values: any));
+    return convertObjectToAST(result);
+  }
+
+  const conditionPermutations = genConditionPermutations(conditions.length);
+  const objEntries = conditionPermutations.map((permutation) => {
+    let i = 0;
+    const args = values.map((v) => {
+      if (Array.isArray(v)) {
+        const [_test, primary, fallback] = v;
+        return permutation[i++] ? primary : fallback;
+      } else {
+        return v;
+      }
+    });
+    const key = permutation.reduce(
+      (soFar, bool) => (soFar << 1) | (bool ? 1 : 0),
+      0,
+    );
+    return t.objectProperty(
+      t.numericLiteral(key),
+      convertObjectToAST(attrs((args: any))),
+    );
+  });
+  const objExpressions = t.objectExpression(objEntries);
+  const conditionsToKey = genBitwiseOrOfConditions(conditions);
+  return t.memberExpression(objExpressions, conditionsToKey, true);
+}
+
+// A function to generate a list of all possible permutations of true and false for a given count of conditional expressions.
+// For example, if there are 2 conditional expressions, this function will return:
+// [[true, true], [true, false], [false, true], [false, false]]
+function genConditionPermutations(count: number): Array<Array<boolean>> {
+  const result = [];
+  for (let i = 0; i < 2 ** count; i++) {
+    const combination = [];
+    for (let j = 0; j < count; j++) {
+      combination.push(Boolean(i & (1 << j)));
+    }
+    result.push(combination);
+  }
+  return result;
+}
+
+// A function to generate a bitwise or of all the conditions.
+// For example, if there are 2 conditional expressions, this function will return:
+// `!!test1 << 2 | !!test2 << 1
+function genBitwiseOrOfConditions(
+  conditions: Array<t.Expression>,
+): t.Expression {
+  const binaryExpressions = conditions.map((condition, i) => {
+    const shift = conditions.length - i - 1;
+    return t.binaryExpression(
+      '<<',
+      t.unaryExpression('!', t.unaryExpression('!', condition)),
+      t.numericLiteral(shift),
+    );
+  });
+  return binaryExpressions.reduce((acc, expr) => {
+    return t.binaryExpression('|', acc, expr);
+  });
+}
+
+function isCalleeIdentifier(
+  path: NodePath<t.CallExpression>,
+  state: StateManager,
+): boolean {
+  const { node } = path;
+  return (
+    node != null &&
+    node.callee != null &&
+    node.callee.type === 'Identifier' &&
+    state.stylexAttrsImport.has(node.callee.name)
+  );
+}
+
+function isCalleeMemberExpression(
+  path: NodePath<t.CallExpression>,
+  state: StateManager,
+): boolean {
+  const { node } = path;
+  return (
+    node != null &&
+    node.callee != null &&
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type === 'Identifier' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'attrs' &&
+    state.stylexImport.has(node.callee.object.name)
+  );
+}

--- a/packages/stylex/src/stylex.js
+++ b/packages/stylex/src/stylex.js
@@ -72,6 +72,31 @@ export function props(
   }
   return result;
 }
+export function attrs(
+  ...styles: $ReadOnlyArray<
+    StyleXArray<
+      ?CompiledStyles | boolean | $ReadOnly<[CompiledStyles, InlineStyles]>,
+    >,
+  >
+): $ReadOnly<{
+  class?: string,
+  style?: string,
+}> {
+  const { className, style } = props(...styles);
+  const result: {
+    class?: string,
+    style?: string,
+  } = {};
+  if (className != null && className !== '') {
+    result.class = className;
+  }
+  if (style != null && Object.keys(style).length > 0) {
+    result.style = Object.keys(style)
+      .map((key) => `${key}:${style[key]};`)
+      .join('');
+  }
+  return result;
+}
 
 function stylexCreate<S: { +[string]: mixed }>(styles: S): MapNamespaces<S> {
   if (__implementations.create != null) {
@@ -243,6 +268,7 @@ function _stylex(
   return className;
 }
 _stylex.props = props;
+_stylex.attrs = attrs;
 _stylex.create = create;
 _stylex.defineVars = defineVars;
 _stylex.createTheme = createTheme;
@@ -263,6 +289,16 @@ type IStyleX = {
   ) => $ReadOnly<{
     className?: string,
     style?: $ReadOnly<{ [string]: string | number }>,
+  }>,
+  attrs: (
+    ...styles: $ReadOnlyArray<
+      StyleXArray<
+        ?CompiledStyles | boolean | $ReadOnly<[CompiledStyles, InlineStyles]>,
+      >,
+    >
+  ) => $ReadOnly<{
+    class?: string,
+    style?: string,
   }>,
   create: Stylex$Create,
   defineVars: StyleX$DefineVars,

--- a/packages/stylex/src/stylex.js
+++ b/packages/stylex/src/stylex.js
@@ -44,6 +44,12 @@ type Cache = WeakMap<
   },
 >;
 
+const errorForFn = (name: string) =>
+  new Error(
+    `'stylex.${name}' should never be called at runtime. It should be compiled away by '@stylexjs/babel-plugin'`,
+  );
+const errorForType = (key: $Keys<typeof types>) => errorForFn(`types.${key}`);
+
 export function props(
   this: ?mixed,
   ...styles: $ReadOnlyArray<
@@ -103,9 +109,7 @@ function stylexCreate<S: { +[string]: mixed }>(styles: S): MapNamespaces<S> {
     const create: Stylex$Create = __implementations.create;
     return create<S>(styles);
   }
-  throw new Error(
-    'stylex.create should never be called. It should be compiled away.',
-  );
+  throw errorForFn('create');
 }
 
 function stylexDefineVars<
@@ -121,9 +125,7 @@ function stylexDefineVars<
   if (__implementations.defineVars) {
     return __implementations.defineVars(styles);
   }
-  throw new Error(
-    'stylex.defineVars should never be called. It should be compiled away.',
-  );
+  throw errorForFn('defineVars');
 }
 
 const stylexCreateTheme: StyleX$CreateTheme = (baseTokens, overrides) => {
@@ -131,9 +133,7 @@ const stylexCreateTheme: StyleX$CreateTheme = (baseTokens, overrides) => {
     // $FlowFixMe
     return __implementations.createTheme(baseTokens, overrides);
   }
-  throw new Error(
-    'stylex.createTheme should never be called. It should be compiled away.',
-  );
+  throw errorForFn('createTheme');
 };
 
 type Stylex$Include = <
@@ -153,9 +153,7 @@ const stylexInclude: Stylex$Include = (styles) => {
   if (__implementations.include) {
     return __implementations.include(styles);
   }
-  throw new Error(
-    'stylex.extends should never be called. It should be compiled away.',
-  );
+  throw errorForFn('include');
 };
 
 export const create: Stylex$Create = stylexCreate;
@@ -199,57 +197,55 @@ interface ICSSType<+T: string | number> {
 
 export const types = {
   angle: <T: number | string>(_v: ValueWithDefault<T>): ICSSType<T> => {
-    throw new Error(errorForType('angle'));
+    throw errorForType('angle');
   },
   color: <T: number | string>(_v: ValueWithDefault<T>): ICSSType<T> => {
-    throw new Error(errorForType('color'));
+    throw errorForType('color');
   },
   url: <T: number | string>(_v: ValueWithDefault<T>): ICSSType<T> => {
-    throw new Error(errorForType('url'));
+    throw errorForType('url');
   },
   image: <T: number | string>(_v: ValueWithDefault<T>): ICSSType<T> => {
-    throw new Error(errorForType('image'));
+    throw errorForType('image');
   },
   integer: <T: number | string>(_v: ValueWithDefault<T>): ICSSType<T> => {
-    throw new Error(errorForType('integer'));
+    throw errorForType('integer');
   },
   lengthPercentage: <T: number | string>(
     _v: ValueWithDefault<T>,
   ): ICSSType<T> => {
-    throw new Error(errorForType('lengthPercentage'));
+    throw errorForType('lengthPercentage');
   },
   length: <T: number | string>(_v: ValueWithDefault<T>): ICSSType<T> => {
-    throw new Error(errorForType('length'));
+    throw errorForType('length');
   },
   percentage: <T: number | string>(_v: ValueWithDefault<T>): ICSSType<T> => {
-    throw new Error(errorForType('percentage'));
+    throw errorForType('percentage');
   },
   number: <T: number | string>(_v: ValueWithDefault<T>): ICSSType<T> => {
-    throw new Error(errorForType('number'));
+    throw errorForType('number');
   },
   resolution: <T: number | string>(_v: ValueWithDefault<T>): ICSSType<T> => {
-    throw new Error(errorForType('resolution'));
+    throw errorForType('resolution');
   },
   time: <T: number | string>(_v: ValueWithDefault<T>): ICSSType<T> => {
-    throw new Error(errorForType('time'));
+    throw errorForType('time');
   },
   transformFunction: <T: number | string>(
     _v: ValueWithDefault<T>,
   ): ICSSType<T> => {
-    throw new Error(errorForType('transformFunction'));
+    throw errorForType('transformFunction');
   },
   transformList: <T: number | string>(_v: ValueWithDefault<T>): ICSSType<T> => {
-    throw new Error(errorForType('transformList'));
+    throw errorForType('transformList');
   },
 };
-const errorForType = (type: $Keys<typeof types>) =>
-  `stylex.types.${type} should be compiled away by @stylexjs/babel-plugin`;
 
 export const keyframes = (keyframes: Keyframes): string => {
   if (__implementations.keyframes) {
     return __implementations.keyframes(keyframes);
   }
-  throw new Error('stylex.keyframes should never be called');
+  throw errorForFn('keyframes');
 };
 
 export const firstThatWorks = <T: string | number>(
@@ -258,7 +254,7 @@ export const firstThatWorks = <T: string | number>(
   if (__implementations.firstThatWorks) {
     return __implementations.firstThatWorks(...styles);
   }
-  throw new Error('stylex.firstThatWorks should never be called.');
+  throw errorForFn('firstThatWorks');
 };
 
 function _stylex(


### PR DESCRIPTION
## What changed / motivation ?

For frameworks such as Solid, Qwik, Svelte, Vue, etc. that require a `class` instead of `className`, there is now a first-class API called `stylex.attrs` which can be used in place of `stylex.attrs`.

`stylex.attrs` returns an object with a `class` key instead of a `className` key and pre-converts the value of `style` to a string as not every framework accepts objects for inline styles.

In all other ways, `stylex.attrs` is identical to `stylex.props`. At runtime it uses `stylex.props` internally. At compile time, it benefits from the same optimisations as `stylex.props`.

@PatrickJS