### PR TITLE
Update 03-installation.mdx add missing installation step for babel pl…

### DIFF
--- a/apps/docs/docs/learn/03-installation.mdx
+++ b/apps/docs/docs/learn/03-installation.mdx
@@ -30,6 +30,8 @@ For development, you need only to configure the Babel plugin so that styles are
 processed at compile-time. The plugin will compile styles and insert runtime
 style injection code into your JavaScript modules.
 
+<DevInstallExample dev={[`@stylexjs/babel-plugin`]} />
+
 ```ts
 // babel.config.js
 import styleXPlugin from '@stylexjs/babel-plugin';


### PR DESCRIPTION


## What changed / motivation ?

While setting up the babel plugin it is nowhere mentioned that you need to install the babel plugin separately. We can add a setup command example before the babel plugin config example. This will make installation a bit easier.


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code