### PR TITLE
fix: eslint allow using vars as key in dynamic styles

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -393,6 +393,26 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       }
     })
     `,
+    // test using vars as keys
+    `
+    import stylex from'stylex';
+    import { componentVars } from './bug.stylex';
+    stylex.create({
+      host: {
+        [componentVars.color]: 'blue',
+      },
+    })
+    `,
+    // test using vars as keys in dynamic styles
+    `
+    import stylex from'stylex';
+    import { tokens } from 'tokens.stylex';
+    stylex.create({
+      root: (position) => ({
+        [tokens.position]: \`\${position}px\`,
+      })
+    })
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -2574,6 +2574,9 @@ const stylexValidStyles = {
             }: Rule.ReportDescriptor),
           );
         }
+        if (isStylexDefineVarsToken(styleKey, stylexDefineVarsTokenImports)) {
+          return undefined;
+        }
         if (style.computed && styleKey.type !== 'Literal') {
           const val = evaluate(styleKey, variables);
           if (val == null) {


### PR DESCRIPTION
## What changed / motivation ?

Fixed the following cases casuing "Computed key cannot be resolved.eslint(@stylexjs/valid-styles)" lint error.

```ts
    import stylex from'stylex';
    import { componentVars } from './bug.stylex';
    stylex.create({
      host: {
        [componentVars.color]: 'blue',
      },
    })
```

```ts
    import stylex from'stylex';
    import { tokens } from 'tokens.stylex';
    stylex.create({
      root: (position) => ({
        [tokens.position]: `${position}px`,
      })
    })
```

## Linked PR/Issues

Fixes #337

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

For dynamic styles (not `style.value.type === 'ObjectExpression'`) we are missing the check for stylex defined variables for object keys, resulting in the "cannot be resolved" error, the fix was to add an early check for the style key being a defined variable and returning early.

TBH I don't quite understand why the first case was broken as reported in #337, how is that not an object expression? But anyways the fix seem to fix it.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code