### PR TITLE
fix (ESLint Plugin): allow font weights between 1 and 1000

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -493,7 +493,7 @@ revert`,
       ],
     },
     {
-      code: 'import stylex from "stylex"; stylex.create({default: {fontWeight: 99}});',
+      code: 'import stylex from "stylex"; stylex.create({default: {fontWeight: 10001}});',
       errors: [
         {
           message: `fontWeight value must be one of:
@@ -501,15 +501,7 @@ normal
 bold
 bolder
 lighter
-100
-200
-300
-400
-500
-600
-700
-800
-900
+a number between 1 and 1000
 a CSS Variable
 null
 initial

--- a/packages/eslint-plugin/src/rules/makeRangeRule.js
+++ b/packages/eslint-plugin/src/rules/makeRangeRule.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type { Node } from 'estree';
+import type {
+  RuleCheck,
+  RuleResponse,
+  Variables,
+} from '../stylex-valid-styles';
+import makeVariableCheckingRule from '../utils/makeVariableCheckingRule';
+
+export default function makeRangeRule(
+  min: number,
+  max: number,
+  message: string,
+): RuleCheck {
+  function rangeChecker(node: Node, _variables?: Variables): RuleResponse {
+    if (
+      node.type === 'Literal' &&
+      typeof node.value === 'number' &&
+      node.value >= min &&
+      node.value <= max
+    ) {
+      return undefined;
+    }
+    return {
+      message,
+    };
+  }
+  return makeVariableCheckingRule(rangeChecker);
+}

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -34,6 +34,7 @@ import micromatch from 'micromatch';
 /*:: import { Rule } from 'eslint'; */
 import isCSSVariable from './rules/isCSSVariable';
 import makeLiteralRule from './rules/makeLiteralRule';
+import makeRangeRule from './rules/makeRangeRule';
 import makeRegExRule from './rules/makeRegExRule';
 import isString from './rules/isString';
 import isHexColor from './rules/isHexColor';
@@ -843,15 +844,7 @@ const fontWeight = makeUnionRule(
   makeLiteralRule('bold'),
   makeLiteralRule('bolder'),
   makeLiteralRule('lighter'),
-  makeLiteralRule(100),
-  makeLiteralRule(200),
-  makeLiteralRule(300),
-  makeLiteralRule(400),
-  makeLiteralRule(500),
-  makeLiteralRule(600),
-  makeLiteralRule(700),
-  makeLiteralRule(800),
-  makeLiteralRule(900),
+  makeRangeRule(1, 1000, 'a number between 1 and 1000'),
   isCSSVariable,
 );
 const gap = isStringOrNumber;


### PR DESCRIPTION
## What changed ?

This PR tells the ESLint plugin to allow  `fontWeight` to have any number between 1 and 1000 instead of some fixed ones like `100`, `200`... Fixes #419.