### PR TITLE
fix: Keep units for 0 within functions

### DIFF
--- a/apps/nextjs-example/tsconfig.json
+++ b/apps/nextjs-example/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,18 +19,9 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ],
+      "@/*": ["./*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/flow-typed/npm/postcss-value-parser_vx.x.x.js
+++ b/flow-typed/npm/postcss-value-parser_vx.x.x.js
@@ -12,24 +12,28 @@ type PostCSSValueASTNode =
       type: 'word' | 'unicode-range',
       value: string,
       sourceIndex: number,
+      sourceEndIndex: number,
     }
   | {
       type: 'string' | 'comment',
       value: string,
       quote: '"' | "'",
       sourceIndex: number,
+      sourceEndIndex: number,
       unclosed?: boolean,
     }
   | {
       type: 'comment',
       value: string,
       sourceIndex: number,
+      sourceEndIndex: number,
       unclosed?: boolean,
     }
   | {
       type: 'div',
       value: ',' | '/' | ':',
       sourceIndex: number,
+      sourceEndIndex: number,
       before: '' | ' ' | '  ' | '   ',
       after: '' | ' ' | '  ' | '   ',
     }
@@ -37,6 +41,7 @@ type PostCSSValueASTNode =
       type: 'space',
       value: ' ' | '  ' | '   ',
       sourceIndex: number,
+      sourceEndIndex: number,
     }
   | {
       type: 'function',
@@ -46,6 +51,7 @@ type PostCSSValueASTNode =
       nodes: Array<PostCSSValueASTNode>,
       unclosed?: boolean,
       sourceIndex: number,
+      sourceEndIndex: number,
     };
 
 declare interface PostCSSValueAST {

--- a/packages/babel-plugin/__tests__/stylex-transform-call-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-call-test.js
@@ -1200,6 +1200,33 @@ describe('@stylexjs/babel-plugin', () => {
         stylex(styles[variant]);"
       `);
     });
+
+    test('stylex keeps spaces around operators', () => {
+      expect(
+        transform(`
+          import stylex from '@stylexjs/stylex';
+          const styles = stylex.create({
+            default: {
+              margin: 'max(0px, (48px - var(--x16dnrjz)) / 2)',
+            },
+          });
+          stylex(styles.default, props);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from '@stylexjs/stylex';
+        var _inject2 = _inject;
+        _inject2(".x1d6cl6p{margin:max(0px,(48px - var(--x16dnrjz)) / 2)}", 1000);
+        const styles = {
+          default: {
+            margin: "x1d6cl6p",
+            $$css: true
+          }
+        };
+        stylex(styles.default, props);"
+      `);
+    });
+
     test('stylex call with composition of external styles', () => {
       expect(
         transform(`

--- a/packages/open-props/__tests__/__snapshots__/open-props-compile-test.js.snap
+++ b/packages/open-props/__tests__/__snapshots__/open-props-compile-test.js.snap
@@ -27,8 +27,8 @@ const slideInUp = "x5q0om7-B";
 const slideInDown = "xiaildr-B";
 const slideInRight = "x1pzz5b5-B";
 const slideInLeft = "x2i3tye-B";
-const shakeX = "x1f21ubi-B";
-const shakeY = "xyj5ijk-B";
+const shakeX = "xui5qpo-B";
+const shakeY = "x1oudpiw-B";
 const spin = "x1uh2x5g-B";
 const ping = "xk6fz2t-B";
 const blink = "x13kz0yu-B";
@@ -193,17 +193,17 @@ exports[`commonJS results of exported styles and variables animationNames.stylex
     1,
   ],
   [
-    "x1f21ubi-B",
+    "xui5qpo-B",
     {
-      "ltr": "@keyframes x1f21ubi-B{0%, 100%{transform:translateX(0);}20%{transform:translateX(-5%);}40%{transform:translateX(5%);}60%{transform:translateX(-5%);}80%{transform:translateX(5%);}}",
+      "ltr": "@keyframes xui5qpo-B{0%, 100%{transform:translateX(0%);}20%{transform:translateX(-5%);}40%{transform:translateX(5%);}60%{transform:translateX(-5%);}80%{transform:translateX(5%);}}",
       "rtl": null,
     },
     1,
   ],
   [
-    "xyj5ijk-B",
+    "x1oudpiw-B",
     {
-      "ltr": "@keyframes xyj5ijk-B{0%, 100%{transform:translateY(0);}20%{transform:translateY(-5%);}40%{transform:translateY(5%);}60%{transform:translateY(-5%);}80%{transform:translateY(5%);}}",
+      "ltr": "@keyframes x1oudpiw-B{0%, 100%{transform:translateY(0%);}20%{transform:translateY(-5%);}40%{transform:translateY(5%);}60%{transform:translateY(-5%);}80%{transform:translateY(5%);}}",
       "rtl": null,
     },
     1,
@@ -259,7 +259,7 @@ exports[`commonJS results of exported styles and variables animationNames.stylex
   [
     "x1p4jv38",
     {
-      "ltr": ":root{--xwgfw4z:x1wv65fh-B;--xwpxwog:x3cospo-B;--x1mrv0ld:x1mi9bte-B;--x1f9mpsk:xd93vs1-B;--x1dlahej:x1gdf4cp-B;--xchc88h:x1uvjygu-B;--x1wwe1u9:xyz4r9t-B;--xojb453:xyz4r9t-B;--x1erxhtw:x1qkfcoh-B;--x2p2omt:x1c1el34-B;--x1lyv700:x5q0om7-B;--x1dhg8ry:xiaildr-B;--x14d2ijb:x1pzz5b5-B;--x1r6uxce:x2i3tye-B;--x1o3zfci:x1f21ubi-B;--xhf4ud:xyj5ijk-B;--x7jv0fk:x1uh2x5g-B;--x1x4v7e3:xk6fz2t-B;--xg5no4m:x13kz0yu-B;--x7mxyyy:xtacmzc-B;--xs1cbdk:xmu8adp-B;--x1gf7j19:x1wtl5zh-B;}",
+      "ltr": ":root{--xwgfw4z:x1wv65fh-B;--xwpxwog:x3cospo-B;--x1mrv0ld:x1mi9bte-B;--x1f9mpsk:xd93vs1-B;--x1dlahej:x1gdf4cp-B;--xchc88h:x1uvjygu-B;--x1wwe1u9:xyz4r9t-B;--xojb453:xyz4r9t-B;--x1erxhtw:x1qkfcoh-B;--x2p2omt:x1c1el34-B;--x1lyv700:x5q0om7-B;--x1dhg8ry:xiaildr-B;--x14d2ijb:x1pzz5b5-B;--x1r6uxce:x2i3tye-B;--x1o3zfci:xui5qpo-B;--xhf4ud:x1oudpiw-B;--x7jv0fk:x1uh2x5g-B;--x1x4v7e3:xk6fz2t-B;--xg5no4m:x13kz0yu-B;--x7mxyyy:xtacmzc-B;--xs1cbdk:xmu8adp-B;--x1gf7j19:x1wtl5zh-B;}",
     },
     0,
   ],

--- a/packages/shared/src/utils/normalizers/whitespace.js
+++ b/packages/shared/src/utils/normalizers/whitespace.js
@@ -32,7 +32,16 @@ export default function normalizeWhitespace(
         node.value = ' ';
         break;
       }
-      case 'div':
+      case 'div': {
+        if (node.value === ',') {
+          node.before = '';
+          node.after = '';
+        } else {
+          node.before = ' ';
+          node.after = ' ';
+        }
+        break;
+      }
       case 'function': {
         node.before = '';
         node.after = '';

--- a/packages/shared/src/utils/normalizers/zero-dimensions.js
+++ b/packages/shared/src/utils/normalizers/zero-dimensions.js
@@ -23,7 +23,15 @@ export default function normalizeZeroDimensions(
   ast: PostCSSValueAST,
   _: mixed,
 ): PostCSSValueAST {
+  let endFunction = 0;
+
   ast.walk((node) => {
+    if (node.type === 'function' && !endFunction) {
+      endFunction = node.sourceEndIndex ?? 0;
+    }
+    if (endFunction > 0 && node.sourceIndex > endFunction) {
+      endFunction = 0;
+    }
     if (node.type !== 'word') {
       return;
     }
@@ -35,7 +43,7 @@ export default function normalizeZeroDimensions(
       node.value = '0deg';
     } else if (timings.indexOf(dimension.unit) !== -1) {
       node.value = '0s';
-    } else {
+    } else if (!endFunction) {
       node.value = '0';
     }
   });


### PR DESCRIPTION
## What changed / motivation ?

Fixes #351 

Possibly due to browser bugs, using a unit-less `0` within `max()` functions doesn't work within certain browsers. Also, within mathematical expressions spaces around units are often required.

This PR fixes both those issues.

NOTE: If the authored code uses a unit-less `0`, a unit will *not* be added.