### PR TITLE
feat: Enable support for types for CSS vars

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-create-theme-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-theme-test.js
@@ -546,5 +546,50 @@ describe('@stylexjs/babel-plugin', () => {
         };"
       `);
     });
+
+    test('transforms typed object overrides', () => {
+      expect(
+        transform(
+          `
+           ${defineVarsOutput}
+           const RADIUS = 2;
+           const buttonThemePositive = stylex.createTheme(buttonTheme, {
+            bgColor: stylex.types.color({
+              default: 'green',
+              '@media (prefers-color-scheme: dark)': 'lightgreen',
+              '@media print': 'transparent',
+            }),
+            bgColorDisabled: stylex.types.color({
+              default: 'antiquewhite',
+              '@media (prefers-color-scheme: dark)': 'floralwhite',
+            }),
+            cornerRadius: stylex.types.length({ default: RADIUS * 2 }),
+            fgColor: stylex.types.color('coral'),
+          });
+         `,
+          { dev: true, ...defaultOpts },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        export const buttonTheme = {
+          bgColor: "var(--xgck17p)",
+          bgColorDisabled: "var(--xpegid5)",
+          cornerRadius: "var(--xrqfjmn)",
+          fgColor: "var(--x4y59db)",
+          __themeName__: "x568ih9"
+        };
+        const RADIUS = 2;
+        _inject2(".x41sqjo{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4px;--x4y59db:coral;}", 0.5);
+        _inject2("@media (prefers-color-scheme: dark){.x41sqjo{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
+        _inject2("@media print{.x41sqjo{--xgck17p:transparent;}}", 0.6);
+        const buttonThemePositive = {
+          TestTheme__buttonThemePositive: "TestTheme__buttonThemePositive",
+          $$css: true,
+          x568ih9: "x41sqjo"
+        };"
+      `);
+    });
   });
 });

--- a/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
@@ -622,5 +622,56 @@ describe('@stylexjs/babel-plugin', () => {
         };"
       `);
     });
+
+    test('transforms variables object with stylex.types wrapper', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          export const buttonTheme = stylex.defineVars({
+            bgColor: stylex.types.color({
+              default: 'blue',
+              '@media (prefers-color-scheme: dark)': 'lightblue',
+              '@media print': 'white',
+            }),
+            bgColorDisabled: stylex.types.color({
+              default: 'grey',
+              '@media (prefers-color-scheme: dark)': 'rgba(0, 0, 0, 0.8)',
+            }),
+            cornerRadius: stylex.types.length('10px'),
+            fgColor: stylex.types.color({
+              default: 'pink',
+            }),
+          });
+        `,
+          {
+            dev: true,
+            unstable_moduleResolution: {
+              type: 'commonJS',
+              rootDir,
+            },
+            filename: '/stylex/packages/utils/NestedTheme.stylex.js',
+          },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2("@property --x1sm8rlu { syntax: \\"<color>\\"; inherits: true; initial-value: blue }", 0);
+        _inject2("@property --xxncinc { syntax: \\"<color>\\"; inherits: true; initial-value: grey }", 0);
+        _inject2("@property --x4e1236 { syntax: \\"<length>\\"; inherits: true; initial-value: 10px }", 0);
+        _inject2("@property --xv9uic { syntax: \\"<color>\\"; inherits: true; initial-value: pink }", 0);
+        _inject2(":root{--x1sm8rlu:blue;--xxncinc:grey;--x4e1236:10px;--xv9uic:pink;}", 0);
+        _inject2("@media (prefers-color-scheme: dark){:root{--x1sm8rlu:lightblue;--xxncinc:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject2("@media print{:root{--x1sm8rlu:white;}}", 0.1);
+        export const buttonTheme = {
+          bgColor: "var(--x1sm8rlu)",
+          bgColorDisabled: "var(--xxncinc)",
+          cornerRadius: "var(--x4e1236)",
+          fgColor: "var(--xv9uic)",
+          __themeName__: "xmpye33"
+        };"
+      `);
+    });
   });
 });

--- a/packages/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/babel-plugin/src/utils/evaluate-path.js
@@ -52,15 +52,12 @@ function isInvalidMethod(val: string): boolean {
 
 export type FunctionConfig = {
   identifiers: {
-    [fnName: string]: {
-      fn: (...args: any[]) => any,
-      takesPath?: boolean,
-    },
+    [fnName: string]: $FlowFixMe,
   },
   memberExpressions: {
     [key: string]: {
       [memberName: string]: {
-        fn: (...args: any[]) => any,
+        fn: (...args: $FlowFixMe[]) => $FlowFixMe,
         takesPath?: boolean,
       },
     },
@@ -693,14 +690,20 @@ function _evaluate(path: NodePath<>, state: State): any {
         func = (val as $FlowFixMe)[property.node.name];
       }
 
-      const parsedObj = evaluate(object, state.traversalState, state.functions);
-      if (parsedObj.confident && pathUtils.isIdentifier(property)) {
-        func = parsedObj.value[property.node.name];
-        context = parsedObj.value;
-      }
-      if (parsedObj.confident && pathUtils.isStringLiteral(property)) {
-        func = parsedObj.value[property.node.value];
-        context = parsedObj.value;
+      if (func == null) {
+        const parsedObj = evaluate(
+          object,
+          state.traversalState,
+          state.functions,
+        );
+        if (parsedObj.confident && pathUtils.isIdentifier(property)) {
+          func = parsedObj.value[property.node.name];
+          context = parsedObj.value;
+        }
+        if (parsedObj.confident && pathUtils.isStringLiteral(property)) {
+          func = parsedObj.value[property.node.value];
+          context = parsedObj.value;
+        }
       }
     }
 

--- a/packages/babel-plugin/src/visitors/stylex-define-vars.js
+++ b/packages/babel-plugin/src/visitors/stylex-define-vars.js
@@ -15,6 +15,7 @@ import {
   messages,
   utils,
   keyframes as stylexKeyframes,
+  types as stylexTypes,
   type InjectableStyle,
 } from '@stylexjs/shared';
 import { convertObjectToAST } from '../utils/js-to-ast';
@@ -93,12 +94,16 @@ export default function transformStyleXDefineVars(
     state.stylexKeyframesImport.forEach((name) => {
       identifiers[name] = { fn: keyframes };
     });
+    state.stylexTypesImport.forEach((name) => {
+      identifiers[name] = stylexTypes;
+    });
     state.stylexImport.forEach((name) => {
       if (memberExpressions[name] === undefined) {
         memberExpressions[name] = {};
       }
 
       memberExpressions[name].keyframes = { fn: keyframes };
+      identifiers[name] = { ...(identifiers[name] ?? {}), types: stylexTypes };
     });
 
     const { confident, value } = evaluate(firstArg, state, {

--- a/packages/dev-runtime/__tests__/stylex-transform-create-theme-test.js
+++ b/packages/dev-runtime/__tests__/stylex-transform-create-theme-test.js
@@ -87,5 +87,65 @@ describe('Development Plugin Transformation', () => {
         ]
       `);
     });
+
+    test('transforms typed style object', () => {
+      expect(
+        stylex.createTheme(
+          {
+            __themeName__: 'TestTheme.stylex.js//buttonTheme',
+            bgColor: 'var(--xgck17p)',
+            bgColorDisabled: 'var(--xpegid5)',
+            cornerRadius: 'var(--xrqfjmn)',
+            fgColor: 'var(--x4y59db)',
+          },
+          {
+            bgColor: stylex.types.color({
+              default: 'green',
+              '@media (prefers-color-scheme: dark)': 'lightgreen',
+              '@media print': 'transparent',
+            }),
+            bgColorDisabled: stylex.types.color({
+              default: 'antiquewhite',
+              '@media (prefers-color-scheme: dark)': 'floralwhite',
+            }),
+            cornerRadius: stylex.types.length({ default: '6px' }),
+            fgColor: stylex.types.color('coral'),
+          },
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "$$css": true,
+          "TestTheme.stylex.js//buttonTheme": "xtrlmmh",
+        }
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        [
+          [
+            "xtrlmmh",
+            {
+              "ltr": ".xtrlmmh{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}",
+              "rtl": undefined,
+            },
+            0.5,
+          ],
+          [
+            "xtrlmmh-1lveb7",
+            {
+              "ltr": "@media (prefers-color-scheme: dark){.xtrlmmh{--xgck17p:lightgreen;--xpegid5:floralwhite;}}",
+              "rtl": undefined,
+            },
+            0.6,
+          ],
+          [
+            "xtrlmmh-bdddrq",
+            {
+              "ltr": "@media print{.xtrlmmh{--xgck17p:transparent;}}",
+              "rtl": undefined,
+            },
+            0.6,
+          ],
+        ]
+      `);
+    });
   });
 });

--- a/packages/dev-runtime/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/dev-runtime/__tests__/stylex-transform-define-vars-test.js
@@ -88,5 +88,97 @@ describe('Development Plugin Transformation', () => {
         ]
       `);
     });
+    test('transforms typed vars', () => {
+      expect(
+        stylex.defineVars(
+          {
+            bgColor: stylex.types.color({
+              default: 'blue',
+              '@media (prefers-color-scheme: dark)': 'lightblue',
+              '@media print': 'white',
+            }),
+            bgColorDisabled: stylex.types.color({
+              default: 'grey',
+              '@media (prefers-color-scheme: dark)': 'rgba(0, 0, 0, 0.8)',
+            }),
+            cornerRadius: stylex.types.length('10px'),
+            fgColor: stylex.types.color({
+              default: 'pink',
+            }),
+          },
+          {
+            themeName: 'buttonTheme',
+          },
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "__themeName__": "x1t4wu1b",
+          "bgColor": "var(--xay5bfx)",
+          "bgColorDisabled": "var(--xptvf7g)",
+          "cornerRadius": "var(--x1byau2i)",
+          "fgColor": "var(--x1ww5d7a)",
+        }
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        [
+          [
+            "xay5bfx",
+            {
+              "ltr": "@property --xay5bfx { syntax: "<color>"; inherits: true; initial-value: blue }",
+              "rtl": undefined,
+            },
+            0,
+          ],
+          [
+            "xptvf7g",
+            {
+              "ltr": "@property --xptvf7g { syntax: "<color>"; inherits: true; initial-value: grey }",
+              "rtl": undefined,
+            },
+            0,
+          ],
+          [
+            "x1byau2i",
+            {
+              "ltr": "@property --x1byau2i { syntax: "<length>"; inherits: true; initial-value: 10px }",
+              "rtl": undefined,
+            },
+            0,
+          ],
+          [
+            "x1ww5d7a",
+            {
+              "ltr": "@property --x1ww5d7a { syntax: "<color>"; inherits: true; initial-value: pink }",
+              "rtl": undefined,
+            },
+            0,
+          ],
+          [
+            "x1t4wu1b",
+            {
+              "ltr": ":root{--xay5bfx:blue;--xptvf7g:grey;--x1byau2i:10px;--x1ww5d7a:pink;}",
+              "rtl": undefined,
+            },
+            0,
+          ],
+          [
+            "x1t4wu1b-1lveb7",
+            {
+              "ltr": "@media (prefers-color-scheme: dark){:root{--xay5bfx:lightblue;--xptvf7g:rgba(0, 0, 0, 0.8);}}",
+              "rtl": undefined,
+            },
+            0.1,
+          ],
+          [
+            "x1t4wu1b-bdddrq",
+            {
+              "ltr": "@media print{:root{--xay5bfx:white;}}",
+              "rtl": undefined,
+            },
+            0.1,
+          ],
+        ]
+      `);
+    });
   });
 });

--- a/packages/shared/src/types/index.js
+++ b/packages/shared/src/types/index.js
@@ -73,19 +73,20 @@ export const isCSSType = (value: mixed): value is CSSType<string | number> => {
   );
 };
 
-type AnguleValue = string;
-export class Angle<+T: AnguleValue> extends BaseCSSType implements CSSType<T> {
+type AngleValue = string;
+export class Angle<+T: AngleValue> extends BaseCSSType implements CSSType<T> {
   +value: ValueWithDefault;
   +syntax: CSSSyntaxType = '<angle>';
   static +syntax: CSSSyntaxType = '<angle>';
 
-  static create<T: AnguleValue = AnguleValue>(
-    value: ValueWithDefault,
-  ): Angle<T> {
+  static create<T: AngleValue = AngleValue>(value: ValueWithDefault): Angle<T> {
     return new Angle(value);
   }
 }
-export const angle = Angle.create;
+export const angle: <T: AngleValue = AngleValue>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => Angle<T> = Angle.create;
 
 type ColorValue = string;
 export class Color<+T: ColorValue> extends BaseCSSType implements CSSType<T> {
@@ -96,7 +97,10 @@ export class Color<+T: ColorValue> extends BaseCSSType implements CSSType<T> {
     return new Color(value);
   }
 }
-export const color = Color.create;
+export const color: <T: ColorValue = ColorValue>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => Color<T> = Color.create;
 
 type URLValue = string;
 
@@ -108,7 +112,9 @@ export class Url<+T: URLValue> extends BaseCSSType implements CSSType<T> {
     return new Url(value);
   }
 }
-export const url = Url.create;
+export const url: <T: URLValue = URLValue>(value: ValueWithDefault) => Url<T> =
+  // $FlowIgnore[method-unbinding]
+  Url.create;
 
 type ImageValue = string;
 
@@ -125,7 +131,10 @@ export class Image<+T: ImageValue> extends Url<T> implements CSSType<T> {
     return new Image(value);
   }
 }
-export const image = Image.create;
+export const image: <T: ImageValue = ImageValue>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => Image<T> = Image.create;
 
 type IntegerValue = number;
 
@@ -140,7 +149,9 @@ export class Integer<+T: IntegerValue>
     return new Integer(convertNumberToStringUsing(String, '0')(value));
   }
 }
-export const integer = Integer.create;
+export const integer: <T: IntegerValue = IntegerValue>(value: T) => Integer<T> =
+  // $FlowIgnore[method-unbinding]
+  Integer.create;
 
 type LengthPercentageValue = string;
 
@@ -163,7 +174,10 @@ export class LengthPercentage<+_T: LengthPercentageValue>
     return new LengthPercentage(convertNumberToPercentage(value));
   }
 }
-export const lengthPercentage = LengthPercentage.createLength;
+export const lengthPercentage: <_T: LengthPercentageValue | number>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => LengthPercentage<string> = LengthPercentage.createLength;
 
 type LengthValue = number | string;
 
@@ -180,7 +194,10 @@ export class Length<+_T: LengthValue>
     return new Length(convertNumberToLength(value));
   }
 }
-export const length = Length.create;
+export const length: <T: LengthValue = LengthValue>(
+  value: NestedWithNumbers,
+  // $FlowIgnore[method-unbinding]
+) => Length<T> = Length.create;
 
 type PercentageValue = string | number;
 
@@ -197,7 +214,10 @@ export class Percentage<+_T: PercentageValue>
     return new Percentage(convertNumberToPercentage(value));
   }
 }
-export const percentage = Percentage.create;
+export const percentage: <T: PercentageValue = PercentageValue>(
+  value: NestedWithNumbers,
+  // $FlowIgnore[method-unbinding]
+) => Percentage<T> = Percentage.create;
 
 type NumberValue = number;
 
@@ -211,7 +231,10 @@ export class Num<+T: NumberValue> extends BaseCSSType implements CSSType<T> {
     return new Num(convertNumberToBareString(value));
   }
 }
-export const number = Num.create;
+export const number: <T: NumberValue = NumberValue>(
+  value: NestedWithNumbers,
+  // $FlowIgnore[method-unbinding]
+) => Num<T> = Num.create;
 
 type ResolutionValue = string | 0;
 
@@ -228,7 +251,10 @@ export class Resolution<+T: ResolutionValue>
     return new Resolution(value);
   }
 }
-export const resolution = Resolution.create;
+export const resolution: <T: ResolutionValue = ResolutionValue>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => Resolution<T> = Resolution.create;
 
 type TimeValue = string | 0;
 
@@ -240,7 +266,10 @@ export class Time<+T: TimeValue> extends BaseCSSType implements CSSType<T> {
     return new Time(value);
   }
 }
-export const time = Time.create;
+export const time: <T: TimeValue = TimeValue>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => Time<T> = Time.create;
 
 type TransformFunctionValue = string;
 
@@ -257,7 +286,12 @@ export class TransformFunction<+T: TransformFunctionValue>
     return new TransformFunction(value);
   }
 }
-export const transformFunction = TransformFunction.create;
+export const transformFunction: <
+  T: TransformFunctionValue = TransformFunctionValue,
+>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => TransformFunction<T> = TransformFunction.create;
 
 type TransformListValue = string;
 
@@ -274,7 +308,10 @@ export class TransformList<T: TransformListValue>
     return new TransformList(value);
   }
 }
-export const transformList = TransformList.create;
+export const transformList: <T: TransformListValue = TransformListValue>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => TransformList<T> = TransformList.create;
 
 const convertNumberToStringUsing =
   (


### PR DESCRIPTION
Adds the ability to give variables types using `stylex.types.*` functions.

- This enables animating things like the angle value in a `conic-gradient`. 

Most of the work for this was already done, this PR does some of the final bits of work to expose the functionality in the Babel plugin and adds a few tests.

---

This PR also fixes a bug where `stylex.keyframes` couldn't be used as a value within `stylex.createTheme`.