### PR TITLE
Fix order of "Learn" documentation sidebar

### DIFF
--- a/apps/docs/docs/learn/04-styling-ui/_category_.json
+++ b/apps/docs/docs/learn/04-styling-ui/_category_.json
@@ -1,3 +1,4 @@
 {
-  "label": "Styles"
+  "label": "Styles",
+  "position": 3
 }

--- a/apps/docs/docs/learn/05-theming/_category_.json
+++ b/apps/docs/docs/learn/05-theming/_category_.json
@@ -1,3 +1,4 @@
 {
-  "label": "Themes"
+  "label": "Themes",
+  "position": 4
 }

--- a/apps/docs/docs/learn/06-static-types.mdx
+++ b/apps/docs/docs/learn/06-static-types.mdx
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-sidebar_position: 6
+sidebar_position: 5
 ---
 
 import Tabs from '@theme/Tabs';

--- a/apps/docs/docs/learn/07-ecosystem.mdx
+++ b/apps/docs/docs/learn/07-ecosystem.mdx
@@ -1,4 +1,8 @@
 ---
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 sidebar_position: 6
 ---
 
@@ -8,7 +12,7 @@ sidebar_position: 6
 
 ### Visual Studio Code
 
-* [StyleX Intellisense](https://marketplace.visualstudio.com/items?itemName=yash-singh.stylex) 
+* [StyleX Intellisense](https://marketplace.visualstudio.com/items?itemName=yash-singh.stylex)
   is an experimental extension for Visual Studio Code that provides auto-complete for StyleX
   and inline previews for colors.
 
@@ -30,10 +34,10 @@ plugins are available for Unplugin:
 
 ## Babel plugins
 
-Custom babel plugins can be used before using the StyleX babel plugin or as the 
+Custom babel plugins can be used before using the StyleX babel plugin or as the
 `babelConfig.plugins` option to the various bundler plugins to add additional features.
 
-* [**tailwind-to-stylex**](https://www.npmjs.com/package/tailwind-to-stylex) converts
+* [tailwind-to-stylex](https://www.npmjs.com/package/tailwind-to-stylex) converts
   Tailwind CSS used within `className` attributes or `tw()` calls to StyleX.
 
 ## Starter templates
@@ -47,5 +51,6 @@ Custom babel plugins can be used before using the StyleX babel plugin or as the
 
 ### Prettier
 
-* [prettier-plugin-stylex-key-sort](https://github.com/nedjulius/prettier-plugin-stylex-key-sort) Prettier plugin that automatically sorts StyleX keys.
+* [prettier-plugin-stylex-key-sort](https://github.com/nedjulius/prettier-plugin-stylex-key-sort) is a 
+  Prettier plugin that automatically sorts StyleX keys.
 


### PR DESCRIPTION
## What changed / motivation ?

Order of pages in "Learn" sidebar. Documenting the library's exported StaticTypes should come before documenting Ecosystem

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code