### PR TITLE
Use stylex.props API in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const styles = stylex.create({
   },
 });
 
-const styleProps = stylex.apply(styles.root, styles.element);
+const styleProps = stylex.props(styles.root, styles.element);
 ```
 
 ## Development


### PR DESCRIPTION
## What changed / motivation ?

I noticed that the example code in the readme is using `stylex.apply` which doesn't seem to exist. Maybe an old version of the API?

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](./CONTRIBUTING.md)
- [x] Performed a self-review of my code