### PR TITLE
docs: add `prettier-plugin-stylex-key-sort` to ecosystem docs

### DIFF
--- a/apps/docs/docs/learn/06-ecosystem.mdx
+++ b/apps/docs/docs/learn/06-ecosystem.mdx
@@ -42,3 +42,10 @@ Custom babel plugins can be used before using the StyleX babel plugin or as the
 * [qwik](https://github.com/nmn/qwik-stylex) A Qwik project that uses StyleX and `tailwind-to-stylex`.
 * [docusaurus 3](https://github.com/nmn/docusaurus-stylex) A docusaurus 3 project with StyleX support.
 * [SvelteKit](https://github.com/nmn/sveltekit-stylex) A SvelteKit project with StyleX support.
+
+## Code formatter plugins
+
+### Prettier
+
+* [prettier-plugin-stylex-key-sort](https://github.com/nedjulius/prettier-plugin-stylex-key-sort) Prettier plugin that automatically sorts StyleX keys.
+


### PR DESCRIPTION
## What changed / motivation ?

Added Prettier plugin that I maintain to the ecosystem docs. The plugin helps to sort StyleX keys and can be used as an alternative to esbuild plugin sort keys auto-fix.

[Link to the plugin](https://github.com/nedjulius/prettier-plugin-stylex-key-sort)

## Linked PR/Issues

N/A

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

N/A

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code