### PR TITLE
fix: support string values for opacity

### DIFF
--- a/packages/stylex/src/StyleXCSSTypes.js
+++ b/packages/stylex/src/StyleXCSSTypes.js
@@ -476,7 +476,7 @@ type MsOverflowStyle =
   | '-ms-autohiding-scrollbar';
 type objectFit = 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
 type objectPosition = string;
-type opacity = number;
+type opacity = number | string;
 type order = number;
 type orphans = number;
 type outline = string;


### PR DESCRIPTION
## What changed / motivation ?

This PR adds support for string values for `opacity`.

## Linked PR/Issues

Fixes #356