### PR TITLE
chore: Unified function to inject styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31637,7 +31637,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -31653,7 +31652,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -31669,7 +31667,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31685,7 +31682,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31701,7 +31697,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31717,7 +31712,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31733,7 +31727,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -31749,7 +31742,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -31765,7 +31757,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -54037,6 +54028,60 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
       "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
+    },
+    "@next/swc-darwin-arm64": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.1.tgz",
+      "integrity": "sha512-JyxnGCS4qT67hdOKQ0CkgFTp+PXub5W1wsGvIq98TNbF3YEIN7iDekYhYsZzc8Ov0pWEsghQt+tANdidITCLaw==",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.1.tgz",
+      "integrity": "sha512-625Z7bb5AyIzswF9hvfZWa+HTwFZw+Jn3lOBNZB87lUS0iuCYDHqk3ujuHCkiyPtSC0xFBtYDLcrZ11mF/ap3w==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.1.tgz",
+      "integrity": "sha512-iVpn3KG3DprFXzVHM09kvb//4CNNXBQ9NB/pTm8LO+vnnnaObnzFdS5KM+w1okwa32xH0g8EvZIhoB3fI3mS1g==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.1.tgz",
+      "integrity": "sha512-mVsGyMxTLWZXyD5sen6kGOTYVOO67lZjLApIj/JsTEEohDDt1im2nkspzfV5MvhfS7diDw6Rp/xvAQaWZTv1Ww==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.1.tgz",
+      "integrity": "sha512-wMqf90uDWN001NqCM/auRl3+qVVeKfjJdT9XW+RMIOf+rhUzadmYJu++tp2y+hUbb6GTRhT+VjQzcgg/QTD9NQ==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.1.tgz",
+      "integrity": "sha512-ol1X1e24w4j4QwdeNjfX0f+Nza25n+ymY0T2frTyalVczUmzkVD7QGgPTZMHfR1aLrO69hBs0G3QBYaj22J5GQ==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.1.tgz",
+      "integrity": "sha512-WEmTEeWs6yRUEnUlahTgvZteh5RJc4sEjCQIodJlZZ5/VJwVP8p2L7l6VhzQhT4h7KvLx/Ed4UViBdne6zpIsw==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.1.tgz",
+      "integrity": "sha512-oFpHphN4ygAgZUKjzga7SoH2VGbEJXZa/KL8bHCAwCjDWle6R1SpiGOdUdA8EJ9YsG1TYWpzY6FTbUA+iAJeww==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.1.tgz",
+      "integrity": "sha512-FFp3nOJ/5qSpeWT0BZQ+YE1pSMk4IMpkME/1DwKBwhg4mJLB9L+6EXuJi4JEwaJdl5iN+UUlmUD3IsR1kx5fAg==",
+      "optional": true
     }
   }
 }

--- a/packages/babel-plugin/src/visitors/stylex-create-theme.js
+++ b/packages/babel-plugin/src/visitors/stylex-create-theme.js
@@ -105,45 +105,11 @@ export default function transformStyleXCreateTheme(
     // This should be a transformed variables object
     callExpressionPath.replaceWith(convertObjectToAST(overridesObj));
 
-    const statementPath: ?NodePath<> = variableDeclaratorPath.parentPath;
+    const listOfStyles = Object.entries(injectedStyles).map(
+      ([key, { priority, ...rest }]) => [key, rest, priority],
+    );
 
-    if (Object.keys(injectedStyles).length === 0) {
-      return;
-    }
-
-    if (state.runtimeInjection != null && statementPath != null) {
-      let injectName: t.Identifier;
-      if (state.injectImportInserted != null) {
-        injectName = state.injectImportInserted;
-      } else {
-        const { from, as } = state.runtimeInjection;
-        injectName =
-          as != null
-            ? state.addNamedImport(statementPath, as, from, {
-                nameHint: 'inject',
-              })
-            : state.addDefaultImport(statementPath, from, {
-                nameHint: 'inject',
-              });
-
-        state.injectImportInserted = injectName;
-      }
-
-      for (const [_k, { ltr, priority }] of Object.entries(injectedStyles)) {
-        statementPath.insertBefore(
-          t.expressionStatement(
-            t.callExpression(injectName, [
-              t.stringLiteral(ltr),
-              t.numericLiteral(priority),
-            ]),
-          ),
-        );
-      }
-    }
-
-    for (const [key, { priority, ltr }] of Object.entries(injectedStyles)) {
-      state.addStyle([key, { ltr }, priority]);
-    }
+    state.registerStyles(listOfStyles, variableDeclaratorPath);
   }
 }
 

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -190,48 +190,16 @@ export default function transformStyleXCreate(
       });
     }
 
+    const listOfStyles = Object.entries(injectedStyles).map(
+      ([key, { priority, ...rest }]) => [key, rest, priority],
+    );
+
+    state.registerStyles(listOfStyles, path);
+
     path.replaceWith(resultAst);
 
     if (Object.keys(injectedStyles).length === 0) {
       return;
-    }
-
-    const statementPath = path.getStatementParent();
-    if (state.runtimeInjection != null && statementPath != null) {
-      let injectName: t.Identifier;
-      if (state.injectImportInserted != null) {
-        injectName = state.injectImportInserted;
-      } else {
-        const { from, as } = state.runtimeInjection;
-        injectName =
-          as != null
-            ? state.addNamedImport(statementPath, as, from, {
-                nameHint: 'inject',
-              })
-            : state.addDefaultImport(statementPath, from, {
-                nameHint: 'inject',
-              });
-
-        state.injectImportInserted = injectName;
-      }
-
-      for (const [_key, { ltr, priority, rtl }] of Object.entries(
-        injectedStyles,
-      )) {
-        statementPath.insertBefore(
-          t.expressionStatement(
-            t.callExpression(injectName, [
-              t.stringLiteral(ltr),
-              t.numericLiteral(priority),
-              ...(rtl != null ? [t.stringLiteral(rtl)] : []),
-            ]),
-          ),
-        );
-      }
-    }
-
-    for (const [key, { priority, ...rest }] of Object.entries(injectedStyles)) {
-      state.addStyle([key, rest, priority]);
     }
   }
   state.inStyleXCreate = false;

--- a/packages/babel-plugin/src/visitors/stylex-define-vars.js
+++ b/packages/babel-plugin/src/visitors/stylex-define-vars.js
@@ -134,45 +134,12 @@ export default function transformStyleXDefineVars(
 
     // This should be a transformed variables object
     callExpressionPath.replaceWith(convertObjectToAST(variablesObj));
-    const statementPath: ?NodePath<> =
-      variableDeclaratorPath.parentPath.parentPath;
 
-    if (Object.keys(injectedStyles).length === 0) {
-      return;
-    }
+    const listOfStyles = Object.entries(injectedStyles).map(
+      ([key, { priority, ...rest }]) => [key, rest, priority],
+    );
 
-    if (state.runtimeInjection != null && statementPath != null) {
-      let injectName: t.Identifier;
-      if (state.injectImportInserted != null) {
-        injectName = state.injectImportInserted;
-      } else {
-        const { from, as } = state.runtimeInjection;
-        injectName =
-          as != null
-            ? state.addNamedImport(statementPath, as, from, {
-                nameHint: 'inject',
-              })
-            : state.addDefaultImport(statementPath, from, {
-                nameHint: 'inject',
-              });
-
-        state.injectImportInserted = injectName;
-      }
-
-      for (const [_k, { ltr, priority }] of Object.entries(injectedStyles)) {
-        statementPath.insertBefore(
-          t.expressionStatement(
-            t.callExpression(injectName, [
-              t.stringLiteral(ltr),
-              t.numericLiteral(priority),
-            ]),
-          ),
-        );
-      }
-    }
-    for (const [key, { priority, ltr }] of Object.entries(injectedStyles)) {
-      state.addStyle([key, { ltr }, priority]);
-    }
+    state.registerStyles(listOfStyles, variableDeclaratorPath);
   }
 }
 

--- a/packages/open-props/__tests__/__snapshots__/open-props-compile-test.js.snap
+++ b/packages/open-props/__tests__/__snapshots__/open-props-compile-test.js.snap
@@ -260,6 +260,7 @@ exports[`commonJS results of exported styles and variables animationNames.stylex
     "x1p4jv38",
     {
       "ltr": ":root{--xwgfw4z:x1wv65fh-B;--xwpxwog:x3cospo-B;--x1mrv0ld:x1mi9bte-B;--x1f9mpsk:xd93vs1-B;--x1dlahej:x1gdf4cp-B;--xchc88h:x1uvjygu-B;--x1wwe1u9:xyz4r9t-B;--xojb453:xyz4r9t-B;--x1erxhtw:x1qkfcoh-B;--x2p2omt:x1c1el34-B;--x1lyv700:x5q0om7-B;--x1dhg8ry:xiaildr-B;--x14d2ijb:x1pzz5b5-B;--x1r6uxce:x2i3tye-B;--x1o3zfci:xui5qpo-B;--xhf4ud:x1oudpiw-B;--x7jv0fk:x1uh2x5g-B;--x1x4v7e3:xk6fz2t-B;--xg5no4m:x13kz0yu-B;--x7mxyyy:xtacmzc-B;--xs1cbdk:xmu8adp-B;--x1gf7j19:x1wtl5zh-B;}",
+      "rtl": null,
     },
     0,
   ],
@@ -267,6 +268,7 @@ exports[`commonJS results of exported styles and variables animationNames.stylex
     "x1p4jv38-1lveb7",
     {
       "ltr": "@media (prefers-color-scheme: dark){:root{--xwpxwog:x1xhkb8m-B;--x1f9mpsk:x18q36hy-B;}}",
+      "rtl": null,
     },
     0.1,
   ],
@@ -743,6 +745,7 @@ exports[`commonJS results of exported styles and variables aspects.stylex.js 2`]
     "x1f3ngow",
     {
       "ltr": ":root{--xf4ju30:1;--x1sfzf88:4/3;--x1ss1gth:3/4;--x494wxg:16/9;--xurb3c9:18/5;--x1o37t1i:1.6180/1;}",
+      "rtl": null,
     },
     0,
   ],
@@ -795,6 +798,7 @@ exports[`commonJS results of exported styles and variables borders.stylex.js 2`]
     "x39jpd4",
     {
       "ltr": ":root{--x1c4d28j:1px;--x1tnavza:2px;--xw9w0ji:5px;--x1w2xhh:10px;--xbk24gy:25px;--x19tsvu4:2px;--x17eca7m:5px;--x161m72u:1rem;--xagv9nx:2rem;--x1ourpcj:4rem;--x5uhb2z:8rem;--x15i6psm:1e5px;--xzs4xe0:clamp(0px, calc(100vw - 100%) * 1e5, 2px);--xv7z80y:clamp(0px, calc(100vw - 100%) * 1e5, 5px));--x5sox4w:clamp(0px, calc(100vw - 100%) * 1e5, 1rem));--x19pda2u:clamp(0px, calc(100vw - 100%) * 1e5, 2rem));--x103yzcm:clamp(0px, calc(100vw - 100%) * 1e5, 4rem));--x1hbo1ek:clamp(0px, calc(100vw - 100%) * 1e5, 8rem));}",
+      "rtl": null,
     },
     0,
   ],
@@ -1070,6 +1074,7 @@ exports[`commonJS results of exported styles and variables colors.stylex.js 2`] 
     "x1c4j7iz",
     {
       "ltr": ":root{--x171bl6o:#f8f9fa;--x53xoeh:#f1f3f5;--xtuf0as:#e9ecef;--xqf33b2:#dee2e6;--x1pjptji:#ced4da;--x16nc6w8:#adb5bd;--x1fmok37:#868e96;--x15g7ll5:#495057;--xzaov8u:#343a40;--x1g9dk52:#212529;--x1kbbkdc:#16191d;--x1mg8qz3:#0d0f12;--xqfn6j6:#030507;--x1nu2jqu:#f8fafb;--x10kmmjn:#f2f4f6;--xjuy73p:#ebedef;--x1i2mtrg:#e0e4e5;--xiby4c1:#d1d6d8;--x1xhyn4h:#b1b6b9;--xol55ef:#979b9d;--x13at81r:#7e8282;--x24hi12:#666968;--xq0t1l8:#50514f;--x4s2ag6:#3a3a37;--x19c3xg5:#252521;--x1fgataf:#121210;--x12gv7as:#fff5f5;--x1iinpj6:#ffe3e3;--x1pr4yew:#ffc9c9;--x1rpwo50:#ffa8a8;--x1n02shk:#ff8787;--x9dg48f:#ff6b6b;--x1s0kfbd:#fa5252;--xnt1wmt:#f03e3e;--x1dma59k:#e03131;--xv7uyjm:#c92a2a;--x158wn9u:#b02525;--xwvl7jc:#962020;--xy3i7qw:#7d1a1a;--x1sde26w:#fff0f6;--xkv4yjn:#ffdeeb;--x1po54hc:#fcc2d7;--x1d58wjb:#faa2c1;--x10iaqhe:#f783ac;--x12be1yj:#f06595;--xzu4ch7:#e64980;--x1e9ny94:#d6336c;--x39u1qa:#c2255c;--xz9csot:#a61e4d;--x171olnb:#8c1941;--x9i5m2d:#731536;--x1773nem:#59102a;--x12fvz3z:#f8f0fc;--x1vh3ru7:#f3d9fa;--x108aj8f:#eebefa;--x1gnkb9m:#e599f7;--x39rz6m:#da77f2;--x1pexsp:#cc5de8;--xj1sfij:#be4bdb;--x1398cd3:#ae3ec9;--xtmtos0:#9c36b5;--x1sw0tu2:#862e9c;--x1ugcz6y:#702682;--xxu9yxx:#5a1e69;--x14eaeg6:#44174f;--xmll37n:#f3f0ff;--xyr5v5q:#e5dbff;--x8u9mr1:#d0bfff;--x1lyaq8k:#b197fc;--x1nr66nz:#9775fa;--xdwq09p:#845ef7;--x19zwvp4:#7950f2;--xnms21g:#7048e8;--x13m2gj3:#6741d9;--x1qt524i:#5f3dc4;--x1lao5jo:#5235ab;--x18nw0nx:#462d91;--x15lapa1:#3a2578;--x6f4ay2:#edf2ff;--x1f1flxc:#dbe4ff;--x1wu3fiq:#bac8ff;--x14kgl22:#91a7ff;--xiy8384:#748ffc;--x1d0ve3d:#5c7cfa;--xabwuzv:#4c6ef5;--xvkuwqd:#4263eb;--x17nx1eb:#3b5bdb;--x2ynr27:#364fc7;--x1l241az:#2f44ad;--x124yx5u:#283a94;--x1ctjb59:#21307a;--x11thc9v:#e7f5ff;--x1w6kana:#d0ebff;--xyvmbbe:#a5d8ff;--x17ai2n4:#74c0fc;--xenmrf7:#4dabf7;--x4z9sw9:#339af0;--x1n0pbdd:#228be6;--x1q3wu0k:#1c7ed6;--x1h7da2x:#1971c2;--x15z1iti:#1864ab;--xzkyt5k:#145591;--x1kxlrob:#114678;--xzsazgi:#0d375e;--x6xq5rn:#e3fafc;--x1n5g7cy:#c5f6fa;--xsnlg07:#99e9f2;--x1ckzrw1:#66d9e8;--xxq5s6r:#3bc9db;--x1j5ifqe:#22b8cf;--xr6o2f:#15aabf;--x6nsyan:#1098ad;--x1pvbtp5:#0c8599;--x1l7oon8:#0b7285;--x2sshvw:#095c6b;--xq1eabj:#074652;--xjly8vc:#053038;--x1p0c955:#e6fcf5;--x1rlr389:#c3fae8;--x1m8nlo8:#96f2d7;--x7xdtc8:#63e6be;--xdu385a:#38d9a9;--x1797x1j:#20c997;--xcgxbsa:#12b886;--x13wvkw0:#0ca678;--x1bety91:#099268;--xcp64yi:#087f5b;--x1teo5rt:#066649;--x6geyig:#054d37;--x5zszyd:#033325;--x1uppcxg:#ebfbee;--x1f24716:#d3f9d8;--x1czfdao:#b2f2bb;--xtymhtk:#8ce99a;--x1cgca4d:#69db7c;--x4bpidi:#51cf66;--xa4gp8g:#40c057;--x1vy84un:#37b24d;--x1h6oidm:#2f9e44;--x1bbn370:#2b8a3e;--x1k01y17:#237032;--xlh2xkx:#1b5727;--x1xtvyrt:#133d1b;--xdo2cpq:#f4fce3;--x1dtv6a6:#e9fac8;--x163wpad:#d8f5a2;--x1iip2t1:#c0eb75;--xhjmjok:#a9e34b;--x1b58uyt:#94d82d;--xp03479:#82c91e;--x11jir38:#74b816;--xzqw3ry:#66a80f;--xnlfq2m:#5c940d;--xjui4ph:#4c7a0b;--x139i8hx:#3c6109;--xq1ztay:#2c4706;--xkv0ppd:#fff9db;--xyknse8:#fff3bf;--x1m69snz:#ffec99;--x1q8y0vp:#ffe066;--x1tm8otj:#ffd43b;--x1p7cwxr:#fcc419;--x1rvavt9:#fab005;--x17ewlhm:#f59f00;--x1n7wesg:#f08c00;--x16d6e50:#e67700;--x4ck66:#b35c00;--x5bfmt0:#804200;--xkpebo4:#663500;--x1p0ltw4:#fff4e6;--xkraadr:#ffe8cc;--x1368088:#ffd8a8;--xnnksgt:#ffc078;--x1phn0v3:#ffa94d;--xh7r8gp:#ff922b;--xmh9tum:#fd7e14;--x16m84st:#f76707;--xk1enzq:#e8590c;--x19t7j6i:#d9480f;--xlmuamo:#bf400d;--xynrm3c:#99330b;--xtkqxm0:#802b09;--xsdm60n:#fff8dc;--xkrsabc:#fce1bc;--xacehvy:#f7ca9e;--x11nqhkk:#f1b280;--x16ijvqu:#e99b62;--x1x7ixpg:#df8545;--x6w9g2q:#d46e25;--x10v14zu:#bd5f1b;--x16otim4:#a45117;--x1bbovs:#8a4513;--x1kilxoa:#703a13;--x1leir5y:#572f12;--x7sz9re:#3d210d;--x1viubac:#faf4eb;--x1wgijih:#ede0d1;--x1fe2z7k:#e0cab7;--x1jqvyfy:#d3b79e;--xiz6tmq:#c5a285;--x1t8tmr1:#b78f6d;--xr3x7rx:#a87c56;--xcry9cq:#956b47;--xxm9xfo:#825b3a;--x99pjb0:#6f4b2d;--xtj2n0b:#5e3a21;--xw0c66b:#4e2b15;--xutornl:#422412;--xib0f03:#f8fafb;--x108j2ok:#e6e4dc;--xvels3w:#d5cfbd;--xo58c7z:#c2b9a0;--xbp491y:#aea58c;--xpadips:#9a9178;--x1t30p1d:#867c65;--xlozb40:#736a53;--xk39fmi:#5f5746;--x1xyn1p3:#4b4639;--x4sb1jd:#38352d;--x3vn90b:#252521;--xlic5yv:#121210;--xj0nr15:#f9fbe7;--x4lbuhq:#e8ed9c;--x1eg4mg6:#d2df4e;--x14ryh7q:#c2ce34;--x1j1ycqg:#b5bb2e;--x1ujbo7l:#a7a827;--xyq708v:#999621;--xsgugnr:#8c851c;--x7j4lc0:#7e7416;--x7p72ph:#6d6414;--x1glnusk:#5d5411;--x1bxxzva:#4d460e;--x1a7rk2u:#36300a;--x16r49b8:#ecfeb0;--xqdemos:#def39a;--x1i423s:#d0e884;--x1f5kxsc:#c2dd6e;--x1ej4z7:#b5d15b;--x14i4gcz:#a8c648;--x1x8176u:#9bbb36;--xan9a21:#8fb024;--xrz8x5t:#84a513;--x1y6wtbp:#7a9908;--x31qami:#658006;--x11t8p7i:#516605;--x6q9vsx:#3d4d04;}",
+      "rtl": null,
     },
     0,
   ],
@@ -1345,6 +1350,7 @@ exports[`commonJS results of exported styles and variables colorsHSL.stylex.js 2
     "xo4dpnp",
     {
       "ltr": ":root{--xep3gyb:210 17% 98%;--x1qy2yzm:210 17% 95%;--x1v5detx:210 16% 93%;--xw6fu9l:210 14% 89%;--x1vzmimr:210 14% 83%;--x5p7ppp:210 11% 71%;--xk8lu8g:210 7% 56%;--xqvn00l:210 9% 31%;--x1btktcl:210 10% 23%;--x1ak5sn9:210 11% 15%;--x1yzjuf5:214 14% 10%;--x19b9hbu:216 16% 6%;--xhxgsjj:210 40% 2%;--x1ucxddk:200 27% 98%;--x1pjm85r:210 18% 96%;--x7j9267:210 11% 93%;--x8meidl:192 9% 89%;--x1ochyx0:197 8% 83%;--x4gr5l2:202 5% 71%;--x1bmzmky:200 3% 60%;--xfno6qc:180 2% 50%;--x1eo1s72:160 1% 41%;--x1cddavu:90 1% 31%;--x7f4tkw:60 3% 22%;--x1ry455g:60 6% 14%;--xixtwep:60 6% 7%;--xga6t8v:0 100% 98%;--xki3els:0 100% 95%;--xp956r1:0 100% 89%;--x3grs5k:0 100% 83%;--xyhbx00:0 100% 76%;--x19w54bt:0 100% 71%;--x8ajwi2:0 94% 65%;--xarpa2s:0 86% 59%;--xfcb0ro:0 74% 54%;--x1h3wp1o:0 65% 48%;--xn36baz:0 65% 42%;--x1cjgzqn:0 65% 36%;--xlu40n5:0 66% 30%;--x1ixqbeg:336 100% 97%;--x1il46g9:336 100% 94%;--x1pjgr7l:338 91% 87%;--x15vxria:339 90% 81%;--x1lqzi76:339 88% 74%;--xkhxit8:339 82% 67%;--x16r1vkv:339 76% 59%;--x1of8uro:339 67% 52%;--x4szd0n:339 68% 45%;--xetpqdc:339 69% 38%;--xgu1b28:339 70% 32%;--x1m8lq7w:339 69% 27%;--x7gmv31:339 70% 21%;--xmv0q7q:280 67% 96%;--x2hd0m:287 77% 92%;--xypyda5:288 86% 86%;--x1n5svxb:289 85% 78%;--x11rwd9c:288 83% 71%;--x1nt3wmy:288 75% 64%;--x1azhr94:288 67% 58%;--x14wm1ma:288 56% 52%;--xdppp7g:288 54% 46%;--xw1fcwj:288 54% 40%;--x1g7022q:288 55% 33%;--x1abyecg:288 56% 26%;--x19f0zk6:288 55% 20%;--x1xsviv0:252 100% 97%;--x1i7p532:257 100% 93%;--x1jp75bt:256 100% 87%;--x1dhw61z:255 94% 79%;--xlqbqsw:255 93% 72%;--x1ac71nz:255 91% 67%;--x1ukkv0h:255 86% 63%;--x2nx9ch:255 78% 60%;--x1rq6qfd:255 67% 55%;--xqbsslu:255 53% 50%;--xyyng9i:255 53% 44%;--x1ugzfo0:255 53% 37%;--xwue7r2:255 53% 31%;--x8465pp:223 100% 96%;--xseqhte:225 100% 93%;--x1x91ell:228 100% 86%;--xmtd91t:228 100% 78%;--x13cp09w:228 96% 72%;--x145g5s7:228 94% 67%;--xd9gvrw:228 89% 63%;--xmzbga7:228 81% 59%;--x1fop7yx:228 69% 55%;--x115l48x:230 57% 50%;--x1wybock:230 57% 43%;--xlx0e21:230 57% 37%;--x15khsgl:230 57% 30%;--xtte4cz:205 100% 95%;--x17g9q5i:206 100% 91%;--xm0qyc2:206 100% 82%;--xkq3tpf:206 96% 72%;--xs4gxep:207 91% 64%;--x1nbvk7u:207 86% 57%;--x15umy01:208 80% 52%;--xd8js7f:208 77% 47%;--x15wgrzn:209 77% 43%;--x6hcqqw:209 75% 38%;--xonl48u:209 76% 32%;--x16b2jzi:209 75% 27%;--x3121xe:209 76% 21%;--x11c5w1n:185 81% 94%;--x1e78vuy:185 84% 88%;--x13be9yn:186 77% 77%;--x1u6mllc:187 74% 65%;--x2vcm8a:187 69% 55%;--x2l9plr:188 72% 47%;--x1msavv9:187 80% 42%;--x1vgsgry:188 83% 37%;--x1s4q5zw:189 85% 32%;--xysnlz6:189 85% 28%;--x1whs59b:189 84% 23%;--xzu7znr:190 84% 17%;--x84u4el:189 84% 12%;--xx35u4w:161 79% 95%;--x1ia6efg:160 85% 87%;--x1oocypr:162 78% 77%;--x175u7ut:162 72% 65%;--x11j4k6s:162 68% 54%;--xnug37u:162 73% 46%;--x6j12ry:162 82% 40%;--xhq42d9:162 87% 35%;--xt79r3h:162 88% 30%;--x11m4kh6:162 88% 26%;--xbg8azi:162 89% 21%;--x4dm333:162 88% 16%;--x1b3b4t5:163 89% 11%;--x2p5azf:131 67% 95%;--x71800h:128 76% 90%;--x1mou8wh:128 71% 82%;--xe635b4:129 68% 73%;--xe90in2:130 61% 64%;--x19mai6:130 57% 56%;--x1bgie0q:131 50% 50%;--x1o9awcm:131 53% 46%;--xj6u7v4:131 54% 40%;--x1wj0iyp:132 52% 35%;--x1ssspn2:132 52% 29%;--x1pqru7z:132 53% 22%;--x11bwhsz:131 53% 16%;--x1lbmqs8:79 81% 94%;--x1p54lmx:80 83% 88%;--x1rjl2mp:81 81% 80%;--x1ubi8mj:82 75% 69%;--x12hrf27:83 73% 59%;--xgdwc26:84 69% 51%;--x4k0b7:85 74% 45%;--x1nxhbwa:85 79% 40%;--x11m5mbv:86 84% 36%;--xrs6skw:85 84% 32%;--x8pqp5z:85 83% 26%;--xj8wgvu:85 83% 21%;--x7kq7f6:85 84% 15%;--xs57jz7:50 100% 93%;--xcczjkc:49 100% 87%;--xziinia:49 100% 80%;--xjg5047:48 100% 70%;--x1cyo597:47 100% 62%;--x1flq8tf:45 97% 54%;--x4n83fv:42 96% 50%;--xl58suc:39 100% 48%;--x11uhems:35 100% 47%;--x742mi2:31 100% 45%;--xtjuq0b:31 100% 35%;--xjinize:31 100% 25%;--xbyzl35:31 100% 20%;--xy417p7:34 100% 95%;--x1gvg9m2:33 100% 90%;--xd5iaoa:33 100% 83%;--x1j6pscn:32 100% 74%;--x1flztp5:31 100% 65%;--x1pcxrv5:29 100% 58%;--x1ge7qtn:27 98% 54%;--xiogoba:24 94% 50%;--xoqe9no:21 90% 48%;--x18w9x9o:17 87% 45%;--xgaxnov:17 87% 40%;--xhoooq5:17 87% 32%;--x19kp5r1:17 87% 27%;--xhgwd7p:48 100% 93%;--xzmu82v:35 91% 86%;--x18v1t95:30 85% 79%;--x1qeznzr:27 80% 72%;--x11i4rit:25 75% 65%;--x1x8quyp:25 71% 57%;--x1rth5am:25 70% 49%;--x6zrpt8:25 75% 42%;--x1qso75h:25 75% 37%;--xpp9yzm:25 76% 31%;--x1smjajl:25 71% 26%;--x3hvkkn:25 66% 21%;--x18k9ek4:25 65% 15%;--x5oz4ql:36 60% 95%;--xgi80ag:32 44% 87%;--xzqpfp:28 40% 80%;--x1dbhtr7:28 38% 72%;--x1da80f5:27 36% 65%;--x1e3u61y:28 34% 57%;--xm6olh3:28 32% 50%;--x1lahh5i:28 35% 43%;--xjlu272:28 38% 37%;--xdf7zrt:27 42% 31%;--xz40s4i:25 48% 25%;--x1u17wcp:23 58% 19%;--xecvz8a:22 57% 16%;--xud021m:200 27% 98%;--x1k7zpzd:48 17% 88%;--xtnmguu:45 22% 79%;--x7122eo:44 22% 69%;--x6rw4xi:44 17% 62%;--x1wbbnsz:44 14% 54%;--x1i6pbxg:42 14% 46%;--xgx2k3s:43 16% 39%;--x5q9vym:41 15% 32%;--x1bu1nut:43 14% 26%;--xrurwoo:44 11% 20%;--x14a3m1o:60 6% 14%;--xmetks3:60 6% 7%;--xcgbcge:66 71% 95%;--xuvlz9i:64 69% 77%;--xemty1t:65 69% 59%;--x1sf47r2:65 61% 51%;--xue0d0g:63 61% 46%;--x96wol0:60 62% 41%;--x1h9am3f:59 65% 36%;--x1tdnzlx:56 67% 33%;--x2zfbkf:54 70% 29%;--x1jywa61:54 69% 25%;--xjdage2:53 69% 22%;--xgzra4h:53 69% 18%;--xkyl2e4:52 69% 13%;--xtb9bq5:74 98% 84%;--xkzx4rb:74 79% 78%;--xslg01j:74 68% 71%;--xip118t:75 62% 65%;--x8ogp6g:74 56% 59%;--x118i5ys:74 53% 53%;--x6b2zv7:74 55% 47%;--x1ko8224:74 66% 42%;--xbi1vlk:74 79% 36%;--xp2vimo:73 90% 32%;--x1ssggii:73 91% 26%;--x1f2zflk:73 91% 21%;--x1t80xh7:73 90% 16%;}",
+      "rtl": null,
     },
     0,
   ],
@@ -1390,6 +1396,7 @@ exports[`commonJS results of exported styles and variables colorsOKLCH.stylex.js
     "x1w7ij5j",
     {
       "ltr": ":root{--xvxpeu4:99% .03;--x17p703c:95% .06;--x7em3a6:88% .12;--x18qqa7n:80% .14;--x1nibu77:74% .16;--x1pbftlq:68% .19;--x1k6bona:63% .20;--x1ah1vxs:58% .21;--x13mln2v:53% .20;--x19th36h:49% .19;--xuayvow:42% .17;--xgtegoq:35% .15;--xhpqi5x:27% .12;--x4jlfl1:20% .09;--x2nysj5:14% .07;--x1mqxmvp:11% .05;--x1sorwk4:65% .3;}",
+      "rtl": null,
     },
     0,
   ],
@@ -1430,6 +1437,7 @@ exports[`commonJS results of exported styles and variables colorsOKLCHHues.style
     "xbi67ks",
     {
       "ltr": ":root{--x1w6s406:25;--x1m2ivtf:350;--x1mf3oql:310;--xu9tbt9:290;--x1i7u3go:270;--x1sr1rs4:240;--xf2w4zz:210;--x1e26lg7:185;--x1if3evm:145;--x5x2c76:125;--xrjq7g0:100;--xb48nck:75;}",
+      "rtl": null,
     },
     0,
   ],
@@ -1567,6 +1575,7 @@ exports[`commonJS results of exported styles and variables easings.stylex.js 2`]
       0.908 72.4%, 0.885, 0.878, 0.885, 0.908 79.4%, 1 83%, 0.954 85.5%, 0.943,
       0.939, 0.943, 0.954 90.5%, 1 93%, 0.977, 0.97, 0.977, 1
     );}",
+      "rtl": null,
     },
     0,
   ],
@@ -1636,6 +1645,7 @@ exports[`commonJS results of exported styles and variables fonts.stylex.js 2`] =
     "xib0cp9",
     {
       "ltr": ":root{--xanpsew:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif;--xv9w050:ui-serif,serif;--x1q5jwrf:Dank Mono,Operator Mono,Inconsolata,Fira Mono,ui-monospace,SF Mono,Monaco,Droid Sans Mono,Source Code Pro,monospace;--x13q41jb:100;--x1w1zwzf:200;--x1k5rcjo:300;--x1xjd60x:400;--x1gbz26p:500;--xxk39i5:600;--x1ih23ey:700;--x1c86xch:800;--x1h2oslr:900;--x3h6pva:.95;--x1guo02n:1.1;--x1dqvqp8:1.25;--x5vo7ea:1.375;--x16xun1t:1.5;--x1mmyvf2:1.75;--x19cuso:2;--x6rgj2r:-.05em;--x1abbisj:.025em;--x182byyj:.050em;--x1x5s38d:.075em;--xqpg8kb:.150em;--x1a92c87:.500em;--x7qwnnj:.750em;--x3jnj2:1em;--x1v80h2e:.5rem;--xd88jmw:.75rem;--x1w37u79:1rem;--xubenyc:1.1rem;--x510uo4:1.25rem;--xj9ty4f:1.5rem;--xsv3ft2:2rem;--x1kesed8:2.5rem;--xxiefrq:3rem;--xffo5yo:3.5rem;--x3f5w2j:clamp(.75rem, 2vw, 1rem);--x6058t9:clamp(1rem, 4vw, 1.5rem);--x13ndac4:clamp(1.5rem, 6vw, 2.5rem);--x9kjul6:clamp(2rem, 9vw, 3.5rem);}",
+      "rtl": null,
     },
     0,
   ],
@@ -1734,6 +1744,7 @@ exports[`commonJS results of exported styles and variables gradients.stylex.js 2
         circle at bottom left,
         hsl(150 100% 84%), hsl(150 100% 84% / 0%)
       );--x12cx7eb:url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.005' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");--xoe3mf4:url("data:image/svg+xml,%3Csvg viewBox='0 0 300 300' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.05' numOctaves='1' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");--x1inqltg:url("data:image/svg+xml,%3Csvg viewBox='0 0 1024 1024' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.25' numOctaves='1' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");--xgyvn3v:url("data:image/svg+xml,%3Csvg viewBox='0 0 2056 2056' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.5' numOctaves='1' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");--x1eiahss:url("data:image/svg+xml,%3Csvg viewBox='0 0 2056 2056' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='1' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");--x6k9yr2:contrast(300%) brightness(100%);--xlpey36:contrast(200%) brightness(150%);--xz9i4ah:contrast(200%) brightness(250%);--xn8azb5:contrast(200%) brightness(500%);--xbu9qyx:contrast(200%) brightness(1000%);}",
+      "rtl": null,
     },
     0,
   ],
@@ -1778,6 +1789,7 @@ exports[`commonJS results of exported styles and variables grayOKLCH.stylex.js 2
     "xluomik",
     {
       "ltr": ":root{--xikvdla:99%;--x1u5ign3:95%;--xge0kc1:88%;--x1ycv5dp:80%;--xtu6ufq:74%;--x1pj7wxv:68%;--x16ixgft:63%;--x1gy9vbq:58%;--x1w3c3ua:53%;--x1rn0w7k:49%;--xy9sot0:43%;--x1o0pc1m:37%;--xenj3nv:31%;--x1fea5c:25%;--xcgkeii:18%;--x17lsm64:10%;}",
+      "rtl": null,
     },
     0,
   ],
@@ -1813,6 +1825,7 @@ exports[`commonJS results of exported styles and variables highlights.stylex.js 
     "xkkhulp",
     {
       "ltr": ":root{--xmjqxfw:10px;--xgorgio:hsl(0 0% 0% / 20%);--x27iylq:0 0 0 10px hsl(0 0% 0% / 20%);}",
+      "rtl": null,
     },
     0,
   ],
@@ -1820,6 +1833,7 @@ exports[`commonJS results of exported styles and variables highlights.stylex.js 
     "xkkhulp-1lveb7",
     {
       "ltr": "@media (prefers-color-scheme: dark){:root{--xgorgio:hsl(0 0% 100% / 20%);--x27iylq:0 0 0 10px hsl(0 0% 100% / 20%);}}",
+      "rtl": null,
     },
     0.1,
   ],
@@ -1877,6 +1891,7 @@ exports[`commonJS results of exported styles and variables layouts.stylex.js 2`]
           ),
         1fr)
     );}",
+      "rtl": null,
     },
     0,
   ],
@@ -1929,6 +1944,7 @@ exports[`commonJS results of exported styles and variables masksCornerCuts.style
       conic-gradient(from 135deg at 4rem calc(100% - 4rem), #0000 25%, #000 0)
       -4rem 100% / 100% 51% repeat-x
     ;}",
+      "rtl": null,
     },
     0,
   ],
@@ -2031,6 +2047,7 @@ exports[`commonJS results of exported styles and variables masksEdges.stylex.js 
     conic-gradient(from 135deg at top   ,#0000,#000 1deg 90deg,#0000 91deg) top    / calc(2 * 20px) 51% repeat-x,
     conic-gradient(from -45deg at bottom,#0000,#000 1deg 90deg,#0000 91deg) bottom / calc(2 * 20px) 51% repeat-x
   ;}",
+      "rtl": null,
     },
     0,
   ],
@@ -2102,6 +2119,7 @@ exports[`commonJS results of exported styles and variables shadows.stylex.js 2`]
       0 22px 18px -2px hsl(220 3% 15% / calc(1% + 5%)),
       0 41px 33px -2px hsl(220 3% 15% / calc(1% + 6%)),
       0 100px 80px -2px hsl(220 3% 15% / calc(1% + 7%));--x11qlsbw:inset 0 0 0 1px hsl(220 3% 15% / calc(1% + 9%));--xa5ok5s:inset 0 1px 2px 0 hsl(220 3% 15% / calc(1% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x15xf9dp:inset 0 1px 4px 0 hsl(220 3% 15% / calc(1% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x1dicv20:inset 0 2px 8px 0 hsl(220 3% 15% / calc(1% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x1yks3sz:inset 0 2px 14px 0 hsl(220 3% 15% / calc(1% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;}",
+      "rtl": null,
     },
     0,
   ],
@@ -2135,6 +2153,7 @@ exports[`commonJS results of exported styles and variables shadows.stylex.js 2`]
       0 22px 18px -2px hsl(220 40% 2% / calc(25% + 5%)),
       0 41px 33px -2px hsl(220 40% 2% / calc(25% + 6%)),
       0 100px 80px -2px hsl(220 40% 2% / calc(25% + 7%));--x11qlsbw:inset 0 0 0 1px hsl(220 40% 2% / calc(25% + 9%));--xa5ok5s:inset 0 1px 2px 0 hsl(220 40% 2% / calc(25% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x15xf9dp:inset 0 1px 4px 0 hsl(220 40% 2% / calc(25% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x1dicv20:inset 0 2px 8px 0 hsl(220 40% 2% / calc(25% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;--x1yks3sz:inset 0 2px 14px 0 hsl(220 40% 2% / calc(25% + 9%)), inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;}}",
+      "rtl": null,
     },
     0.1,
   ],
@@ -2220,6 +2239,7 @@ exports[`commonJS results of exported styles and variables sizes.stylex.js 2`] =
     "xrvxprj",
     {
       "ltr": ":root{--xnmueqm:-.5rem;--x104et4o:-.25rem;--xdq7fed:.25rem;--xb215zq:.5rem;--x1x5fmop:1rem;--x92ffkq:1.25rem;--xe0b098:1.5rem;--xz29dv2:1.75rem;--x1hmgbyf:2rem;--xeemxq0:3rem;--x18w8zzv:4rem;--xn1t2s4:5rem;--x3f439p:7.5rem;--xjt9i9e:10rem;--x1ja7xie:15rem;--x1ovkd5q:20rem;--x1fdjknu:30rem;--x1gcsi40:clamp(.5rem, 1vw, 1rem);--xjgt9dg:clamp(1rem, 2vw, 1.5rem);--xtt7ebj:clamp(1.5rem, 3vw, 2rem);--xqev5ec:clamp(2rem, 4vw, 3rem);--xuzvajy:clamp(4rem, 5vw, 5rem);--xovadhh:clamp(5rem, 7vw, 7.5rem);--xjyj8kc:clamp(7.5rem, 10vw, 10rem);--x9uj4o1:clamp(10rem, 20vw, 15rem);--x1hihu17:clamp(15rem, 30vw, 20rem);--x10z2nc1:clamp(20rem, 40vw, 30rem);--xx2o4kd:20ch;--x1hs9oux:45ch;--xmo6vec:60ch;--x19hm07g:20ch;--x1iswacu:25ch;--x1a9h1xp:35ch;--xqkhnbe:240px;--x34kpk2:360px;--xlqy9bw:480px;--x1qc7hse:768px;--xr85rl5:1024px;--xa5hxd:1440px;--x1caek2l:1920px;--xfpbg41:-.5ch;--x1ra01ix:-.25ch;--x1v6ufr4:.25ch;--x18om8sv:.5ch;--xrbmo34:1ch;--xf6c0o8:1.25ch;--xybj6ds:1.5ch;--xe2897r:1.75ch;--x1uom5sa:2ch;--x1t4716e:3ch;--xv4w5a4:4ch;--x1dvrmtj:5ch;--x9igfg4:7.5ch;--xpdc9cj:10ch;--x92y7qi:15ch;--x1g3w1y7:20ch;--x1cfyxxz:30ch;}",
+      "rtl": null,
     },
     0,
   ],
@@ -2251,6 +2271,7 @@ exports[`commonJS results of exported styles and variables svg.stylex.js 2`] = `
     "xqcr4k6",
     {
       "ltr": ":root{--x1tho6n9:url("data:image/svg+xml,%3Csvg viewbox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d=' M 0, 75 C 0, 18.75 18.75, 0 75, 0 S 150, 18.75 150, 75 131.25, 150 75, 150 0, 131.25 0, 75 ' fill='%23FADB5F' transform='rotate( 0, 100, 100 ) translate( 25 25 )'%3E%3C/path%3E%3C/svg%3E");--xuuij38:url("data:image/svg+xml,%3Csvg viewbox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d=' M 0, 75 C 0, 13.500000000000004 13.500000000000004, 0 75, 0 S 150, 13.500000000000004 150, 75 136.5, 150 75, 150 0, 136.5 0, 75 ' fill='%23FADB5F' transform='rotate( 0, 100, 100 ) translate( 25 25 )'%3E%3C/path%3E%3C/svg%3E");--x11v3omg:url("data:image/svg+xml,%3Csvg viewbox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d=' M 0, 75 C 0, 5.999999999999997 5.999999999999997, 0 75, 0 S 150, 5.999999999999997 150, 75 144, 150 75, 150 0, 144 0, 75 ' fill='%23FADB5F' transform='rotate( 0, 100, 100 ) translate( 25 25 )'%3E%3C/path%3E%3C/svg%3E");}",
+      "rtl": null,
     },
     0,
   ],
@@ -2285,6 +2306,7 @@ exports[`commonJS results of exported styles and variables zIndex.stylex.js 2`] 
     "x1nmakcm",
     {
       "ltr": ":root{--xwoxhb1:1;--xgbqxci:2;--x12z0mro:3;--xqe0k3d:4;--x78f1es:5;--xom5p78:2147483647;}",
+      "rtl": null,
     },
     0,
   ],


### PR DESCRIPTION
## What changed / motivation ?

Creates a new function to the `StateManager` to take all the injected styles and set the `metadata` and, if needed, insert the code for injecting those styles at runtime.

This makes the code DRY and unifies the style injection code.

This is also a prerequisite for using CSS data imports for styles.