### PR TITLE
bug: check for `keyframes` imports in `animationName` eslint rule

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -148,6 +148,42 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     },
     {
       code: `
+        import { keyframes as kf, create } from 'stylex';
+        const fadeIn = kf({
+          '0%': {
+            opacity: 0,
+          },
+          '100%': {
+            opacity: 1,
+          },
+        }); 
+        const styles = create({
+          main: {
+            animationName: fadeIn,
+          },
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stlx from 'stylex';
+        const fadeIn = stlx.keyframes({
+          '0%': {
+            opacity: 0,
+          },
+          '100%': {
+            opacity: 1,
+          },
+        }); 
+        const styles = create({
+          main: {
+            animationName: fadeIn,
+          },
+        });
+      `,
+    },
+    {
+      code: `
         import stylex from 'stylex';
         const styles = stylex.create({
           default: {

--- a/packages/eslint-plugin/src/rules/isAnimationName.js
+++ b/packages/eslint-plugin/src/rules/isAnimationName.js
@@ -12,60 +12,74 @@ import type { RuleResponse, Variables } from '../stylex-valid-styles';
 import type { Node } from 'estree';
 
 export default function isAnimationName(
-  node: Node,
-  variables?: Variables,
-): RuleResponse {
-  if (
-    node.type === 'CallExpression' &&
-    node.callee.type === 'MemberExpression' &&
-    node.callee.object.type === 'Identifier' &&
-    node.callee.object.name === 'stylex' &&
-    node.callee.property.type === 'Identifier' &&
-    node.callee.property.name === 'keyframes'
-  ) {
-    return undefined;
-  }
-  if (node.type === 'Identifier' && variables && variables.has(node.name)) {
-    const variable = variables.get(node.name);
-    if (variable === 'ARG') {
+  styleXDefaultImports: Set<string>,
+  styleXKeyframesImports: Set<string>,
+): (node: Node, variables?: Variables) => RuleResponse {
+  return function isAnimationNameRec(
+    node: Node,
+    variables?: Variables,
+  ): RuleResponse {
+    if (
+      node.type === 'CallExpression' &&
+      node.callee.type === 'MemberExpression' &&
+      node.callee.object.type === 'Identifier' &&
+      node.callee.property.type === 'Identifier' &&
+      node.callee.property.name === 'keyframes' &&
+      (node.callee.object.name === 'stylex' ||
+        styleXDefaultImports.has(node.callee.object.name))
+    ) {
       return undefined;
     }
-    if (variable != null) {
-      return isAnimationName(variable, variables);
-    } else {
-      return {
-        message:
-          'All expressions in a template literal must be a `stylex.keyframes(...)` function call',
-      };
-    }
-  }
-  if (node.type === 'TemplateLiteral') {
     if (
-      !node.expressions.every(
-        (expr) => isAnimationName(expr, variables) === undefined,
-      )
+      node.type === 'CallExpression' &&
+      node.callee.type === 'Identifier' &&
+      (node.callee.name === 'keyframes' ||
+        styleXKeyframesImports.has(node.callee.name))
     ) {
-      return {
-        message:
-          'All expressions in a template literal must be a `stylex.keyframes(...)` function call',
-      };
+      return undefined;
     }
-    if (
-      !node.quasis.every((quasi, index, { length }) =>
-        index === 0 || index === length - 1
-          ? quasi.value.raw === ''
-          : quasi.value.raw === ', ',
-      )
-    ) {
-      return {
-        message:
-          'animation names must be separated by a comma and a space (", ")',
-      };
+    if (node.type === 'Identifier' && variables && variables.has(node.name)) {
+      const variable = variables.get(node.name);
+      if (variable === 'ARG') {
+        return undefined;
+      }
+      if (variable != null) {
+        return isAnimationNameRec(variable, variables);
+      } else {
+        return {
+          message:
+            'All expressions in a template literal must be a `stylex.keyframes(...)` function call',
+        };
+      }
     }
-    return undefined;
-  }
-  return {
-    message:
-      'a `stylex.keyframes(...)` function call, a reference to it or a many such valid',
+    if (node.type === 'TemplateLiteral') {
+      if (
+        !node.expressions.every(
+          (expr) => isAnimationNameRec(expr, variables) === undefined,
+        )
+      ) {
+        return {
+          message:
+            'All expressions in a template literal must be a `stylex.keyframes(...)` function call',
+        };
+      }
+      if (
+        !node.quasis.every((quasi, index, { length }) =>
+          index === 0 || index === length - 1
+            ? quasi.value.raw === ''
+            : quasi.value.raw === ', ',
+        )
+      ) {
+        return {
+          message:
+            'animation names must be separated by a comma and a space (", ")',
+        };
+      }
+      return undefined;
+    }
+    return {
+      message:
+        'a `stylex.keyframes(...)` function call, a reference to it or a many such valid',
+    };
   };
 }


### PR DESCRIPTION
## What changed / motivation ?

This PR fixes the issue, where `eslint` would show an error when using `keyframes` named import as `animationName` property value.

## Linked PR/Issues

Fixes #322 

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code