### PR TITLE
Fix return value in esbuild plugin `onLoad` hook

### DIFF
--- a/packages/esbuild-plugin/src/index.js
+++ b/packages/esbuild-plugin/src/index.js
@@ -126,14 +126,14 @@ export default function stylexPlugin({
 
           if (transformResult === null) {
             console.warn('StyleX: transformAsync returned null');
-            return { code: inputCode, loader };
+            return { contents: inputCode, loader };
           }
 
           const { code, metadata } = transformResult;
 
           if (code === null) {
             console.warn('StyleX: transformAsync returned null code');
-            return { code: inputCode, loader };
+            return { contents: inputCode, loader };
           }
 
           if (


### PR DESCRIPTION
## What changed / motivation ?

This PR fixes the return value of `onLoad` hook of the StyleX esbuild plugin (of the if branch when babel transform returns no code). Previously, it would return an object with property `code`, which resulted in undefined output of the plugin.

## Linked PR/Issues

I did not create an issue for this since it's a very small fix.

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code