### PR TITLE
fix: Remove duplicate keys in type definition

### DIFF
--- a/packages/stylex/src/StyleXCSSTypes.js
+++ b/packages/stylex/src/StyleXCSSTypes.js
@@ -936,7 +936,6 @@ export type CSSProperties = $ReadOnly<{
     | 'padding-box'
     | 'content-box'
     | 'text',
-  backgroundClip?: all | 'border-box' | 'padding-box' | 'content-box' | 'text',
 
   WebkitBoxOrient?:
     | null
@@ -1192,9 +1191,6 @@ export type CSSProperties = $ReadOnly<{
   fontWeight?: all | fontWeight,
   // fontHeight?: all | number | string,
   // fontWidth?: all | number | string,
-  fontFeatureSettings?: all | string,
-  fontKerning?: all | 'auto' | 'normal' | 'none',
-  fontLanguageOverride?: all | string,
   fontOpticalSizing?: all | 'auto' | 'none',
   fontPalette?: all | 'light' | 'dark' | string,
   fontVariationSettings?: all | string,


### PR DESCRIPTION
## What changed / motivation ?

A few CSS properties were duplicated.

## Linked PR/Issues

Fixes #452

