### PR TITLE
fix: Ensure stylex.include calls are kept correctly

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -379,6 +379,34 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
+    test('Using stylex.include keeps the compiled object', () => {
+      expect(
+        transform(`
+           import stylex from 'stylex';
+           const styles = stylex.create({
+             foo: {
+               ...stylex.include(importedStyles.foo),
+               color: 'red',
+             }
+           });
+           stylex.props(styles.foo);
+         `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        const styles = {
+          foo: {
+            ...importedStyles.foo,
+            color: "x1e2nbdu",
+            $$css: true
+          }
+        };
+        stylex.props(styles.foo);"
+      `);
+    });
+
     test('Uses stylex.firstThatWorks correctly', () => {
       expect(
         transform(`

--- a/packages/babel-plugin/src/utils/js-to-ast.js
+++ b/packages/babel-plugin/src/utils/js-to-ast.js
@@ -7,6 +7,8 @@
  * @flow strict
  */
 
+import type { FlatCompiledStyles } from '../../../shared/src/common-types';
+
 import * as t from '@babel/types';
 import { IncludedStyles } from '@stylexjs/shared';
 
@@ -40,6 +42,18 @@ export function convertObjectToAST(
                     : convertObjectToAST(value),
           ),
     ),
+  );
+}
+
+export function removeObjectsWithSpreads(obj: {
+  +[string]: FlatCompiledStyles,
+}): { +[string]: FlatCompiledStyles } {
+  return Object.fromEntries(
+    Object.entries(obj)
+      .filter(([_key, value]) =>
+        Object.values(value).every((val) => !(val instanceof IncludedStyles)),
+      )
+      .filter(Boolean),
   );
 }
 

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -22,7 +22,10 @@ import {
   injectDevClassNames,
   convertToTestStyles,
 } from '../../utils/dev-classname';
-import { convertObjectToAST } from '../../utils/js-to-ast';
+import {
+  convertObjectToAST,
+  removeObjectsWithSpreads,
+} from '../../utils/js-to-ast';
 import { messages } from '@stylexjs/shared';
 import * as pathUtils from '../../babel-path-utils';
 import { evaluateStyleXCreateArg } from './parse-stylex-create-arg';
@@ -147,7 +150,8 @@ export default function transformStyleXCreate(
     }
 
     if (varName != null) {
-      state.styleMap.set(varName, compiledStyles);
+      const stylesToRemember = removeObjectsWithSpreads(compiledStyles);
+      state.styleMap.set(varName, stylesToRemember);
       state.styleVars.set(varName, (path.parentPath: $FlowFixMe));
     }
 


### PR DESCRIPTION
## What changed / motivation ?

A recent change to optimise the compiled output of `stylex.props` (and `stylex.attrs`)
would accidentally ignore the usage of `stylex.include` within style definitions and inline
the rest of the styles as classNames and remove the original object entirely.

This change makes it so that usage of any `stylex.include` will cause the entire style object
to behave as an external unknown style object.


## Linked PR/Issues

Fixes #394 

## Additional Context

Added a new test to verify the change. I verified the bug with this test and was able to fix it after making
the necessary change.
