### PR TITLE
fix: Allow all strings/numbers along with specific values

### DIFF
--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -2323,7 +2323,11 @@ const stylexValidStyles = {
                     {
                       type: 'array',
                       items: {
-                        oneOf: [{ type: 'string' }, { type: 'number' }],
+                        oneOf: [
+                          { type: 'null' },
+                          { type: 'string' },
+                          { type: 'number' },
+                        ],
                       },
                     },
                   ],
@@ -2411,7 +2415,21 @@ const stylexValidStyles = {
                 : typeof limit === 'string' || typeof limit === 'number'
                   ? makeUnionRule(limit, all)
                   : Array.isArray(limit)
-                    ? makeUnionRule(...limit, all)
+                    ? makeUnionRule(
+                        ...limit.map((l) => {
+                          if (l === '*') {
+                            return makeUnionRule(isString, isNumber);
+                          }
+                          if (l === 'string') {
+                            return isString;
+                          }
+                          if (l === 'number') {
+                            return isNumber;
+                          }
+                          return l;
+                        }),
+                        all,
+                      )
                     : undefined;
       if (overrideValue === undefined) {
         // skip


### PR DESCRIPTION
The ESLint Plugin lets you define custom limits for various properties. So far this can be:
- `*` for any value
- `string` for all strings
- `number` for all numbers
- or an array of specific options which can be globs.

However, using `['string', 'number']` would not work as expected, and instead treat `'string'` and `'number'` as constants.

Sometimes, it might be useful to accept any number along with specific strings or globs. This PR allows for such a pattern and will interpret `'string'` to mean the type string, and `'number'` to mean the type number, even when used within an array.