### PR TITLE
feat: Handle variable fallbacks with firstThatWorks

### DIFF
--- a/packages/shared/__tests__/convert-to-className-test.js
+++ b/packages/shared/__tests__/convert-to-className-test.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import { convertStyleToClassName } from '../src/convert-to-className';
+
+const extractBody = (str: string) => str.slice(str.indexOf('{') + 1, -1);
+
+const convert = (styles: Parameters<typeof convertStyleToClassName>[0]) =>
+  extractBody(convertStyleToClassName(styles, [], [])[2].ltr);
+
+describe('convert-to-className test', () => {
+  test('converts style to className', () => {
+    expect(convert(['margin', 10])).toEqual('margin:10px');
+  });
+  test('converts margin number to px', () => {
+    expect(convert(['margin', 10])).toEqual('margin:10px');
+  });
+  test('keeps number for zIndex', () => {
+    expect(convert(['zIndex', 10])).toEqual('z-index:10');
+  });
+  test('keeps number for opacity', () => {
+    expect(convert(['opacity', 0.25])).toEqual('opacity:.25');
+  });
+  test('handles array of values', () => {
+    // Last value wins.
+    expect(convert(['height', [500, '100vh', '100dvh']])).toEqual(
+      'height:500px;height:100vh;height:100dvh',
+    );
+  });
+  test('handles array of values with var', () => {
+    expect(convert(['height', [500, 'var(--height)', '100dvh']])).toEqual(
+      'height:var(--height,500px);height:100dvh',
+    );
+  });
+  test('handles array with multiple vars', () => {
+    expect(
+      convert(['height', [500, 'var(--x)', 'var(--y)', '100dvh']]),
+    ).toEqual('height:var(--y,var(--x,500px));height:100dvh');
+  });
+  test('handles array with multiple vars and multiple fallbacks', () => {
+    expect(
+      convert(['height', [500, '100vh', 'var(--x)', 'var(--y)', '100dvh']]),
+    ).toEqual(
+      'height:var(--y,var(--x,500px));height:var(--y,var(--x,100vh));height:100dvh',
+    );
+  });
+});

--- a/packages/shared/__tests__/stylex-first-that-works-test.js
+++ b/packages/shared/__tests__/stylex-first-that-works-test.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import firstThatWorks from '../src/stylex-first-that-works';
+
+describe('stylex-first-that-works test', () => {
+  test('reverses simple array of values', () => {
+    expect(firstThatWorks('a', 'b', 'c')).toEqual(['c', 'b', 'a']);
+  });
+});

--- a/packages/shared/src/messages.js
+++ b/packages/shared/src/messages.js
@@ -69,3 +69,5 @@ export const ANONYMOUS_THEME =
   'stylex.createTheme() must be bound to a named constant.';
 export const ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS =
   'Only named parameters are allowed in Dynamic Style functions. Destructuring, spreading or default values are not allowed.';
+export const NON_CONTIGUOUS_VARS =
+  'All variables passed to `stylex.firstThatWorks` must be contiguous.';

--- a/packages/shared/src/stylex-first-that-works.js
+++ b/packages/shared/src/stylex-first-that-works.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-export default function stylexFirstThatWorks<T>(
+export default function stylexFirstThatWorks<T: string>(
   ...args: $ReadOnlyArray<T>
 ): $ReadOnlyArray<T> {
   return [...args].reverse();


### PR DESCRIPTION
## What changed / motivation ?

This PR makes it possible to use `stylex.firstThatWorks` to also work
for fallback values for CSS variables.

Something like this should now work:

```tsx
margin: stylex.firstThatWorks(vars.foo, 200)
```

## Linked PR/Issues

Fixes #432 

## Additional Context

A unit test has been added for the new behaviour.

----

`stylex.firstThatWorks` is a lightweight transform that simply converts the arguments to an array reverses them. This transform is still unchanged. This is important so that we can convert numbers to the correct type of string.

But after the values are converted to `px` (or not), it now looks for variables within the array of values and compresses them to handle this case correctly.

It can handle `[...values, ...variables, ...values]`;

Non-contiguous variables are not allowed.

Therefore a complex value like this would work:

```tsx
height: stylex.firstThatWorks('100dvh', vars.foo, vars.bar, '100vh', 500)
```

Which will result in the following CSS:

```css
height:var(--foo,var(--bar, 500px));
height:var(--foo,var(--bar, 100vh));
height:100dvh;
```

---

The question here is if the first line should just be `500px` instead.

IMO, this depends on how CSS handles a CSS variable within an unknown fallback value.
If `var(--x, bla)` is considered a valid style then a change should be made.


