### PR TITLE
chore: Add cjs to rollup-plugin

### DIFF
--- a/packages/rollup-plugin/.babelrc.cjs
+++ b/packages/rollup-plugin/.babelrc.cjs
@@ -8,7 +8,10 @@ module.exports = {
       {
         exclude: ['@babel/plugin-transform-typeof-symbol'],
         targets: 'defaults',
-        modules: process.env.NODE_ENV === 'test' ? 'commonjs' : false,
+        modules:
+          process.env.NODE_ENV === 'test' || process.env.BABEL_ENV === 'cjs'
+            ? 'commonjs'
+            : false,
       },
     ],
     '@babel/preset-flow',

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -2,13 +2,21 @@
   "name": "@stylexjs/rollup-plugin",
   "version": "0.5.1",
   "description": "Rollup plugin for StyleX",
-  "main": "lib/index.js",
-  "type": "module",
+  "main": "./lib/index.js",
+  "module": "./lib/es/index.mjs",
+  "types": "./lib/index.d.ts",
+  "exports": {
+    "import": "./lib/es/index.mjs",
+    "require": "./lib/index.js",
+    "types": "./lib/index.d.ts"
+  },
   "repository": "https://www.github.com/facebook/stylex",
   "license": "MIT",
   "scripts": {
     "prebuild": "gen-types -i src/ -o lib/",
-    "build": "babel src/ --out-dir lib/ --copy-files",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src/ --out-dir lib/ --copy-files",
+    "build:esm": "cross-env BABEL_ENV=esm babel src/ --out-dir lib/es --out-file-extension .mjs",
+    "build": "npm run build:cjs && npm run build:esm",
     "test": "jest"
   },
   "jest": {


### PR DESCRIPTION
## What changed / motivation ?

I had came to a need of stylex rollup-plugin in the cjs flavor. See this issue for relevant context. https://github.com/facebook/stylex/issues/451

So I added it. My PR is very much inspired by the current implementation in `packages/styles/package.json`

## Linked PR/Issues

Fixes https://github.com/facebook/stylex/issues/451

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

The rollup-plugin now generates `lib/*` and `lib/es/*` folders. See screenshot:

<img width="161" alt="image" src="https://github.com/facebook/stylex/assets/5146396/34218d04-b1b3-4654-a469-22adcc05d79a">


I had run all the tests and lints. But as I'm unfamiliar with the repository. I'd gladly ask for a double check that I didn't break anything vital. 🙏 

What I have manually tested:
* The output `lib/es/index.mjs` is identical with the old `lib/index.js`
* The cjs flavor of the library was tested in my project and seems to be building correctly

Tagging @nmn as a follow-up to our discussion


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code