### PR TITLE
chore: add `.DS_Store` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.log*
 .build
 .docusaurus
+.DS_Store
 .stylex
 build
 coverage


### PR DESCRIPTION
## What changed / motivation ?

As I was working on several PRs I noticed that my local `.DS_Store` file gets committed to the `git` history.

I am not sure if there's a reason why it's not ignored, but it would be handy if it was. I think development environments with `Mac OS` are common enough to justify this change.

## Linked PR/Issues

Sorry for not creating an issue, it's just a very small nit that I didn't think was worthy of an issue.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code