### PR TITLE
fix: og:image

### DIFF
--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -166,7 +166,7 @@ const config = {
         },
         {
           name: 'og:image',
-          content: '/img/stylex-cover-photo.png',
+          content: 'https://stylexjs.com/img/stylex-cover-photo.png',
         },
       ],
     },


### PR DESCRIPTION
## What changed / motivation ?

This is current `og:image`.

`<meta data-rh="true" name="og:image" content="/img/stylex-cover-photo.png">`

`og:image` is url, not path. Therefore, this fixed it.
https://ogp.me/


## Linked PR/Issues



## Additional Context



## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code