### PR TITLE
Fix: Add missing CSS properties to types and ESLint

### DIFF
--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -2056,11 +2056,17 @@ const CSSProperties = {
   rubyAlign: rubyAlign,
   rubyMerge: rubyMerge,
   rubyPosition: rubyPosition,
+
+  scrollbarColor: color,
+  scrollbarGutter: makeUnionRule('auto', 'stable', 'stable both-edges'),
+  scrollbarWidth: makeUnionRule('auto', 'thin', 'none'),
+
   scrollBehavior: scrollBehavior,
   scrollSnapPaddingBottom: scrollSnapPaddingBottom,
   scrollSnapPaddingTop: scrollSnapPaddingTop,
   scrollSnapAlign: scrollSnapAlign,
   scrollSnapType: scrollSnapType,
+  scrollSnapStop: makeUnionRule('normal', 'always'),
 
   // scrollMargin: makeUnionRule(isNumber, isString),
   scrollMarginBlockEnd: makeUnionRule(isNumber, isString),
@@ -2168,7 +2174,7 @@ const CSSProperties = {
   zIndex: zIndex,
 
   // Purposely not supported because it is not supported in Firefox.
-  // zoom: makeUnionRule('normal', 'reset', isNumber),
+  zoom: makeUnionRule('normal', 'reset', isNumber, isPercentage),
 };
 const CSSPropertyKeys = Object.keys(CSSProperties);
 for (const key of CSSPropertyKeys) {

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -732,6 +732,7 @@ const display = makeUnionRule(
   makeLiteralRule('inline-flex'),
   makeLiteralRule('grid'),
   makeLiteralRule('inline-grid'),
+  makeLiteralRule('-webkit-box'),
   makeLiteralRule('run-in'),
   makeLiteralRule('ruby'),
   makeLiteralRule('ruby-base'),
@@ -1546,6 +1547,14 @@ const SupportedVendorSpecificCSSProperties = {
   WebkitAppearance: makeLiteralRule('textfield'),
   WebkitTapHighlightColor: color,
   WebkitOverflowScrolling: makeLiteralRule('touch'),
+
+  WebkitBoxOrient: makeUnionRule(
+    'horizontal',
+    'vertical',
+    'inline-axis',
+    'block-axis',
+  ),
+  WebkitLineClamp: isNumber,
 
   WebkitMaskImage: maskImage,
 

--- a/packages/stylex/src/StyleXCSSTypes.js
+++ b/packages/stylex/src/StyleXCSSTypes.js
@@ -241,6 +241,7 @@ type display =
   | 'inline-flex'
   | 'grid'
   | 'inline-grid'
+  | '-webkit-box'
   | 'run-in'
   | 'ruby'
   | 'ruby-base'

--- a/packages/stylex/src/StyleXCSSTypes.js
+++ b/packages/stylex/src/StyleXCSSTypes.js
@@ -1364,7 +1364,6 @@ export type CSSProperties = $ReadOnly<{
   mathShift?: all | 'normal' | 'compact',
   mathStyle?: all | 'normal' | 'compact',
 
-  scrollbarWidth?: all | string | number,
   scrollBehavior?: all | scrollBehavior,
 
   scrollMargin?: all | number | string,
@@ -1400,7 +1399,8 @@ export type CSSProperties = $ReadOnly<{
   scrollTimelineName?: all | string,
 
   scrollbarColor?: all | color,
-  scrollbarWidth?: all | width,
+  scrollbarGutter?: all | 'auto' | 'stable' | 'stable both-edges',
+  scrollbarWidth?: all | 'auto' | 'thin' | 'none',
 
   shapeImageThreshold?: all | shapeImageThreshold,
   shapeMargin?: all | shapeMargin,
@@ -1504,4 +1504,6 @@ export type CSSProperties = $ReadOnly<{
   wordWrap?: all | wordWrap,
   writingMode?: all | writingMode,
   zIndex?: all | zIndex,
+
+  zoom?: all | 'normal' | number | string,
 }>;

--- a/packages/stylex/src/StyleXTypes.d.ts
+++ b/packages/stylex/src/StyleXTypes.d.ts
@@ -55,6 +55,12 @@ type CSSPropertiesWithExtras = Partial<
       '::spelling-error': CSSProperties;
       '::target-text': CSSProperties;
       '::-webkit-scrollbar'?: CSSProperties;
+      '::-webkit-scrollbar-button'?: CSSProperties;
+      '::-webkit-scrollbar-thumb'?: CSSProperties;
+      '::-webkit-scrollbar-track'?: CSSProperties;
+      '::-webkit-scrollbar-track-piece'?: CSSProperties;
+      '::-webkit-scrollbar-corner'?: CSSProperties;
+      '::-webkit-resizer'?: CSSProperties;
       // webkit styles used for Search in Safari
       '::-webkit-search-decoration'?: CSSProperties;
       '::-webkit-search-cancel-button'?: CSSProperties;


### PR DESCRIPTION
## What changed / motivation ?

Adds some missing CSS properties that were either missing in the type definitions or the ESLint rule.

Fixes #135 

