### PR TITLE
Fix: Ensure 'inject' variable is defined before use

### DIFF
--- a/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
@@ -66,10 +66,10 @@ describe('Evaluation of imported values works based on configuration', () => {
       expect(transformation.code).toContain(expectedVarName);
       expect(transformation.code).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
         import stylex from 'stylex';
         import 'otherFile.stylex';
         import { MyTheme } from 'otherFile.stylex';
-        var _inject2 = _inject;
         _inject2(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
         "__hashed_var__1r7rkhg";"
       `);
@@ -112,10 +112,10 @@ describe('Evaluation of imported values works based on configuration', () => {
       expect(transformation.code).toContain(expectedVarName);
       expect(transformation.code).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
         import stylex from 'stylex';
         import 'otherFile.stylex';
         import { MyTheme } from 'otherFile.stylex';
-        var _inject2 = _inject;
         _inject2("@keyframes __hashed_var__1cb153o-B{from{color:var(--__hashed_var__1jqb1tb);}}", 1);
         const fade = "__hashed_var__1cb153o-B";
         _inject2(".__hashed_var__1xwo6t1{animation-name:__hashed_var__1cb153o-B}", 3000);
@@ -163,10 +163,10 @@ describe('Evaluation of imported values works based on configuration', () => {
       expect(transformation.code).toContain(expectedVarName);
       expect(transformation.code).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
         import stylex from 'stylex';
         import 'otherFile.stylex.js';
         import { MyTheme } from 'otherFile.stylex.js';
-        var _inject2 = _inject;
         _inject2(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
         "__hashed_var__1r7rkhg";"
       `);
@@ -203,10 +203,10 @@ describe('Evaluation of imported values works based on configuration', () => {
       expect(transformation.code).toContain(expectedVarName);
       expect(transformation.code).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
         import stylex from 'stylex';
         import 'otherFile.stylex.js';
         import { MyTheme as mt } from 'otherFile.stylex.js';
-        var _inject2 = _inject;
         _inject2(".__hashed_var__1r7rkhg{color:var(--__hashed_var__1jqb1tb)}", 3000);
         "__hashed_var__1r7rkhg";"
       `);
@@ -253,10 +253,10 @@ describe('Evaluation of imported values works based on configuration', () => {
 
       expect(transformation.code).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
         import stylex from 'stylex';
         import 'otherFile.stylex';
         import { MyTheme } from 'otherFile.stylex';
-        var _inject2 = _inject;
         _inject2(".__hashed_var__1g7q0my{--__hashed_var__1jqb1tb:red}", 1);
         "__hashed_var__1g7q0my";"
       `);
@@ -288,10 +288,10 @@ describe('Evaluation of imported values works based on configuration', () => {
 
       expect(transformation.code).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
         import stylex from 'stylex';
         import 'otherFile.stylex';
         import { MyTheme } from 'otherFile.stylex';
-        var _inject2 = _inject;
         _inject2(".__hashed_var__15x39w1{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb,revert)}", 1);
         const styles = {
           color: color => [{

--- a/packages/babel-plugin/__tests__/stylex-transform-call-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-call-test.js
@@ -52,8 +52,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
@@ -75,8 +75,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         "x1e2nbdu x1t391ir";"
@@ -99,8 +99,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         "x1e2nbdu x1t391ir";"
@@ -123,8 +123,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import { create } from '@stylexjs/stylex';
         var _inject2 = _inject;
+        import { create } from '@stylexjs/stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
@@ -154,8 +154,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
@@ -179,8 +179,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         "x1e2nbdu x1t391ir";"
@@ -200,8 +200,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         const a = function () {
           return "x1e2nbdu";
@@ -226,8 +226,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
@@ -261,8 +261,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         export default function MyExportDefault() {
           return "x1e2nbdu";
@@ -286,8 +286,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14odnwx{padding:5px}", 1000);
         "x14odnwx";"
       `);
@@ -306,8 +306,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14odnwx{padding:5px}", 1000);
         export const styles = {
           foo: {
@@ -350,8 +350,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14odnwx{padding:5px}", 1000);
         _inject2(".xp59q4u{padding-block:10px}", 2000);
         _inject2(".xm7lytj{padding-top:7px}", 4000);
@@ -392,8 +392,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14odnwx{padding:5px}", 1000);
         _inject2(".xp59q4u{padding-block:10px}", 2000);
         _inject2(".xm7lytj{padding-top:7px}", 4000);
@@ -442,8 +442,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14odnwx{padding:5px}", 1000);
         _inject2(".xp59q4u{padding-block:10px}", 2000);
         _inject2(".xm7lytj{padding-top:7px}", 4000);
@@ -486,8 +486,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14odnwx{padding:5px}", 1000);
         _inject2(".xp59q4u{padding-block:10px}", 2000);
         _inject2(".xm7lytj{padding-top:7px}", 4000);
@@ -526,8 +526,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         "x1e2nbdu x17z2mba";"
@@ -550,8 +550,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         "x1e2nbdu x17z2mba";"
@@ -577,8 +577,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
@@ -603,8 +603,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
@@ -631,8 +631,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
         _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
@@ -657,8 +657,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
         _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
@@ -686,8 +686,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".xrkmrrc{background-color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           ({
@@ -715,8 +715,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".xrkmrrc{background-color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
@@ -750,8 +750,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           "xju2f9n";
@@ -776,8 +776,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           "";
           "x1e2nbdu";"
@@ -803,8 +803,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x14odnwx{padding:5px}", 1000);
           _inject2(".x2vl965{padding-inline-end:10px}", 3000);
           _inject2(".x1i3ajwb{padding:2px}", 1000);
@@ -832,8 +832,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x14odnwx{padding:5px}", 1000);
           _inject2(".x2vl965{padding-inline-end:10px}", 3000);
           _inject2(".x1i3ajwb{padding:2px}", 1000);
@@ -860,8 +860,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           ({
@@ -889,8 +889,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
@@ -926,8 +926,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           ({
             0: "x1e2nbdu",
@@ -954,8 +954,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             red: {
@@ -994,8 +994,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           "FooBar__styles.default x1e2nbdu";"
         `);
@@ -1027,8 +1027,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".x1t391ir{background-color:blue}", 3000);
           ({
@@ -1063,8 +1063,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
@@ -1110,8 +1110,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           ({
@@ -1145,8 +1145,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
@@ -1183,8 +1183,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
@@ -1214,8 +1214,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from '@stylexjs/stylex';
         var _inject2 = _inject;
+        import stylex from '@stylexjs/stylex';
         _inject2(".x1d6cl6p{margin:max(0px,(48px - var(--x16dnrjz)) / 2)}", 1000);
         const styles = {
           default: {
@@ -1240,8 +1240,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         const styles = {
           default: {
@@ -1271,8 +1271,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         export const styles = {
@@ -1304,8 +1304,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         export const styles = {
@@ -1336,8 +1336,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           stylex(styles[variant]);
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".x1t391ir{background-color:blue}", 3000);
@@ -1381,8 +1381,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           function MyComponent() {
             return <>
                             <div className={"x1e2nbdu"} />
@@ -1414,8 +1414,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           stylex(styles.default, props);
           _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
@@ -1443,8 +1443,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x16gpukw{border-top:5px solid blue}", 2000);
           _inject2(".x13nwy86{border-left:5px solid blue}", 2000);
           _inject2(".x2ekbea{border-right:5px solid blue}", 2000);
@@ -1480,8 +1480,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           "x17z2mba xc445zv";
           _inject2(".x17z2mba:hover{color:blue}", 3130);
           _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
@@ -1513,8 +1513,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'custom-stylex-path';
         var _inject2 = _inject;
+        import stylex from 'custom-stylex-path';
         _inject2(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
@@ -1535,8 +1535,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import { css as stylex } from 'custom-stylex-path';
         var _inject2 = _inject;
+        import { css as stylex } from 'custom-stylex-path';
         _inject2(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
@@ -1557,8 +1557,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import { css } from 'custom-stylex-path';
         var _inject2 = _inject;
+        import { css } from 'custom-stylex-path';
         _inject2(".x1e2nbdu{color:red}", 3000);
         "x1e2nbdu";"
       `);
@@ -1606,8 +1606,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from '@stylexjs/stylex';
         var _inject2 = _inject;
+        import stylex from '@stylexjs/stylex';
         _inject2(".x9f619{box-sizing:border-box}", 3000);
         _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
         _inject2(".x1fdo2jl{grid-area:content}", 1000);
@@ -1667,8 +1667,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from '@stylexjs/stylex';
         var _inject2 = _inject;
+        import stylex from '@stylexjs/stylex';
         _inject2(".x9f619{box-sizing:border-box}", 3000);
         _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
         _inject2(".x1fdo2jl{grid-area:content}", 1000);
@@ -1776,8 +1776,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from '@stylexjs/stylex';
         var _inject2 = _inject;
+        import stylex from '@stylexjs/stylex';
         _inject2(".x9f619{box-sizing:border-box}", 3000);
         _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
         _inject2(".x1fdo2jl{grid-area:content}", 1000);
@@ -1884,8 +1884,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from '@stylexjs/stylex';
         var _inject2 = _inject;
+        import stylex from '@stylexjs/stylex';
         _inject2(".x9f619{box-sizing:border-box}", 3000);
         _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
         _inject2(".x1fdo2jl{grid-area:content}", 1000);

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -40,8 +40,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xju2f9n{color:blue}", 3000);"
       `);
@@ -60,8 +60,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import * as foo from 'stylex';
         var _inject2 = _inject;
+        import * as foo from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xju2f9n{color:blue}", 3000);"
       `);
@@ -80,8 +80,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import { create } from 'stylex';
         var _inject2 = _inject;
+        import { create } from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xju2f9n{color:blue}", 3000);"
       `);
@@ -99,8 +99,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xgau0yw{--background-color:red}", 1);"
       `);
     });
@@ -117,8 +117,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x13tgbkp{--final-color:var(--background-color)}", 1);"
       `);
     });
@@ -138,8 +138,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xju2f9n{color:blue}", 3000);"
       `);
@@ -157,8 +157,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xd71okc{content:attr(some-attribute)}", 3000);"
       `);
     });
@@ -185,8 +185,8 @@ describe('@stylexjs/babel-plugin', () => {
 
       expect(camelCased).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1cfch2b{transition-property:margin-top}", 3000);"
       `);
     });
@@ -203,8 +203,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x17389it{transition-property:--foo}", 3000);"
       `);
     });
@@ -224,8 +224,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1gykpug:hover{background-color:red}", 3130);
         _inject2(".x17z2mba:hover{color:blue}", 3130);"
       `);
@@ -248,8 +248,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1gykpug:hover{background-color:red}", 3130);
         _inject2(".x17z2mba:hover{color:blue}", 3130);"
       `);
@@ -267,8 +267,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1ruww2u{position:sticky;position:fixed}", 3000);"
       `);
     });
@@ -288,8 +288,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xixxii4{position:fixed}", 3000);
         _inject2("@media (min-width: 768px){.x1vazst0.x1vazst0{position:sticky;position:fixed}}", 3200);"
       `);
@@ -308,8 +308,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x87ps6o{user-select:none}", 3000);"
       `);
     });
@@ -329,8 +329,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xb3r6kr{overflow:hidden}", 2000);
         _inject2(".xbsl7fq{border-style:dashed}", 2000);
         _inject2(".xmkeg23{border-width:1px}", 2000);"
@@ -391,8 +391,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x15oojuh{position:fixed;position:sticky}", 3000);
         export const styles = {
           foo: {
@@ -415,8 +415,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xxnfx33{box-shadow:0 2px 4px var(--shadow-1)}", 3000);"
       `);
     });
@@ -438,8 +438,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x19iys6w:invalpwdijad{background-color:red}", 3040);
           _inject2(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
         `);
@@ -468,8 +468,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x17z2mba:hover{color:blue}", 3130);
           _inject2(".x96fq8s:active{color:red}", 3170);
           _inject2(".x1wvtd7d:focus{color:yellow}", 3150);
@@ -491,8 +491,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
         `);
       });
@@ -513,8 +513,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x19iys6w:invalpwdijad{background-color:red}", 3040);
           _inject2(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
         `);
@@ -537,8 +537,8 @@ describe('@stylexjs/babel-plugin', () => {
          `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x17z2mba:hover{color:blue}", 3130);
           _inject2(".x96fq8s:active{color:red}", 3170);
           _inject2(".x1wvtd7d:focus{color:yellow}", 3150);
@@ -560,8 +560,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
         `);
       });
@@ -586,8 +586,8 @@ describe('@stylexjs/babel-plugin', () => {
            `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x16oeupf::before{color:red}", 8000);
           _inject2(".xdaarc3::after{color:blue}", 8000);"
         `);
@@ -607,8 +607,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x6yu8oj::placeholder{color:gray}", 8000);"
         `);
       });
@@ -627,8 +627,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1en94km::-webkit-slider-thumb, .x1en94km::-moz-range-thumb, .x1en94km::-ms-thumb{width:16px}", 9000);"
         `);
       });
@@ -653,8 +653,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".xrkmrrc{background-color:red}", 3000);
           _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
           _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);"
@@ -679,8 +679,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".xrkmrrc{background-color:red}", 3000);
           _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
           _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);"
@@ -705,8 +705,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".xrkmrrc{background-color:red}", 3000);
           _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
           _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);"
@@ -729,8 +729,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".xrkmrrc{background-color:red}", 3000);
           _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
           _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);"
@@ -774,8 +774,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         const borderRadius = 2;
         _inject2(".xe4njm9{margin:calc((100% - 50px) * .5) 20px 0}", 1000);
         _inject2(".xs4buau{border-color:red blue}", 2000);
@@ -815,8 +815,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         const borderRadius = 2;
         _inject2(".x1ok221b{margin-top:5px}", 4000);
         _inject2(".x1sa5p1d{margin-inline-end:10px}", 3000);
@@ -1121,8 +1121,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
         export const styles = {
@@ -1150,8 +1150,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".x17fnjtu{width:var(--width,revert)}", 4000);
         export const styles = {
@@ -1182,8 +1182,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
         _inject2(".x1mqxbix{color:black}", 3000);
@@ -1215,8 +1215,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
         export const styles = {
           default: bgColor => [{
@@ -1243,8 +1243,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1gykpug:hover{background-color:red}", 3130);
         _inject2(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
         export const styles = {
@@ -1274,8 +1274,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
         _inject2(".x1mqxbix{color:black}", 3000);
@@ -1307,8 +1307,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
         export const styles = {
           default: bgColor => [{
@@ -1335,8 +1335,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1gykpug:hover{background-color:red}", 3130);
         _inject2(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
         export const styles = {

--- a/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
@@ -204,8 +204,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
         _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
         _inject2("@media print{:root{--xgck17p:white;}}", 0.1);
@@ -286,8 +286,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
         _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
         _inject2("@media print{:root{--xgck17p:white;}}", 0.1);
@@ -385,8 +385,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
         _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
         _inject2("@media print{:root{--xgck17p:white;}}", 0.1);
@@ -434,8 +434,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         const RADIUS = 10;
         _inject2(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
         _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
@@ -476,8 +476,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         const color = 'blue';
         _inject2(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
         _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
@@ -518,8 +518,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         const name = 'light';
         _inject2(":root{--xgck17p:lightblue;--xpegid5:grey;--xrqfjmn:10;--x4y59db:pink;}", 0);
         _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
@@ -560,8 +560,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         const RADIUS = 2;
         _inject2(":root{--xgck17p:blue;--xpegid5:grey;--xrqfjmn:4;--x4y59db:pink;}", 0);
         _inject2("@media (prefers-color-scheme: dark){:root{--xgck17p:lightblue;--xpegid5:rgba(0, 0, 0, 0.8);}}", 0.1);
@@ -608,8 +608,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(":root{--x1sm8rlu:blue;--xxncinc:grey;--x4e1236:10;--xv9uic:pink;}", 0);
         _inject2("@media (prefers-color-scheme: dark){:root{--x1sm8rlu:lightblue;--xxncinc:rgba(0, 0, 0, 0.8);}}", 0.1);
         _inject2("@media print{:root{--x1sm8rlu:white;}}", 0.1);

--- a/packages/babel-plugin/__tests__/stylex-transform-import-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-import-test.js
@@ -65,8 +65,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         export const styles = {
           foo: {
@@ -108,8 +108,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         const styles = {
           foo: {
@@ -133,8 +133,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         export default {
           foo: {
@@ -158,8 +158,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         const styles = {
           foo: {
@@ -189,8 +189,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import foobar from 'stylex';
         var _inject2 = _inject;
+        import foobar from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xju2f9n{color:blue}", 3000);
         _inject2(".x14odnwx{padding:5px}", 1000);
@@ -230,8 +230,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import * as foobar from 'stylex';
         var _inject2 = _inject;
+        import * as foobar from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xju2f9n{color:blue}", 3000);
         _inject2(".x14odnwx{padding:5px}", 1000);
@@ -271,8 +271,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import { create } from 'stylex';
         var _inject2 = _inject;
+        import { create } from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xju2f9n{color:blue}", 3000);
         _inject2(".x14odnwx{padding:5px}", 1000);
@@ -312,8 +312,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import { create as css } from 'stylex';
         var _inject2 = _inject;
+        import { create as css } from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xju2f9n{color:blue}", 3000);
         _inject2(".x14odnwx{padding:5px}", 1000);
@@ -355,8 +355,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'foo-bar';
         var _inject2 = _inject;
+        import stylex from 'foo-bar';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xju2f9n{color:blue}", 3000);"
       `);
@@ -378,8 +378,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import * as stylex from 'foo-bar';
         var _inject2 = _inject;
+        import * as stylex from 'foo-bar';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xju2f9n{color:blue}", 3000);"
       `);
@@ -401,8 +401,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import { css } from 'react-strict-dom';
         var _inject2 = _inject;
+        import { css } from 'react-strict-dom';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xju2f9n{color:blue}", 3000);"
       `);
@@ -424,8 +424,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import { html, css } from 'react-strict-dom';
         var _inject2 = _inject;
+        import { html, css } from 'react-strict-dom';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xju2f9n{color:blue}", 3000);"
       `);

--- a/packages/babel-plugin/__tests__/stylex-transform-keyframes-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-keyframes-test.js
@@ -42,8 +42,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
         const name = "xbopttm-B";"
       `);
@@ -65,8 +65,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import * as stylex from 'stylex';
         var _inject2 = _inject;
+        import * as stylex from 'stylex';
         _inject2("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
         const name = "xbopttm-B";"
       `);
@@ -88,8 +88,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import { keyframes } from 'stylex';
         var _inject2 = _inject;
+        import { keyframes } from 'stylex';
         _inject2("@keyframes xbopttm-B{from{background-color:red;}to{background-color:blue;}}", 1);
         const name = "xbopttm-B";"
       `);
@@ -116,8 +116,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2("@keyframes x3zqmp-B{from{background-color:blue;}to{background-color:red;}}", 1);
         const name = "x3zqmp-B";
         _inject2(".x1qs41r0{animation:3s x3zqmp-B}", 1000);"
@@ -144,8 +144,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2("@keyframes x3zqmp-B{from{background-color:blue;}to{background-color:red;}}", 1);
         _inject2(".xcoz2pf{animation-name:x3zqmp-B}", 3000);"
       `);
@@ -173,8 +173,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2("@keyframes x1jkcf39-B{from{inset-inline-start:0;}to{inset-inline-start:500px;}}", 1);
         const name = "x1jkcf39-B";
         _inject2(".x1vfi257{animation-name:x1jkcf39-B}", 3000);

--- a/packages/babel-plugin/__tests__/stylex-transform-legacy-shorthands-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-legacy-shorthands-test.js
@@ -52,8 +52,8 @@ describe('Legacy-shorthand-expansion resolution', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
         _inject2(".x1mpkggp{padding-right:5px}", 3000, ".x1mpkggp{padding-left:5px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);
@@ -89,8 +89,8 @@ describe('Legacy-shorthand-expansion resolution', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
         _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);
@@ -121,8 +121,8 @@ describe('Legacy-shorthand-expansion resolution', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
         _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);
@@ -148,8 +148,8 @@ describe('Legacy-shorthand-expansion resolution', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
         _inject2(".x1mpkggp{padding-right:5px}", 3000, ".x1mpkggp{padding-left:5px}");
         export const styles = {
@@ -183,8 +183,8 @@ describe('Legacy-shorthand-expansion resolution', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
         _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);
@@ -215,8 +215,8 @@ describe('Legacy-shorthand-expansion resolution', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
         _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);

--- a/packages/babel-plugin/__tests__/stylex-transform-logical-properties-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-logical-properties-test.js
@@ -41,8 +41,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1lkbs04{border-block-color:0}", 3000);
         const classnames = "x1lkbs04";"
       `);
@@ -57,8 +57,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x4q076{border-top-color:0}", 3000);
         const classnames = "x4q076";"
       `);
@@ -73,8 +73,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1ylptbq{border-bottom-color:0}", 4000);
         const classnames = "x1ylptbq";"
       `);
@@ -89,8 +89,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1v09clb{border-inline-color:0}", 2000);
         const classnames = "x1v09clb";"
       `);
@@ -105,8 +105,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1t19a1o{border-inline-start-color:0}", 3000);
         const classnames = "x1t19a1o";"
       `);
@@ -121,8 +121,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14mj1wy{border-inline-end-color:0}", 3000);
         const classnames = "x14mj1wy";"
       `);
@@ -139,8 +139,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x7mea6a{border-block-style:0}", 3000);
         const classnames = "x7mea6a";"
       `);
@@ -155,8 +155,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1d917x0{border-top-style:0}", 3000);
         const classnames = "x1d917x0";"
       `);
@@ -171,8 +171,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1nmap2y{border-bottom-style:0}", 4000);
         const classnames = "x1nmap2y";"
       `);
@@ -187,8 +187,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xt8kkye{border-inline-style:0}", 2000);
         const classnames = "xt8kkye";"
       `);
@@ -203,8 +203,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xl8mozw{border-inline-start-style:0}", 3000);
         const classnames = "xl8mozw";"
       `);
@@ -219,8 +219,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x10o505a{border-inline-end-style:0}", 3000);
         const classnames = "x10o505a";"
       `);
@@ -237,8 +237,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1616tdu{border-block-width:0}", 3000);
         const classnames = "x1616tdu";"
       `);
@@ -253,8 +253,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x972fbf{border-top-width:0}", 3000);
         const classnames = "x972fbf";"
       `);
@@ -269,8 +269,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1qhh985{border-bottom-width:0}", 4000);
         const classnames = "x1qhh985";"
       `);
@@ -285,8 +285,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xuxrje7{border-inline-width:0}", 2000);
         const classnames = "xuxrje7";"
       `);
@@ -301,8 +301,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14e42zd{border-inline-start-width:0}", 3000);
         const classnames = "x14e42zd";"
       `);
@@ -317,8 +317,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x10w94by{border-inline-end-width:0}", 3000);
         const classnames = "x10w94by";"
       `);
@@ -335,8 +335,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x13vifvy{top:0}", 4000);
         const classnames = "x13vifvy";"
       `);
@@ -351,8 +351,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x10no89f{inset-block:0}", 2000);
         const classnames = "x10no89f";"
       `);
@@ -367,8 +367,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1ey2m1c{bottom:0}", 4000);
         const classnames = "x1ey2m1c";"
       `);
@@ -383,8 +383,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x13vifvy{top:0}", 4000);
         const classnames = "x13vifvy";"
       `);
@@ -399,8 +399,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x17y0mx6{inset-inline:0}", 2000);
         const classnames = "x17y0mx6";"
       `);
@@ -415,8 +415,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xtijo5x{inset-inline-end:0}", 3000);
         const classnames = "xtijo5x";"
       `);
@@ -431,8 +431,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1o0tod{inset-inline-start:0}", 3000);
         const classnames = "x1o0tod";"
       `);
@@ -449,8 +449,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x10im51j{margin-block:0}", 2000);
         const classnames = "x10im51j";"
       `);
@@ -465,8 +465,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xat24cr{margin-bottom:0}", 4000);
         const classnames = "xat24cr";"
       `);
@@ -481,8 +481,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xdj266r{margin-top:0}", 4000);
         const classnames = "xdj266r";"
       `);
@@ -497,8 +497,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrxpjvj{margin-inline:0}", 2000);
         const classnames = "xrxpjvj";"
       `);
@@ -513,8 +513,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14z9mp{margin-inline-end:0}", 3000);
         const classnames = "x14z9mp";"
       `);
@@ -529,8 +529,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1lziwak{margin-inline-start:0}", 3000);
         const classnames = "x1lziwak";"
       `);
@@ -547,8 +547,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xt970qd{padding-block:0}", 2000);
         const classnames = "xt970qd";"
       `);
@@ -563,8 +563,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x18d9i69{padding-bottom:0}", 4000);
         const classnames = "x18d9i69";"
       `);
@@ -579,8 +579,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xexx8yu{padding-top:0}", 4000);
         const classnames = "xexx8yu";"
       `);
@@ -595,8 +595,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xnjsko4{padding-inline:0}", 2000);
         const classnames = "xnjsko4";"
       `);
@@ -611,8 +611,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xyri2b{padding-inline-end:0}", 3000);
         const classnames = "xyri2b";"
       `);
@@ -627,8 +627,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1c1uobl{padding-inline-start:0}", 3000);
         const classnames = "x1c1uobl";"
       `);
@@ -647,8 +647,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xceh6e4{inset-inline-end:5px}", 3000);
         const classnames = "xceh6e4";"
       `);
@@ -663,8 +663,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14z9mp{margin-inline-end:0}", 3000);
         const classnames = "x14z9mp";"
       `);
@@ -679,8 +679,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrxpjvj{margin-inline:0}", 2000);
         const classnames = "xrxpjvj";"
       `);
@@ -695,8 +695,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1lziwak{margin-inline-start:0}", 3000);
         const classnames = "x1lziwak";"
       `);
@@ -711,8 +711,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x10im51j{margin-block:0}", 2000);
         const classnames = "x10im51j";"
       `);
@@ -727,8 +727,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xyri2b{padding-inline-end:0}", 3000);
         const classnames = "xyri2b";"
       `);
@@ -743,8 +743,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xnjsko4{padding-inline:0}", 2000);
         const classnames = "xnjsko4";"
       `);
@@ -759,8 +759,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1c1uobl{padding-inline-start:0}", 3000);
         const classnames = "x1c1uobl";"
       `);
@@ -775,8 +775,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xt970qd{padding-block:0}", 2000);
         const classnames = "xt970qd";"
       `);
@@ -791,8 +791,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1fb7gu6{inset-inline-start:5px}", 3000);
         const classnames = "x1fb7gu6";"
       `);
@@ -815,8 +815,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xi71r3n{margin:1 2 3 4}", 1000);
         "xi71r3n";"
       `);

--- a/packages/babel-plugin/__tests__/stylex-transform-logical-values-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-logical-values-test.js
@@ -43,8 +43,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xof8tvn{clear:inline-end}", 3000);
         const classnames = "xof8tvn";"
       `);
@@ -59,8 +59,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x18lmvvi{clear:inline-start}", 3000);
         const classnames = "x18lmvvi";"
       `);
@@ -75,8 +75,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1h0q493{float:inline-end}", 3000);
         const classnames = "x1h0q493";"
       `);
@@ -91,8 +91,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1kmio9f{float:inline-start}", 3000);
         const classnames = "x1kmio9f";"
       `);
@@ -107,8 +107,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xp4054r{text-align:right}", 3000, ".xp4054r{text-align:left}");
         const classnames = "xp4054r";"
       `);
@@ -123,8 +123,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1yc453h{text-align:left}", 3000, ".x1yc453h{text-align:right}");
         const classnames = "x1yc453h";"
       `);
@@ -143,8 +143,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xodj72a{clear:right}", 3000, ".xodj72a{clear:left}");
         const classnames = "xodj72a";"
       `);
@@ -159,8 +159,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x390i0x{clear:left}", 3000, ".x390i0x{clear:right}");
         const classnames = "x390i0x";"
       `);
@@ -175,8 +175,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1guec7k{float:right}", 3000, ".x1guec7k{float:left}");
         const classnames = "x1guec7k";"
       `);
@@ -191,8 +191,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrbpyxo{float:left}", 3000, ".xrbpyxo{float:right}");
         const classnames = "xrbpyxo";"
       `);
@@ -211,8 +211,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14mnfz1{cursor:e-resize}", 3000, ".x14mnfz1{cursor:w-resize}");
         const classnames = "x14mnfz1";"
       `);
@@ -227,8 +227,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14isd7o{cursor:w-resize}", 3000, ".x14isd7o{cursor:e-resize}");
         const classnames = "x14isd7o";"
       `);
@@ -243,8 +243,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xc7edbc{cursor:ne-resize}", 3000, ".xc7edbc{cursor:nw-resize}");
         const classnames = "xc7edbc";"
       `);
@@ -259,8 +259,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrpsa6j{cursor:nw-resize}", 3000, ".xrpsa6j{cursor:ne-resize}");
         const classnames = "xrpsa6j";"
       `);
@@ -275,8 +275,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xp35lg9{cursor:se-resize}", 3000, ".xp35lg9{cursor:sw-resize}");
         const classnames = "xp35lg9";"
       `);
@@ -291,8 +291,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1egwzy8{cursor:sw-resize}", 3000, ".x1egwzy8{cursor:se-resize}");
         const classnames = "x1egwzy8";"
       `);
@@ -312,8 +312,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x13xdq3h{animation-name:ignore}", 3000);
         const classnames = "x13xdq3h";"
       `);
@@ -328,8 +328,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xl0ducr{background-position:top right}", 2000, ".xl0ducr{background-position:top left}");
         const classnames = "xl0ducr";"
       `);
@@ -341,8 +341,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xgg80n4{background-position:top left}", 2000, ".xgg80n4{background-position:top right}");
         const classnames = "xgg80n4";"
       `);
@@ -357,8 +357,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1gnnqk1{box-shadow:none}", 3000);
         const classnames = "x1gnnqk1";"
       `);
@@ -370,8 +370,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xtgyqtp{box-shadow:1px 1px #000}", 3000, ".xtgyqtp{box-shadow:-1px 1px #000}");
         const classnames = "xtgyqtp";"
       `);
@@ -383,8 +383,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1d2r41h{box-shadow:-1px -1px #000}", 3000, ".x1d2r41h{box-shadow:1px -1px #000}");
         const classnames = "x1d2r41h";"
       `);
@@ -396,8 +396,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1x0mpz7{box-shadow:inset 1px 1px #000}", 3000, ".x1x0mpz7{box-shadow:inset -1px 1px #000}");
         const classnames = "x1x0mpz7";"
       `);
@@ -409,8 +409,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1fumi7f{box-shadow:1px 1px 1px 1px #000}", 3000, ".x1fumi7f{box-shadow:-1px 1px 1px 1px #000}");
         const classnames = "x1fumi7f";"
       `);
@@ -422,8 +422,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1fs23zf{box-shadow:inset 1px 1px 1px 1px #000}", 3000, ".x1fs23zf{box-shadow:inset -1px 1px 1px 1px #000}");
         const classnames = "x1fs23zf";"
       `);
@@ -435,8 +435,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xtgmjod{box-shadow:2px 2px 2px 2px red,inset 1px 1px 1px 1px #000}", 3000, ".xtgmjod{box-shadow:-2px 2px 2px 2px red, inset -1px 1px 1px 1px #000}");
         const classnames = "xtgmjod";"
       `);
@@ -451,8 +451,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x19pm5ym{text-shadow:none}", 3000);
         const classnames = "x19pm5ym";"
       `);
@@ -464,8 +464,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x12y90mb{text-shadow:1px 1px #000}", 3000, ".x12y90mb{text-shadow:-1px 1px #000}");
         const classnames = "x12y90mb";"
       `);
@@ -477,8 +477,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1l3mtsg{text-shadow:-1px -1px #000}", 3000, ".x1l3mtsg{text-shadow:1px -1px #000}");
         const classnames = "x1l3mtsg";"
       `);
@@ -490,8 +490,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x67hq7l{text-shadow:1px 1px 1px #000}", 3000, ".x67hq7l{text-shadow:-1px 1px 1px #000}");
         const classnames = "x67hq7l";"
       `);

--- a/packages/babel-plugin/__tests__/stylex-transform-override-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-override-vars-test.js
@@ -114,8 +114,8 @@ describe('@stylexjs/babel-plugin', () => {
       );
       expect(output1).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -168,8 +168,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -231,8 +231,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -303,8 +303,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -353,8 +353,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -398,8 +398,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -443,8 +443,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -488,8 +488,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",
@@ -527,8 +527,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         export const buttonTheme = {
           bgColor: "var(--xgck17p)",
           bgColorDisabled: "var(--xpegid5)",

--- a/packages/babel-plugin/__tests__/stylex-transform-stylex-attrs-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-stylex-attrs-test.js
@@ -52,8 +52,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import * as stylex from 'stylex';
         var _inject2 = _inject;
+        import * as stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         ({
           class: "x1e2nbdu"
@@ -77,8 +77,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         ({
@@ -103,8 +103,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         ({
@@ -126,8 +126,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         ({
           class: "x1e2nbdu"
@@ -153,8 +153,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import { create, attrs } from 'stylex';
         var _inject2 = _inject;
+        import { create, attrs } from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         ({
@@ -176,8 +176,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         const a = function () {
           return {
@@ -204,8 +204,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
@@ -241,8 +241,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         export default function MyExportDefault() {
           return {
@@ -270,8 +270,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14odnwx{padding:5px}", 1000);
         ({
           class: "x14odnwx"
@@ -292,8 +292,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14odnwx{padding:5px}", 1000);
         export const styles = {
           foo: {
@@ -331,8 +331,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         ({
@@ -357,8 +357,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import * as stylex from 'stylex';
         var _inject2 = _inject;
+        import * as stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         ({
@@ -386,8 +386,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
@@ -414,8 +414,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
@@ -444,8 +444,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
         _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
@@ -472,8 +472,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
         _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
@@ -503,8 +503,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".xrkmrrc{background-color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           ({
@@ -536,8 +536,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".xrkmrrc{background-color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
@@ -571,8 +571,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           ({
@@ -601,8 +601,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           ({});
           ({
@@ -630,8 +630,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x14odnwx{padding:5px}", 1000);
           _inject2(".x2vl965{padding-inline-end:10px}", 3000);
           _inject2(".x1i3ajwb{padding:2px}", 1000);
@@ -661,8 +661,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x14odnwx{padding:5px}", 1000);
           _inject2(".x2vl965{padding-inline-end:10px}", 3000);
           _inject2(".x1i3ajwb{padding:2px}", 1000);
@@ -691,8 +691,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           ({
@@ -724,8 +724,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
@@ -761,8 +761,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           ({
             0: {
@@ -791,8 +791,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             red: {
@@ -831,8 +831,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           ({
             class: "FooBar__styles.default x1e2nbdu"
@@ -866,8 +866,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".x1t391ir{background-color:blue}", 3000);
           ({
@@ -906,8 +906,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
@@ -953,8 +953,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           ({
@@ -986,8 +986,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
@@ -1016,8 +1016,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         const styles = {
           default: {
@@ -1047,8 +1047,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         export const styles = {
@@ -1081,8 +1081,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           stylex.attrs(styles[variant]);
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".x1t391ir{background-color:blue}", 3000);
@@ -1126,8 +1126,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           function MyComponent() {
             return <>
                             <div {...{
@@ -1165,8 +1165,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           stylex.attrs([styles.default, props]);
           _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
@@ -1196,8 +1196,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           ({
             class: "x17z2mba xc445zv"
           });
@@ -1231,8 +1231,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'custom-stylex-path';
         var _inject2 = _inject;
+        import stylex from 'custom-stylex-path';
         _inject2(".x1e2nbdu{color:red}", 3000);
         ({
           class: "x1e2nbdu"
@@ -1282,8 +1282,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from '@stylexjs/stylex';
         var _inject2 = _inject;
+        import stylex from '@stylexjs/stylex';
         _inject2(".x9f619{box-sizing:border-box}", 3000);
         _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
         _inject2(".x1fdo2jl{grid-area:content}", 1000);
@@ -1397,8 +1397,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from '@stylexjs/stylex';
         var _inject2 = _inject;
+        import stylex from '@stylexjs/stylex';
         _inject2(".x9f619{box-sizing:border-box}", 3000);
         _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
         _inject2(".x1fdo2jl{grid-area:content}", 1000);

--- a/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
@@ -52,8 +52,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         ({
           className: "x1e2nbdu"
@@ -77,8 +77,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         ({
@@ -103,8 +103,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         ({
@@ -126,8 +126,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         ({
           className: "x1e2nbdu"
@@ -153,8 +153,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import { create, props } from 'stylex';
         var _inject2 = _inject;
+        import { create, props } from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         ({
@@ -176,8 +176,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         const a = function () {
           return {
@@ -204,8 +204,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
@@ -241,8 +241,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         export default function MyExportDefault() {
           return {
@@ -270,8 +270,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14odnwx{padding:5px}", 1000);
         ({
           className: "x14odnwx"
@@ -292,8 +292,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14odnwx{padding:5px}", 1000);
         export const styles = {
           foo: {
@@ -331,8 +331,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         ({
@@ -357,8 +357,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import * as stylex from 'stylex';
         var _inject2 = _inject;
+        import * as stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         ({
@@ -386,8 +386,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
@@ -414,8 +414,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
@@ -444,8 +444,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
         _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
@@ -472,8 +472,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
         _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
@@ -503,8 +503,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".xrkmrrc{background-color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           ({
@@ -536,8 +536,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".xrkmrrc{background-color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
@@ -571,8 +571,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           ({
@@ -601,8 +601,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           ({});
           ({
@@ -630,8 +630,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x14odnwx{padding:5px}", 1000);
           _inject2(".x2vl965{padding-inline-end:10px}", 3000);
           _inject2(".x1i3ajwb{padding:2px}", 1000);
@@ -661,8 +661,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x14odnwx{padding:5px}", 1000);
           _inject2(".x2vl965{padding-inline-end:10px}", 3000);
           _inject2(".x1i3ajwb{padding:2px}", 1000);
@@ -691,8 +691,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           ({
@@ -724,8 +724,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           const styles = {
@@ -761,8 +761,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           ({
             0: {
@@ -791,8 +791,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             red: {
@@ -831,8 +831,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           ({
             className: "FooBar__styles.default x1e2nbdu"
@@ -866,8 +866,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".x1t391ir{background-color:blue}", 3000);
           ({
@@ -906,8 +906,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
             default: {
@@ -953,8 +953,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".xju2f9n{color:blue}", 3000);
           ({
@@ -986,8 +986,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         _inject2(".x1t391ir{background-color:blue}", 3000);
         const styles = {
@@ -1016,8 +1016,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1e2nbdu{color:red}", 3000);
         const styles = {
           default: {
@@ -1047,8 +1047,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
         export const styles = {
@@ -1081,8 +1081,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           stylex.props(styles[variant]);
           _inject2(".x1e2nbdu{color:red}", 3000);
           _inject2(".x1t391ir{background-color:blue}", 3000);
@@ -1126,8 +1126,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           function MyComponent() {
             return <>
                             <div {...{
@@ -1165,8 +1165,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           stylex.props([styles.default, props]);
           _inject2(".x1e2nbdu{color:red}", 3000);
           const styles = {
@@ -1196,8 +1196,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           ({
             className: "x17z2mba xc445zv"
           });
@@ -1231,8 +1231,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'custom-stylex-path';
         var _inject2 = _inject;
+        import stylex from 'custom-stylex-path';
         _inject2(".x1e2nbdu{color:red}", 3000);
         ({
           className: "x1e2nbdu"
@@ -1282,8 +1282,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from '@stylexjs/stylex';
         var _inject2 = _inject;
+        import stylex from '@stylexjs/stylex';
         _inject2(".x9f619{box-sizing:border-box}", 3000);
         _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
         _inject2(".x1fdo2jl{grid-area:content}", 1000);
@@ -1397,8 +1397,8 @@ describe('@stylexjs/babel-plugin', () => {
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from '@stylexjs/stylex';
         var _inject2 = _inject;
+        import stylex from '@stylexjs/stylex';
         _inject2(".x9f619{box-sizing:border-box}", 3000);
         _inject2(".x1yc5d2u{grid-area:sidebar}", 1000);
         _inject2(".x1fdo2jl{grid-area:content}", 1000);

--- a/packages/babel-plugin/__tests__/stylex-transform-value-normalize-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-value-normalize-test.js
@@ -51,8 +51,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x18qx21s{transform:rotate(10deg) translate3d(0,0,0)}", 3000);"
       `);
       expect(
@@ -62,8 +62,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xe1l9yr{color:rgba(1,222,33,.5)}", 3000);"
       `);
     });
@@ -79,8 +79,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1ghz6dp{margin:0}", 1000);
         _inject2(".xgsvwom{margin-left:1px}", 4000);"
       `);
@@ -94,8 +94,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1wsgiic{transition-duration:.5s}", 3000);"
       `);
     });
@@ -112,8 +112,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1jpfit1{transform:0deg}", 3000);"
       `);
     });
@@ -126,8 +126,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1hauit9{width:calc((100% + 3% - 100px) / 7)}", 4000);"
       `);
     });
@@ -143,8 +143,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xpvlhck{transition-duration:.01s}", 3000);
         _inject2(".xxziih7{transition-timing-function:cubic-bezier(.08,.52,.52,1)}", 3000);"
       `);
@@ -158,8 +158,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x169joja{quotes:\\"\\"}", 3000);"
       `);
     });
@@ -176,8 +176,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xsa3hc2{transition-duration:1.234s}", 3000);
         _inject2(".xpvlhck{transition-duration:.01s}", 3000);
         _inject2(".xjd9b36{transition-duration:1ms}", 3000);"
@@ -203,8 +203,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1egiwwb{height:500px}", 4000);
         _inject2(".x1oin6zd{margin:10px}", 1000);
         _inject2(".xvue9z{width:500px}", 4000);
@@ -222,8 +222,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x1vvwc6p{height:33.3333px}", 4000);"
       `);
     });
@@ -246,8 +246,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".x14axycx{content:\\"\\"}", 3000);
         _inject2(".xmmpjw1{content:\\"next\\"}", 3000);
         _inject2(".x12vzfr8{content:\\"prev\\"}", 3000);"
@@ -262,8 +262,8 @@ describe('@stylexjs/babel-plugin', () => {
         `),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        import stylex from 'stylex';
         var _inject2 = _inject;
+        import stylex from 'stylex';
         _inject2(".xzw3067{color:red!important}", 3000);"
       `);
     });
@@ -292,8 +292,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".xngnso2{font-size:1.5rem}", 3000);
           _inject2(".x1c3i2sq{font-size:1.125rem}", 3000);
           _inject2(".x1603h9y{font-size:1.25rem}", 3000);
@@ -313,8 +313,8 @@ describe('@stylexjs/babel-plugin', () => {
           `),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x37c5sx{font-size:calc(100% - 1.5rem)}", 3000);"
         `);
       });
@@ -344,8 +344,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1pvqxga{font-size:24px}", 3000);
           _inject2(".xosj86m{font-size:18px}", 3000);
           _inject2(".x1603h9y{font-size:1.25rem}", 3000);
@@ -368,8 +368,8 @@ describe('@stylexjs/babel-plugin', () => {
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          import stylex from 'stylex';
           var _inject2 = _inject;
+          import stylex from 'stylex';
           _inject2(".x1upkca{font-size:calc(100% - 24px)}", 3000);"
         `);
       });

--- a/packages/babel-plugin/__tests__/stylex-transform-variable-removal-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-variable-removal-test.js
@@ -38,8 +38,8 @@ describe('[optimization] Removes `styles` variable when not needed', () => {
     `);
     expect(result.code).toMatchInlineSnapshot(`
       "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-      import stylex from 'stylex';
       var _inject2 = _inject;
+      import stylex from 'stylex';
       _inject2(".xrkmrrc{background-color:red}", 3000);
       _inject2(".xju2f9n{color:blue}", 3000);
       const styles = {
@@ -88,8 +88,8 @@ describe('[optimization] Removes `styles` variable when not needed', () => {
     `);
     expect(result.code).toMatchInlineSnapshot(`
       "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-      import stylex from 'stylex';
       var _inject2 = _inject;
+      import stylex from 'stylex';
       _inject2(".xrkmrrc{background-color:red}", 3000);
       _inject2(".xju2f9n{color:blue}", 3000);"
     `);

--- a/packages/babel-plugin/src/utils/state-manager.js
+++ b/packages/babel-plugin/src/utils/state-manager.js
@@ -337,17 +337,27 @@ export default class StateManager {
       return identifier;
     }
     const bodyPath: Array<NodePath<t.Statement>> = programPath.get('body');
-    let lastImportIndex = -1;
+    let targetImportIndex = -1;
     for (let i = 0; i < bodyPath.length; i++) {
       const statement = bodyPath[i];
       if (pathUtils.isImportDeclaration(statement)) {
-        lastImportIndex = i;
+        targetImportIndex = i;
+        if (
+          statement.node.specifiers.find(
+            (s) =>
+              s.type === 'ImportSpecifier' &&
+              s.local.type === 'Identifier' &&
+              s.local.name === identifier.name,
+          )
+        ) {
+          break;
+        }
       }
     }
-    if (lastImportIndex === -1) {
+    if (targetImportIndex === -1) {
       return identifier;
     }
-    const lastImport = bodyPath[lastImportIndex];
+    const lastImport = bodyPath[targetImportIndex];
     if (lastImport == null) {
       return identifier;
     }
@@ -373,17 +383,27 @@ export default class StateManager {
       return identifier;
     }
     const bodyPath: Array<NodePath<t.Statement>> = programPath.get('body');
-    let lastImportIndex = -1;
+    let targetImportIndex = -1;
     for (let i = 0; i < bodyPath.length; i++) {
       const statement = bodyPath[i];
       if (pathUtils.isImportDeclaration(statement)) {
-        lastImportIndex = i;
+        targetImportIndex = i;
+        if (
+          statement.node.specifiers.find(
+            (s) =>
+              s.type === 'ImportDefaultSpecifier' &&
+              s.local.type === 'Identifier' &&
+              s.local.name === identifier.name,
+          )
+        ) {
+          break;
+        }
       }
     }
-    if (lastImportIndex === -1) {
+    if (targetImportIndex === -1) {
       return identifier;
     }
-    const lastImport = bodyPath[lastImportIndex];
+    const lastImport = bodyPath[targetImportIndex];
     if (lastImport == null) {
       return identifier;
     }


### PR DESCRIPTION
## What changed / motivation ?

A previous change ensures that the `inject` function is imported and then aliased as a variable before being used.
This change is a workaround for the way Babel deals with ES6 imports.

Previously, this `inject` alias variable was inserted after the last import statement. However, this breaks in some edge-cases where import statements may exist *after* `inject` has already been used.

This PR changes the behaviour to add the variable alias immediately after the `inject` function is imported.

