### PR TITLE
feat: add `fix` to `eslint-plugin/sort-keys` rule

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -389,5 +389,43 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         },
       ],
     },
+    {
+      code: `
+      import { create } from 'stylex';
+      const styles = create({
+        foo: {
+          display: 'flex',
+          backgroundColor: {
+            // foo
+            default: 'red',
+            // bar
+            /* Block comment */
+            ':hover': 'brown',
+          },
+        }
+      });
+      `,
+      output: `
+      import { create } from 'stylex';
+      const styles = create({
+        foo: {
+          backgroundColor: {
+            // foo
+            default: 'red',
+            // bar
+            /* Block comment */
+            ':hover': 'brown',
+          },
+          display: 'flex',
+        }
+      });
+      `,
+      errors: [
+        {
+          message:
+            'StyleX property key "backgroundColor" should be above "display"',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -363,30 +363,6 @@ eslintTester.run('stylex-sort-keys', rule.default, {
       import { create } from 'stylex';
       const styles = create({
         main: {
-          display: 'flex',
-          borderColor: 'red',
-        },
-      });`,
-      output: `
-      import { create } from 'stylex';
-      const styles = create({
-        main: {
-          borderColor: 'red',
-          display: 'flex',
-        },
-      });`,
-      errors: [
-        {
-          message:
-            'StyleX property key "borderColor" should be above "display"',
-        },
-      ],
-    },
-    {
-      code: `
-      import { create } from 'stylex';
-      const styles = create({
-        main: {
           backgroundColor: {
             // a
             ':hover': 'blue', // a

--- a/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -457,5 +457,50 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         },
       ],
     },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: { backgroundColor: 'red', alignItems: 'center', }
+      })
+      `,
+      output: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: { alignItems: 'center', backgroundColor: 'red', }
+      })
+      `,
+      errors: [
+        {
+          message:
+            'StyleX property key "alignItems" should be above "backgroundColor"',
+        },
+      ],
+    },
+    // {
+    //   code: `
+    //   import stylex from 'stylex';
+    //   const styles = stylex.create({
+    //     foo: { backgroundColor: 'red',
+    //       alignItems: 'center',
+    //     }
+    //   })
+    //   `,
+    //   output: `
+    //   import stylex from 'stylex';
+    //   const styles = stylex.create({
+    //     foo: { alignItems: 'center',
+    //       backgroundColor: 'red',
+    //     }
+    //   })
+    //   `,
+    //   only: true,
+    //   errors: [
+    //     {
+    //       message:
+    //         'StyleX property key "alignItems" should be above "backgroundColor"',
+    //     },
+    //   ],
+    // },
   ],
 });

--- a/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -199,7 +199,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
             alignItems: 'center',
             display: 'flex',
             ...obj,
-            borderColor: 'red',
+            borderColor: 'red', // ok
             alignSelf: 'center',
           }
         });
@@ -213,7 +213,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
             display: 'flex',
             ...obj,
             alignSelf: 'center',
-            borderColor: 'red',
+            borderColor: 'red', // ok
           }
         });
       `,
@@ -477,30 +477,133 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         },
       ],
     },
-    // {
-    //   code: `
-    //   import stylex from 'stylex';
-    //   const styles = stylex.create({
-    //     foo: { backgroundColor: 'red',
-    //       alignItems: 'center',
-    //     }
-    //   })
-    //   `,
-    //   output: `
-    //   import stylex from 'stylex';
-    //   const styles = stylex.create({
-    //     foo: { alignItems: 'center',
-    //       backgroundColor: 'red',
-    //     }
-    //   })
-    //   `,
-    //   only: true,
-    //   errors: [
-    //     {
-    //       message:
-    //         'StyleX property key "alignItems" should be above "backgroundColor"',
-    //     },
-    //   ],
-    // },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: { // foo
+          // foo
+          backgroundColor: 'red', // bar
+          // bar
+          alignItems: 'center' // baz
+          // qux
+        }
+      })
+      `,
+      output: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: { // foo
+          // bar
+          alignItems: 'center', // baz
+          // foo
+          backgroundColor: 'red', // bar
+          // qux
+        }
+      })
+      `,
+      errors: [
+        {
+          message:
+            'StyleX property key "alignItems" should be above "backgroundColor"',
+        },
+      ],
+    },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: {
+          /*
+          *
+          * foo
+          * bar
+          * baz
+          *
+          */
+          backgroundColor: 'red',
+          alignItems: 'center'
+        }
+      })
+      `,
+      output: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: {
+          alignItems: 'center',
+          /*
+          *
+          * foo
+          * bar
+          * baz
+          *
+          */
+          backgroundColor: 'red',
+        }
+      })
+      `,
+      errors: [
+        {
+          message:
+            'StyleX property key "alignItems" should be above "backgroundColor"',
+        },
+      ],
+    },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: {      
+          backgroundColor: 'red',             //       foo
+          alignItems: 'center'       // baz
+        }
+      })
+      `,
+      output: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: {      
+          alignItems: 'center',       // baz
+          backgroundColor: 'red',             //       foo
+        }
+      })
+      `,
+      errors: [
+        {
+          message:
+            'StyleX property key "alignItems" should be above "backgroundColor"',
+        },
+      ],
+    },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: {
+          /*
+          * foo
+          */ backgroundColor: 'red',
+          alignItems: 'center'
+        }
+      })
+      `,
+      output: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: {
+          alignItems: 'center',
+          /*
+          * foo
+          */ backgroundColor: 'red',
+        }
+      })
+      `,
+      errors: [
+        {
+          message:
+            'StyleX property key "alignItems" should be above "backgroundColor"',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -605,5 +605,72 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         },
       ],
     },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: {
+          // foo
+
+          backgroundColor: 'red',
+          alignItems: 'center'
+        }
+      })
+      `,
+      output: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: {
+          // foo
+
+          alignItems: 'center',
+          backgroundColor: 'red',
+        }
+      })
+      `,
+      errors: [
+        {
+          message:
+            'StyleX property key "alignItems" should be above "backgroundColor"',
+        },
+      ],
+    },
+    {
+      options: [{ allowLineSeparatedGroups: true }],
+      code: `
+      import { create as cr } from '@stylexjs/stylex';
+      const styles = cr({
+        button: {
+          alignItems: 'center',
+          display: 'flex',
+          // foo
+
+          // bar
+          borderColor: 'black',
+          alignSelf: 'center',
+        }
+      });
+      `,
+      output: `
+      import { create as cr } from '@stylexjs/stylex';
+      const styles = cr({
+        button: {
+          alignItems: 'center',
+          display: 'flex',
+          // foo
+
+          alignSelf: 'center',
+          // bar
+          borderColor: 'black',
+        }
+      });
+      `,
+      errors: [
+        {
+          message:
+            'StyleX property key "alignSelf" should be above "borderColor"',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -427,5 +427,36 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         },
       ],
     },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: {
+          // zee
+          backgroundColor: 'red', // foo
+          // bar
+          alignItems: 'center' // eee
+        }
+      })
+      `,
+      output: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        foo: {
+          // bar
+          alignItems: 'center', // eee
+          // zee
+          backgroundColor: 'red', // foo
+        }
+      })
+      `,
+      only: true,
+      errors: [
+        {
+          message:
+            'StyleX property key "alignItems" should be above "backgroundColor"',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -173,6 +173,16 @@ eslintTester.run('stylex-sort-keys', rule.default, {
           }
         });
       `,
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            animationDuration: '100ms',
+            padding: 10,
+            fontSize: 12,
+          }
+        });
+      `,
       errors: [
         {
           message:
@@ -194,6 +204,19 @@ eslintTester.run('stylex-sort-keys', rule.default, {
           }
         });
       `,
+      output: `
+        import stylex from 'stylex';
+        const obj = { fontSize: '12px' };
+        const styles = stylex.create({
+          button: {
+            alignItems: 'center',
+            display: 'flex',
+            ...obj,
+            alignSelf: 'center',
+            borderColor: 'red',
+          }
+        });
+      `,
       errors: [
         {
           message:
@@ -209,6 +232,16 @@ eslintTester.run('stylex-sort-keys', rule.default, {
             alignItems: 'center',
             display: 'flex',
             borderColor: 'red',
+          }
+        });
+      `,
+      output: `
+        import { create } from 'stylex';
+        const styles = create({
+          button: {
+            alignItems: 'center',
+            borderColor: 'red',
+            display: 'flex',
           }
         });
       `,
@@ -233,6 +266,19 @@ eslintTester.run('stylex-sort-keys', rule.default, {
           },
         });
       `,
+      output: `
+        import stylex from 'stylex';
+        const someAnimation = stylex.keyframes({
+          '0%': {
+            borderColor: 'red',
+            display: 'none',
+          },
+          '100%': {
+            borderColor: 'green',
+            display: 'flex',
+          },
+        });
+      `,
       errors: [
         {
           message:
@@ -251,6 +297,19 @@ eslintTester.run('stylex-sort-keys', rule.default, {
           '100%': {
             display: 'flex',
             borderColor: 'green',
+          },
+        });
+      `,
+      output: `
+        import { keyframes as kf } from 'stylex';
+        const someAnimation = kf({
+          '0%': {
+            borderColor: 'red',
+            display: 'none',
+          },
+          '100%': {
+            borderColor: 'green',
+            display: 'flex',
           },
         });
       `,
@@ -275,6 +334,19 @@ eslintTester.run('stylex-sort-keys', rule.default, {
           borderRadius: 10,
         },
       });`,
+      output: `
+      import { create } from 'stylex';
+      const styles = create({
+        main: {
+          borderColor: {
+            default: 'green',
+            '@media (min-width: 1540px)': 1366,
+            ':hover': 'red',
+          },
+          display: 'flex',
+          borderRadius: 10,
+        },
+      });`,
       errors: [
         {
           message:
@@ -283,6 +355,61 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         {
           message:
             'StyleX property key ":hover" should be above "@media (min-width: 1540px)"',
+        },
+      ],
+    },
+    {
+      code: `
+      import { create } from 'stylex';
+      const styles = create({
+        main: {
+          display: 'flex',
+          borderColor: 'red',
+        },
+      });`,
+      output: `
+      import { create } from 'stylex';
+      const styles = create({
+        main: {
+          borderColor: 'red',
+          display: 'flex',
+        },
+      });`,
+      errors: [
+        {
+          message:
+            'StyleX property key "borderColor" should be above "display"',
+        },
+      ],
+    },
+    {
+      code: `
+      import { create } from 'stylex';
+      const styles = create({
+        main: {
+          backgroundColor: {
+            // a
+            ':hover': 'blue', // a
+            // b
+            default: 'red', // b
+          },
+        },
+      });`,
+      output: `
+      import { create } from 'stylex';
+      const styles = create({
+        main: {
+          backgroundColor: {
+            // a
+            default: 'red', // a
+            // b
+            ':hover': 'blue', // b
+          },
+        },
+      });`,
+      errors: [
+        {
+          message: 'StyleX property key "default" should be above ":hover"',
         },
       ],
     },

--- a/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -376,10 +376,10 @@ eslintTester.run('stylex-sort-keys', rule.default, {
       const styles = create({
         main: {
           backgroundColor: {
-            // a
-            default: 'red', // a
             // b
-            ':hover': 'blue', // b
+            default: 'red', // b
+            // a
+            ':hover': 'blue', // a
           },
         },
       });`,
@@ -450,7 +450,6 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         }
       })
       `,
-      only: true,
       errors: [
         {
           message:

--- a/packages/eslint-plugin/flow_modules/eslint/eslint-rule.js.flow
+++ b/packages/eslint-plugin/flow_modules/eslint/eslint-rule.js.flow
@@ -25,7 +25,7 @@ export type RuleFixer = {
   insertTextAfterRange(range: AST.Range, text: string): Fix,
   insertTextBefore(nodeOrToken: ESTree.Node | AST.Token, text: string): Fix,
   insertTextBeforeRange(range: AST.Range, text: string): Fix,
-  remove(nodeOrToken: ESTree.Node | AST.Token): Fix,
+  remove(nodeOrToken: ESTree.Node | AST.Token | ESTree.Comment): Fix,
   removeRange(range: AST.Range): Fix,
   replaceText(nodeOrToken: ESTree.Node | AST.Token, text: string): Fix,
   replaceTextRange(range: AST.Range, text: string): Fix,
@@ -70,6 +70,7 @@ type Node = ESTree.Node & NodeParentExtension;
 
 export type SourceCode = {
   getTokensBetween(left: $ReadOnly<{...ESTree.Property, ...}>, right: $ReadOnly<{...ESTree.Property, ...}>, options: { includeComments?: boolean }): Array<AST.Token | ESTree.Comment>;
+  getText(node?: ESTree.Node, beforeCount?: number, afterCount?: number): string;
 };
 
 export type RuleContext = {

--- a/packages/eslint-plugin/flow_modules/eslint/eslint-rule.js.flow
+++ b/packages/eslint-plugin/flow_modules/eslint/eslint-rule.js.flow
@@ -25,7 +25,7 @@ export type RuleFixer = {
   insertTextAfterRange(range: AST.Range, text: string): Fix,
   insertTextBefore(nodeOrToken: ESTree.Node | AST.Token, text: string): Fix,
   insertTextBeforeRange(range: AST.Range, text: string): Fix,
-  remove(nodeOrToken: ESTree.Node | AST.Token | ESTree.Comment): Fix,
+  remove(nodeOrToken: ESTree.Node | AST.Token): Fix,
   removeRange(range: AST.Range): Fix,
   replaceText(nodeOrToken: ESTree.Node | AST.Token, text: string): Fix,
   replaceTextRange(range: AST.Range, text: string): Fix,

--- a/packages/eslint-plugin/flow_modules/eslint/eslint-rule.js.flow
+++ b/packages/eslint-plugin/flow_modules/eslint/eslint-rule.js.flow
@@ -21,11 +21,14 @@ export type Fix = {
 };
 
 export type RuleFixer = {
-  insertTextAfter(nodeOrToken: ESTree.Node | AST.Token, text: string): Fix,
+  insertTextAfter(
+    nodeOrToken: ESTree.Node | AST.Token | ESTree.Comment,
+    text: string,
+  ): Fix,
   insertTextAfterRange(range: AST.Range, text: string): Fix,
   insertTextBefore(nodeOrToken: ESTree.Node | AST.Token, text: string): Fix,
   insertTextBeforeRange(range: AST.Range, text: string): Fix,
-  remove(nodeOrToken: ESTree.Node | AST.Token): Fix,
+  remove(nodeOrToken: ESTree.Node | ESTree.Comment | AST.Token): Fix,
   removeRange(range: AST.Range): Fix,
   replaceText(nodeOrToken: ESTree.Node | AST.Token, text: string): Fix,
   replaceTextRange(range: AST.Range, text: string): Fix,
@@ -68,9 +71,34 @@ export type NodeParentExtension = {
 };
 type Node = ESTree.Node & NodeParentExtension;
 
+type SkipOptions = {
+  includeComments?: false | void,
+  skip?: number | void,
+  filter?: ((token: AST.Token) => boolean) | undefined,
+};
+
 export type SourceCode = {
-  getTokensBetween(left: $ReadOnly<{...ESTree.Property, ...}>, right: $ReadOnly<{...ESTree.Property, ...}>, options: { includeComments?: boolean }): Array<AST.Token | ESTree.Comment>;
-  getText(node?: ESTree.Node, beforeCount?: number, afterCount?: number): string;
+  lines: string[],
+  getTokensBetween(
+    left: $ReadOnly<{ ...ESTree.Property, ... }>,
+    right: $ReadOnly<{ ...ESTree.Property, ... }>,
+    options: { includeComments?: boolean },
+  ): Array<AST.Token | ESTree.Comment>,
+  getTokenAfter(
+    node: ESTree.Node | ESTree.Comment | AST.Token,
+    options: SkipOptions,
+  ): AST.Token | null,
+  getTokenBefore(
+    node: ESTree.Node | ESTree.Comment | AST.Token,
+    options: SkipOptions,
+  ): AST.Token | null,
+  getText(
+    node?: ESTree.Node | ESTree.Comment,
+    beforeCount?: number,
+    afterCount?: number,
+  ): string,
+  getCommentsBefore(nodeOrToken: ESTree.Node | AST.Token): ESTree.Comment[],
+  getCommentsAfter(nodeOrToken: ESTree.Node | AST.Token): ESTree.Comment[],
 };
 
 export type RuleContext = {
@@ -80,7 +108,7 @@ export type RuleContext = {
   parserPath: string,
   // parserOptions: Linter.ParserOptions;
   // parserServices: SourceCode.ParserServices;
-  sourceCode: SourceCode;
+  sourceCode: SourceCode,
   getAncestors(): Array<ESTree.Node>,
 
   // getDeclaredVariables(node: ESTree.Node): Scope.Variable[];

--- a/packages/eslint-plugin/flow_modules/eslint/eslint-rule.js.flow
+++ b/packages/eslint-plugin/flow_modules/eslint/eslint-rule.js.flow
@@ -99,6 +99,10 @@ export type SourceCode = {
   ): string,
   getCommentsBefore(nodeOrToken: ESTree.Node | AST.Token): ESTree.Comment[],
   getCommentsAfter(nodeOrToken: ESTree.Node | AST.Token): ESTree.Comment[],
+  isSpaceBetween(
+    nodeOrToken: ESTree.Node | AST.Token | ESTree.Comment,
+    nodeOrToken: ESTree.Node | AST.Token | ESTree.Comment,
+  ): boolean,
 };
 
 export type RuleContext = {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -10,7 +10,7 @@
     "build": "babel src/ --out-dir lib/",
     "prebuild-haste": "gen-types -i src/ -o lib/",
     "build-haste": "rollup --config ./rollup.config.mjs",
-    "test": "jest --detectOpenHandles"
+    "test": "jest --detectOpenHandles --watch"
   },
   "dependencies": {
     "micromatch": "^4.0.5"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -10,7 +10,7 @@
     "build": "babel src/ --out-dir lib/",
     "prebuild-haste": "gen-types -i src/ -o lib/",
     "build-haste": "rollup --config ./rollup.config.mjs",
-    "test": "jest --detectOpenHandles --watch"
+    "test": "jest --detectOpenHandles"
   },
   "dependencies": {
     "micromatch": "^4.0.5"

--- a/packages/eslint-plugin/src/stylex-sort-keys.js
+++ b/packages/eslint-plugin/src/stylex-sort-keys.js
@@ -401,7 +401,7 @@ function createFix({
     const lowerNodeLine = lowerNode.loc?.start.line;
 
     if (upperNodeLine === undefined || lowerNodeLine === undefined) {
-      throw new Error('Invalide node location');
+      throw new Error('Invalid node location');
     }
 
     return sourceCode.lines

--- a/packages/eslint-plugin/src/stylex-sort-keys.js
+++ b/packages/eslint-plugin/src/stylex-sort-keys.js
@@ -317,8 +317,7 @@ function createFix({
   return function (fixer: RuleFixer) {
     const fixes = [];
 
-    // Retrieve comments before previous node
-    // Filter only comments that are on the line by themselves
+    // Retrieve comments before the previous node
     const prevNodeCommentsBefore = getPropertyCommentsBefore(
       sourceCode,
       prevNode,
@@ -357,7 +356,7 @@ function createFix({
 
     fixes.push(
       fixer.removeRange([
-        // If previous token is not in the same line, we remove an extra char to account for newline
+        // If previous token is not on the same line, we remove an extra char to account for newline
         rangeStart - Number(!isTokenBeforeSameLineAsNode),
         rangeEnd,
       ]),
@@ -380,8 +379,8 @@ function createFix({
     }
 
     const newLine = isSameLine(prevNode, currNode) ? '' : '\n';
-    // If token after the current node is comma then we insert after the comma
-    // Otherwise we insert after current node because there is already a fix to add comma (code above)
+    // If token after the current node is a comma then we insert after the comma
+    // Otherwise we insert after the current node because there is a guaranteed fix to add comma (above)
     const fallbackNode =
       hasCommaAfterCurrNode && tokenAfterCurrNode
         ? tokenAfterCurrNode


### PR DESCRIPTION
## What changed / motivation ?

Adds a `fix` for `sort-keys` ESLint rule.

This implementation has one major limitation, however. The comments are not taken into consideration for the fixes. The major reason for this is that taking care of adjacent comments introduces many edge cases and too often we cannot guarantee persistent formatting of the edited text. The current fix works like this:

*Before:*
```typescript
const styles = stylex.create({
  foo: {
    // bar
    display: 'flex',
    // baz
    alignItems: 'center',
  },
});
```

*After:*
```typescript
const styles = stylex.create({
  foo: {
    // bar
    alignItems: 'center',
    // baz
    display: 'flex',
  },
});
```

Let's discuss this limitation -- would like to hear some opinions of how critical you think it is to move around the comments.

## Linked PR/Issues

Fixes #415 

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code