### PR TITLE
Add babel plugin options comment to esbuild example

### DIFF
--- a/apps/esbuild-example/scripts/build.mjs
+++ b/apps/esbuild-example/scripts/build.mjs
@@ -30,6 +30,8 @@ esbuild
     outfile: OUTFILE,
     minify: true,
     plugins: [
+      // See all options in the babel plugin configuration docs:
+      // https://stylexjs.com/docs/api/configuration/babel-plugin/
       stylexPlugin({
         useCSSLayers: true,
         generatedCSSFileName: STYLEX_BUNDLE_PATH,

--- a/apps/nextjs-example/.babelrc.js
+++ b/apps/nextjs-example/.babelrc.js
@@ -4,6 +4,8 @@ module.exports = {
   plugins: [
     [
       '@stylexjs/babel-plugin',
+      // See all options in the babel plugin configuration docs:
+      // https://stylexjs.com/docs/api/configuration/babel-plugin/
       {
         dev: process.env.NODE_ENV === 'development',
         genConditionalClasses: true,

--- a/apps/rollup-example/rollup.config.mjs
+++ b/apps/rollup-example/rollup.config.mjs
@@ -15,6 +15,8 @@ const config = {
     file: './.build/bundle.js',
     format: 'es',
   },
+  // See all options in the babel plugin configuration docs:
+  // https://stylexjs.com/docs/api/configuration/babel-plugin/
   plugins: [stylexPlugin({ fileName: 'stylex.css' })],
 };
 

--- a/apps/webpack-example/webpack.config.js
+++ b/apps/webpack-example/webpack.config.js
@@ -30,6 +30,8 @@ const config = (env, argv) => ({
     ],
   },
   plugins: [
+    // See all options in the babel plugin configuration docs:
+    // https://stylexjs.com/docs/api/configuration/babel-plugin/
     new StylexPlugin({
       filename: 'styles.[contenthash].css',
       // get webpack mode and set value for dev


### PR DESCRIPTION
## What changed / motivation?

I spent half a day trying to work out why my stylex variables were getting stripped out unless I had a `console.log` logging them. It turns out there's an option for the [babel plugin options](https://stylexjs.com/docs/api/configuration/babel-plugin/) of `treeshakeCompensation` which solved the issue.

It was not obvious to me that the object here was being passed to the babel plugin behind the scenes, which I only discovered by digging through the source code. Hopefully this comment helps others gain a better understanding of how the `stylexPlugin` works under the hood.

## Additional Context

Documentation (comment) only change

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code