### PR TITLE
feat: Using CSS data urls for bundling

### DIFF
--- a/packages/babel-plugin/src/utils/css-serialize.js
+++ b/packages/babel-plugin/src/utils/css-serialize.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+type Rule = [string, { ltr: string, rtl?: string | null }, number];
+
+export function ruleToCSSDataURI([_, { ltr, rtl }, priority]: Rule): string {
+  const ltrLayer = `@layer __stylex__ltr { ${ltr} }`;
+  const rtlLayer = rtl != null ? `@layer __stylex__rtl { ${rtl} }` : '';
+  const css = `@layer __stylex__${priority} {  ${ltrLayer} ${rtlLayer} }`;
+
+  return `data:text/css;charset=utf-8,${encodeURIComponent(css)}`;
+}


### PR DESCRIPTION
Resolving #297 

## Idea

The idea is that the Babel plugin should be able to generate import statements that import CSS as data URLs. After this, bundlers should be able to generate CSS bundles to include this CSS and a PostCSS/LightningCSS plugin can post-process the CSS file after the fact.

## Challenge

I am unable to figure out a valid format for CSS data URL that can be put into a JS import statement.

I tried to come up with the simplest possible example of trying to inject `body{background:pink}` and tried the following import statements:


```js
import 'data:text/css;charset=utf-8,body{background:pink}';
import 'data:text/css;charset=utf-8,body{background:pink}';
import 'css?data:text/css;charset=utf-8,body{background:pink}';
import '?css:data:text/css;charset=utf-8,body{background:pink}';
import 'css-loader?data:text/css;charset=utf-8,body{background:pink}';
import 'data:text/css;charset=utf-8,body{background:pink}?css';
import 'data:text/css;charset=utf-8,body{background:pink}?css-loader';

import 'data:text/css;charset=utf-8,body{background:pink}';
import 'data:text/css;charset=utf-8,body%7Bbackground%3Apink%7D';
import 'css?data:text/css;charset=utf-8,body%7Bbackground%3Apink%7D';
import '?css:data:text/css;charset=utf-8,body%7Bbackground%3Apink%7D';
import 'css-loader?data:text/css;charset=utf-8,body%7Bbackground%3Apink%7D';
import 'data:text/css;charset=utf-8,body%7Bbackground%3Apink%7D?css';
import 'data:text/css;charset=utf-8,body%7Bbackground%3Apink%7D?css-loader';

import 'data:text/css,body{background:pink}';
import 'data:text/css,body%7Bbackground%3Apink%7D';
import 'css?data:text/css,body%7Bbackground%3Apink%7D';
import '?css:data:text/css,body%7Bbackground%3Apink%7D';
import 'css-loader?data:text/css,body%7Bbackground%3Apink%7D';
import 'data:text/css,body%7Bbackground%3Apink%7D?css';
import 'data:text/css,body%7Bbackground%3Apink%7D?css-loader';

import 'style-loader?data:text/css;charset=utf-8,body{background:pink}';
import 'style-loader?data:text/css;charset=utf-8,body%7Bbackground%3Apink%7D';
import 'style-loader?data:text/css,body%7Bbackground%3Apink%7D';
```


I wasn't able to get any of them work in a fresh NextJS example. Webpack did not understand any of these imports.

I tried the same in Vite with similar results.

## Is there a particular way to make bundlers bundle CSS provided this way?

Is this approach even feasible? I'm putting up this PR in case someone has further insight here.

We are independently working on a CLI to work around bundlers entirely in the meantime.