### PR TITLE
fix: rollup watch mode shouldn't clean cache

### DIFF
--- a/packages/rollup-plugin/src/index.js
+++ b/packages/rollup-plugin/src/index.js
@@ -41,10 +41,18 @@ export default function stylexPlugin({
   ...options
 }: PluginOptions = {}): Plugin<> {
   let stylexRules: { [string]: $ReadOnlyArray<Rule> } = {};
+  let isWatchMode = process.argv.some((c) => ['--watch', '-w'].includes(c));
   return {
     name: 'rollup-plugin-stylex',
+    options(option) {
+      if (option.watch && !isWatchMode) {
+        isWatchMode = true;
+      }
+    },
     buildStart() {
-      stylexRules = {};
+      if (!isWatchMode) {
+        stylexRules = {};
+      }
     },
     generateBundle(this: PluginContext) {
       const rules: Array<Rule> = Object.values(stylexRules).flat();


### PR DESCRIPTION
## What changed / motivation ?

Add disable clean cache logic for rollup plugin in watch mode.

## Linked PR/Issues

Fixes #363 

## Additional Context

In Rollup watch mode, when a file is modified, the Rollup instance is reloaded, and all hooks are rerun. Currently, we clean the CSS record at buildStart so that in watch mode, only the modified file is recorded. However, other files that contain StyleX logic may be missing from the record.

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

First load

<img width="574" alt="image" src="https://github.com/facebook/stylex/assets/52351095/db473b37-1701-4663-a3ba-ca3da7eedd33">


After modify

<img width="688" alt="image" src="https://github.com/facebook/stylex/assets/52351095/7c18ab22-7517-433e-96e1-e36f7f0334e7">


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code