### PR TITLE
chore: remove useless comment

### DIFF
--- a/packages/esbuild-plugin/src/index.js
+++ b/packages/esbuild-plugin/src/index.js
@@ -8,7 +8,6 @@
  */
 
 import path from 'path';
-// import { readFile, writeFile, mkdir } from 'fs/promises';
 import { promises } from 'fs';
 import { transformAsync, type PluginItem } from '@babel/core';
 import stylexBabelPlugin from '@stylexjs/babel-plugin';


### PR DESCRIPTION
## What changed / motivation ?

A very minor nit. I realized there was a useless comment left in the main file of the `esbuild-plugin` module. This PR removes it.

## Linked PR/Issues

none

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code