### PR TITLE
fix: Corrected wrong import location of esbuild plugin in README

### DIFF
--- a/packages/esbuild-plugin/README.md
+++ b/packages/esbuild-plugin/README.md
@@ -3,7 +3,7 @@
 Use StyleX with _esbuild_ bundler.
 
 This plugin transforms files that contain `stylexjs` imports and generates a
-`stylexjs` `CSS` bundle.
+`stylexjs` CSS bundle.
 
 ## Installation
 

--- a/packages/esbuild-plugin/README.md
+++ b/packages/esbuild-plugin/README.md
@@ -15,7 +15,7 @@ npm install --save-dev @stylexjs/esbuild-plugin
 
 ```typescript
 import esbuild from 'esbuild';
-import stylexPlugin from '@stylexjs/stylex';
+import stylexPlugin from '@stylexjs/esbuild-plugin';
 import path from 'path';
 import { fileURLToPath } from 'url';
 


### PR DESCRIPTION
## What changed / motivation ?
Fixed wrong import location in esbuild plugin.

## Linked PR/Issues

None

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

None

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code