### PR TITLE
Fix: stylex package build on windows

### DIFF
--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -32,8 +32,8 @@
   "license": "MIT",
   "scripts": {
     "prebuild": "gen-types -i src/ -o lib/",
-    "build:cjs": "BABEL_ENV=cjs babel src/ --out-dir lib/ --copy-files",
-    "build:esm": "BABEL_ENV=esm babel src/ --out-dir lib/es --out-file-extension .mjs",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src/ --out-dir lib/ --copy-files",
+    "build:esm": "cross-env BABEL_ENV=esm babel src/ --out-dir lib/es --out-file-extension .mjs",
     "postbuild:esm": "rollup -c ./rollup.config.mjs",
     "build": "npm run build:cjs && npm run build:esm",
     "build-haste": "rewrite-imports -i src/ -o lib/",

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -45,7 +45,8 @@
     "styleq": "0.1.3"
   },
   "devDependencies": {
-    "@stylexjs/scripts": "0.5.1"
+    "@stylexjs/scripts": "0.5.1",
+    "cross-env": "^7.0.3"
   },
   "jest": {},
   "files": [


### PR DESCRIPTION
I was attempting to build on windows and was getting that `BABEL_ENV` wasn't found. Seems like adding `cross-env` like the other `NODE_ENV` in the repo uses fixes it.