### PR TITLE
fix: fix eslint sort-keys handling nested properties

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -147,6 +147,19 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         });
       `,
     },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        nav: {
+          maxWidth: {
+            default: "1080px",
+            "@media (min-width: 2000px)": "calc((1080 / 24) * 1rem)"
+          },
+          paddingVertical: 0,
+        },
+      });`,
+    },
   ],
   invalid: [
     {
@@ -170,7 +183,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     {
       code: `
         import stylex from 'stylex';
-        const obj = { fontSize: '12px' }; 
+        const obj = { fontSize: '12px' };
         const styles = stylex.create({
           button: {
             alignItems: 'center',

--- a/packages/eslint-plugin/src/stylex-sort-keys.js
+++ b/packages/eslint-plugin/src/stylex-sort-keys.js
@@ -169,7 +169,7 @@ const stylexSortKeys = {
           objectExpressionNestingLevel++;
         }
 
-        if (objectExpressionNestingLevel === 1) {
+        if (objectExpressionNestingLevel > 0) {
           stack = {
             upper: stack,
             prevNode: null,


### PR DESCRIPTION
## What changed / motivation ?

Fix a bug where the `sort-keys` rule is giving errors for nested keys, comparing them to the parent keys.

## Linked PR/Issues

Fixes #391 

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

I *think* the issue here is that, after adding the outer object to the stack, subsequent nested objects are never actually pushed onto this stack, resulting in a stack that maintains only a single layer.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code