### PR TITLE
fix: Add file extensions to ESM exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
     'lib',
     'node_modules',
     'next-env.d.ts',
+    'next.config.js',
   ],
   globals: {
     $Call: 'readonly',

--- a/packages/stylex/.babelrc.js
+++ b/packages/stylex/.babelrc.js
@@ -25,6 +25,27 @@ function makeHaste() {
   };
 }
 
+function extensionsForESM() {
+  return {
+    visitor: {
+      ImportDeclaration(path) {
+        if (path.get('source').isStringLiteral()) {
+          const node = path.get('source').node;
+          const source = node.value;
+          if (!source.startsWith('.') || source.endsWith('.mjs')) {
+            return;
+          }
+          if (source.endsWith('.js')) {
+            node.value = source.slice(0, -3) + '.mjs';
+            return;
+          }
+          node.value = source + '.mjs';
+        }
+      },
+    },
+  };
+}
+
 const presets = process.env['HASTE']
   ? []
   : [
@@ -47,7 +68,10 @@ const plugins = process.env['HASTE']
       // '@babel/plugin-syntax-jsx',
       ['babel-plugin-syntax-hermes-parser', { flow: 'detect' }],
     ]
-  : [['babel-plugin-syntax-hermes-parser', { flow: 'detect' }]];
+  : [
+      ...(BABEL_ENV === 'esm' ? [extensionsForESM] : []),
+      ['babel-plugin-syntax-hermes-parser', { flow: 'detect' }],
+    ];
 
 module.exports = {
   assumptions: {


### PR DESCRIPTION
## What changed / motivation ?

Resolving an issue discovered in 0.5.0-beta.2 in the issue #47 discussion.

Sometimes, Vite breaks because ESM exports didn't have file extensions in the import statements.

