### PR TITLE
Docs: Document VarGroup and Theme types

### DIFF
--- a/apps/docs/docs/api/index.mdx
+++ b/apps/docs/docs/api/index.mdx
@@ -29,3 +29,5 @@ sidebar_position: 1
 - [`type StyleXStyles`](/docs/api/types/StyleXStyles/)
 - [`type StyleXStylesWithout`](/docs/api/types/StyleXStylesWithout/)
 - [`type StaticStyles`](/docs/api/types/StaticStyles/)
+- [`type VarGroup`](/docs/api/types/VarGroup/)
+- [`type Theme`](/docs/api/types/Theme/)

--- a/apps/docs/docs/api/types/Theme.mdx
+++ b/apps/docs/docs/api/types/Theme.mdx
@@ -9,7 +9,7 @@ sidebar_position: 5
 # `Theme<>`
 
 ```tsx
-type Theme<T extends VarGroup<unknown, symbol>, Tag extends symbol = symbol>
+type Theme<T extends VarGroup<unknown, symbol>>
 ```
 
 A `Theme` is a type that represents a style that *themes* a set of variables in a given
@@ -30,18 +30,37 @@ export const theme: Theme<typeof vars> = stylex.createTheme(vars, {
 
 The most common use-case for `Theme` is to accept a theme for a particular set of variables.
 
-By default, all themes for the same `VarGroup` are compatible with each other and have the same
-type. However, the second type argument to `Theme<>` can be used to give a theme a unique type.
-  
-```tsx
-import type {VarGroup} from '@stylexjs/stylex';
-import * as stylex from '@stylexjs/stylex';
+While, it's not needed in most cases, `Theme` also accepts an optional second type type argument.
 
+<details>
+<summary>
+  <p style={{margin: 0}}>
+    <strong>
+      Advanced use-case: unique type identity for a `Theme`
+    </strong>
+  </p>
+</summary>
+
+Two themes for the same `VarGroup` have the same type by default. In most cases,
+this is the desired behavior. However, in some cases, you may want each theme to
+have a unique type identity to constrain the themes that can be passed into a
+particular component.
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+import type {Theme} from '@stylexjs/stylex';
 import {vars} from './vars.stylex';
 
-declare const DarkThemeTag: unique symbol;
-export const theme: Theme<typeof vars, DarkThemeTag> = stylex.createTheme(vars, {
+declare const Tag: unique symbol;
+export const theme1: Theme<typeof vars, Tag> = stylex.createTheme(vars, {
   color: 'red', // OK
   backgroundColor: 'blue', // OK
 });
 ```
+
+Now, `theme1` has a unique type identity and a different `Theme` for `vars`
+would not satisfy `typeof theme1`.
+
+This advanced use-case should be rarely needed, but it's available when it is.
+  
+</details>

--- a/apps/docs/docs/api/types/Theme.mdx
+++ b/apps/docs/docs/api/types/Theme.mdx
@@ -1,0 +1,47 @@
+---
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+sidebar_position: 5
+---
+
+# `Theme<>`
+
+```tsx
+type Theme<T extends VarGroup<unknown, symbol>, Tag extends symbol = symbol>
+```
+
+A `Theme` is a type that represents a style that *themes* a set of variables in a given
+`VarGroup`. It's the result of calling [`stylex.createTheme`](../javascript/createTheme.mdx).
+
+
+```tsx
+import type {VarGroup} from '@stylexjs/stylex';
+import * as stylex from '@stylexjs/stylex';
+
+import {vars} from './vars.stylex';
+
+export const theme: Theme<typeof vars> = stylex.createTheme(vars, {
+  color: 'red', // OK
+  backgroundColor: 'blue', // OK
+});
+```
+
+The most common use-case for `Theme` is to accept a theme for a particular set of variables.
+
+By default, all themes for the same `VarGroup` are compatible with each other and have the same
+type. However, the second type argument to `Theme<>` can be used to give a theme a unique type.
+  
+```tsx
+import type {VarGroup} from '@stylexjs/stylex';
+import * as stylex from '@stylexjs/stylex';
+
+import {vars} from './vars.stylex';
+
+declare const DarkThemeTag: unique symbol;
+export const theme: Theme<typeof vars, DarkThemeTag> = stylex.createTheme(vars, {
+  color: 'red', // OK
+  backgroundColor: 'blue', // OK
+});
+```

--- a/apps/docs/docs/api/types/VarGroup.mdx
+++ b/apps/docs/docs/api/types/VarGroup.mdx
@@ -9,7 +9,7 @@ sidebar_position: 4
 # `VarGroup<>` 
 
 ```tsx
-type VarGroup<Tokens extends {}, ID extends symbol = symbol>
+type VarGroup<Tokens extends {}>
 ```
 
 A `VarGroup` is the type of the object that is generated as a result of calling
@@ -59,32 +59,79 @@ Now when a theme for `vars` is being created, the values for `color` and `backgr
 can only be one of the specified values.
 
 ```tsx
+import * as stylex from '@stylexjs/stylex';
+import {vars} from './vars.stylex';
+
 export const theme1 = stylex.createTheme(vars, {
   color: 'red', // OK
   backgroundColor: 'blue', // OK
 });
 
 export const theme2 = stylex.createTheme(vars, {
-  color: 'orange', // Error: 'orange' is not assignable to 'red' | 'blue' | 'green' | 'yellow'
+  // Error: 'orange' is not assignable to 'red' | 'blue' | 'green' | 'yellow'
+  color: 'orange', 
 });
 ```
 
-You can also pass the second type argument to `VarGroup` to specify the unique identifier.
+While, it’s not needed in most cases, `VarGroup` also accepts an optional second type type argument.
+
+
+<details>
+
+<summary>
+  <p style={{margin: 0}}>
+    <strong>
+      Advanced use-case: unique type identity for a `VarGroup`
+    </strong>
+  </p>
+</summary>
+
+TypeScript (and Flow) use structural typing, which means that two objects with the same
+shape are considered to be the same type. However, each usage `stylex.defineVars` results
+in a new set of variables.
+
+It can be useful to have a unique type identity for each `VarGroup` created to be able to
+distinguish between them and accept themes for only a specific `VarGroup`. This is also
+known as "nominal typing" and can be achieved by using a unique symbol as the second type
+argument to `VarGroup`.
+
+The complete type signature of `VarGroup` is:
+
+```tsx
+type VarGroup<Tokens extends {}, ID extends symbol = symbol>
+```
+
+It can be used like this:
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';
 import type {VarGroup} from '@stylexjs/stylex';
 
-declare const myVars: unique symbol;
+type Shape = {
+  color: string,
+  backgroundColor: string,
+};
 
-const vars: VarGroup<{
-  color: 'red' | 'blue' | 'green' | 'yellow',
-  backgroundColor: 'red' | 'blue' | 'green' | 'yellow',
-}, typeof myVars> = stylex.defineVars({
-  color: 'red',
-  backgroundColor: 'blue',
-});
+declare const BaseColors: unique symbol;
+export const baseColors: VarGroup<Shape, typeof BaseColors> =
+  stylex.defineVars({
+    color: 'red',
+    backgroundColor: 'blue',
+  });
+
+declare const CardColors: unique symbol;
+export const cardColors: VarGroup<Shape, typeof CardColors> =
+  stylex.defineVars({
+    color: 'red',
+    backgroundColor: 'blue',
+  });
 ```
 
-This can be useful when you want to create multiple `VarGroup`s with the same shape, but
-different types.
+Here `baseColors` and `cardColors` are `VarGroup` objects of the same shape, but with two
+distinct type identities. This ensures that a `Theme` for one can't be used with the other.
+
+It should be rare that two separate `VarGroup` objects are defined with the same shape
+and so this feature is not needed in most cases. In the rare cases where it *is*
+needed, it is available.
+
+</details>

--- a/apps/docs/docs/api/types/VarGroup.mdx
+++ b/apps/docs/docs/api/types/VarGroup.mdx
@@ -19,7 +19,7 @@ to CSS custom properties.
 `VarGroup` is also the required type for the first argument to 
 [`stylex.createTheme`](../javascript/createTheme.mdx)
 
-Usually, you don't need to specify the type of `VarGroup` explicitly, as it can be 
+Usually, `VarGroup` is not needed explicitly, as it can be 
 inferred from the argument to `stylex.defineVars`.
 
 ```tsx
@@ -39,8 +39,8 @@ export type Vars = typeof vars;
 */
 ```
 
-In some cases, however, you may need to specify the type of `VarGroup` explicitly, to
-constrain the values that variables can take when creating themes:
+In some cases, however, `VarGroup` may be needed explicitly, to
+constrain the values of the variables within themes:
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';
@@ -73,7 +73,7 @@ export const theme2 = stylex.createTheme(vars, {
 });
 ```
 
-While, it’s not needed in most cases, `VarGroup` also accepts an optional second type type argument.
+While, it's not needed in most cases, `VarGroup` also accepts an optional second type type argument.
 
 
 <details>
@@ -87,7 +87,7 @@ While, it’s not needed in most cases, `VarGroup` also accepts an optional seco
 </summary>
 
 TypeScript (and Flow) use structural typing, which means that two objects with the same
-shape are considered to be the same type. However, each usage `stylex.defineVars` results
+shape are considered to be the same type. However, each usage of `stylex.defineVars` results
 in a new set of variables.
 
 It can be useful to have a unique type identity for each `VarGroup` created to be able to

--- a/apps/docs/docs/api/types/VarGroup.mdx
+++ b/apps/docs/docs/api/types/VarGroup.mdx
@@ -1,0 +1,90 @@
+---
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+sidebar_position: 4
+---
+
+# `VarGroup<>` 
+
+```tsx
+type VarGroup<Tokens extends {}, ID extends symbol = symbol>
+```
+
+A `VarGroup` is the type of the object that is generated as a result of calling
+[`stylex.defineVars`](../javascript/defineVars.mdx). It maps keys to references 
+to CSS custom properties.
+
+`VarGroup` is also the required type for the first argument to 
+[`stylex.createTheme`](../javascript/createTheme.mdx)
+
+Usually, you don't need to specify the type of `VarGroup` explicitly, as it can be 
+inferred from the argument to `stylex.defineVars`.
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+
+export const vars = stylex.defineVars({
+  color: 'red',
+  backgroundColor: 'blue',
+});
+
+export type Vars = typeof vars;
+/*
+  Vars = VarGroup<{
+    color: string,
+    backgroundColor: string,
+  }>
+*/
+```
+
+In some cases, however, you may need to specify the type of `VarGroup` explicitly, to
+constrain the values that variables can take when creating themes:
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+import type {VarGroup} from '@stylexjs/stylex';
+
+const vars: VarGroup<{
+  color: 'red' | 'blue' | 'green' | 'yellow',
+  backgroundColor: 'red' | 'blue' | 'green' | 'yellow',
+}> = stylex.defineVars({
+  color: 'red',
+  backgroundColor: 'blue',
+});
+```
+
+Now when a theme for `vars` is being created, the values for `color` and `backgroundColor`
+can only be one of the specified values.
+
+```tsx
+export const theme1 = stylex.createTheme(vars, {
+  color: 'red', // OK
+  backgroundColor: 'blue', // OK
+});
+
+export const theme2 = stylex.createTheme(vars, {
+  color: 'orange', // Error: 'orange' is not assignable to 'red' | 'blue' | 'green' | 'yellow'
+});
+```
+
+You can also pass the second type argument to `VarGroup` to specify the unique identifier.
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+import type {VarGroup} from '@stylexjs/stylex';
+
+declare const myVars: unique symbol;
+
+const vars: VarGroup<{
+  color: 'red' | 'blue' | 'green' | 'yellow',
+  backgroundColor: 'red' | 'blue' | 'green' | 'yellow',
+}, typeof myVars> = stylex.defineVars({
+  color: 'red',
+  backgroundColor: 'blue',
+});
+```
+
+This can be useful when you want to create multiple `VarGroup`s with the same shape, but
+different types.


### PR DESCRIPTION
## What changed / motivation ?

Document public types `VarGroup` and `Theme`. The writing could probably be better,
but sharing early for feedback.

## Linked PR/Issues

Fixes #424 