### PR TITLE
fix: add eslint support for -webkit-backdrop-filter

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -1105,6 +1105,66 @@ describe('@stylexjs/babel-plugin', () => {
         };"
       `);
     });
+
+    test('Transforms vendor prefix', () => {
+      expect(
+        transform(`
+          import stylex from'stylex';
+          export const styles = stylex.create({
+            root: {
+              MozOsxFontSmoothing: 'grayscale',
+              WebkitAppearance: 'none',
+              WebkitBackdropFilter: 'blur(10px)',
+              WebkitBackgroundClip: 'border-box',
+              WebkitBoxOrient: 'horizontal',
+              WebkitFontSmoothing: 'antialiased',
+              WebkitLineClamp: 123,
+              WebkitMaskImage: 'image(url(mask.png), skyblue)',
+              WebkitOverflowScrolling: 'touch',
+              WebkitTapHighlightColor: '#fff',
+              WebkitTextFillColor: '#fff',
+              WebkitTextStrokeColor: '#fff',
+              WebkitTextStrokeWidth: '20px',
+            }
+          })
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xlh3980{-moz-osx-font-smoothing:grayscale}", 3000);
+        _inject2(".x1lugfcp{-webkit-appearance:none}", 3000);
+        _inject2(".x1fh82p7{-webkit-backdrop-filter:blur(10px)}", 3000);
+        _inject2(".xodbz5m{-webkit-background-clip:border-box}", 3000);
+        _inject2(".x1y52mlm{-webkit-box-orient:horizontal}", 3000);
+        _inject2(".xvmahel{-webkit-font-smoothing:antialiased}", 3000);
+        _inject2(".xrvxlg5{-webkit-line-clamp:123}", 3000);
+        _inject2(".x6b0i8a{-webkit-mask-image:image(url(mask.png),skyblue)}", 3000);
+        _inject2(".x5lxg6s{-webkit-overflow-scrolling:touch}", 3000);
+        _inject2(".xtdamnt{-webkit-tap-highlight-color:#fff}", 3000);
+        _inject2(".x13o35d1{-webkit-text-fill-color:#fff}", 3000);
+        _inject2(".x14s97nz{-webkit-text-stroke-color:#fff}", 3000);
+        _inject2(".x10gl3gy{-webkit-text-stroke-width:20px}", 3000);
+        export const styles = {
+          root: {
+            MozOsxFontSmoothing: "xlh3980",
+            WebkitAppearance: "x1lugfcp",
+            WebkitBackdropFilter: "x1fh82p7",
+            WebkitBackgroundClip: "xodbz5m",
+            WebkitBoxOrient: "x1y52mlm",
+            WebkitFontSmoothing: "xvmahel",
+            WebkitLineClamp: "xrvxlg5",
+            WebkitMaskImage: "x6b0i8a",
+            WebkitOverflowScrolling: "x5lxg6s",
+            WebkitTapHighlightColor: "xtdamnt",
+            WebkitTextFillColor: "x13o35d1",
+            WebkitTextStrokeColor: "x14s97nz",
+            WebkitTextStrokeWidth: "x10gl3gy",
+            $$css: true
+          }
+        };"
+      `);
+    });
   });
 
   describe('[transform] stylex.create() with functions', () => {

--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -393,6 +393,27 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       }
     })
     `,
+    // test for vendor prefixed properties
+    `
+    import stylex from'stylex';
+    stylex.create({
+      root: {
+        MozOsxFontSmoothing: 'grayscale',
+        WebkitAppearance: 'none',
+        WebkitBackdropFilter: 'blur(10px)',
+        WebkitBackgroundClip: 'border-box',
+        WebkitBoxOrient: 'horizontal',
+        WebkitFontSmoothing: 'antialiased',
+        WebkitLineClamp: 123,
+        WebkitMaskImage: 'image(url(mask.png), skyblue)',
+        WebkitOverflowScrolling: 'touch',
+        WebkitTapHighlightColor: '#fff',
+        WebkitTextFillColor: '#fff',
+        WebkitTextStrokeColor: '#fff',
+        WebkitTextStrokeWidth: '20px',
+      }
+    })
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -1578,31 +1578,28 @@ const top = isStringOrNumber;
 
 const SupportedVendorSpecificCSSProperties = {
   MozOsxFontSmoothing: makeLiteralRule('grayscale'),
-  WebkitFontSmoothing: makeLiteralRule('antialiased'),
-  WebkitAppearance: makeLiteralRule('textfield'),
-  WebkitTapHighlightColor: color,
-  WebkitOverflowScrolling: makeLiteralRule('touch'),
-
-  WebkitBoxOrient: makeUnionRule(
-    'horizontal',
-    'vertical',
-    'inline-axis',
-    'block-axis',
-  ),
-  WebkitLineClamp: isNumber,
-
-  WebkitMaskImage: maskImage,
-
-  WebkitTextFillColor: color,
-  textFillColor: color,
-  WebkitTextStrokeWidth: borderWidth,
-  WebkitTextStrokeColor: color,
+  WebkitAppearance: appearance,
+  WebkitBackdropFilter: backdropFilter,
   WebkitBackgroundClip: makeUnionRule(
     'border-box',
     'padding-box',
     'content-box',
     'text',
   ),
+  WebkitBoxOrient: makeUnionRule(
+    'horizontal',
+    'vertical',
+    'inline-axis',
+    'block-axis',
+  ),
+  WebkitFontSmoothing: makeLiteralRule('antialiased'),
+  WebkitLineClamp: isNumber,
+  WebkitMaskImage: maskImage,
+  WebkitOverflowScrolling: makeLiteralRule('touch'),
+  WebkitTapHighlightColor: color,
+  WebkitTextFillColor: color,
+  WebkitTextStrokeColor: color,
+  WebkitTextStrokeWidth: borderWidth,
 };
 
 const SVGProperties = {
@@ -2175,6 +2172,7 @@ const CSSProperties = {
   textEmphasisColor: textEmphasisColor,
   textEmphasisPosition: textEmphasisPosition,
   textEmphasisStyle: textEmphasisStyle,
+  textFillColor: color,
   textIndent: textIndent,
   textOrientation: textOrientation,
   textOverflow: textOverflow,

--- a/packages/stylex/src/StyleXCSSTypes.js
+++ b/packages/stylex/src/StyleXCSSTypes.js
@@ -910,8 +910,27 @@ type OptionalArray<T> = Array<T> | T;
 export type SupportedVendorSpecificCSSProperties = $ReadOnly<{
   MozOsxFontSmoothing?: null | 'grayscale',
   WebkitAppearance?: null | appearance,
+  WebkitBackdropFilter?: all | backdropFilter,
+  WebkitBackgroundClip?:
+    | null
+    | 'border-box'
+    | 'padding-box'
+    | 'content-box'
+    | 'text',
+  WebkitBoxOrient?:
+    | null
+    | 'vertical'
+    | 'horizontal'
+    | 'inline-axis'
+    | 'block-axis',
   WebkitFontSmoothing?: null | 'antialiased',
+  WebkitLineClamp?: all | number,
+  WebkitMaskImage?: all | maskImage,
+  WebkitOverflowScrolling?: all | 'touch',
   WebkitTapHighlightColor?: null | color,
+  WebkitTextFillColor?: all | color,
+  WebkitTextStrokeColor?: all | color,
+  WebkitTextStrokeWidth?: all | number | string,
 }>;
 
 export type CSSProperties = $ReadOnly<{
@@ -919,32 +938,29 @@ export type CSSProperties = $ReadOnly<{
   theme?: all | string,
 
   // ...$Exact<SupportedVendorSpecificCSSProperties>, for TypeScript compatibility
-  MozOsxFontSmoothing?: all | 'grayscale',
-  WebkitAppearance?: all | appearance,
-  WebkitFontSmoothing?: all | 'antialiased',
-  WebkitTapHighlightColor?: all | color,
-
-  WebkitMaskImage?: all | maskImage,
-
-  WebkitTextFillColor?: all | color,
-  textFillColor?: all | color,
-  WebkitTextStrokeWidth?: all | number | string,
-  WebkitTextStrokeColor?: all | color,
+  MozOsxFontSmoothing?: null | 'grayscale',
+  WebkitAppearance?: null | appearance,
+  WebkitBackdropFilter?: all | backdropFilter,
   WebkitBackgroundClip?:
     | null
     | 'border-box'
     | 'padding-box'
     | 'content-box'
     | 'text',
-  backgroundClip?: all | 'border-box' | 'padding-box' | 'content-box' | 'text',
-
   WebkitBoxOrient?:
     | null
     | 'vertical'
     | 'horizontal'
     | 'inline-axis'
     | 'block-axis',
+  WebkitFontSmoothing?: null | 'antialiased',
   WebkitLineClamp?: all | number,
+  WebkitMaskImage?: all | maskImage,
+  WebkitOverflowScrolling?: all | 'touch',
+  WebkitTapHighlightColor?: null | color,
+  WebkitTextFillColor?: all | color,
+  WebkitTextStrokeColor?: all | color,
+  WebkitTextStrokeWidth?: all | number | string,
   // ENDOF ...$Exact<SupportedVendorSpecificCSSProperties>,
 
   accentColor?: all | color,
@@ -1486,6 +1502,7 @@ export type CSSProperties = $ReadOnly<{
   textEmphasisColor?: all | textEmphasisColor,
   textEmphasisPosition?: all | textEmphasisPosition,
   textEmphasisStyle?: all | textEmphasisStyle,
+  textFillColor?: all | color,
   textIndent?: all | textIndent,
   textJustify?:
     | null


### PR DESCRIPTION
## What changed / motivation ?

- The motivation for this PR was to add the `-webkit-backdrop-filter` support to the eslint plugin.
- While doing that I tried to make the typings more consistent and alphabetically sorted so adding additional vendor prefixes in the future should be a bit easier.
- Added tests.

## Linked PR/Issues

Fixes #390 

## Additional Context

NA.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code