### PR TITLE
fix: Use a variable for inject function

### DIFF
--- a/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
@@ -69,7 +69,8 @@ describe('Evaluation of imported values works based on configuration', () => {
         import stylex from 'stylex';
         import 'otherFile.stylex';
         import { MyTheme } from 'otherFile.stylex';
-        _inject(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
+        var _inject2 = _inject;
+        _inject2(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
         "__hashed_var__1r7rkhg";"
       `);
       expect(transformation.metadata.stylex).toMatchInlineSnapshot(`
@@ -114,9 +115,10 @@ describe('Evaluation of imported values works based on configuration', () => {
         import stylex from 'stylex';
         import 'otherFile.stylex';
         import { MyTheme } from 'otherFile.stylex';
-        _inject("@keyframes __hashed_var__1cb153o-B{from{color:var(--__hashed_var__1jqb1tb);}}", 1);
+        var _inject2 = _inject;
+        _inject2("@keyframes __hashed_var__1cb153o-B{from{color:var(--__hashed_var__1jqb1tb);}}", 1);
         const fade = "__hashed_var__1cb153o-B";
-        _inject(".__hashed_var__1xwo6t1{animation-name:__hashed_var__1cb153o-B}", 3000);
+        _inject2(".__hashed_var__1xwo6t1{animation-name:__hashed_var__1cb153o-B}", 3000);
         "__hashed_var__1xwo6t1";"
       `);
       expect(transformation.metadata.stylex).toMatchInlineSnapshot(`
@@ -164,7 +166,8 @@ describe('Evaluation of imported values works based on configuration', () => {
         import stylex from 'stylex';
         import 'otherFile.stylex.js';
         import { MyTheme } from 'otherFile.stylex.js';
-        _inject(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
+        var _inject2 = _inject;
+        _inject2(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
         "__hashed_var__1r7rkhg";"
       `);
       expect(transformation.metadata.stylex).toMatchInlineSnapshot(`
@@ -203,7 +206,8 @@ describe('Evaluation of imported values works based on configuration', () => {
         import stylex from 'stylex';
         import 'otherFile.stylex.js';
         import { MyTheme as mt } from 'otherFile.stylex.js';
-        _inject(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
+        var _inject2 = _inject;
+        _inject2(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
         "__hashed_var__1r7rkhg";"
       `);
       expect(transformation.metadata.stylex).toMatchInlineSnapshot(`

--- a/packages/babel-plugin/__tests__/stylex-transform-call-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-call-test.js
@@ -53,7 +53,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
     });
@@ -75,8 +76,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         "x1e2nbdu x1t391ir";"
       `);
     });
@@ -98,8 +100,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         "x1e2nbdu x1t391ir";"
       `);
     });
@@ -121,8 +124,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import { create } from '@stylexjs/stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
           "0": {
             color: "x1e2nbdu",
@@ -151,7 +155,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
     });
@@ -175,8 +180,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         "x1e2nbdu x1t391ir";"
       `);
     });
@@ -195,7 +201,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         const a = function () {
           return "x1e2nbdu";
         };"
@@ -220,8 +227,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
           foo: {
             color: "x1e2nbdu",
@@ -254,7 +262,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         export default function MyExportDefault() {
           return "x1e2nbdu";
         }
@@ -278,7 +287,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14odnwx{padding:5px}", 1000);
+        var _inject2 = _inject;
+        _inject2(".x14odnwx{padding:5px}", 1000);
         "x14odnwx";"
       `);
     });
@@ -297,7 +307,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14odnwx{padding:5px}", 1000);
+        var _inject2 = _inject;
+        _inject2(".x14odnwx{padding:5px}", 1000);
         export const styles = {
           foo: {
             padding: "x14odnwx",
@@ -340,9 +351,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14odnwx{padding:5px}", 1000);
-        _inject(".xp59q4u{padding-block:10px}", 2000);
-        _inject(".xm7lytj{padding-top:7px}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x14odnwx{padding:5px}", 1000);
+        _inject2(".xp59q4u{padding-block:10px}", 2000);
+        _inject2(".xm7lytj{padding-top:7px}", 4000);
         const styles = {
           foo: {
             padding: "x14odnwx",
@@ -381,9 +393,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14odnwx{padding:5px}", 1000);
-        _inject(".xp59q4u{padding-block:10px}", 2000);
-        _inject(".xm7lytj{padding-top:7px}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x14odnwx{padding:5px}", 1000);
+        _inject2(".xp59q4u{padding-block:10px}", 2000);
+        _inject2(".xm7lytj{padding-top:7px}", 4000);
         const styles = {
           foo: {
             padding: "x14odnwx",
@@ -430,9 +443,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14odnwx{padding:5px}", 1000);
-        _inject(".xp59q4u{padding-block:10px}", 2000);
-        _inject(".xm7lytj{padding-top:7px}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x14odnwx{padding:5px}", 1000);
+        _inject2(".xp59q4u{padding-block:10px}", 2000);
+        _inject2(".xm7lytj{padding-top:7px}", 4000);
         const styles = {
           foo: {
             padding: "x14odnwx",
@@ -473,9 +487,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14odnwx{padding:5px}", 1000);
-        _inject(".xp59q4u{padding-block:10px}", 2000);
-        _inject(".xm7lytj{padding-top:7px}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x14odnwx{padding:5px}", 1000);
+        _inject2(".xp59q4u{padding-block:10px}", 2000);
+        _inject2(".xm7lytj{padding-top:7px}", 4000);
         const styles = {
           foo: {
             padding: "x14odnwx",
@@ -512,8 +527,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x17z2mba:hover{color:blue}", 3130);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x17z2mba:hover{color:blue}", 3130);
         "x1e2nbdu x17z2mba";"
       `);
     });
@@ -535,8 +551,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x17z2mba:hover{color:blue}", 3130);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x17z2mba:hover{color:blue}", 3130);
         "x1e2nbdu x17z2mba";"
       `);
     });
@@ -561,9 +578,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-        _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
         "xrkmrrc xc445zv x1ssfqz5";"
       `);
     });
@@ -586,9 +604,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-        _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
         "xrkmrrc xc445zv x1ssfqz5";"
       `);
     });
@@ -613,9 +632,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-        _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+        _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
         "xrkmrrc x6m3b6q x6um648";"
       `);
     });
@@ -638,9 +658,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-        _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+        _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
         "xrkmrrc x6m3b6q x6um648";"
       `);
     });
@@ -666,8 +687,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".xrkmrrc{background-color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           ({
             0: "xrkmrrc",
             1: "xrkmrrc xju2f9n"
@@ -694,8 +716,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".xrkmrrc{background-color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
             default: {
               backgroundColor: "xrkmrrc",
@@ -728,8 +751,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           "xju2f9n";
           "x1e2nbdu";"
         `);
@@ -753,7 +777,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           "";
           "x1e2nbdu";"
         `);
@@ -779,10 +804,11 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x14odnwx{padding:5px}", 1000);
-          _inject(".x2vl965{padding-inline-end:10px}", 3000);
-          _inject(".x1i3ajwb{padding:2px}", 1000);
-          _inject(".xe2zdcy{padding-inline-start:10px}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x14odnwx{padding:5px}", 1000);
+          _inject2(".x2vl965{padding-inline-end:10px}", 3000);
+          _inject2(".x1i3ajwb{padding:2px}", 1000);
+          _inject2(".xe2zdcy{padding-inline-start:10px}", 3000);
           "x2vl965 x1i3ajwb xe2zdcy";"
         `);
       });
@@ -807,9 +833,10 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x14odnwx{padding:5px}", 1000);
-          _inject(".x2vl965{padding-inline-end:10px}", 3000);
-          _inject(".x1i3ajwb{padding:2px}", 1000);
+          var _inject2 = _inject;
+          _inject2(".x14odnwx{padding:5px}", 1000);
+          _inject2(".x2vl965{padding-inline-end:10px}", 3000);
+          _inject2(".x1i3ajwb{padding:2px}", 1000);
           "x2vl965 x1i3ajwb";"
         `);
       });
@@ -834,8 +861,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           ({
             0: "x1e2nbdu",
             1: "xju2f9n"
@@ -862,8 +890,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
             red: {
               color: "x1e2nbdu",
@@ -898,7 +927,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           ({
             0: "x1e2nbdu",
             1: ""
@@ -925,7 +955,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             red: {
               color: "x1e2nbdu",
@@ -964,7 +995,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           "FooBar__styles.default x1e2nbdu";"
         `);
       });
@@ -996,8 +1028,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".x1t391ir{background-color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".x1t391ir{background-color:blue}", 3000);
           ({
             0: "FooBar__styles.default x1e2nbdu",
             1: "FooBar__styles.default x1e2nbdu FooBar__otherStyles.default x1t391ir"
@@ -1031,7 +1064,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
               "FooBar__styles.default": "FooBar__styles.default",
@@ -1039,7 +1073,7 @@ describe('@stylexjs/babel-plugin', () => {
               $$css: true
             }
           };
-          _inject(".x1t391ir{background-color:blue}", 3000);
+          _inject2(".x1t391ir{background-color:blue}", 3000);
           const otherStyles = {
             default: {
               "FooBar__otherStyles.default": "FooBar__otherStyles.default",
@@ -1077,8 +1111,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           ({
             0: "FooBar__styles.default x1e2nbdu",
             1: "FooBar__styles.default FooBar__styles.active xju2f9n"
@@ -1111,8 +1146,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
             default: {
               "FooBar__styles.default": "FooBar__styles.default",
@@ -1148,8 +1184,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
           "0": {
             color: "x1e2nbdu",
@@ -1177,7 +1214,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         const styles = {
           default: {
             color: "x1e2nbdu",
@@ -1207,8 +1245,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x17z2mba:hover{color:blue}", 3130);
-        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        var _inject2 = _inject;
+        _inject2(".x17z2mba:hover{color:blue}", 3130);
+        _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         export const styles = {
           default: {
             ":hover_color": "x17z2mba",
@@ -1239,8 +1278,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x17z2mba:hover{color:blue}", 3130);
-        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        var _inject2 = _inject;
+        _inject2(".x17z2mba:hover{color:blue}", 3130);
+        _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         export const styles = {
           default: {
             color: "x17z2mba",
@@ -1270,9 +1310,10 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
+          var _inject2 = _inject;
           stylex(styles[variant]);
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".x1t391ir{background-color:blue}", 3000);
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".x1t391ir{background-color:blue}", 3000);
           const styles = {
             "0": {
               color: "x1e2nbdu",
@@ -1314,6 +1355,7 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
+          var _inject2 = _inject;
           function MyComponent() {
             return <>
                             <div className={"x1e2nbdu"} />
@@ -1322,8 +1364,8 @@ describe('@stylexjs/babel-plugin', () => {
                             <div className={"x1e2nbdu x1t391ir"} />
                           </>;
           }
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".x1t391ir{background-color:blue}", 3000);
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".x1t391ir{background-color:blue}", 3000);
           const styles = {
             foo: {
               color: "x1e2nbdu",
@@ -1346,8 +1388,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
+          var _inject2 = _inject;
           stylex(styles.default, props);
-          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
               color: "x1e2nbdu",
@@ -1374,10 +1417,11 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x16gpukw{border-top:5px solid blue}", 2000);
-          _inject(".x13nwy86{border-left:5px solid blue}", 2000);
-          _inject(".x2ekbea{border-right:5px solid blue}", 2000);
-          _inject(".x1o3008b{border-bottom:5px solid blue}", 2000);
+          var _inject2 = _inject;
+          _inject2(".x16gpukw{border-top:5px solid blue}", 2000);
+          _inject2(".x13nwy86{border-left:5px solid blue}", 2000);
+          _inject2(".x2ekbea{border-right:5px solid blue}", 2000);
+          _inject2(".x1o3008b{border-bottom:5px solid blue}", 2000);
           const styles = {
             default: {
               borderTop: "x16gpukw",
@@ -1410,9 +1454,10 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
+          var _inject2 = _inject;
           "x17z2mba xc445zv";
-          _inject(".x17z2mba:hover{color:blue}", 3130);
-          _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+          _inject2(".x17z2mba:hover{color:blue}", 3130);
+          _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
           export const styles = {
             default: {
               ":hover_color": "x17z2mba",
@@ -1442,7 +1487,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'custom-stylex-path';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
     });
@@ -1463,7 +1509,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import { css as stylex } from 'custom-stylex-path';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
     });
@@ -1484,7 +1531,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import { css } from 'custom-stylex-path';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
     });
@@ -1532,18 +1580,19 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from '@stylexjs/stylex';
-        _inject(".x9f619{box-sizing:border-box}", 3000);
-        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        _inject(".x1fdo2jl{grid-area:content}", 1000);
-        _inject(".xrvj5dj{display:grid}", 3000);
-        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x9f619{box-sizing:border-box}", 3000);
+        _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject2(".x1fdo2jl{grid-area:content}", 1000);
+        _inject2(".xrvj5dj{display:grid}", 3000);
+        _inject2(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject2(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject2(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject2(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject2("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject2("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject2("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject2(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         ({
           0: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4",
           1: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x"
@@ -1592,18 +1641,19 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from '@stylexjs/stylex';
-        _inject(".x9f619{box-sizing:border-box}", 3000);
-        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        _inject(".x1fdo2jl{grid-area:content}", 1000);
-        _inject(".xrvj5dj{display:grid}", 3000);
-        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x9f619{box-sizing:border-box}", 3000);
+        _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject2(".x1fdo2jl{grid-area:content}", 1000);
+        _inject2(".xrvj5dj{display:grid}", 3000);
+        _inject2(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject2(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject2(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject2(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject2("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject2("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject2("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject2(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         export const styles = {
           sidebar: {
             "UnknownFile__styles.sidebar": "UnknownFile__styles.sidebar",
@@ -1700,18 +1750,19 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from '@stylexjs/stylex';
-        _inject(".x9f619{box-sizing:border-box}", 3000);
-        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        _inject(".x1fdo2jl{grid-area:content}", 1000);
-        _inject(".xrvj5dj{display:grid}", 3000);
-        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x9f619{box-sizing:border-box}", 3000);
+        _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject2(".x1fdo2jl{grid-area:content}", 1000);
+        _inject2(".xrvj5dj{display:grid}", 3000);
+        _inject2(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject2(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject2(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject2(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject2("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject2("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject2("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject2(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         export const styles = {
           sidebar: {
             "UnknownFile__styles.sidebar": "UnknownFile__styles.sidebar",
@@ -1807,18 +1858,19 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from '@stylexjs/stylex';
-        _inject(".x9f619{box-sizing:border-box}", 3000);
-        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        _inject(".x1fdo2jl{grid-area:content}", 1000);
-        _inject(".xrvj5dj{display:grid}", 3000);
-        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x9f619{box-sizing:border-box}", 3000);
+        _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject2(".x1fdo2jl{grid-area:content}", 1000);
+        _inject2(".xrvj5dj{display:grid}", 3000);
+        _inject2(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject2(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject2(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject2(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject2("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject2("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject2("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject2(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         const complex = {
           0: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4",
           4: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x",

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -41,8 +41,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject(".xju2f9n{color:blue}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xju2f9n{color:blue}", 3000);"
       `);
     });
 
@@ -60,8 +61,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import * as foo from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject(".xju2f9n{color:blue}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xju2f9n{color:blue}", 3000);"
       `);
     });
 
@@ -79,8 +81,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import { create } from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject(".xju2f9n{color:blue}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xju2f9n{color:blue}", 3000);"
       `);
     });
 
@@ -97,7 +100,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xgau0yw{--background-color:red}", 1);"
+        var _inject2 = _inject;
+        _inject2(".xgau0yw{--background-color:red}", 1);"
       `);
     });
 
@@ -114,7 +118,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x13tgbkp{--final-color:var(--background-color)}", 1);"
+        var _inject2 = _inject;
+        _inject2(".x13tgbkp{--final-color:var(--background-color)}", 1);"
       `);
     });
 
@@ -134,8 +139,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject(".xju2f9n{color:blue}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xju2f9n{color:blue}", 3000);"
       `);
     });
 
@@ -152,7 +158,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xd71okc{content:attr(some-attribute)}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".xd71okc{content:attr(some-attribute)}", 3000);"
       `);
     });
 
@@ -179,7 +186,8 @@ describe('@stylexjs/babel-plugin', () => {
       expect(camelCased).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1cfch2b{transition-property:margin-top}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".x1cfch2b{transition-property:margin-top}", 3000);"
       `);
     });
 
@@ -196,7 +204,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x17389it{transition-property:--foo}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".x17389it{transition-property:--foo}", 3000);"
       `);
     });
 
@@ -216,8 +225,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1gykpug:hover{background-color:red}", 3130);
-        _inject(".x17z2mba:hover{color:blue}", 3130);"
+        var _inject2 = _inject;
+        _inject2(".x1gykpug:hover{background-color:red}", 3130);
+        _inject2(".x17z2mba:hover{color:blue}", 3130);"
       `);
     });
 
@@ -239,8 +249,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1gykpug:hover{background-color:red}", 3130);
-        _inject(".x17z2mba:hover{color:blue}", 3130);"
+        var _inject2 = _inject;
+        _inject2(".x1gykpug:hover{background-color:red}", 3130);
+        _inject2(".x17z2mba:hover{color:blue}", 3130);"
       `);
     });
 
@@ -257,7 +268,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1ruww2u{position:sticky;position:fixed}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".x1ruww2u{position:sticky;position:fixed}", 3000);"
       `);
     });
 
@@ -277,8 +289,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xixxii4{position:fixed}", 3000);
-        _inject("@media (min-width: 768px){.x1vazst0.x1vazst0{position:sticky;position:fixed}}", 3200);"
+        var _inject2 = _inject;
+        _inject2(".xixxii4{position:fixed}", 3000);
+        _inject2("@media (min-width: 768px){.x1vazst0.x1vazst0{position:sticky;position:fixed}}", 3200);"
       `);
     });
 
@@ -296,7 +309,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x87ps6o{user-select:none}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".x87ps6o{user-select:none}", 3000);"
       `);
     });
 
@@ -316,9 +330,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xb3r6kr{overflow:hidden}", 2000);
-        _inject(".xbsl7fq{border-style:dashed}", 2000);
-        _inject(".xmkeg23{border-width:1px}", 2000);"
+        var _inject2 = _inject;
+        _inject2(".xb3r6kr{overflow:hidden}", 2000);
+        _inject2(".xbsl7fq{border-style:dashed}", 2000);
+        _inject2(".xmkeg23{border-width:1px}", 2000);"
       `);
     });
 
@@ -377,7 +392,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x15oojuh{position:fixed;position:sticky}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x15oojuh{position:fixed;position:sticky}", 3000);
         export const styles = {
           foo: {
             position: "x15oojuh",
@@ -400,7 +416,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xxnfx33{box-shadow:0 2px 4px var(--shadow-1)}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".xxnfx33{box-shadow:0 2px 4px var(--shadow-1)}", 3000);"
       `);
     });
 
@@ -422,8 +439,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x19iys6w:invalpwdijad{background-color:red}", 3040);
-          _inject(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
+          var _inject2 = _inject;
+          _inject2(".x19iys6w:invalpwdijad{background-color:red}", 3040);
+          _inject2(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
         `);
       });
 
@@ -451,10 +469,11 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x17z2mba:hover{color:blue}", 3130);
-          _inject(".x96fq8s:active{color:red}", 3170);
-          _inject(".x1wvtd7d:focus{color:yellow}", 3150);
-          _inject(".x126ychx:nth-child(2n){color:purple}", 3060);"
+          var _inject2 = _inject;
+          _inject2(".x17z2mba:hover{color:blue}", 3130);
+          _inject2(".x96fq8s:active{color:red}", 3170);
+          _inject2(".x1wvtd7d:focus{color:yellow}", 3150);
+          _inject2(".x126ychx:nth-child(2n){color:purple}", 3060);"
         `);
       });
 
@@ -473,7 +492,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
+          var _inject2 = _inject;
+          _inject2(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
         `);
       });
     });
@@ -494,8 +514,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x19iys6w:invalpwdijad{background-color:red}", 3040);
-          _inject(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
+          var _inject2 = _inject;
+          _inject2(".x19iys6w:invalpwdijad{background-color:red}", 3040);
+          _inject2(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
         `);
       });
 
@@ -517,10 +538,11 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x17z2mba:hover{color:blue}", 3130);
-          _inject(".x96fq8s:active{color:red}", 3170);
-          _inject(".x1wvtd7d:focus{color:yellow}", 3150);
-          _inject(".x126ychx:nth-child(2n){color:purple}", 3060);"
+          var _inject2 = _inject;
+          _inject2(".x17z2mba:hover{color:blue}", 3130);
+          _inject2(".x96fq8s:active{color:red}", 3170);
+          _inject2(".x1wvtd7d:focus{color:yellow}", 3150);
+          _inject2(".x126ychx:nth-child(2n){color:purple}", 3060);"
         `);
       });
 
@@ -539,7 +561,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
+          var _inject2 = _inject;
+          _inject2(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
         `);
       });
     });
@@ -564,8 +587,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x16oeupf::before{color:red}", 8000);
-          _inject(".xdaarc3::after{color:blue}", 8000);"
+          var _inject2 = _inject;
+          _inject2(".x16oeupf::before{color:red}", 8000);
+          _inject2(".xdaarc3::after{color:blue}", 8000);"
         `);
       });
 
@@ -584,7 +608,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x6yu8oj::placeholder{color:gray}", 8000);"
+          var _inject2 = _inject;
+          _inject2(".x6yu8oj::placeholder{color:gray}", 8000);"
         `);
       });
 
@@ -603,7 +628,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1en94km::-webkit-slider-thumb, .x1en94km::-moz-range-thumb, .x1en94km::-ms-thumb{width:16px}", 9000);"
+          var _inject2 = _inject;
+          _inject2(".x1en94km::-webkit-slider-thumb, .x1en94km::-moz-range-thumb, .x1en94km::-ms-thumb{width:16px}", 9000);"
         `);
       });
     });
@@ -628,9 +654,10 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".xrkmrrc{background-color:red}", 3000);
-          _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-          _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);"
+          var _inject2 = _inject;
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+          _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);"
         `);
       });
 
@@ -653,9 +680,10 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".xrkmrrc{background-color:red}", 3000);
-          _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-          _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);"
+          var _inject2 = _inject;
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+          _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);"
         `);
       });
     });
@@ -678,9 +706,10 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".xrkmrrc{background-color:red}", 3000);
-          _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-          _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);"
+          var _inject2 = _inject;
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+          _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);"
         `);
       });
 
@@ -701,9 +730,10 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".xrkmrrc{background-color:red}", 3000);
-          _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-          _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);"
+          var _inject2 = _inject;
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+          _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);"
         `);
       });
     });
@@ -745,21 +775,22 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         const borderRadius = 2;
-        _inject(".xe4njm9{margin:calc((100% - 50px) * .5) 20px 0}", 1000);
-        _inject(".xs4buau{border-color:red blue}", 2000);
-        _inject(".xbsl7fq{border-style:dashed}", 2000);
-        _inject(".xn43iik{border-width:0 0 2px 0}", 2000);
-        _inject(".xmkeg23{border-width:1px}", 2000);
-        _inject(".xa309fb{border-bottom-width:5px}", 4000);
-        _inject(".x1y0btm7{border-style:solid}", 2000);
-        _inject(".x1q0q8m5{border-bottom-style:solid}", 4000);
-        _inject(".x1lh7sze{border-color:var(--divider)}", 2000);
-        _inject(".xud65wk{border-bottom-color:red}", 4000);
-        _inject(".x12oqio5{border-radius:4px}", 2000);
-        _inject(".x1lmef92{padding:calc((100% - 50px) * .5) var(--rightpadding,20px)}", 1000);
-        _inject(".xexx8yu{padding-top:0}", 4000);
-        _inject(".x1bg2uv5{border-color:green}", 2000);"
+        _inject2(".xe4njm9{margin:calc((100% - 50px) * .5) 20px 0}", 1000);
+        _inject2(".xs4buau{border-color:red blue}", 2000);
+        _inject2(".xbsl7fq{border-style:dashed}", 2000);
+        _inject2(".xn43iik{border-width:0 0 2px 0}", 2000);
+        _inject2(".xmkeg23{border-width:1px}", 2000);
+        _inject2(".xa309fb{border-bottom-width:5px}", 4000);
+        _inject2(".x1y0btm7{border-style:solid}", 2000);
+        _inject2(".x1q0q8m5{border-bottom-style:solid}", 4000);
+        _inject2(".x1lh7sze{border-color:var(--divider)}", 2000);
+        _inject2(".xud65wk{border-bottom-color:red}", 4000);
+        _inject2(".x12oqio5{border-radius:4px}", 2000);
+        _inject2(".x1lmef92{padding:calc((100% - 50px) * .5) var(--rightpadding,20px)}", 1000);
+        _inject2(".xexx8yu{padding-top:0}", 4000);
+        _inject2(".x1bg2uv5{border-color:green}", 2000);"
       `);
     });
 
@@ -785,12 +816,13 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         const borderRadius = 2;
-        _inject(".x1ok221b{margin-top:5px}", 4000);
-        _inject(".x1sa5p1d{margin-inline-end:10px}", 3000);
-        _inject(".x1fqp7bg{margin-bottom:15px}", 4000);
-        _inject(".xqsn43r{margin-inline-start:20px}", 3000);
-        _inject(".x1ghz6dp{margin:0}", 1000);
+        _inject2(".x1ok221b{margin-top:5px}", 4000);
+        _inject2(".x1sa5p1d{margin-inline-end:10px}", 3000);
+        _inject2(".x1fqp7bg{margin-bottom:15px}", 4000);
+        _inject2(".xqsn43r{margin-inline-start:20px}", 3000);
+        _inject2(".x1ghz6dp{margin:0}", 1000);
         "x1ghz6dp";"
       `);
     });
@@ -1090,8 +1122,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject(".x19dipnz{color:var(--color,revert)}", 3000);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
@@ -1118,8 +1151,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject(".x17fnjtu{width:var(--width,revert)}", 4000);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".x17fnjtu{width:var(--width,revert)}", 4000);
         export const styles = {
           default: width => [{
             backgroundColor: "xrkmrrc",
@@ -1149,9 +1183,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject(".x19dipnz{color:var(--color,revert)}", 3000);
-        _inject(".x1mqxbix{color:black}", 3000);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject2(".x1mqxbix{color:black}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
@@ -1181,7 +1216,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
+        var _inject2 = _inject;
+        _inject2(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
         export const styles = {
           default: bgColor => [{
             "--background-color": "xyv4n8w",
@@ -1208,8 +1244,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1gykpug:hover{background-color:red}", 3130);
-        _inject(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
+        var _inject2 = _inject;
+        _inject2(".x1gykpug:hover{background-color:red}", 3130);
+        _inject2(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
         export const styles = {
           default: color => [{
             ":hover_backgroundColor": "x1gykpug",
@@ -1238,9 +1275,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject(".x19dipnz{color:var(--color,revert)}", 3000);
-        _inject(".x1mqxbix{color:black}", 3000);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject2(".x1mqxbix{color:black}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
@@ -1270,7 +1308,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
+        var _inject2 = _inject;
+        _inject2(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
         export const styles = {
           default: bgColor => [{
             "--background-color": "xyv4n8w",
@@ -1297,8 +1336,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1gykpug:hover{background-color:red}", 3130);
-        _inject(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
+        var _inject2 = _inject;
+        _inject2(".x1gykpug:hover{background-color:red}", 3130);
+        _inject2(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
         export const styles = {
           default: color => [{
             ":hover_backgroundColor": "x1gykpug",

--- a/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
@@ -205,9 +205,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
-        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
+        var _inject2 = _inject;
+        _inject2(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
+        _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject2("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -286,9 +287,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
-        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
+        var _inject2 = _inject;
+        _inject2(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
+        _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject2("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -384,9 +386,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
-        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
+        var _inject2 = _inject;
+        _inject2(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
+        _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject2("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -394,8 +397,8 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(":root{--xcateir:white;--xmj7ivn:black;--x13gxjix:8;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xmj7ivn:white;}}", 0.1);
+        _inject2(":root{--xcateir:white;--xmj7ivn:black;--x13gxjix:8;}", 0);
+        _inject2("@media (prefers-color-scheme: dark){:root{--xmj7ivn:white;}}", 0.1);
         export const textInputTheme = {
           bgColor: "var(--xcateir)",
           labelColor: "var(--xmj7ivn)",
@@ -432,10 +435,11 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         const RADIUS = 10;
-        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
-        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
+        _inject2(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
+        _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject2("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -473,10 +477,11 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         const color = 'blue';
-        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
-        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
+        _inject2(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
+        _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject2("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -514,10 +519,11 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         const name = 'light';
-        _inject(":root{--xgck17p:lightblue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
-        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
+        _inject2(":root{--xgck17p:lightblue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
+        _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject2("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -555,10 +561,11 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         const RADIUS = 2;
-        _inject(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:4;--x4y59db:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
-        _inject("@media print{:root{--xgck17p:white;}}", 0.1);
+        _inject2(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:4;--x4y59db:pink;}", 0);
+        _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject2("@media print{:root{--xgck17p:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -602,9 +609,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(":root{--x1sm8rlu:blue;--xxncinc:grey;--x4e1236:10;--xv9uic:pink;}", 0);
-        _inject("@media (prefers-color-scheme: dark){:root{--x1sm8rlu:lightblue;--xxncinc:rgba(0, 0, 0, 0.8);}}", 0.1);
-        _inject("@media print{:root{--x1sm8rlu:white;}}", 0.1);
+        var _inject2 = _inject;
+        _inject2(":root{--x1sm8rlu:blue;--xxncinc:grey;--x4e1236:10;--xv9uic:pink;}", 0);
+        _inject2("@media (prefers-color-scheme: dark){:root{--x1sm8rlu:lightblue;--xxncinc:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject2("@media print{:root{--x1sm8rlu:white;}}", 0.1);
         export const buttonTheme = {
           bgColor: "var(--x1sm8rlu)",
           bgColorDisabled: "var(--xxncinc)",

--- a/packages/babel-plugin/__tests__/stylex-transform-import-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-import-test.js
@@ -66,7 +66,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         export const styles = {
           foo: {
             color: "x1e2nbdu",
@@ -108,7 +109,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         const styles = {
           foo: {
             color: "x1e2nbdu",
@@ -132,7 +134,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         export default {
           foo: {
             color: "x1e2nbdu",
@@ -156,7 +159,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         const styles = {
           foo: {
             color: "x1e2nbdu",
@@ -186,9 +190,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import foobar from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject(".xju2f9n{color:blue}", 3000);
-        _inject(".x14odnwx{padding:5px}", 1000);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xju2f9n{color:blue}", 3000);
+        _inject2(".x14odnwx{padding:5px}", 1000);
         const styles = {
           default: {
             backgroundColor: "xrkmrrc",
@@ -226,9 +231,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import * as foobar from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject(".xju2f9n{color:blue}", 3000);
-        _inject(".x14odnwx{padding:5px}", 1000);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xju2f9n{color:blue}", 3000);
+        _inject2(".x14odnwx{padding:5px}", 1000);
         const styles = {
           default: {
             backgroundColor: "xrkmrrc",
@@ -266,9 +272,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import { create } from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject(".xju2f9n{color:blue}", 3000);
-        _inject(".x14odnwx{padding:5px}", 1000);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xju2f9n{color:blue}", 3000);
+        _inject2(".x14odnwx{padding:5px}", 1000);
         const styles = {
           default: {
             backgroundColor: "xrkmrrc",
@@ -306,9 +313,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import { create as css } from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject(".xju2f9n{color:blue}", 3000);
-        _inject(".x14odnwx{padding:5px}", 1000);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xju2f9n{color:blue}", 3000);
+        _inject2(".x14odnwx{padding:5px}", 1000);
         const styles = {
           default: {
             backgroundColor: "xrkmrrc",
@@ -326,6 +334,100 @@ describe('@stylexjs/babel-plugin', () => {
           }
         };
         styles;"
+      `);
+    });
+  });
+
+  describe('[transform] With custom imports', () => {
+    test('Handles custom default imports', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'foo-bar';
+          const styles = stylex.create({
+            default: {
+              backgroundColor: 'red',
+              color: 'blue',
+            }
+          });
+        `,
+          { importSources: ['foo-bar'] },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'foo-bar';
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xju2f9n{color:blue}", 3000);"
+      `);
+    });
+
+    test('Handles custom * as imports', () => {
+      expect(
+        transform(
+          `
+          import * as stylex from 'foo-bar';
+          const styles = stylex.create({
+            default: {
+              backgroundColor: 'red',
+              color: 'blue',
+            }
+          });
+        `,
+          { importSources: ['foo-bar'] },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import * as stylex from 'foo-bar';
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xju2f9n{color:blue}", 3000);"
+      `);
+    });
+
+    test('Handles custom named imports', () => {
+      expect(
+        transform(
+          `
+          import {css} from 'react-strict-dom';
+          const styles = css.create({
+            default: {
+              backgroundColor: 'red',
+              color: 'blue',
+            }
+          });
+        `,
+          { importSources: [{ from: 'react-strict-dom', as: 'css' }] },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import { css } from 'react-strict-dom';
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xju2f9n{color:blue}", 3000);"
+      `);
+    });
+
+    test('Handles custom named imports with other named imports', () => {
+      expect(
+        transform(
+          `
+          import {html, css} from 'react-strict-dom';
+          const styles = css.create({
+            default: {
+              backgroundColor: 'red',
+              color: 'blue',
+            }
+          });
+        `,
+          { importSources: [{ from: 'react-strict-dom', as: 'css' }] },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import { html, css } from 'react-strict-dom';
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xju2f9n{color:blue}", 3000);"
       `);
     });
   });

--- a/packages/babel-plugin/__tests__/stylex-transform-keyframes-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-keyframes-test.js
@@ -43,7 +43,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
+        var _inject2 = _inject;
+        _inject2("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
         const name = "xbopttm-B";"
       `);
     });
@@ -65,7 +66,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import * as stylex from 'stylex';
-        _inject("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
+        var _inject2 = _inject;
+        _inject2("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
         const name = "xbopttm-B";"
       `);
     });
@@ -87,7 +89,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import { keyframes } from 'stylex';
-        _inject("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
+        var _inject2 = _inject;
+        _inject2("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
         const name = "xbopttm-B";"
       `);
     });
@@ -114,9 +117,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject("@keyframes x3zqmp-B{from{background-color:blue;}to{background-color:red;}}", 1);
+        var _inject2 = _inject;
+        _inject2("@keyframes x3zqmp-B{from{background-color:blue;}to{background-color:red;}}", 1);
         const name = "x3zqmp-B";
-        _inject(".x1qs41r0{animation:3s x3zqmp-B}", 1000);"
+        _inject2(".x1qs41r0{animation:3s x3zqmp-B}", 1000);"
       `);
     });
 
@@ -141,8 +145,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject("@keyframes x3zqmp-B{from{background-color:blue;}to{background-color:red;}}", 1);
-        _inject(".xcoz2pf{animation-name:x3zqmp-B}", 3000);"
+        var _inject2 = _inject;
+        _inject2("@keyframes x3zqmp-B{from{background-color:blue;}to{background-color:red;}}", 1);
+        _inject2(".xcoz2pf{animation-name:x3zqmp-B}", 3000);"
       `);
     });
 
@@ -169,9 +174,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject("@keyframes x1jkcf39-B{from{inset-inline-start:0;}to{inset-inline-start:500px;}}", 1);
+        var _inject2 = _inject;
+        _inject2("@keyframes x1jkcf39-B{from{inset-inline-start:0;}to{inset-inline-start:500px;}}", 1);
         const name = "x1jkcf39-B";
-        _inject(".x1vfi257{animation-name:x1jkcf39-B}", 3000);
+        _inject2(".x1vfi257{animation-name:x1jkcf39-B}", 3000);
         export const styles = {
           root: {
             animationName: "x1vfi257",

--- a/packages/babel-plugin/__tests__/stylex-transform-legacy-shorthands-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-legacy-shorthands-test.js
@@ -53,10 +53,11 @@ describe('Legacy-shorthand-expansion resolution', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x123j3cw{padding-top:5px}", 4000);
-        _inject(".x1mpkggp{padding-right:5px}", 3000, ".x1mpkggp{padding-left:5px}");
-        _inject(".xs9asl8{padding-bottom:5px}", 4000);
-        _inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        var _inject2 = _inject;
+        _inject2(".x123j3cw{padding-top:5px}", 4000);
+        _inject2(".x1mpkggp{padding-right:5px}", 3000, ".x1mpkggp{padding-left:5px}");
+        _inject2(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
         export const styles = {
           foo: {
             paddingTop: "x123j3cw",
@@ -89,14 +90,15 @@ describe('Legacy-shorthand-expansion resolution', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x123j3cw{padding-top:5px}", 4000);
-        _inject(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
-        _inject(".xs9asl8{padding-bottom:5px}", 4000);
-        _inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
-        _inject(".x1nn3v0j{padding-top:2px}", 4000);
-        _inject(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
-        _inject(".x1120s5i{padding-bottom:2px}", 4000);
-        _inject(".x1sln4lm{padding-left:10px}", 3000, ".x1sln4lm{padding-right:10px}");
+        var _inject2 = _inject;
+        _inject2(".x123j3cw{padding-top:5px}", 4000);
+        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
+        _inject2(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1nn3v0j{padding-top:2px}", 4000);
+        _inject2(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
+        _inject2(".x1120s5i{padding-bottom:2px}", 4000);
+        _inject2(".x1sln4lm{padding-left:10px}", 3000, ".x1sln4lm{padding-right:10px}");
         "x1nn3v0j xg83lxy x1120s5i x1sln4lm";"
       `);
     });
@@ -120,13 +122,14 @@ describe('Legacy-shorthand-expansion resolution', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x123j3cw{padding-top:5px}", 4000);
-        _inject(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
-        _inject(".xs9asl8{padding-bottom:5px}", 4000);
-        _inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
-        _inject(".x1nn3v0j{padding-top:2px}", 4000);
-        _inject(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
-        _inject(".x1120s5i{padding-bottom:2px}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x123j3cw{padding-top:5px}", 4000);
+        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
+        _inject2(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1nn3v0j{padding-top:2px}", 4000);
+        _inject2(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
+        _inject2(".x1120s5i{padding-bottom:2px}", 4000);
         "x1nn3v0j xg83lxy x1120s5i";"
       `);
     });
@@ -146,8 +149,9 @@ describe('Legacy-shorthand-expansion resolution', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
-        _inject(".x1mpkggp{padding-right:5px}", 3000, ".x1mpkggp{padding-left:5px}");
+        var _inject2 = _inject;
+        _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1mpkggp{padding-right:5px}", 3000, ".x1mpkggp{padding-left:5px}");
         export const styles = {
           foo: {
             paddingStart: "x1t2a60a",
@@ -180,14 +184,15 @@ describe('Legacy-shorthand-expansion resolution', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x123j3cw{padding-top:5px}", 4000);
-        _inject(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
-        _inject(".xs9asl8{padding-bottom:5px}", 4000);
-        _inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
-        _inject(".x1nn3v0j{padding-top:2px}", 4000);
-        _inject(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
-        _inject(".x1120s5i{padding-bottom:2px}", 4000);
-        _inject(".x1sln4lm{padding-left:10px}", 3000, ".x1sln4lm{padding-right:10px}");
+        var _inject2 = _inject;
+        _inject2(".x123j3cw{padding-top:5px}", 4000);
+        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
+        _inject2(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1nn3v0j{padding-top:2px}", 4000);
+        _inject2(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
+        _inject2(".x1120s5i{padding-bottom:2px}", 4000);
+        _inject2(".x1sln4lm{padding-left:10px}", 3000, ".x1sln4lm{padding-right:10px}");
         "x1nn3v0j xg83lxy x1120s5i x1sln4lm";"
       `);
     });
@@ -211,13 +216,14 @@ describe('Legacy-shorthand-expansion resolution', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x123j3cw{padding-top:5px}", 4000);
-        _inject(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
-        _inject(".xs9asl8{padding-bottom:5px}", 4000);
-        _inject(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
-        _inject(".x1nn3v0j{padding-top:2px}", 4000);
-        _inject(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
-        _inject(".x1120s5i{padding-bottom:2px}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x123j3cw{padding-top:5px}", 4000);
+        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
+        _inject2(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1nn3v0j{padding-top:2px}", 4000);
+        _inject2(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
+        _inject2(".x1120s5i{padding-bottom:2px}", 4000);
         "x1nn3v0j xg83lxy x1120s5i";"
       `);
     });

--- a/packages/babel-plugin/__tests__/stylex-transform-logical-properties-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-logical-properties-test.js
@@ -42,7 +42,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1lkbs04{border-block-color:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1lkbs04{border-block-color:0}", 3000);
         const classnames = "x1lkbs04";"
       `);
     });
@@ -57,7 +58,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x4q076{border-top-color:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x4q076{border-top-color:0}", 3000);
         const classnames = "x4q076";"
       `);
     });
@@ -72,7 +74,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1ylptbq{border-bottom-color:0}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x1ylptbq{border-bottom-color:0}", 4000);
         const classnames = "x1ylptbq";"
       `);
     });
@@ -87,7 +90,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1v09clb{border-inline-color:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".x1v09clb{border-inline-color:0}", 2000);
         const classnames = "x1v09clb";"
       `);
     });
@@ -102,7 +106,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1t19a1o{border-inline-start-color:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1t19a1o{border-inline-start-color:0}", 3000);
         const classnames = "x1t19a1o";"
       `);
     });
@@ -117,7 +122,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14mj1wy{border-inline-end-color:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x14mj1wy{border-inline-end-color:0}", 3000);
         const classnames = "x14mj1wy";"
       `);
     });
@@ -134,7 +140,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x7mea6a{border-block-style:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x7mea6a{border-block-style:0}", 3000);
         const classnames = "x7mea6a";"
       `);
     });
@@ -149,7 +156,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1d917x0{border-top-style:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1d917x0{border-top-style:0}", 3000);
         const classnames = "x1d917x0";"
       `);
     });
@@ -164,7 +172,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1nmap2y{border-bottom-style:0}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x1nmap2y{border-bottom-style:0}", 4000);
         const classnames = "x1nmap2y";"
       `);
     });
@@ -179,7 +188,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xt8kkye{border-inline-style:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".xt8kkye{border-inline-style:0}", 2000);
         const classnames = "xt8kkye";"
       `);
     });
@@ -194,7 +204,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xl8mozw{border-inline-start-style:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".xl8mozw{border-inline-start-style:0}", 3000);
         const classnames = "xl8mozw";"
       `);
     });
@@ -209,7 +220,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x10o505a{border-inline-end-style:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x10o505a{border-inline-end-style:0}", 3000);
         const classnames = "x10o505a";"
       `);
     });
@@ -226,7 +238,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1616tdu{border-block-width:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1616tdu{border-block-width:0}", 3000);
         const classnames = "x1616tdu";"
       `);
     });
@@ -241,7 +254,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x972fbf{border-top-width:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x972fbf{border-top-width:0}", 3000);
         const classnames = "x972fbf";"
       `);
     });
@@ -256,7 +270,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1qhh985{border-bottom-width:0}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x1qhh985{border-bottom-width:0}", 4000);
         const classnames = "x1qhh985";"
       `);
     });
@@ -271,7 +286,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xuxrje7{border-inline-width:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".xuxrje7{border-inline-width:0}", 2000);
         const classnames = "xuxrje7";"
       `);
     });
@@ -286,7 +302,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14e42zd{border-inline-start-width:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x14e42zd{border-inline-start-width:0}", 3000);
         const classnames = "x14e42zd";"
       `);
     });
@@ -301,7 +318,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x10w94by{border-inline-end-width:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x10w94by{border-inline-end-width:0}", 3000);
         const classnames = "x10w94by";"
       `);
     });
@@ -318,7 +336,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x13vifvy{top:0}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x13vifvy{top:0}", 4000);
         const classnames = "x13vifvy";"
       `);
     });
@@ -333,7 +352,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x10no89f{inset-block:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".x10no89f{inset-block:0}", 2000);
         const classnames = "x10no89f";"
       `);
     });
@@ -348,7 +368,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1ey2m1c{bottom:0}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x1ey2m1c{bottom:0}", 4000);
         const classnames = "x1ey2m1c";"
       `);
     });
@@ -363,7 +384,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x13vifvy{top:0}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x13vifvy{top:0}", 4000);
         const classnames = "x13vifvy";"
       `);
     });
@@ -378,7 +400,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x17y0mx6{inset-inline:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".x17y0mx6{inset-inline:0}", 2000);
         const classnames = "x17y0mx6";"
       `);
     });
@@ -393,7 +416,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xtijo5x{inset-inline-end:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".xtijo5x{inset-inline-end:0}", 3000);
         const classnames = "xtijo5x";"
       `);
     });
@@ -408,7 +432,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1o0tod{inset-inline-start:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1o0tod{inset-inline-start:0}", 3000);
         const classnames = "x1o0tod";"
       `);
     });
@@ -425,7 +450,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x10im51j{margin-block:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".x10im51j{margin-block:0}", 2000);
         const classnames = "x10im51j";"
       `);
     });
@@ -440,7 +466,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xat24cr{margin-bottom:0}", 4000);
+        var _inject2 = _inject;
+        _inject2(".xat24cr{margin-bottom:0}", 4000);
         const classnames = "xat24cr";"
       `);
     });
@@ -455,7 +482,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xdj266r{margin-top:0}", 4000);
+        var _inject2 = _inject;
+        _inject2(".xdj266r{margin-top:0}", 4000);
         const classnames = "xdj266r";"
       `);
     });
@@ -470,7 +498,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrxpjvj{margin-inline:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".xrxpjvj{margin-inline:0}", 2000);
         const classnames = "xrxpjvj";"
       `);
     });
@@ -485,7 +514,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14z9mp{margin-inline-end:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x14z9mp{margin-inline-end:0}", 3000);
         const classnames = "x14z9mp";"
       `);
     });
@@ -500,7 +530,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1lziwak{margin-inline-start:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1lziwak{margin-inline-start:0}", 3000);
         const classnames = "x1lziwak";"
       `);
     });
@@ -517,7 +548,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xt970qd{padding-block:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".xt970qd{padding-block:0}", 2000);
         const classnames = "xt970qd";"
       `);
     });
@@ -532,7 +564,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x18d9i69{padding-bottom:0}", 4000);
+        var _inject2 = _inject;
+        _inject2(".x18d9i69{padding-bottom:0}", 4000);
         const classnames = "x18d9i69";"
       `);
     });
@@ -547,7 +580,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xexx8yu{padding-top:0}", 4000);
+        var _inject2 = _inject;
+        _inject2(".xexx8yu{padding-top:0}", 4000);
         const classnames = "xexx8yu";"
       `);
     });
@@ -562,7 +596,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xnjsko4{padding-inline:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".xnjsko4{padding-inline:0}", 2000);
         const classnames = "xnjsko4";"
       `);
     });
@@ -577,7 +612,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xyri2b{padding-inline-end:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".xyri2b{padding-inline-end:0}", 3000);
         const classnames = "xyri2b";"
       `);
     });
@@ -592,7 +628,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1c1uobl{padding-inline-start:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1c1uobl{padding-inline-start:0}", 3000);
         const classnames = "x1c1uobl";"
       `);
     });
@@ -611,7 +648,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xceh6e4{inset-inline-end:5px}", 3000);
+        var _inject2 = _inject;
+        _inject2(".xceh6e4{inset-inline-end:5px}", 3000);
         const classnames = "xceh6e4";"
       `);
     });
@@ -626,7 +664,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14z9mp{margin-inline-end:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x14z9mp{margin-inline-end:0}", 3000);
         const classnames = "x14z9mp";"
       `);
     });
@@ -641,7 +680,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrxpjvj{margin-inline:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".xrxpjvj{margin-inline:0}", 2000);
         const classnames = "xrxpjvj";"
       `);
     });
@@ -656,7 +696,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1lziwak{margin-inline-start:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1lziwak{margin-inline-start:0}", 3000);
         const classnames = "x1lziwak";"
       `);
     });
@@ -671,7 +712,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x10im51j{margin-block:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".x10im51j{margin-block:0}", 2000);
         const classnames = "x10im51j";"
       `);
     });
@@ -686,7 +728,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xyri2b{padding-inline-end:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".xyri2b{padding-inline-end:0}", 3000);
         const classnames = "xyri2b";"
       `);
     });
@@ -701,7 +744,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xnjsko4{padding-inline:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".xnjsko4{padding-inline:0}", 2000);
         const classnames = "xnjsko4";"
       `);
     });
@@ -716,7 +760,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1c1uobl{padding-inline-start:0}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1c1uobl{padding-inline-start:0}", 3000);
         const classnames = "x1c1uobl";"
       `);
     });
@@ -731,7 +776,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xt970qd{padding-block:0}", 2000);
+        var _inject2 = _inject;
+        _inject2(".xt970qd{padding-block:0}", 2000);
         const classnames = "xt970qd";"
       `);
     });
@@ -746,7 +792,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1fb7gu6{inset-inline-start:5px}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1fb7gu6{inset-inline-start:5px}", 3000);
         const classnames = "x1fb7gu6";"
       `);
     });
@@ -769,7 +816,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xi71r3n{margin:1 2 3 4}", 1000);
+        var _inject2 = _inject;
+        _inject2(".xi71r3n{margin:1 2 3 4}", 1000);
         "xi71r3n";"
       `);
     });

--- a/packages/babel-plugin/__tests__/stylex-transform-logical-values-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-logical-values-test.js
@@ -44,7 +44,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xof8tvn{clear:inline-end}", 3000);
+        var _inject2 = _inject;
+        _inject2(".xof8tvn{clear:inline-end}", 3000);
         const classnames = "xof8tvn";"
       `);
     });
@@ -59,7 +60,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x18lmvvi{clear:inline-start}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x18lmvvi{clear:inline-start}", 3000);
         const classnames = "x18lmvvi";"
       `);
     });
@@ -74,7 +76,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1h0q493{float:inline-end}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1h0q493{float:inline-end}", 3000);
         const classnames = "x1h0q493";"
       `);
     });
@@ -89,7 +92,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1kmio9f{float:inline-start}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1kmio9f{float:inline-start}", 3000);
         const classnames = "x1kmio9f";"
       `);
     });
@@ -104,7 +108,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xp4054r{text-align:right}", 3000, ".xp4054r{text-align:left}");
+        var _inject2 = _inject;
+        _inject2(".xp4054r{text-align:right}", 3000, ".xp4054r{text-align:left}");
         const classnames = "xp4054r";"
       `);
     });
@@ -119,7 +124,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1yc453h{text-align:left}", 3000, ".x1yc453h{text-align:right}");
+        var _inject2 = _inject;
+        _inject2(".x1yc453h{text-align:left}", 3000, ".x1yc453h{text-align:right}");
         const classnames = "x1yc453h";"
       `);
     });
@@ -138,7 +144,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xodj72a{clear:right}", 3000, ".xodj72a{clear:left}");
+        var _inject2 = _inject;
+        _inject2(".xodj72a{clear:right}", 3000, ".xodj72a{clear:left}");
         const classnames = "xodj72a";"
       `);
     });
@@ -153,7 +160,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x390i0x{clear:left}", 3000, ".x390i0x{clear:right}");
+        var _inject2 = _inject;
+        _inject2(".x390i0x{clear:left}", 3000, ".x390i0x{clear:right}");
         const classnames = "x390i0x";"
       `);
     });
@@ -168,7 +176,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1guec7k{float:right}", 3000, ".x1guec7k{float:left}");
+        var _inject2 = _inject;
+        _inject2(".x1guec7k{float:right}", 3000, ".x1guec7k{float:left}");
         const classnames = "x1guec7k";"
       `);
     });
@@ -183,7 +192,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrbpyxo{float:left}", 3000, ".xrbpyxo{float:right}");
+        var _inject2 = _inject;
+        _inject2(".xrbpyxo{float:left}", 3000, ".xrbpyxo{float:right}");
         const classnames = "xrbpyxo";"
       `);
     });
@@ -202,7 +212,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14mnfz1{cursor:e-resize}", 3000, ".x14mnfz1{cursor:w-resize}");
+        var _inject2 = _inject;
+        _inject2(".x14mnfz1{cursor:e-resize}", 3000, ".x14mnfz1{cursor:w-resize}");
         const classnames = "x14mnfz1";"
       `);
     });
@@ -217,7 +228,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14isd7o{cursor:w-resize}", 3000, ".x14isd7o{cursor:e-resize}");
+        var _inject2 = _inject;
+        _inject2(".x14isd7o{cursor:w-resize}", 3000, ".x14isd7o{cursor:e-resize}");
         const classnames = "x14isd7o";"
       `);
     });
@@ -232,7 +244,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xc7edbc{cursor:ne-resize}", 3000, ".xc7edbc{cursor:nw-resize}");
+        var _inject2 = _inject;
+        _inject2(".xc7edbc{cursor:ne-resize}", 3000, ".xc7edbc{cursor:nw-resize}");
         const classnames = "xc7edbc";"
       `);
     });
@@ -247,7 +260,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrpsa6j{cursor:nw-resize}", 3000, ".xrpsa6j{cursor:ne-resize}");
+        var _inject2 = _inject;
+        _inject2(".xrpsa6j{cursor:nw-resize}", 3000, ".xrpsa6j{cursor:ne-resize}");
         const classnames = "xrpsa6j";"
       `);
     });
@@ -262,7 +276,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xp35lg9{cursor:se-resize}", 3000, ".xp35lg9{cursor:sw-resize}");
+        var _inject2 = _inject;
+        _inject2(".xp35lg9{cursor:se-resize}", 3000, ".xp35lg9{cursor:sw-resize}");
         const classnames = "xp35lg9";"
       `);
     });
@@ -277,7 +292,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1egwzy8{cursor:sw-resize}", 3000, ".x1egwzy8{cursor:se-resize}");
+        var _inject2 = _inject;
+        _inject2(".x1egwzy8{cursor:sw-resize}", 3000, ".x1egwzy8{cursor:se-resize}");
         const classnames = "x1egwzy8";"
       `);
     });
@@ -297,7 +313,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x13xdq3h{animation-name:ignore}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x13xdq3h{animation-name:ignore}", 3000);
         const classnames = "x13xdq3h";"
       `);
     });
@@ -312,7 +329,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xl0ducr{background-position:top right}", 2000, ".xl0ducr{background-position:top left}");
+        var _inject2 = _inject;
+        _inject2(".xl0ducr{background-position:top right}", 2000, ".xl0ducr{background-position:top left}");
         const classnames = "xl0ducr";"
       `);
       expect(
@@ -324,7 +342,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xgg80n4{background-position:top left}", 2000, ".xgg80n4{background-position:top right}");
+        var _inject2 = _inject;
+        _inject2(".xgg80n4{background-position:top left}", 2000, ".xgg80n4{background-position:top right}");
         const classnames = "xgg80n4";"
       `);
     });
@@ -339,7 +358,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1gnnqk1{box-shadow:none}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1gnnqk1{box-shadow:none}", 3000);
         const classnames = "x1gnnqk1";"
       `);
       expect(
@@ -351,7 +371,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xtgyqtp{box-shadow:1px 1px #000}", 3000, ".xtgyqtp{box-shadow:-1px 1px #000}");
+        var _inject2 = _inject;
+        _inject2(".xtgyqtp{box-shadow:1px 1px #000}", 3000, ".xtgyqtp{box-shadow:-1px 1px #000}");
         const classnames = "xtgyqtp";"
       `);
       expect(
@@ -363,7 +384,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1d2r41h{box-shadow:-1px -1px #000}", 3000, ".x1d2r41h{box-shadow:1px -1px #000}");
+        var _inject2 = _inject;
+        _inject2(".x1d2r41h{box-shadow:-1px -1px #000}", 3000, ".x1d2r41h{box-shadow:1px -1px #000}");
         const classnames = "x1d2r41h";"
       `);
       expect(
@@ -375,7 +397,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1x0mpz7{box-shadow:inset 1px 1px #000}", 3000, ".x1x0mpz7{box-shadow:inset -1px 1px #000}");
+        var _inject2 = _inject;
+        _inject2(".x1x0mpz7{box-shadow:inset 1px 1px #000}", 3000, ".x1x0mpz7{box-shadow:inset -1px 1px #000}");
         const classnames = "x1x0mpz7";"
       `);
       expect(
@@ -387,7 +410,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1fumi7f{box-shadow:1px 1px 1px 1px #000}", 3000, ".x1fumi7f{box-shadow:-1px 1px 1px 1px #000}");
+        var _inject2 = _inject;
+        _inject2(".x1fumi7f{box-shadow:1px 1px 1px 1px #000}", 3000, ".x1fumi7f{box-shadow:-1px 1px 1px 1px #000}");
         const classnames = "x1fumi7f";"
       `);
       expect(
@@ -399,7 +423,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1fs23zf{box-shadow:inset 1px 1px 1px 1px #000}", 3000, ".x1fs23zf{box-shadow:inset -1px 1px 1px 1px #000}");
+        var _inject2 = _inject;
+        _inject2(".x1fs23zf{box-shadow:inset 1px 1px 1px 1px #000}", 3000, ".x1fs23zf{box-shadow:inset -1px 1px 1px 1px #000}");
         const classnames = "x1fs23zf";"
       `);
       expect(
@@ -411,7 +436,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xtgmjod{box-shadow:2px 2px 2px 2px red,inset 1px 1px 1px 1px #000}", 3000, ".xtgmjod{box-shadow:-2px 2px 2px 2px red, inset -1px 1px 1px 1px #000}");
+        var _inject2 = _inject;
+        _inject2(".xtgmjod{box-shadow:2px 2px 2px 2px red,inset 1px 1px 1px 1px #000}", 3000, ".xtgmjod{box-shadow:-2px 2px 2px 2px red, inset -1px 1px 1px 1px #000}");
         const classnames = "xtgmjod";"
       `);
     });
@@ -426,7 +452,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x19pm5ym{text-shadow:none}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x19pm5ym{text-shadow:none}", 3000);
         const classnames = "x19pm5ym";"
       `);
       expect(
@@ -438,7 +465,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x12y90mb{text-shadow:1px 1px #000}", 3000, ".x12y90mb{text-shadow:-1px 1px #000}");
+        var _inject2 = _inject;
+        _inject2(".x12y90mb{text-shadow:1px 1px #000}", 3000, ".x12y90mb{text-shadow:-1px 1px #000}");
         const classnames = "x12y90mb";"
       `);
       expect(
@@ -450,7 +478,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1l3mtsg{text-shadow:-1px -1px #000}", 3000, ".x1l3mtsg{text-shadow:1px -1px #000}");
+        var _inject2 = _inject;
+        _inject2(".x1l3mtsg{text-shadow:-1px -1px #000}", 3000, ".x1l3mtsg{text-shadow:1px -1px #000}");
         const classnames = "x1l3mtsg";"
       `);
       expect(
@@ -462,7 +491,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x67hq7l{text-shadow:1px 1px 1px #000}", 3000, ".x67hq7l{text-shadow:-1px 1px 1px #000}");
+        var _inject2 = _inject;
+        _inject2(".x67hq7l{text-shadow:1px 1px 1px #000}", 3000, ".x67hq7l{text-shadow:-1px 1px 1px #000}");
         const classnames = "x67hq7l";"
       `);
     });

--- a/packages/babel-plugin/__tests__/stylex-transform-override-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-override-vars-test.js
@@ -115,6 +115,7 @@ describe('@stylexjs/babel-plugin', () => {
       expect(output1).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -122,9 +123,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
-        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
-        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
+        _inject2(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject2("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject2("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -168,6 +169,7 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -175,9 +177,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
-        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
-        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
+        _inject2(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject2("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject2("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -230,6 +232,7 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -237,9 +240,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
-        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
-        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
+        _inject2(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject2("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject2("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -301,6 +304,7 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -308,15 +312,15 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
-        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
-        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
+        _inject2(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject2("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject2("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
           "TestTheme.stylex.js__buttonThemePositive": "TestTheme.stylex.js__buttonThemePositive"
         };
-        _inject(".xpsjjyf{--xgck17p:white;--xpegid5:black;--xrqfjmn:0px;}", 0.8);
+        _inject2(".xpsjjyf{--xgck17p:white;--xpegid5:black;--xrqfjmn:0px;}", 0.8);
         const buttonThemeMonochromatic = {
           $$css: true,
           x568ih9: "xpsjjyf",
@@ -350,6 +354,7 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -358,9 +363,9 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const RADIUS = 10;
-        _inject(".xrpt93l{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:10;--x4y59db:coral;}", 0.8);
-        _inject("@media (prefers-color-scheme: dark){.xrpt93l{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
-        _inject("@media print{.xrpt93l{--xgck17p:transparent;}}", 0.9);
+        _inject2(".xrpt93l{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:10;--x4y59db:coral;}", 0.8);
+        _inject2("@media (prefers-color-scheme: dark){.xrpt93l{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject2("@media print{.xrpt93l{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xrpt93l",
@@ -394,6 +399,7 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -402,9 +408,9 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const COLOR = 'coral';
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
-        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
-        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
+        _inject2(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject2("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject2("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",
@@ -438,6 +444,7 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -446,9 +453,9 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const name = 'light';
-        _inject(".x1u43pop{--xgck17p:lightgreen;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
-        _inject("@media (prefers-color-scheme: dark){.x1u43pop{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
-        _inject("@media print{.x1u43pop{--xgck17p:transparent;}}", 0.9);
+        _inject2(".x1u43pop{--xgck17p:lightgreen;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject2("@media (prefers-color-scheme: dark){.x1u43pop{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject2("@media print{.x1u43pop{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "x1u43pop",
@@ -482,6 +489,7 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -490,9 +498,9 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x568ih9"
         };
         const RADIUS = 2;
-        _inject(".x1ubmxd4{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4;--x4y59db:coral;}", 0.8);
-        _inject("@media (prefers-color-scheme: dark){.x1ubmxd4{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
-        _inject("@media print{.x1ubmxd4{--xgck17p:transparent;}}", 0.9);
+        _inject2(".x1ubmxd4{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4;--x4y59db:coral;}", 0.8);
+        _inject2("@media (prefers-color-scheme: dark){.x1ubmxd4{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject2("@media print{.x1ubmxd4{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "x1ubmxd4",
@@ -520,6 +528,7 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
+        var _inject2 = _inject;
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -527,9 +536,9 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
-        _inject("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
-        _inject("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
+        _inject2(".xfmksyk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.8);
+        _inject2("@media (prefers-color-scheme: dark){.xfmksyk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.9);
+        _inject2("@media print{.xfmksyk{--xgck17p:transparent;}}", 0.9);
         const buttonThemePositive = {
           $$css: true,
           x568ih9: "xfmksyk",

--- a/packages/babel-plugin/__tests__/stylex-transform-stylex-attrs-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-stylex-attrs-test.js
@@ -53,7 +53,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import * as stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         ({
           class: "x1e2nbdu"
         });"
@@ -77,8 +78,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         ({
           class: "x1e2nbdu x1t391ir"
         });"
@@ -102,8 +104,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         ({
           class: "x1e2nbdu x1t391ir"
         });"
@@ -124,7 +127,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         ({
           class: "x1e2nbdu"
         });"
@@ -150,8 +154,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import { create, attrs } from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         ({
           class: "x1e2nbdu x1t391ir"
         });"
@@ -172,7 +177,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         const a = function () {
           return {
             class: "x1e2nbdu"
@@ -199,8 +205,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
           foo: {
             color: "x1e2nbdu",
@@ -235,7 +242,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         export default function MyExportDefault() {
           return {
             class: "x1e2nbdu"
@@ -263,7 +271,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14odnwx{padding:5px}", 1000);
+        var _inject2 = _inject;
+        _inject2(".x14odnwx{padding:5px}", 1000);
         ({
           class: "x14odnwx"
         });"
@@ -284,7 +293,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14odnwx{padding:5px}", 1000);
+        var _inject2 = _inject;
+        _inject2(".x14odnwx{padding:5px}", 1000);
         export const styles = {
           foo: {
             padding: "x14odnwx",
@@ -322,8 +332,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x17z2mba:hover{color:blue}", 3130);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x17z2mba:hover{color:blue}", 3130);
         ({
           class: "x1e2nbdu x17z2mba"
         });"
@@ -347,8 +358,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import * as stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x17z2mba:hover{color:blue}", 3130);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x17z2mba:hover{color:blue}", 3130);
         ({
           class: "x1e2nbdu x17z2mba"
         });"
@@ -375,9 +387,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-        _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
         ({
           class: "xrkmrrc xc445zv x1ssfqz5"
         });"
@@ -402,9 +415,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-        _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
         ({
           class: "xrkmrrc xc445zv x1ssfqz5"
         });"
@@ -431,9 +445,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-        _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+        _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
         ({
           class: "xrkmrrc x6m3b6q x6um648"
         });"
@@ -458,9 +473,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-        _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+        _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
         ({
           class: "xrkmrrc x6m3b6q x6um648"
         });"
@@ -488,8 +504,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".xrkmrrc{background-color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           ({
             0: {
               class: "xrkmrrc"
@@ -520,8 +537,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".xrkmrrc{background-color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
             default: {
               backgroundColor: "xrkmrrc",
@@ -554,8 +572,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           ({
             class: "xju2f9n"
           });
@@ -583,7 +602,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           ({});
           ({
             class: "x1e2nbdu"
@@ -611,10 +631,11 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x14odnwx{padding:5px}", 1000);
-          _inject(".x2vl965{padding-inline-end:10px}", 3000);
-          _inject(".x1i3ajwb{padding:2px}", 1000);
-          _inject(".xe2zdcy{padding-inline-start:10px}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x14odnwx{padding:5px}", 1000);
+          _inject2(".x2vl965{padding-inline-end:10px}", 3000);
+          _inject2(".x1i3ajwb{padding:2px}", 1000);
+          _inject2(".xe2zdcy{padding-inline-start:10px}", 3000);
           ({
             class: "x2vl965 x1i3ajwb xe2zdcy"
           });"
@@ -641,9 +662,10 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x14odnwx{padding:5px}", 1000);
-          _inject(".x2vl965{padding-inline-end:10px}", 3000);
-          _inject(".x1i3ajwb{padding:2px}", 1000);
+          var _inject2 = _inject;
+          _inject2(".x14odnwx{padding:5px}", 1000);
+          _inject2(".x2vl965{padding-inline-end:10px}", 3000);
+          _inject2(".x1i3ajwb{padding:2px}", 1000);
           ({
             class: "x2vl965 x1i3ajwb"
           });"
@@ -670,8 +692,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           ({
             0: {
               class: "x1e2nbdu"
@@ -702,8 +725,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
             red: {
               color: "x1e2nbdu",
@@ -738,7 +762,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           ({
             0: {
               class: "x1e2nbdu"
@@ -767,7 +792,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             red: {
               color: "x1e2nbdu",
@@ -806,7 +832,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           ({
             class: "FooBar__styles.default x1e2nbdu"
           });"
@@ -840,8 +867,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".x1t391ir{background-color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".x1t391ir{background-color:blue}", 3000);
           ({
             0: {
               class: "FooBar__styles.default x1e2nbdu"
@@ -879,7 +907,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
               "FooBar__styles.default": "FooBar__styles.default",
@@ -887,7 +916,7 @@ describe('@stylexjs/babel-plugin', () => {
               $$css: true
             }
           };
-          _inject(".x1t391ir{background-color:blue}", 3000);
+          _inject2(".x1t391ir{background-color:blue}", 3000);
           const otherStyles = {
             default: {
               "FooBar__otherStyles.default": "FooBar__otherStyles.default",
@@ -925,8 +954,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           ({
             0: {
               class: "FooBar__styles.default x1e2nbdu"
@@ -957,8 +987,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
           "0": {
             color: "x1e2nbdu",
@@ -986,7 +1017,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         const styles = {
           default: {
             color: "x1e2nbdu",
@@ -1016,8 +1048,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x17z2mba:hover{color:blue}", 3130);
-        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        var _inject2 = _inject;
+        _inject2(".x17z2mba:hover{color:blue}", 3130);
+        _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         export const styles = {
           default: {
             ":hover_color": "x17z2mba",
@@ -1049,9 +1082,10 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
+          var _inject2 = _inject;
           stylex.attrs(styles[variant]);
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".x1t391ir{background-color:blue}", 3000);
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".x1t391ir{background-color:blue}", 3000);
           const styles = {
             "0": {
               color: "x1e2nbdu",
@@ -1093,6 +1127,7 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
+          var _inject2 = _inject;
           function MyComponent() {
             return <>
                             <div {...{
@@ -1107,8 +1142,8 @@ describe('@stylexjs/babel-plugin', () => {
               }} />
                           </>;
           }
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".x1t391ir{background-color:blue}", 3000);
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".x1t391ir{background-color:blue}", 3000);
           const styles = {
             foo: {
               color: "x1e2nbdu",
@@ -1131,8 +1166,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
+          var _inject2 = _inject;
           stylex.attrs([styles.default, props]);
-          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
               color: "x1e2nbdu",
@@ -1161,11 +1197,12 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
+          var _inject2 = _inject;
           ({
             class: "x17z2mba xc445zv"
           });
-          _inject(".x17z2mba:hover{color:blue}", 3130);
-          _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+          _inject2(".x17z2mba:hover{color:blue}", 3130);
+          _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
           export const styles = {
             default: {
               ":hover_color": "x17z2mba",
@@ -1195,7 +1232,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'custom-stylex-path';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         ({
           class: "x1e2nbdu"
         });"
@@ -1245,18 +1283,19 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from '@stylexjs/stylex';
-        _inject(".x9f619{box-sizing:border-box}", 3000);
-        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        _inject(".x1fdo2jl{grid-area:content}", 1000);
-        _inject(".xrvj5dj{display:grid}", 3000);
-        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x9f619{box-sizing:border-box}", 3000);
+        _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject2(".x1fdo2jl{grid-area:content}", 1000);
+        _inject2(".xrvj5dj{display:grid}", 3000);
+        _inject2(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject2(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject2(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject2(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject2("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject2("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject2("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject2(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         export const styles = {
           sidebar: {
             "UnknownFile__styles.sidebar": "UnknownFile__styles.sidebar",
@@ -1359,18 +1398,19 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from '@stylexjs/stylex';
-        _inject(".x9f619{box-sizing:border-box}", 3000);
-        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        _inject(".x1fdo2jl{grid-area:content}", 1000);
-        _inject(".xrvj5dj{display:grid}", 3000);
-        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x9f619{box-sizing:border-box}", 3000);
+        _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject2(".x1fdo2jl{grid-area:content}", 1000);
+        _inject2(".xrvj5dj{display:grid}", 3000);
+        _inject2(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject2(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject2(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject2(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject2("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject2("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject2("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject2(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         const complex = {
           0: {
             class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"

--- a/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
@@ -53,7 +53,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         ({
           className: "x1e2nbdu"
         });"
@@ -77,8 +78,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         ({
           className: "x1e2nbdu x1t391ir"
         });"
@@ -102,8 +104,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         ({
           className: "x1e2nbdu x1t391ir"
         });"
@@ -124,7 +127,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         ({
           className: "x1e2nbdu"
         });"
@@ -150,8 +154,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import { create, props } from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         ({
           className: "x1e2nbdu x1t391ir"
         });"
@@ -172,7 +177,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         const a = function () {
           return {
             className: "x1e2nbdu"
@@ -199,8 +205,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
           foo: {
             color: "x1e2nbdu",
@@ -235,7 +242,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         export default function MyExportDefault() {
           return {
             className: "x1e2nbdu"
@@ -263,7 +271,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14odnwx{padding:5px}", 1000);
+        var _inject2 = _inject;
+        _inject2(".x14odnwx{padding:5px}", 1000);
         ({
           className: "x14odnwx"
         });"
@@ -284,7 +293,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14odnwx{padding:5px}", 1000);
+        var _inject2 = _inject;
+        _inject2(".x14odnwx{padding:5px}", 1000);
         export const styles = {
           foo: {
             padding: "x14odnwx",
@@ -322,8 +332,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x17z2mba:hover{color:blue}", 3130);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x17z2mba:hover{color:blue}", 3130);
         ({
           className: "x1e2nbdu x17z2mba"
         });"
@@ -347,8 +358,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import * as stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x17z2mba:hover{color:blue}", 3130);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x17z2mba:hover{color:blue}", 3130);
         ({
           className: "x1e2nbdu x17z2mba"
         });"
@@ -375,9 +387,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-        _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
         ({
           className: "xrkmrrc xc445zv x1ssfqz5"
         });"
@@ -402,9 +415,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-        _inject("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
         ({
           className: "xrkmrrc xc445zv x1ssfqz5"
         });"
@@ -431,9 +445,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-        _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+        _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
         ({
           className: "xrkmrrc x6m3b6q x6um648"
         });"
@@ -458,9 +473,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xrkmrrc{background-color:red}", 3000);
-        _inject("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-        _inject("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+        var _inject2 = _inject;
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+        _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
         ({
           className: "xrkmrrc x6m3b6q x6um648"
         });"
@@ -488,8 +504,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".xrkmrrc{background-color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           ({
             0: {
               className: "xrkmrrc"
@@ -520,8 +537,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".xrkmrrc{background-color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
             default: {
               backgroundColor: "xrkmrrc",
@@ -554,8 +572,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           ({
             className: "xju2f9n"
           });
@@ -583,7 +602,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           ({});
           ({
             className: "x1e2nbdu"
@@ -611,10 +631,11 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x14odnwx{padding:5px}", 1000);
-          _inject(".x2vl965{padding-inline-end:10px}", 3000);
-          _inject(".x1i3ajwb{padding:2px}", 1000);
-          _inject(".xe2zdcy{padding-inline-start:10px}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x14odnwx{padding:5px}", 1000);
+          _inject2(".x2vl965{padding-inline-end:10px}", 3000);
+          _inject2(".x1i3ajwb{padding:2px}", 1000);
+          _inject2(".xe2zdcy{padding-inline-start:10px}", 3000);
           ({
             className: "x2vl965 x1i3ajwb xe2zdcy"
           });"
@@ -641,9 +662,10 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x14odnwx{padding:5px}", 1000);
-          _inject(".x2vl965{padding-inline-end:10px}", 3000);
-          _inject(".x1i3ajwb{padding:2px}", 1000);
+          var _inject2 = _inject;
+          _inject2(".x14odnwx{padding:5px}", 1000);
+          _inject2(".x2vl965{padding-inline-end:10px}", 3000);
+          _inject2(".x1i3ajwb{padding:2px}", 1000);
           ({
             className: "x2vl965 x1i3ajwb"
           });"
@@ -670,8 +692,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           ({
             0: {
               className: "x1e2nbdu"
@@ -702,8 +725,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
             red: {
               color: "x1e2nbdu",
@@ -738,7 +762,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           ({
             0: {
               className: "x1e2nbdu"
@@ -767,7 +792,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             red: {
               color: "x1e2nbdu",
@@ -806,7 +832,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           ({
             className: "FooBar__styles.default x1e2nbdu"
           });"
@@ -840,8 +867,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".x1t391ir{background-color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".x1t391ir{background-color:blue}", 3000);
           ({
             0: {
               className: "FooBar__styles.default x1e2nbdu"
@@ -879,7 +907,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
               "FooBar__styles.default": "FooBar__styles.default",
@@ -887,7 +916,7 @@ describe('@stylexjs/babel-plugin', () => {
               $$css: true
             }
           };
-          _inject(".x1t391ir{background-color:blue}", 3000);
+          _inject2(".x1t391ir{background-color:blue}", 3000);
           const otherStyles = {
             default: {
               "FooBar__otherStyles.default": "FooBar__otherStyles.default",
@@ -925,8 +954,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".xju2f9n{color:blue}", 3000);
+          var _inject2 = _inject;
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
           ({
             0: {
               className: "FooBar__styles.default x1e2nbdu"
@@ -957,8 +987,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
-        _inject(".x1t391ir{background-color:blue}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
           "0": {
             color: "x1e2nbdu",
@@ -986,7 +1017,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         const styles = {
           default: {
             color: "x1e2nbdu",
@@ -1016,8 +1048,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x17z2mba:hover{color:blue}", 3130);
-        _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        var _inject2 = _inject;
+        _inject2(".x17z2mba:hover{color:blue}", 3130);
+        _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         export const styles = {
           default: {
             ":hover_color": "x17z2mba",
@@ -1049,9 +1082,10 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
+          var _inject2 = _inject;
           stylex.props(styles[variant]);
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".x1t391ir{background-color:blue}", 3000);
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".x1t391ir{background-color:blue}", 3000);
           const styles = {
             "0": {
               color: "x1e2nbdu",
@@ -1093,6 +1127,7 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
+          var _inject2 = _inject;
           function MyComponent() {
             return <>
                             <div {...{
@@ -1107,8 +1142,8 @@ describe('@stylexjs/babel-plugin', () => {
               }} />
                           </>;
           }
-          _inject(".x1e2nbdu{color:red}", 3000);
-          _inject(".x1t391ir{background-color:blue}", 3000);
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          _inject2(".x1t391ir{background-color:blue}", 3000);
           const styles = {
             foo: {
               color: "x1e2nbdu",
@@ -1131,8 +1166,9 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
+          var _inject2 = _inject;
           stylex.props([styles.default, props]);
-          _inject(".x1e2nbdu{color:red}", 3000);
+          _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
               color: "x1e2nbdu",
@@ -1161,11 +1197,12 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
+          var _inject2 = _inject;
           ({
             className: "x17z2mba xc445zv"
           });
-          _inject(".x17z2mba:hover{color:blue}", 3130);
-          _inject("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+          _inject2(".x17z2mba:hover{color:blue}", 3130);
+          _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
           export const styles = {
             default: {
               ":hover_color": "x17z2mba",
@@ -1195,7 +1232,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'custom-stylex-path';
-        _inject(".x1e2nbdu{color:red}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x1e2nbdu{color:red}", 3000);
         ({
           className: "x1e2nbdu"
         });"
@@ -1245,18 +1283,19 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from '@stylexjs/stylex';
-        _inject(".x9f619{box-sizing:border-box}", 3000);
-        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        _inject(".x1fdo2jl{grid-area:content}", 1000);
-        _inject(".xrvj5dj{display:grid}", 3000);
-        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x9f619{box-sizing:border-box}", 3000);
+        _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject2(".x1fdo2jl{grid-area:content}", 1000);
+        _inject2(".xrvj5dj{display:grid}", 3000);
+        _inject2(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject2(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject2(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject2(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject2("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject2("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject2("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject2(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         export const styles = {
           sidebar: {
             "UnknownFile__styles.sidebar": "UnknownFile__styles.sidebar",
@@ -1359,18 +1398,19 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from '@stylexjs/stylex';
-        _inject(".x9f619{box-sizing:border-box}", 3000);
-        _inject(".x1yc5d2u{grid-area:sidebar}", 1000);
-        _inject(".x1fdo2jl{grid-area:content}", 1000);
-        _inject(".xrvj5dj{display:grid}", 3000);
-        _inject(".x7k18q3{grid-template-rows:100%}", 3000);
-        _inject(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
-        _inject(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
-        _inject(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
-        _inject("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
-        _inject("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
-        _inject("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
-        _inject(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
+        var _inject2 = _inject;
+        _inject2(".x9f619{box-sizing:border-box}", 3000);
+        _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
+        _inject2(".x1fdo2jl{grid-area:content}", 1000);
+        _inject2(".xrvj5dj{display:grid}", 3000);
+        _inject2(".x7k18q3{grid-template-rows:100%}", 3000);
+        _inject2(".x5gp9wm{grid-template-areas:\\"content\\"}", 2000);
+        _inject2(".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}", 3000);
+        _inject2(".x17lh93j{grid-template-areas:\\"sidebar content\\"}", 2000);
+        _inject2("@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}", 3200);
+        _inject2("@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}", 2200);
+        _inject2("@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}", 3200);
+        _inject2(".x1mkdm3x{grid-template-columns:minmax(0,1fr)}", 3000);
         const complex = {
           0: {
             className: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"

--- a/packages/babel-plugin/__tests__/stylex-transform-value-normalize-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-value-normalize-test.js
@@ -52,7 +52,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x18qx21s{transform:rotate(10deg) translate3d(0,0,0)}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".x18qx21s{transform:rotate(10deg) translate3d(0,0,0)}", 3000);"
       `);
       expect(
         transform(`
@@ -62,7 +63,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xe1l9yr{color:rgba(1,222,33,.5)}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".xe1l9yr{color:rgba(1,222,33,.5)}", 3000);"
       `);
     });
 
@@ -78,8 +80,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1ghz6dp{margin:0}", 1000);
-        _inject(".xgsvwom{margin-left:1px}", 4000);"
+        var _inject2 = _inject;
+        _inject2(".x1ghz6dp{margin:0}", 1000);
+        _inject2(".xgsvwom{margin-left:1px}", 4000);"
       `);
     });
 
@@ -92,7 +95,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1wsgiic{transition-duration:.5s}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".x1wsgiic{transition-duration:.5s}", 3000);"
       `);
     });
 
@@ -109,7 +113,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1jpfit1{transform:0deg}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".x1jpfit1{transform:0deg}", 3000);"
       `);
     });
 
@@ -122,7 +127,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1hauit9{width:calc((100% + 3% - 100px) / 7)}", 4000);"
+        var _inject2 = _inject;
+        _inject2(".x1hauit9{width:calc((100% + 3% - 100px) / 7)}", 4000);"
       `);
     });
 
@@ -138,8 +144,9 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xpvlhck{transition-duration:.01s}", 3000);
-        _inject(".xxziih7{transition-timing-function:cubic-bezier(.08,.52,.52,1)}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".xpvlhck{transition-duration:.01s}", 3000);
+        _inject2(".xxziih7{transition-timing-function:cubic-bezier(.08,.52,.52,1)}", 3000);"
       `);
     });
 
@@ -152,7 +159,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x169joja{quotes:\\"\\"}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".x169joja{quotes:\\"\\"}", 3000);"
       `);
     });
 
@@ -169,9 +177,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xsa3hc2{transition-duration:1.234s}", 3000);
-        _inject(".xpvlhck{transition-duration:.01s}", 3000);
-        _inject(".xjd9b36{transition-duration:1ms}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".xsa3hc2{transition-duration:1.234s}", 3000);
+        _inject2(".xpvlhck{transition-duration:.01s}", 3000);
+        _inject2(".xjd9b36{transition-duration:1ms}", 3000);"
       `);
     });
 
@@ -195,12 +204,13 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1egiwwb{height:500px}", 4000);
-        _inject(".x1oin6zd{margin:10px}", 1000);
-        _inject(".xvue9z{width:500px}", 4000);
-        _inject(".xk50ysn{font-weight:500}", 3000);
-        _inject(".x1evy7pa{line-height:1.5}", 3000);
-        _inject(".xbyyjgo{opacity:.5}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".x1egiwwb{height:500px}", 4000);
+        _inject2(".x1oin6zd{margin:10px}", 1000);
+        _inject2(".xvue9z{width:500px}", 4000);
+        _inject2(".xk50ysn{font-weight:500}", 3000);
+        _inject2(".x1evy7pa{line-height:1.5}", 3000);
+        _inject2(".xbyyjgo{opacity:.5}", 3000);"
       `);
     });
 
@@ -213,7 +223,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x1vvwc6p{height:33.3333px}", 4000);"
+        var _inject2 = _inject;
+        _inject2(".x1vvwc6p{height:33.3333px}", 4000);"
       `);
     });
 
@@ -236,9 +247,10 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".x14axycx{content:\\"\\"}", 3000);
-        _inject(".xmmpjw1{content:\\"next\\"}", 3000);
-        _inject(".x12vzfr8{content:\\"prev\\"}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".x14axycx{content:\\"\\"}", 3000);
+        _inject2(".xmmpjw1{content:\\"next\\"}", 3000);
+        _inject2(".x12vzfr8{content:\\"prev\\"}", 3000);"
       `);
     });
 
@@ -251,7 +263,8 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         import stylex from 'stylex';
-        _inject(".xzw3067{color:red!important}", 3000);"
+        var _inject2 = _inject;
+        _inject2(".xzw3067{color:red!important}", 3000);"
       `);
     });
   });
@@ -280,10 +293,11 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".xngnso2{font-size:1.5rem}", 3000);
-          _inject(".x1c3i2sq{font-size:1.125rem}", 3000);
-          _inject(".x1603h9y{font-size:1.25rem}", 3000);
-          _inject(".x1qlqyl8{font-size:inherit}", 3000);"
+          var _inject2 = _inject;
+          _inject2(".xngnso2{font-size:1.5rem}", 3000);
+          _inject2(".x1c3i2sq{font-size:1.125rem}", 3000);
+          _inject2(".x1603h9y{font-size:1.25rem}", 3000);
+          _inject2(".x1qlqyl8{font-size:inherit}", 3000);"
         `);
       });
 
@@ -300,7 +314,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x37c5sx{font-size:calc(100% - 1.5rem)}", 3000);"
+          var _inject2 = _inject;
+          _inject2(".x37c5sx{font-size:calc(100% - 1.5rem)}", 3000);"
         `);
       });
     });
@@ -330,10 +345,11 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1pvqxga{font-size:24px}", 3000);
-          _inject(".xosj86m{font-size:18px}", 3000);
-          _inject(".x1603h9y{font-size:1.25rem}", 3000);
-          _inject(".x1qlqyl8{font-size:inherit}", 3000);"
+          var _inject2 = _inject;
+          _inject2(".x1pvqxga{font-size:24px}", 3000);
+          _inject2(".xosj86m{font-size:18px}", 3000);
+          _inject2(".x1603h9y{font-size:1.25rem}", 3000);
+          _inject2(".x1qlqyl8{font-size:inherit}", 3000);"
         `);
       });
 
@@ -353,7 +369,8 @@ describe('@stylexjs/babel-plugin', () => {
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           import stylex from 'stylex';
-          _inject(".x1upkca{font-size:calc(100% - 24px)}", 3000);"
+          var _inject2 = _inject;
+          _inject2(".x1upkca{font-size:calc(100% - 24px)}", 3000);"
         `);
       });
     });

--- a/packages/babel-plugin/__tests__/stylex-transform-variable-removal-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-variable-removal-test.js
@@ -39,8 +39,9 @@ describe('[optimization] Removes `styles` variable when not needed', () => {
     expect(result.code).toMatchInlineSnapshot(`
       "import _inject from "@stylexjs/stylex/lib/stylex-inject";
       import stylex from 'stylex';
-      _inject(".xrkmrrc{background-color:red}", 3000);
-      _inject(".xju2f9n{color:blue}", 3000);
+      var _inject2 = _inject;
+      _inject2(".xrkmrrc{background-color:red}", 3000);
+      _inject2(".xju2f9n{color:blue}", 3000);
       const styles = {
         default: {
           backgroundColor: "xrkmrrc",
@@ -88,8 +89,9 @@ describe('[optimization] Removes `styles` variable when not needed', () => {
     expect(result.code).toMatchInlineSnapshot(`
       "import _inject from "@stylexjs/stylex/lib/stylex-inject";
       import stylex from 'stylex';
-      _inject(".xrkmrrc{background-color:red}", 3000);
-      _inject(".xju2f9n{color:blue}", 3000);"
+      var _inject2 = _inject;
+      _inject2(".xrkmrrc{background-color:red}", 3000);
+      _inject2(".xju2f9n{color:blue}", 3000);"
     `);
     expect(result.metadata).toMatchInlineSnapshot(`
       {

--- a/packages/babel-plugin/src/visitors/stylex-create-theme.js
+++ b/packages/babel-plugin/src/visitors/stylex-create-theme.js
@@ -9,7 +9,6 @@
 
 import * as t from '@babel/types';
 import type { NodePath } from '@babel/traverse';
-import { addDefault, addNamed } from '@babel/helper-module-imports';
 import StateManager from '../utils/state-manager';
 import { createTheme as stylexCreateTheme, messages } from '@stylexjs/shared';
 import { convertObjectToAST } from '../utils/js-to-ast';
@@ -120,8 +119,12 @@ export default function transformStyleXCreateTheme(
         const { from, as } = state.runtimeInjection;
         injectName =
           as != null
-            ? addNamed(statementPath, as, from, { nameHint: 'inject' })
-            : addDefault(statementPath, from, { nameHint: 'inject' });
+            ? state.addNamedImport(statementPath, as, from, {
+                nameHint: 'inject',
+              })
+            : state.addDefaultImport(statementPath, from, {
+                nameHint: 'inject',
+              });
 
         state.injectImportInserted = injectName;
       }

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -9,7 +9,6 @@
 
 import * as t from '@babel/types';
 import type { NodePath } from '@babel/traverse';
-import { addDefault, addNamed } from '@babel/helper-module-imports';
 import type { FunctionConfig } from '../../utils/evaluate-path';
 import StateManager from '../../utils/state-manager';
 import {
@@ -202,8 +201,12 @@ export default function transformStyleXCreate(
         const { from, as } = state.runtimeInjection;
         injectName =
           as != null
-            ? addNamed(statementPath, as, from, { nameHint: 'inject' })
-            : addDefault(statementPath, from, { nameHint: 'inject' });
+            ? state.addNamedImport(statementPath, as, from, {
+                nameHint: 'inject',
+              })
+            : state.addDefaultImport(statementPath, from, {
+                nameHint: 'inject',
+              });
 
         state.injectImportInserted = injectName;
       }

--- a/packages/babel-plugin/src/visitors/stylex-define-vars.js
+++ b/packages/babel-plugin/src/visitors/stylex-define-vars.js
@@ -9,7 +9,6 @@
 
 import * as t from '@babel/types';
 import type { NodePath } from '@babel/traverse';
-import { addDefault, addNamed } from '@babel/helper-module-imports';
 import StateManager from '../utils/state-manager';
 import {
   defineVars as stylexDefineVars,
@@ -150,8 +149,12 @@ export default function transformStyleXDefineVars(
         const { from, as } = state.runtimeInjection;
         injectName =
           as != null
-            ? addNamed(statementPath, as, from, { nameHint: 'inject' })
-            : addDefault(statementPath, from, { nameHint: 'inject' });
+            ? state.addNamedImport(statementPath, as, from, {
+                nameHint: 'inject',
+              })
+            : state.addDefaultImport(statementPath, from, {
+                nameHint: 'inject',
+              });
 
         state.injectImportInserted = injectName;
       }

--- a/packages/babel-plugin/src/visitors/stylex-keyframes.js
+++ b/packages/babel-plugin/src/visitors/stylex-keyframes.js
@@ -9,7 +9,6 @@
 
 import * as t from '@babel/types';
 import type { NodePath } from '@babel/traverse';
-import { addDefault, addNamed } from '@babel/helper-module-imports';
 import StateManager from '../utils/state-manager';
 import { keyframes as stylexKeyframes, messages } from '@stylexjs/shared';
 import * as pathUtils from '../babel-path-utils';
@@ -101,8 +100,12 @@ export default function transformStyleXKeyframes(
         const { from, as } = state.runtimeInjection;
         injectName =
           as != null
-            ? addNamed(statementPath, as, from, { nameHint: 'inject' })
-            : addDefault(statementPath, from, { nameHint: 'inject' });
+            ? state.addNamedImport(statementPath, as, from, {
+                nameHint: 'inject',
+              })
+            : state.addDefaultImport(statementPath, from, {
+                nameHint: 'inject',
+              });
 
         state.injectImportInserted = injectName;
       }

--- a/packages/esbuild-plugin/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/esbuild-plugin/__tests__/__snapshots__/index-test.js.snap
@@ -140,8 +140,9 @@ exports[`esbuild-plugin-stylex preserves stylex.inject calls and does not extrac
   // __tests__/__fixtures__/fooStyles.js
   var import_stylex_inject = __toESM(__require("@stylexjs/stylex/lib/stylex-inject"), 1);
   var import_stylex = __toESM(__require("@stylexjs/stylex"), 1);
-  (0, import_stylex_inject.default)(".xt0psk2{display:inline}", 3e3);
-  (0, import_stylex_inject.default)(".xh8yej3{width:100%}", 4e3);
+  var _inject2 = import_stylex_inject.default;
+  _inject2(".xt0psk2{display:inline}", 3e3);
+  _inject2(".xh8yej3{width:100%}", 4e3);
   var fooStyles_default = {
     foo: {
       fooStyles__foo: "fooStyles__foo",
@@ -154,9 +155,10 @@ exports[`esbuild-plugin-stylex preserves stylex.inject calls and does not extrac
   // __tests__/__fixtures__/bazStyles.js
   var import_stylex_inject2 = __toESM(__require("@stylexjs/stylex/lib/stylex-inject"), 1);
   var import_stylex2 = __toESM(__require("@stylexjs/stylex"), 1);
-  (0, import_stylex_inject2.default)(".x1lliihq{display:block}", 3e3);
-  (0, import_stylex_inject2.default)(".xnsd7bc{height:900px}", 4e3);
-  (0, import_stylex_inject2.default)(".x3hqpx7{width:50%}", 4e3);
+  var _inject22 = import_stylex_inject2.default;
+  _inject22(".x1lliihq{display:block}", 3e3);
+  _inject22(".xnsd7bc{height:900px}", 4e3);
+  _inject22(".x3hqpx7{width:50%}", 4e3);
   var bazStyles_default = {
     baz: {
       bazStyles__baz: "bazStyles__baz",
@@ -168,13 +170,14 @@ exports[`esbuild-plugin-stylex preserves stylex.inject calls and does not extrac
   };
 
   // __tests__/__fixtures__/index.js
-  (0, import_stylex_inject3.default)("@keyframes xekv6nw-B{0%{opacity:0;}100%{opacity:1;}}", 1);
-  (0, import_stylex_inject3.default)(".x127lhb5{animation-name:xekv6nw-B}", 3e3);
-  (0, import_stylex_inject3.default)(".x78zum5{display:flex}", 3e3);
-  (0, import_stylex_inject3.default)(".x16ydxro{margin-left:10px}", 4e3);
-  (0, import_stylex_inject3.default)(".x1xa6b72{height:700px}", 4e3);
-  (0, import_stylex_inject3.default)(".xrkmrrc{background-color:red}", 3e3);
-  (0, import_stylex_inject3.default)(".x1r3o6fz:hover{background-color:pink}", 3130);
+  var _inject23 = import_stylex_inject3.default;
+  _inject23("@keyframes xekv6nw-B{0%{opacity:0;}100%{opacity:1;}}", 1);
+  _inject23(".x127lhb5{animation-name:xekv6nw-B}", 3e3);
+  _inject23(".x78zum5{display:flex}", 3e3);
+  _inject23(".x16ydxro{margin-left:10px}", 4e3);
+  _inject23(".x1xa6b72{height:700px}", 4e3);
+  _inject23(".xrkmrrc{background-color:red}", 3e3);
+  _inject23(".x1r3o6fz:hover{background-color:pink}", 3130);
   var styles = {
     bar: {
       "index__styles.bar": "index__styles.bar",

--- a/packages/rollup-plugin/__tests__/index-test.js
+++ b/packages/rollup-plugin/__tests__/index-test.js
@@ -185,8 +185,9 @@ describe('rollup-plugin-stylex', () => {
          *
          */
 
-        _inject(".x1lliihq{display:block}", 3000);
-        _inject(".xh8yej3{width:100%}", 4000);
+        var _inject2$2 = _inject;
+        _inject2$2(".x1lliihq{display:block}", 3000);
+        _inject2$2(".xh8yej3{width:100%}", 4000);
         var styles$2 = {
           bar: {
             "otherStyles__styles.bar": "otherStyles__styles.bar",
@@ -205,9 +206,10 @@ describe('rollup-plugin-stylex', () => {
          *
          */
 
-        _inject(".xt0psk2{display:inline}", 3000);
-        _inject(".x1egiwwb{height:500px}", 4000);
-        _inject(".x3hqpx7{width:50%}", 4000);
+        var _inject2$1 = _inject;
+        _inject2$1(".xt0psk2{display:inline}", 3000);
+        _inject2$1(".x1egiwwb{height:500px}", 4000);
+        _inject2$1(".x3hqpx7{width:50%}", 4000);
         const styles$1 = {
           baz: {
             "npmStyles__styles.baz": "npmStyles__styles.baz",
@@ -227,13 +229,14 @@ describe('rollup-plugin-stylex', () => {
          *
          */
 
-        _inject("@keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}", 1);
-        _inject(".xeuoslp{animation-name:xgnty7z-B}", 3000);
-        _inject(".x78zum5{display:flex}", 3000);
-        _inject(".x1hm9lzh{margin-inline-start:10px}", 3000);
-        _inject(".xlrshdv{margin-top:99px}", 4000);
-        _inject(".x1egiwwb{height:500px}", 4000);
-        _inject(".x1oz5o6v:hover{background:red}", 1130);
+        var _inject2 = _inject;
+        _inject2("@keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}", 1);
+        _inject2(".xeuoslp{animation-name:xgnty7z-B}", 3000);
+        _inject2(".x78zum5{display:flex}", 3000);
+        _inject2(".x1hm9lzh{margin-inline-start:10px}", 3000);
+        _inject2(".xlrshdv{margin-top:99px}", 4000);
+        _inject2(".x1egiwwb{height:500px}", 4000);
+        _inject2(".x1oz5o6v:hover{background:red}", 1130);
         var styles = {
           foo: {
             "index__styles.foo": "index__styles.foo",

--- a/packages/webpack-plugin/__tests__/index-test.js
+++ b/packages/webpack-plugin/__tests__/index-test.js
@@ -547,14 +547,15 @@ describe('webpack-plugin-stylex', () => {
           var _otherStyles = _interopRequireDefault(__webpack_require__("./otherStyles.js"));
           var _npmStyles = _interopRequireDefault(__webpack_require__("./npmStyles.js"));
           function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-          (0, _stylexInject.default)("@keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}", 1);
+          var _inject2 = _stylexInject.default;
+          _inject2("@keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}", 1);
           var fadeAnimation = "xgnty7z-B";
-          _inject(".xeuoslp{animation-name:xgnty7z-B}", 3000);
-          _inject(".x78zum5{display:flex}", 3000);
-          _inject(".x1hm9lzh{margin-inline-start:10px}", 3000);
-          _inject(".xlrshdv{margin-top:99px}", 4000);
-          _inject(".x1egiwwb{height:500px}", 4000);
-          _inject(".x1oz5o6v:hover{background:red}", 1130);
+          _inject2(".xeuoslp{animation-name:xgnty7z-B}", 3000);
+          _inject2(".x78zum5{display:flex}", 3000);
+          _inject2(".x1hm9lzh{margin-inline-start:10px}", 3000);
+          _inject2(".xlrshdv{margin-top:99px}", 4000);
+          _inject2(".x1egiwwb{height:500px}", 4000);
+          _inject2(".x1oz5o6v:hover{background:red}", 1130);
           var styles = {
             foo: {
               "index__styles.foo": "index__styles.foo",
@@ -608,8 +609,9 @@ describe('webpack-plugin-stylex', () => {
           var _stylexInject = _interopRequireDefault(__webpack_require__("../../../stylex/lib/stylex-inject.js"));
           var _stylex = _interopRequireDefault(__webpack_require__("stylex"));
           function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-          (0, _stylexInject.default)(".x1lliihq{display:block}", 3000);
-          _inject(".xh8yej3{width:100%}", 4000);
+          var _inject2 = _stylexInject.default;
+          _inject2(".x1lliihq{display:block}", 3000);
+          _inject2(".xh8yej3{width:100%}", 4000);
           var styles = {
             bar: {
               "otherStyles__styles.bar": "otherStyles__styles.bar",
@@ -703,9 +705,10 @@ describe('webpack-plugin-stylex', () => {
           var _stylexInject = _interopRequireDefault(__webpack_require__("../../../stylex/lib/stylex-inject.js"));
           var _stylex = _interopRequireDefault(__webpack_require__("stylex"));
           function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-          (0, _stylexInject.default)(".xt0psk2{display:inline}", 3000);
-          _inject(".x1egiwwb{height:500px}", 4000);
-          _inject(".x3hqpx7{width:50%}", 4000);
+          var _inject2 = _stylexInject.default;
+          _inject2(".xt0psk2{display:inline}", 3000);
+          _inject2(".x1egiwwb{height:500px}", 4000);
+          _inject2(".x3hqpx7{width:50%}", 4000);
           const styles = {
             baz: {
               "npmStyles__styles.baz": "npmStyles__styles.baz",


### PR DESCRIPTION
This is to solve a conflict that occurs when using runtimeInjection with the `@babel/plugin-transform-modules-commonjs` plugin.

This is a workaround, since the bug is a consequence of how Babel works.