### PR TITLE
Fix: Allow undefined within StyleXStyles and StaticStyles

### DIFF
--- a/apps/nextjs-example/typetests/test1.tsx
+++ b/apps/nextjs-example/typetests/test1.tsx
@@ -29,3 +29,7 @@ const styles = stylex.create({
 function OtherComponent() {
   return <Component xstyle={styles.base} />;
 }
+
+function OtherComponent2() {
+  return <Component xstyle={[styles.base, undefined]} />;
+}

--- a/packages/stylex/src/StyleXTypes.d.ts
+++ b/packages/stylex/src/StyleXTypes.d.ts
@@ -144,7 +144,7 @@ type GenStylePropType<CSS extends UserAuthoredStyles> = Readonly<
 // Replace `XStyle` with this.
 export type StaticStyles<
   CSS extends UserAuthoredStyles = CSSPropertiesWithExtras,
-> = StyleXArray<false | null | GenStylePropType<CSS>>;
+> = StyleXArray<false | null | undefined | GenStylePropType<CSS>>;
 
 export type StaticStylesWithout<CSS extends UserAuthoredStyles> = StaticStyles<
   Omit<CSSPropertiesWithExtras, keyof CSS>
@@ -154,6 +154,7 @@ export type StyleXStyles<
   CSS extends UserAuthoredStyles = CSSPropertiesWithExtras,
 > = StyleXArray<
   | null
+  | undefined
   | false
   | GenStylePropType<CSS>
   | Readonly<[GenStylePropType<CSS>, InlineStyles]>


### PR DESCRIPTION
## What changed / motivation ?

The typescript type definitions for `StyleXStyles` and `StaticStyles` did not accept `undefined` but they did accept `null`. This was an oversight, and has been fixed in this PR.

## Linked PR/Issues

Fixes #417 

## Additional Context

A type test has been added to verify the fix.
