### PR TITLE
fix: usage of styles in a loop and non-existent styles

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-call-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-call-test.js
@@ -1910,5 +1910,28 @@ describe('@stylexjs/babel-plugin', () => {
         }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];"
       `);
     });
+
+    test('Using styles from a for loop', () => {
+      expect(
+        transform(
+          `
+          import stylex from '@stylexjs/stylex';
+          function test(colors, obj) {
+            for (const color of colors) {
+              obj[color.key] = stylex(color.style);
+            }
+          }
+        `,
+          { dev: true, genConditionalClasses: true },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import stylex from '@stylexjs/stylex';
+        function test(colors, obj) {
+          for (const color of colors) {
+            obj[color.key] = stylex(color.style);
+          }
+        }"
+      `);
+    });
   });
 });

--- a/packages/babel-plugin/__tests__/stylex-transform-call-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-call-test.js
@@ -1564,7 +1564,7 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
   });
-  describe('Specific edge-case bugs', () => {
+  describe('Extreme use-cases', () => {
     test('Basic stylex call', () => {
       expect(
         transform(
@@ -1910,8 +1910,9 @@ describe('@stylexjs/babel-plugin', () => {
         }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];"
       `);
     });
-
-    test('Using styles from a for loop', () => {
+  });
+  describe('Accounts for edge-cases', () => {
+    test('Using stylex() in a for loop', () => {
       expect(
         transform(
           `
@@ -1931,6 +1932,74 @@ describe('@stylexjs/babel-plugin', () => {
             obj[color.key] = stylex(color.style);
           }
         }"
+      `);
+    });
+    test('Using stylex.props() in a for loop', () => {
+      expect(
+        transform(
+          `
+          import stylex from '@stylexjs/stylex';
+          function test(colors, obj) {
+            for (const color of colors) {
+              obj[color.key] = stylex.props(color.style);
+            }
+          }
+        `,
+          { dev: true, genConditionalClasses: true },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import stylex from '@stylexjs/stylex';
+        function test(colors, obj) {
+          for (const color of colors) {
+            obj[color.key] = stylex.props(color.style);
+          }
+        }"
+      `);
+    });
+    test('trying to use an unknown style in stylex()', () => {
+      expect(
+        transform(
+          `
+          import stylex from '@stylexjs/stylex';
+          const styles = stylex.create({
+            tileHeading: {
+              marginRight: 12,
+            },
+          });
+          stylex(styles.unknown);
+        `,
+          { dev: true, genConditionalClasses: true },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from '@stylexjs/stylex';
+        _inject2(".x1wsuqlk{margin-right:12px}", 4000);
+        const styles = {};
+        stylex(styles.unknown);"
+      `);
+    });
+    test('trying to use an unknown style in stylex.props()', () => {
+      expect(
+        transform(
+          `
+          import stylex from '@stylexjs/stylex';
+          const styles = stylex.create({
+            tileHeading: {
+              marginRight: 12,
+            },
+          });
+          stylex.props(styles.unknown);
+        `,
+          { dev: true, genConditionalClasses: true },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from '@stylexjs/stylex';
+        _inject2(".x1wsuqlk{margin-right:12px}", 4000);
+        const styles = {};
+        stylex.props(styles.unknown);"
       `);
     });
   });

--- a/packages/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/babel-plugin/src/utils/evaluate-path.js
@@ -210,6 +210,11 @@ function evaluateCached(path: NodePath<>, state: State): any {
     const item: Result = { resolved: false };
     seen.set(node, item);
 
+    if (node == null) {
+      deopt(path, state);
+      return;
+    }
+
     const val = _evaluate(path, state);
     if (state.confident) {
       item.resolved = true;

--- a/packages/babel-plugin/src/visitors/stylex-attrs.js
+++ b/packages/babel-plugin/src/visitors/stylex-attrs.js
@@ -166,7 +166,7 @@ export default function transformStylexAttrs(
           styleNonNullProps = true;
         } else {
           const { confident, value: styleValue } = evaluate(path, state);
-          if (!confident) {
+          if (!confident || styleValue == null) {
             nonNullProps = true;
             styleNonNullProps = true;
           } else {

--- a/packages/babel-plugin/src/visitors/stylex-merge.js
+++ b/packages/babel-plugin/src/visitors/stylex-merge.js
@@ -164,7 +164,7 @@ export default function transformStyleXMerge(
           styleNonNullProps = true;
         } else {
           const { confident, value: styleValue } = evaluate(path, state);
-          if (!confident) {
+          if (!confident || styleValue == null) {
             nonNullProps = true;
             styleNonNullProps = true;
           } else {

--- a/packages/babel-plugin/src/visitors/stylex-props.js
+++ b/packages/babel-plugin/src/visitors/stylex-props.js
@@ -166,7 +166,7 @@ export default function transformStylexProps(
           styleNonNullProps = true;
         } else {
           const { confident, value: styleValue } = evaluate(path, state);
-          if (!confident) {
+          if (!confident || styleValue == null) {
             nonNullProps = true;
             styleNonNullProps = true;
           } else {

--- a/packages/scripts/rewrite-imports.js
+++ b/packages/scripts/rewrite-imports.js
@@ -62,7 +62,7 @@ async function rewriteImportsInFolder(
     );
     if (fileName === 'stylex.js') {
       outputFile = outputFile.replace(
-        'export default (_stylex: IStyleX);\n',
+        'export default _stylex as IStyleX;\n',
         '',
       );
     }

--- a/packages/stylex/src/StyleXTypes.js
+++ b/packages/stylex/src/StyleXTypes.js
@@ -165,8 +165,8 @@ type TTokens = $ReadOnly<{
 
 type UnwrapVars<T> = T extends StyleXVar<infer U> ? U : T;
 export type FlattenTokens<T: TTokens> = {
-  +[Key in keyof T]: T[Key] extends CSSType<>
-    ? UnwrapVars<T[Key]['value']>
+  +[Key in keyof T]: T[Key] extends CSSType<string | number>
+    ? UnwrapVars<T[Key]>
     : T[Key] extends { +default: infer X, +[string]: infer Y }
       ? UnwrapVars<X | Y>
       : UnwrapVars<T[Key]>,

--- a/packages/stylex/src/StyleXTypes.js
+++ b/packages/stylex/src/StyleXTypes.js
@@ -135,17 +135,17 @@ declare class Var<+T> {
 // This is the type for the variables object
 export opaque type StyleXVar<+Val: mixed> = Var<Val>;
 
-export opaque type VarGroup<
+export type VarGroup<
   +Tokens: { +[string]: mixed },
   +_ID: string = string,
->: $ReadOnly<{ [Key in keyof Tokens]: StyleXVar<Tokens[Key]> }> = $ReadOnly<{
+> = $ReadOnly<{
   [Key in keyof Tokens]: StyleXVar<Tokens[Key]>,
 }>;
 
-export type TokensFromVarGroup<T: VarGroup<{ +[string]: mixed }>> =
-  T extends VarGroup<infer Tokens extends { +[string]: mixed }>
-    ? Tokens
-    : empty;
+export type TokensFromVarGroup<T: VarGroup<{ +[string]: mixed }>> = $ReadOnly<{
+  [Key in keyof T]: T[Key] extends StyleXVar<infer U> ? U : empty,
+}>;
+
 type IDFromVarGroup<+T: VarGroup<{ +[string]: mixed }>> =
   T extends VarGroup<{ +[string]: mixed }, infer ID> ? ID : empty;
 

--- a/packages/stylex/src/stylex.js
+++ b/packages/stylex/src/stylex.js
@@ -125,7 +125,7 @@ function stylexCreate<S: { +[string]: mixed }>(styles: S): MapNamespaces<S> {
   throw errorForFn('create');
 }
 
-function stylexDefineVars(styles: any) {
+function stylexDefineVars(styles: $FlowFixMe) {
   if (__implementations.defineVars) {
     return __implementations.defineVars(styles);
   }


### PR DESCRIPTION
Found and fixed a bug in the optimisation step for optimising `stylex.props()` and `stylex()` calls within a `for-of` loop.

The custom `evaluate` logic would fail to bail out and throw a null pointer exception instead.

The fix was to check for that null value and bail out instead.

-----

Also, internally there are some rare example of non-existent styles (`styles.unknown`) being used which can cause the Babel plugin to throw an error.

Added a check to bail out instead of throwing an error for such cases and added a couple of test cases to verify that the fix works for `stylex()`, `stylex.props()` and `stylex.attrs()`.