### PR TITLE
Fix: Handle variables as keys in dynamic styles correctly

### DIFF
--- a/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
@@ -238,5 +238,83 @@ describe('Evaluation of imported values works based on configuration', () => {
       `);
       expect(transformation).toThrow();
     });
+
+    test('Imported vars with ".stylex" suffix can be used as style keys', () => {
+      const transformation = transform(`
+        import stylex from 'stylex';
+        import { MyTheme } from 'otherFile.stylex';
+        const styles = stylex.create({
+          red: {
+            [MyTheme.foreground]: 'red',
+          }
+        });
+        stylex(styles.red);
+      `);
+
+      expect(transformation.code).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        import 'otherFile.stylex';
+        import { MyTheme } from 'otherFile.stylex';
+        var _inject2 = _inject;
+        _inject2(".__hashed_var__1g7q0my{--__hashed_var__1jqb1tb:red}", 1);
+        "__hashed_var__1g7q0my";"
+      `);
+      expect(transformation.metadata.stylex).toMatchInlineSnapshot(`
+        [
+          [
+            "__hashed_var__1g7q0my",
+            {
+              "ltr": ".__hashed_var__1g7q0my{--__hashed_var__1jqb1tb:red}",
+              "rtl": null,
+            },
+            1,
+          ],
+        ]
+      `);
+    });
+
+    test('Imported vars with ".stylex" suffix can be used as style keys dynamically', () => {
+      const transformation = transform(`
+        import stylex from 'stylex';
+        import { MyTheme } from 'otherFile.stylex';
+        const styles = stylex.create({
+          color: (color) => ({
+            [MyTheme.foreground]: color,
+          })
+        });
+        stylex.props(styles.color('red'));
+      `);
+
+      expect(transformation.code).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        import stylex from 'stylex';
+        import 'otherFile.stylex';
+        import { MyTheme } from 'otherFile.stylex';
+        var _inject2 = _inject;
+        _inject2(".__hashed_var__15x39w1{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb,revert)}", 1);
+        const styles = {
+          color: color => [{
+            "--__hashed_var__1jqb1tb": "__hashed_var__15x39w1",
+            $$css: true
+          }, {
+            "----__hashed_var__1jqb1tb": color != null ? color : "initial"
+          }]
+        };
+        stylex.props(styles.color('red'));"
+      `);
+      expect(transformation.metadata.stylex).toMatchInlineSnapshot(`
+        [
+          [
+            "__hashed_var__15x39w1",
+            {
+              "ltr": ".__hashed_var__15x39w1{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb,revert)}",
+              "rtl": null,
+            },
+            1,
+          ],
+        ]
+      `);
+    });
   });
 });

--- a/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
@@ -139,7 +139,10 @@ function evaluatePartialObjectRecursively(
       if (!keyResult.confident) {
         return { confident: false, deopt: keyResult.deopt, value: null };
       }
-      const key = keyResult.value;
+      let key = keyResult.value;
+      if (key.startsWith('var(') && key.endsWith(')')) {
+        key = key.slice(4, -1);
+      }
 
       const valuePath: NodePath<t.Expression | t.PatternLike> =
         prop.get('value');

--- a/packages/dev-runtime/__tests__/stylex-transform-create-test.js
+++ b/packages/dev-runtime/__tests__/stylex-transform-create-test.js
@@ -711,6 +711,39 @@ describe('Development Plugin Transformation', () => {
       `);
     });
 
+    test('transforms style object with wrapped custom property', () => {
+      const styles = stylex.create({
+        default: (bgColor) => ({
+          'var(--background-color)': bgColor,
+        }),
+      });
+
+      expect(styles.default('red')).toMatchInlineSnapshot(`
+        [
+          {
+            "$$css": true,
+            "--background-color": "xyv4n8w",
+          },
+          {
+            "----background-color": "initial",
+          },
+        ]
+      `);
+
+      expect(metadata).toMatchInlineSnapshot(`
+        [
+          [
+            "xyv4n8w",
+            {
+              "ltr": ".xyv4n8w{--background-color:var(----background-color,revert)}",
+              "rtl": null,
+            },
+            1,
+          ],
+        ]
+      `);
+    });
+
     test('transforms nested pseudo-class to CSS', () => {
       const styles = stylex.create({
         default: (color) => ({

--- a/packages/shared/src/preprocess-rules/basic-validation.js
+++ b/packages/shared/src/preprocess-rules/basic-validation.js
@@ -50,6 +50,7 @@ export function validateNamespace(
       }
       continue;
     }
+
     throw new Error(messages.ILLEGAL_PROP_VALUE);
   }
 }

--- a/packages/shared/src/preprocess-rules/index.js
+++ b/packages/shared/src/preprocess-rules/index.js
@@ -31,7 +31,11 @@ export default function flatMapExpandedShorthands(
   objEntry: $ReadOnly<[string, TStyleValue]>,
   options: StyleXOptions,
 ): $ReadOnlyArray<[string, TStyleValue]> {
-  const [key, value] = objEntry;
+  // eslint-disable-next-line prefer-const
+  let [key, value] = objEntry;
+  if (key.startsWith('var(') && key.endsWith(')')) {
+    key = key.slice(4, -1);
+  }
   const expansion: (
     string | number | null,
   ) => $ReadOnlyArray<[string, TStyleValue]> =


### PR DESCRIPTION
## What changed / motivation ?

When using variables defined with `defineVars` as keys within dynamic styles, it was using `var(--foo): var(--var(--foo))` instead of the expected `--foo: var(----foo)`.

On first glance `--foo: var(----foo)` may seem a bit indirect as, in many cases, we could set `--foo` as an inline style directly, instead of setting `----foo` in the inline style. However, when media queries, pseudo-classes etc. are involved using direct inline styles would cause specificity issues.

Fixes #276 

