### PR TITLE
fix: Remove webpack dependency from webpack plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31693,11 +31693,14 @@
         "@babel/plugin-syntax-flow": "^7.23.3",
         "@babel/plugin-syntax-jsx": "^7.23.3",
         "@babel/plugin-syntax-typescript": "^7.23.3",
-        "@stylexjs/babel-plugin": "0.5.1",
-        "webpack": "^5.88.2"
+        "@stylexjs/babel-plugin": "0.5.1"
       },
       "devDependencies": {
-        "@babel/plugin-transform-modules-commonjs": "^7.23.3"
+        "@babel/plugin-transform-modules-commonjs": "^7.23.3",
+        "webpack": "^5.88.2"
+      },
+      "peerDependencies": {
+        "webpack": ">=5.0.0"
       }
     },
     "packages/website": {

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -24,10 +24,13 @@
     "@babel/plugin-syntax-flow": "^7.23.3",
     "@babel/plugin-syntax-jsx": "^7.23.3",
     "@babel/plugin-syntax-typescript": "^7.23.3",
-    "@stylexjs/babel-plugin": "0.5.1",
-    "webpack": "^5.88.2"
+    "@stylexjs/babel-plugin": "0.5.1"
+  },
+  "peerDependencies": {
+    "webpack": ">=5.0.0"
   },
   "devDependencies": {
-    "@babel/plugin-transform-modules-commonjs": "^7.23.3"
+    "@babel/plugin-transform-modules-commonjs": "^7.23.3",
+    "webpack": "^5.88.2"
   }
 }


### PR DESCRIPTION
## What changed / motivation ?

The webpack plugin should not have a dependency on webpack. Instead, it now uses a peerDependency with a more widely accepted version.

This should allow using the webpack plugin with various different versions of webpack.

## Linked PR/Issues

Fixes #461 