### PR TITLE
docs: Add documentation for `stylex.types.*` functions

### DIFF
--- a/apps/docs/blog/2024-04-16-Release-v0.6.1.mdx
+++ b/apps/docs/blog/2024-04-16-Release-v0.6.1.mdx
@@ -1,0 +1,129 @@
+---
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+slug: v0.6.1
+title: Release 0.6.1
+authors: 
+  - nmn
+tags: 
+  - release
+---
+
+We're excited to release Stylex v0.5.0 with some big improvements for working
+with CSS custom properties (aka "variables") as well as numerous bug-fixes.
+
+## Improvements for Variables
+
+We've added some new features and improvements for working with variables
+and themes in StyleX.
+
+### Fallback values for variables
+
+You can now provide a fallback value for variables defined with the `stylex.defineVars` API.
+This new capability does not introduce any new API. Instead, the existing `stylex.firstThatWorks` API
+now supports variables as arguments.
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+import {colors} from './tokens.stylex';
+
+const styles = stylex.create({
+  container: {
+    color: stylex.firstThatWorks(colors.primary, 'black'),
+  },
+});
+```
+
+Using a list of fallbacks variables is supported.
+
+### Typed variables
+
+StyleX introduces a brand new set of APIs for defining `<syntax>` types for CSS
+variables. This results in `@property` rules in the generated CSS output which
+can be used to animate CSS variables as well as other special use-cases.
+
+The new `stylex.types.*` functions can be used when defining variables to define
+them with a particular type.
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+
+const typedTokens = stylex.defineVars({
+  bgColor: stylex.types.color<string>({
+    default: 'cyan',
+    [DARK]: 'navy',
+  }),
+  cornerRadius: stylex.types.length<string | number>({
+    default: '4px',
+    '@media (max-width: 600px)': 0,
+  }),
+  translucent: stylex.types.number<number>(0.5),
+  angle: stylex.types.angle<string>('0deg'),
+  shortAnimation: stylex.types.time<string>('0.5s'),
+});
+```
+
+Once variables have been defined with types, they can be animated
+with `stylex.kerframes` just like any other CSS property.
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+import {typedTokens} from './tokens.stylex';
+
+const rotatingGradient = stylex.keyframes({
+  from: {
+    [typedTokens.angle]: '0deg',
+  },
+  to: {
+    [typedTokens.angle]: '360deg',
+  },
+});
+```
+
+This can be used achieve some interesting effects, such as animating the
+`angle` angle of a linear-gradient 
+(like in this [great example from Kevin Powell](https://www.youtube.com/watch?v=-VOUK-xFAyk)).
+
+import AnimatedGradientBox from '../components/AnimatedGradientBox/AnimatedGradientBox';
+
+<AnimatedGradientBox />
+
+NOTE: TODO
+
+These new capability is primarily about CSS types, but the new API
+also makes the TypeScript (or Flow) types for the variables more powerful.
+
+As can be seen in the example, generic type arguments can be used to constrain
+the values the variable can take when creating themes with `stylex.createTheme`.
+
+
+## ESlint plugin
+
+### New `sort-keys` rule
+
+We've added a new `sort-keys` rule to the StyleX ESlint plugin. This rule
+is a stylistic rule to enforce a consistent order for keys for your StyleX
+styles.
+
+Thanks [nedjulius](https://github.com/nedjulius) & [QingqiShi](https://github.com/QingqiShi)
+
+### Improvements to `propLimits` for `valid-styles` rule.
+
+The `valid-styles` rule has been improved to allow more expressive
+"prop limits".
+
+## Miscellaneous
+
+- ESlint `'valid-styles'` rule now allows using variables created with
+  `stylex.defineVars` as keys within dynamic styles.
+- Bug-fixes to the experimental `stylex.include` API
+- Fixed debug className generation for `stylex.createTheme`
+- Units are no longer removed from `0` values
+- Compilation bug-fixes
+
+Our [Ecosystem](/docs/learn/ecosystem/) page continues to grow with community projects. Including a
+[Prettier plugin](https://github.com/nedjulius/prettier-plugin-stylex-key-sort) for sorting StyleX styles.
+
+

--- a/apps/docs/blog/2024-04-16-Release-v0.6.1.mdx
+++ b/apps/docs/blog/2024-04-16-Release-v0.6.1.mdx
@@ -66,21 +66,30 @@ const typedTokens = stylex.defineVars({
 ```
 
 Once variables have been defined with types, they can be animated
-with `stylex.kerframes` just like any other CSS property.
+with `stylex.keyframes` just like any other CSS property.
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';
 import {typedTokens} from './tokens.stylex';
 
-const rotatingGradient = stylex.keyframes({
+const rotate = stylex.keyframes({
   from: { [typedTokens.angle]: '0deg' },
   to: { [typedTokens.angle]: '360deg' },
 });
+
+const styles = stylex.create({
+  gradient: {
+    backgroundImage: `conic-gradient(from ${tokens.angle}, ...colors)`,
+    animationName: rotate,
+    animationDuration: '10s',
+    animationTimingFunction: 'linear',
+    animationIterationCount: 'infinite',
+  },
+})
 ```
 
 This can be used achieve some interesting effects, such as animating the
-`angle` angle of a linear-gradient 
-(like in this [great example from Kevin Powell](https://www.youtube.com/watch?v=-VOUK-xFAyk)).
+`angle` angle of a conic-gradient:
 
 import AnimatedGradientBox from '../components/AnimatedGradientBox/AnimatedGradientBox';
 

--- a/apps/docs/blog/2024-04-16-Release-v0.6.1.mdx
+++ b/apps/docs/blog/2024-04-16-Release-v0.6.1.mdx
@@ -11,7 +11,7 @@ tags:
   - release
 ---
 
-We're excited to release Stylex v0.5.0 with some big improvements for working
+We're excited to release Stylex v0.6.1 with some big improvements for working
 with CSS custom properties (aka "variables") as well as numerous bug-fixes.
 
 ## Improvements for Variables
@@ -89,13 +89,13 @@ const styles = stylex.create({
 ```
 
 This can be used achieve some interesting effects, such as animating the
-`angle` angle of a conic-gradient:
+`angle` of a conic-gradient:
 
 import AnimatedGradientBox from '../components/AnimatedGradientBox/AnimatedGradientBox';
 
 <AnimatedGradientBox />
 
-These new capability is primarily about CSS types, but the new API
+This new capability is primarily about CSS types, but the new API
 also makes the TypeScript (or Flow) types for the variables more powerful.
 
 As can be seen in the example, generic type arguments can be used to constrain

--- a/apps/docs/blog/2024-04-16-Release-v0.6.1.mdx
+++ b/apps/docs/blog/2024-04-16-Release-v0.6.1.mdx
@@ -11,10 +11,10 @@ tags:
   - release
 ---
 
-We're excited to release Stylex v0.6.1 with some big improvements for working
+We're excited to release StyleX v0.6.1 with some big improvements for working
 with CSS custom properties (aka "variables") as well as numerous bug-fixes.
 
-## Improvements for Variables
+## Improvements for variables
 
 We've added some new features and improvements for working with variables
 and themes in StyleX.

--- a/apps/docs/blog/2024-04-16-Release-v0.6.1.mdx
+++ b/apps/docs/blog/2024-04-16-Release-v0.6.1.mdx
@@ -73,12 +73,8 @@ import * as stylex from '@stylexjs/stylex';
 import {typedTokens} from './tokens.stylex';
 
 const rotatingGradient = stylex.keyframes({
-  from: {
-    [typedTokens.angle]: '0deg',
-  },
-  to: {
-    [typedTokens.angle]: '360deg',
-  },
+  from: { [typedTokens.angle]: '0deg' },
+  to: { [typedTokens.angle]: '360deg' },
 });
 ```
 
@@ -89,8 +85,6 @@ This can be used achieve some interesting effects, such as animating the
 import AnimatedGradientBox from '../components/AnimatedGradientBox/AnimatedGradientBox';
 
 <AnimatedGradientBox />
-
-NOTE: TODO
 
 These new capability is primarily about CSS types, but the new API
 also makes the TypeScript (or Flow) types for the variables more powerful.

--- a/apps/docs/components/AnimatedGradientBox/AnimatedGradientBox.js
+++ b/apps/docs/components/AnimatedGradientBox/AnimatedGradientBox.js
@@ -15,7 +15,11 @@ import { tokens } from './tokens.stylex';
 export default function AnimatedGradientBox() {
   return (
     <div {...stylex.props(styles.container)}>
-      <div {...stylex.props(styles.card)} />
+      <div {...stylex.props(styles.card)}>
+        <div {...stylex.props(styles.gradient)} />
+        <div {...stylex.props(styles.gradient, styles.blur)} />
+        <div {...stylex.props(styles.bgColor)} />
+      </div>
     </div>
   );
 }
@@ -33,30 +37,41 @@ const rotate = stylex.keyframes({
 
 const styles = stylex.create({
   container: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     aspectRatio: '16 / 9',
     backgroundColor: COLOR_2,
     borderRadius: 8,
     boxSizing: 'border-box',
-    padding: 64,
     width: '100%',
     marginBlock: 16,
+    zIndex: 0,
   },
   card: {
-    backgroundColor: COLOR_1,
-    borderRadius: 8,
-    height: '100%',
+    borderRadius: 16,
+    height: '65%',
     position: 'relative',
-    width: '100%',
+    width: '65%',
+    boxSizing: 'border-box',
+  },
+  blur: {
+    filter: 'blur(25px)',
   },
   gradient: {
     position: 'absolute',
-    inset: -8,
-    zIndex: -1,
+    inset: 0,
     backgroundImage: `conic-gradient(from ${tokens.angle}, ${COLOR_3}, ${COLOR_4}, ${COLOR_5}, ${COLOR_4}, ${COLOR_3})`,
     borderRadius: 16,
     animationName: rotate,
     animationDuration: '10s',
     animationTimingFunction: 'linear',
     animationIterationCount: 'infinite',
+  },
+  bgColor: {
+    position: 'absolute',
+    inset: '8px',
+    backgroundColor: COLOR_1,
+    borderRadius: 8,
   },
 });

--- a/apps/docs/components/AnimatedGradientBox/AnimatedGradientBox.js
+++ b/apps/docs/components/AnimatedGradientBox/AnimatedGradientBox.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+import * as React from 'react';
+import * as stylex from '@stylexjs/stylex';
+
+import { tokens } from './tokens.stylex';
+
+export default function AnimatedGradientBox() {
+  return (
+    <div {...stylex.props(styles.container)}>
+      <div {...stylex.props(styles.card)} />
+    </div>
+  );
+}
+
+const COLOR_1 = '#052b2f';
+const COLOR_2 = '#073438';
+const COLOR_3 = '#0e4b50';
+const COLOR_4 = '#2d8f85';
+const COLOR_5 = '#637c54';
+
+const rotate = stylex.keyframes({
+  '0%': { [tokens.angle]: '0deg' },
+  '100%': { [tokens.angle]: '360deg' },
+});
+
+const styles = stylex.create({
+  container: {
+    aspectRatio: '16 / 9',
+    backgroundColor: COLOR_2,
+    borderRadius: 8,
+    boxSizing: 'border-box',
+    padding: 64,
+    width: '100%',
+    marginBlock: 16,
+  },
+  card: {
+    backgroundColor: COLOR_1,
+    borderRadius: 8,
+    height: '100%',
+    position: 'relative',
+    width: '100%',
+  },
+  gradient: {
+    position: 'absolute',
+    inset: -8,
+    zIndex: -1,
+    backgroundImage: `conic-gradient(from ${tokens.angle}, ${COLOR_3}, ${COLOR_4}, ${COLOR_5}, ${COLOR_4}, ${COLOR_3})`,
+    borderRadius: 16,
+    animationName: rotate,
+    animationDuration: '10s',
+    animationTimingFunction: 'linear',
+    animationIterationCount: 'infinite',
+  },
+});

--- a/apps/docs/components/AnimatedGradientBox/AnimatedGradientBox.js
+++ b/apps/docs/components/AnimatedGradientBox/AnimatedGradientBox.js
@@ -18,17 +18,19 @@ export default function AnimatedGradientBox() {
       <div {...stylex.props(styles.card)}>
         <div {...stylex.props(styles.gradient)} />
         <div {...stylex.props(styles.gradient, styles.blur)} />
-        <div {...stylex.props(styles.bgColor)} />
       </div>
     </div>
   );
 }
 
-const COLOR_1 = '#052b2f';
-const COLOR_2 = '#073438';
-const COLOR_3 = '#0e4b50';
-const COLOR_4 = '#2d8f85';
-const COLOR_5 = '#637c54';
+const COLOR_1 = '#ffadad';
+const COLOR_2 = '#ffd6a5';
+const COLOR_3 = '#fdffb6';
+const COLOR_4 = '#caffbf';
+const COLOR_5 = '#9bf6ff';
+const COLOR_6 = '#a0c4ff';
+const COLOR_7 = '#bdb2ff';
+const COLOR_8 = '#ffc6ff';
 
 const rotate = stylex.keyframes({
   '0%': { [tokens.angle]: '0deg' },
@@ -41,7 +43,6 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     aspectRatio: '16 / 9',
-    backgroundColor: COLOR_2,
     borderRadius: 8,
     boxSizing: 'border-box',
     width: '100%',
@@ -61,17 +62,11 @@ const styles = stylex.create({
   gradient: {
     position: 'absolute',
     inset: 0,
-    backgroundImage: `conic-gradient(from ${tokens.angle}, ${COLOR_3}, ${COLOR_4}, ${COLOR_5}, ${COLOR_4}, ${COLOR_3})`,
+    backgroundImage: `conic-gradient(from ${tokens.angle}, ${COLOR_1}, ${COLOR_2}, ${COLOR_3}, ${COLOR_4}, ${COLOR_5}, ${COLOR_6}, ${COLOR_7}, ${COLOR_8}, ${COLOR_1})`,
     borderRadius: 16,
     animationName: rotate,
     animationDuration: '10s',
     animationTimingFunction: 'linear',
     animationIterationCount: 'infinite',
-  },
-  bgColor: {
-    position: 'absolute',
-    inset: '8px',
-    backgroundColor: COLOR_1,
-    borderRadius: 8,
   },
 });

--- a/apps/docs/components/AnimatedGradientBox/tokens.stylex.js
+++ b/apps/docs/components/AnimatedGradientBox/tokens.stylex.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+import * as stylex from '@stylexjs/stylex';
+
+export const tokens = stylex.defineVars({
+  angle: '0deg',
+});

--- a/apps/docs/components/AnimatedGradientBox/tokens.stylex.js
+++ b/apps/docs/components/AnimatedGradientBox/tokens.stylex.js
@@ -10,5 +10,5 @@
 import * as stylex from '@stylexjs/stylex';
 
 export const tokens = stylex.defineVars({
-  angle: '0deg',
+  angle: stylex.types.angle('0deg'),
 });

--- a/apps/docs/docs/api/index.mdx
+++ b/apps/docs/docs/api/index.mdx
@@ -23,11 +23,12 @@ sidebar_position: 1
 - [`stylex.firstThatWorks()`](./javascript/firstThatWorks.mdx)
 - [`stylex.defineVars()`](./javascript/defineVars.mdx)
 - [`stylex.createTheme()`](./javascript/createTheme.mdx)
+- [`stylex.types.*()`](./javascript/types.mdx)
 
 ## Static types
 
-- [`type StyleXStyles`](/docs/api/types/StyleXStyles/)
-- [`type StyleXStylesWithout`](/docs/api/types/StyleXStylesWithout/)
-- [`type StaticStyles`](/docs/api/types/StaticStyles/)
-- [`type VarGroup`](/docs/api/types/VarGroup/)
-- [`type Theme`](/docs/api/types/Theme/)
+- [`type StyleXStyles`](./types/StyleXStyles.mdx)
+- [`type StyleXStylesWithout`](./types/StyleXStylesWithout.mdx)
+- [`type StaticStyles`](./types/StaticStyles.mdx)
+- [`type VarGroup`](./types/VarGroup.mdx)
+- [`type Theme`](./types/Theme.mdx)

--- a/apps/docs/docs/api/javascript/types.mdx
+++ b/apps/docs/docs/api/javascript/types.mdx
@@ -1,0 +1,67 @@
+---
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+sidebar_position: 7
+---
+
+# `stylex.types.*`
+
+A set of helper functions to be used within [`stylex.defineVars`](./defineVars.mdx)
+and [`stylex.createTheme`](./createTheme.mdx) to define CSS types for variables.
+
+These functions result in `@property` CSS rules for the variables with the appropriate
+`syntax` value.
+
+### Example use:
+
+The `types.*` functions are compatible with all patterns that are supported
+by `stylex.defineVars` and `stylex.createTheme` already.
+
+For example, consider the following set of variables:
+
+```tsx title="vars.stylex.js"
+import * as stylex from '@stylexjs/stylex';
+
+export const colors = stylex.defineVars({
+  accent: {
+    default: 'blue',
+    '@media (prefers-color-scheme: dark)': 'lightblue',
+  },
+  sm: '4px',
+});
+```
+
+You can give the two variables types like so:
+
+```tsx title="vars.stylex.js"
+import * as stylex from '@stylexjs/stylex';
+
+export const colors = stylex.defineVars({
+  accent: stylex.types.color({
+    default: 'blue',
+    '@media (prefers-color-scheme: dark)': 'lightblue',
+  }),
+  sm: stylex.types.length('4px'),
+});
+```
+
+## Available types
+
+The following types are available:
+
+- `stylex.types.angle`
+- `stylex.types.color`
+- `stylex.types.url`
+- `stylex.types.image`
+- `stylex.types.integer`
+- `stylex.types.lengthPercentage`
+- `stylex.types.length`
+- `stylex.types.percentage`
+- `stylex.types.number`
+- `stylex.types.resolution`
+- `stylex.types.time`
+- `stylex.types.transformFunction`
+- `stylex.types.transformList`
+

--- a/apps/docs/docs/api/javascript/types.mdx
+++ b/apps/docs/docs/api/javascript/types.mdx
@@ -51,17 +51,81 @@ export const colors = stylex.defineVars({
 
 The following types are available:
 
-- `stylex.types.angle`
-- `stylex.types.color`
-- `stylex.types.url`
-- `stylex.types.image`
-- `stylex.types.integer`
-- `stylex.types.lengthPercentage`
-- `stylex.types.length`
-- `stylex.types.percentage`
-- `stylex.types.number`
-- `stylex.types.resolution`
-- `stylex.types.time`
-- `stylex.types.transformFunction`
-- `stylex.types.transformList`
+### `stylex.types.angle`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with a [`<angle>`](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
+
+### `stylex.types.color`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with a [`<color>`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
+
+### `stylex.types.url`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with a [`<url>`](https://developer.mozilla.org/en-US/docs/Web/CSS/url)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
+
+### `stylex.types.image`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with an [`<image>`](https://developer.mozilla.org/en-US/docs/Web/CSS/image)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
+
+### `stylex.types.integer`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with an [`<integer>`](https://developer.mozilla.org/en-US/docs/Web/CSS/integer)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
+
+### `stylex.types.lengthPercentage`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with a [`<length-percentage>`](https://developer.mozilla.org/en-US/docs/Web/CSS/length-percentage)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
+
+### `stylex.types.length`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with a [`<length>`](https://developer.mozilla.org/en-US/docs/Web/CSS/length)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
+
+### `stylex.types.percentage`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with a [`<percentage>`](https://developer.mozilla.org/en-US/docs/Web/CSS/percentage)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
+
+### `stylex.types.number`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with a [`<number>`](https://developer.mozilla.org/en-US/docs/Web/CSS/number)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
+
+### `stylex.types.resolution`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with a [`<resolution>`](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
+
+### `stylex.types.time`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with a [`<time>`](https://developer.mozilla.org/en-US/docs/Web/CSS/time)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
+
+### `stylex.types.transformFunction`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with a [`<transform-function>`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
+
+### `stylex.types.transformList`
+
+Generates a [`@property` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+for the generated CSS variable with a [`<transform-list>`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function)
+[syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax).
 

--- a/apps/docs/docs/learn/05-theming/04-variable-types.mdx
+++ b/apps/docs/docs/learn/05-theming/04-variable-types.mdx
@@ -21,7 +21,7 @@ option needs to be enabled in the StyleX Babel configuration to enable theming A
 :::warning Advanced use-cases
 
 Declaring types for variables is an advanced use-case. It is not necessary for
-the majority of theming use-cases.
+the majority of use-cases.
 
 :::
 
@@ -159,7 +159,7 @@ a value is assigned.
 
 ### Animating gradients
 
-It is usally not possible to animate gradients. However, by using a typed
+It is usually not possible to animate gradients. However, by using a typed
 `angle` variable, the gradient can be animated by animating the angle used
 within it.
 

--- a/apps/docs/docs/learn/05-theming/04-variable-types.mdx
+++ b/apps/docs/docs/learn/05-theming/04-variable-types.mdx
@@ -41,21 +41,7 @@ with CSS. Some examples include:
 To assign types to variables in StyleX, you can use the various functions, such
 as `stylex.types.color` or `stylex.types.length`.
 
-The complete list of type functions is:
-
-- `stylex.types.angle`
-- `stylex.types.color`
-- `stylex.types.url`
-- `stylex.types.image`
-- `stylex.types.integer`
-- `stylex.types.lengthPercentage`
-- `stylex.types.length`
-- `stylex.types.percentage`
-- `stylex.types.number`
-- `stylex.types.resolution`
-- `stylex.types.time`
-- `stylex.types.transformFunction`
-- `stylex.types.transformList`
+Reference the [API documentation](../../api/javascript/types.mdx) for a full list of available functions.
 
 ## Usage
 
@@ -134,11 +120,11 @@ is required by the static types for type-safety.
 
 ## Example use-cases
 
-### Simulating `round()`
+### Simulating [`round()`](https://developer.mozilla.org/en-US/docs/Web/CSS/round)
 
-Modern browsers are [starting to support](https://caniuse.com/?search=round())
-the `round()` function in CSS. However, the feature can be simulated with
-a variable with an `integer` type:
+Modern browsers are starting to support
+the [`round()`](https://developer.mozilla.org/en-US/docs/Web/CSS/round) function in CSS. 
+However, the feature can be simulated with a variable with an `integer` type:
 
 ```tsx
 const styles = stylex.create({

--- a/apps/docs/docs/learn/05-theming/04-variable-types.mdx
+++ b/apps/docs/docs/learn/05-theming/04-variable-types.mdx
@@ -1,0 +1,193 @@
+---
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+sidebar_position: 4
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Types for Variables
+
+:::info Note
+
+The [`unstable_moduleResolution`](/docs/api/configuration/babel-plugin/#unstable_moduleresolution)
+option needs to be enabled in the StyleX Babel configuration to enable theming APIs.
+
+:::
+
+:::warning Advanced use-cases
+
+Declaring types for variables is an advanced use-case. It is not necessary for
+the majority of theming use-cases.
+
+:::
+
+By default, variables values are strings. This is the correct choice for the
+majority of use-cases. However, modern browsers support defining types for CSS
+variables. A variable can be declared with an `@property` rule that specifies
+the `<syntax>` type of the variable.
+
+Doing so can enable some interesting use-cases that would otherwise not be possible
+with CSS. Some examples include:
+- Animating gradients by animating an angle or color variables
+- Capturing the value of `1em` on an element and using it on a descendant
+- Converting a floating point number to an integer
+
+## API
+
+To assign types to variables in StyleX, you can use the various functions, such
+as `stylex.types.color` or `stylex.types.length`.
+
+The complete list of type functions is:
+
+- `stylex.types.angle`
+- `stylex.types.color`
+- `stylex.types.url`
+- `stylex.types.image`
+- `stylex.types.integer`
+- `stylex.types.lengthPercentage`
+- `stylex.types.length`
+- `stylex.types.percentage`
+- `stylex.types.number`
+- `stylex.types.resolution`
+- `stylex.types.time`
+- `stylex.types.transformFunction`
+- `stylex.types.transformList`
+
+## Usage
+
+To assign types to variables, the value of the variable can be wrapped in
+with the appropriate type function.
+
+For example, consider the following set of variables:
+
+```tsx title="tokens.stylex.js"
+import * as stylex from '@stylexjs/stylex';
+
+export const tokens = stylex.defineVars({
+  primaryText: 'black',
+  secondaryText: '#333',
+  borderRadius: '4px',
+  angle: '0deg',
+  int: '2',
+});
+```
+
+Currently, all the values can be arbitrary strings. To assign types to the
+variables, they can be wrapped with the appropriate type function:
+
+```tsx title="tokens.stylex.js"
+import * as stylex from '@stylexjs/stylex';
+
+export const tokens = stylex.defineVars({
+  primaryText: stylex.types.color('black'),
+  secondaryText: stylex.types.color('#333'),
+  borderRadius: stylex.types.length('4px'),
+  angle: stylex.types.angle('0deg'),
+  int: stylex.types.integer(2),
+});
+```
+
+### Conditional Values
+
+The usage remains unchanged even when at-rules are used within the values.
+The following is completely valid:
+
+```tsx title="tokens.stylex.js"
+import * as stylex from '@stylexjs/stylex';
+
+export const colors = stylex.defineVars({
+  primaryText: stylex.types.color({default: 'black', [DARK]: 'white'}),
+});
+```
+
+## Type-safety in your source code
+
+The primary utility of `stylex.types.*` functions is to enable functionality
+by declaring types for variables in the generated CSS. However, the StyleX API
+also enhances the type-safety within your own codebase.
+
+When a variable is declared with a certain type within `stylex.defineVars`, the
+static types will enforce that the same type function is used when the variable
+is themed within a `stylex.createTheme` call.
+
+
+```tsx title="theme.js"
+import * as stylex from '@stylexjs/stylex';
+import {tokens} from './tokens.stylex.js';
+
+export const highContrast = stylex.defineVars({
+  primaryText: stylex.types.color('black'),
+  secondaryText: stylex.types.color('#222'),
+  borderRadius: stylex.types.length('8px'),
+  angle: stylex.types.angle('0deg'),
+  int: stylex.types.integer(4),
+});
+```
+
+Since the types for the variables are already declared within the `stylex.defineVars`
+call, the usage type functions within `stylex.createTheme` is functionally a no-op, but
+is required by the static types for type-safety.
+
+## Example use-cases
+
+### Simulating `round()`
+
+Modern browsers are [starting to support](https://caniuse.com/?search=round())
+the `round()` function in CSS. However, the feature can be simulated with
+a variable with an `integer` type:
+
+```tsx
+const styles = stylex.create({
+  gradient: {
+    // Math.floor
+    [tokens.int]: `calc(16 / 9)`
+
+    // Math.round
+    [tokens.int]: `calc((16 / 9) + 0.5)`
+  },
+})
+```
+
+Since `tokens.int` is declared with an `integer` type, any fractional
+value is discarded and the value is cast into an integer type whenever
+a value is assigned.
+
+
+### Animating gradients
+
+It is usally not possible to animate gradients. However, by using a typed
+`angle` variable, the gradient can be animated by animating the angle used
+within it.
+
+Instead of animating a *normal* CSS property, the `angle` variable can be
+animated with `stylex.keyframes`:
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+import {tokens} from './tokens.stylex';
+
+const rotate = stylex.keyframes({
+  from: { [tokens.angle]: '0deg' },
+  to: { [tokens.angle]: '360deg' },
+});
+
+const styles = stylex.create({
+  gradient: {
+    backgroundImage: `conic-gradient(from ${tokens.angle}, ...colors)`,
+    animationName: rotate,
+    animationDuration: '10s',
+    animationTimingFunction: 'linear',
+    animationIterationCount: 'infinite',
+  },
+})
+```
+
+This can be used to create rotating conic gradients:
+
+import AnimatedGradientBox from '../../../components/AnimatedGradientBox/AnimatedGradientBox';
+
+<AnimatedGradientBox />

--- a/packages/babel-plugin/__tests__/stylex-transform-create-theme-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-theme-test.js
@@ -546,5 +546,50 @@ describe('@stylexjs/babel-plugin', () => {
         };"
       `);
     });
+
+    test('transforms typed object overrides', () => {
+      expect(
+        transform(
+          `
+           ${defineVarsOutput}
+           const RADIUS = 2;
+           const buttonThemePositive = stylex.createTheme(buttonTheme, {
+            bgColor: stylex.types.color({
+              default: 'green',
+              '@media (prefers-color-scheme: dark)': 'lightgreen',
+              '@media print': 'transparent',
+            }),
+            bgColorDisabled: stylex.types.color({
+              default: 'antiquewhite',
+              '@media (prefers-color-scheme: dark)': 'floralwhite',
+            }),
+            cornerRadius: stylex.types.length({ default: RADIUS * 2 }),
+            fgColor: stylex.types.color('coral'),
+          });
+         `,
+          { dev: true, ...defaultOpts },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        export const buttonTheme = {
+          bgColor: "var(--xgck17p)",
+          bgColorDisabled: "var(--xpegid5)",
+          cornerRadius: "var(--xrqfjmn)",
+          fgColor: "var(--x4y59db)",
+          __themeName__: "x568ih9"
+        };
+        const RADIUS = 2;
+        _inject2(".x41sqjo{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4px;--x4y59db:coral;}", 0.5);
+        _inject2("@media (prefers-color-scheme: dark){.x41sqjo{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
+        _inject2("@media print{.x41sqjo{--xgck17p:transparent;}}", 0.6);
+        const buttonThemePositive = {
+          TestTheme__buttonThemePositive: "TestTheme__buttonThemePositive",
+          $$css: true,
+          x568ih9: "x41sqjo"
+        };"
+      `);
+    });
   });
 });

--- a/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
@@ -622,5 +622,56 @@ describe('@stylexjs/babel-plugin', () => {
         };"
       `);
     });
+
+    test('transforms variables object with stylex.types wrapper', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          export const buttonTheme = stylex.defineVars({
+            bgColor: stylex.types.color({
+              default: 'blue',
+              '@media (prefers-color-scheme: dark)': 'lightblue',
+              '@media print': 'white',
+            }),
+            bgColorDisabled: stylex.types.color({
+              default: 'grey',
+              '@media (prefers-color-scheme: dark)': 'rgba(0, 0, 0, 0.8)',
+            }),
+            cornerRadius: stylex.types.length('10px'),
+            fgColor: stylex.types.color({
+              default: 'pink',
+            }),
+          });
+        `,
+          {
+            dev: true,
+            unstable_moduleResolution: {
+              type: 'commonJS',
+              rootDir,
+            },
+            filename: '/stylex/packages/utils/NestedTheme.stylex.js',
+          },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2("@property --x1sm8rlu { syntax: \\"<color>\\"; inherits: true; initial-value: blue }", 0);
+        _inject2("@property --xxncinc { syntax: \\"<color>\\"; inherits: true; initial-value: grey }", 0);
+        _inject2("@property --x4e1236 { syntax: \\"<length>\\"; inherits: true; initial-value: 10px }", 0);
+        _inject2("@property --xv9uic { syntax: \\"<color>\\"; inherits: true; initial-value: pink }", 0);
+        _inject2(":root{--x1sm8rlu:blue;--xxncinc:grey;--x4e1236:10px;--xv9uic:pink;}", 0);
+        _inject2("@media (prefers-color-scheme: dark){:root{--x1sm8rlu:lightblue;--xxncinc:rgba(0, 0, 0, 0.8);}}", 0.1);
+        _inject2("@media print{:root{--x1sm8rlu:white;}}", 0.1);
+        export const buttonTheme = {
+          bgColor: "var(--x1sm8rlu)",
+          bgColorDisabled: "var(--xxncinc)",
+          cornerRadius: "var(--x4e1236)",
+          fgColor: "var(--xv9uic)",
+          __themeName__: "xmpye33"
+        };"
+      `);
+    });
   });
 });

--- a/packages/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/babel-plugin/src/utils/evaluate-path.js
@@ -52,15 +52,12 @@ function isInvalidMethod(val: string): boolean {
 
 export type FunctionConfig = {
   identifiers: {
-    [fnName: string]: {
-      fn: (...args: any[]) => any,
-      takesPath?: boolean,
-    },
+    [fnName: string]: $FlowFixMe,
   },
   memberExpressions: {
     [key: string]: {
       [memberName: string]: {
-        fn: (...args: any[]) => any,
+        fn: (...args: $FlowFixMe[]) => $FlowFixMe,
         takesPath?: boolean,
       },
     },
@@ -693,14 +690,20 @@ function _evaluate(path: NodePath<>, state: State): any {
         func = (val as $FlowFixMe)[property.node.name];
       }
 
-      const parsedObj = evaluate(object, state.traversalState, state.functions);
-      if (parsedObj.confident && pathUtils.isIdentifier(property)) {
-        func = parsedObj.value[property.node.name];
-        context = parsedObj.value;
-      }
-      if (parsedObj.confident && pathUtils.isStringLiteral(property)) {
-        func = parsedObj.value[property.node.value];
-        context = parsedObj.value;
+      if (func == null) {
+        const parsedObj = evaluate(
+          object,
+          state.traversalState,
+          state.functions,
+        );
+        if (parsedObj.confident && pathUtils.isIdentifier(property)) {
+          func = parsedObj.value[property.node.name];
+          context = parsedObj.value;
+        }
+        if (parsedObj.confident && pathUtils.isStringLiteral(property)) {
+          func = parsedObj.value[property.node.value];
+          context = parsedObj.value;
+        }
       }
     }
 

--- a/packages/babel-plugin/src/visitors/stylex-define-vars.js
+++ b/packages/babel-plugin/src/visitors/stylex-define-vars.js
@@ -15,6 +15,7 @@ import {
   messages,
   utils,
   keyframes as stylexKeyframes,
+  types as stylexTypes,
   type InjectableStyle,
 } from '@stylexjs/shared';
 import { convertObjectToAST } from '../utils/js-to-ast';
@@ -93,12 +94,16 @@ export default function transformStyleXDefineVars(
     state.stylexKeyframesImport.forEach((name) => {
       identifiers[name] = { fn: keyframes };
     });
+    state.stylexTypesImport.forEach((name) => {
+      identifiers[name] = stylexTypes;
+    });
     state.stylexImport.forEach((name) => {
       if (memberExpressions[name] === undefined) {
         memberExpressions[name] = {};
       }
 
       memberExpressions[name].keyframes = { fn: keyframes };
+      identifiers[name] = { ...(identifiers[name] ?? {}), types: stylexTypes };
     });
 
     const { confident, value } = evaluate(firstArg, state, {

--- a/packages/dev-runtime/__tests__/stylex-transform-create-theme-test.js
+++ b/packages/dev-runtime/__tests__/stylex-transform-create-theme-test.js
@@ -87,5 +87,65 @@ describe('Development Plugin Transformation', () => {
         ]
       `);
     });
+
+    test('transforms typed style object', () => {
+      expect(
+        stylex.createTheme(
+          {
+            __themeName__: 'TestTheme.stylex.js//buttonTheme',
+            bgColor: 'var(--xgck17p)',
+            bgColorDisabled: 'var(--xpegid5)',
+            cornerRadius: 'var(--xrqfjmn)',
+            fgColor: 'var(--x4y59db)',
+          },
+          {
+            bgColor: stylex.types.color({
+              default: 'green',
+              '@media (prefers-color-scheme: dark)': 'lightgreen',
+              '@media print': 'transparent',
+            }),
+            bgColorDisabled: stylex.types.color({
+              default: 'antiquewhite',
+              '@media (prefers-color-scheme: dark)': 'floralwhite',
+            }),
+            cornerRadius: stylex.types.length({ default: '6px' }),
+            fgColor: stylex.types.color('coral'),
+          },
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "$$css": true,
+          "TestTheme.stylex.js//buttonTheme": "xtrlmmh",
+        }
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        [
+          [
+            "xtrlmmh",
+            {
+              "ltr": ".xtrlmmh{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}",
+              "rtl": undefined,
+            },
+            0.5,
+          ],
+          [
+            "xtrlmmh-1lveb7",
+            {
+              "ltr": "@media (prefers-color-scheme: dark){.xtrlmmh{--xgck17p:lightgreen;--xpegid5:floralwhite;}}",
+              "rtl": undefined,
+            },
+            0.6,
+          ],
+          [
+            "xtrlmmh-bdddrq",
+            {
+              "ltr": "@media print{.xtrlmmh{--xgck17p:transparent;}}",
+              "rtl": undefined,
+            },
+            0.6,
+          ],
+        ]
+      `);
+    });
   });
 });

--- a/packages/dev-runtime/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/dev-runtime/__tests__/stylex-transform-define-vars-test.js
@@ -88,5 +88,97 @@ describe('Development Plugin Transformation', () => {
         ]
       `);
     });
+    test('transforms typed vars', () => {
+      expect(
+        stylex.defineVars(
+          {
+            bgColor: stylex.types.color({
+              default: 'blue',
+              '@media (prefers-color-scheme: dark)': 'lightblue',
+              '@media print': 'white',
+            }),
+            bgColorDisabled: stylex.types.color({
+              default: 'grey',
+              '@media (prefers-color-scheme: dark)': 'rgba(0, 0, 0, 0.8)',
+            }),
+            cornerRadius: stylex.types.length('10px'),
+            fgColor: stylex.types.color({
+              default: 'pink',
+            }),
+          },
+          {
+            themeName: 'buttonTheme',
+          },
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "__themeName__": "x1t4wu1b",
+          "bgColor": "var(--xay5bfx)",
+          "bgColorDisabled": "var(--xptvf7g)",
+          "cornerRadius": "var(--x1byau2i)",
+          "fgColor": "var(--x1ww5d7a)",
+        }
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        [
+          [
+            "xay5bfx",
+            {
+              "ltr": "@property --xay5bfx { syntax: "<color>"; inherits: true; initial-value: blue }",
+              "rtl": undefined,
+            },
+            0,
+          ],
+          [
+            "xptvf7g",
+            {
+              "ltr": "@property --xptvf7g { syntax: "<color>"; inherits: true; initial-value: grey }",
+              "rtl": undefined,
+            },
+            0,
+          ],
+          [
+            "x1byau2i",
+            {
+              "ltr": "@property --x1byau2i { syntax: "<length>"; inherits: true; initial-value: 10px }",
+              "rtl": undefined,
+            },
+            0,
+          ],
+          [
+            "x1ww5d7a",
+            {
+              "ltr": "@property --x1ww5d7a { syntax: "<color>"; inherits: true; initial-value: pink }",
+              "rtl": undefined,
+            },
+            0,
+          ],
+          [
+            "x1t4wu1b",
+            {
+              "ltr": ":root{--xay5bfx:blue;--xptvf7g:grey;--x1byau2i:10px;--x1ww5d7a:pink;}",
+              "rtl": undefined,
+            },
+            0,
+          ],
+          [
+            "x1t4wu1b-1lveb7",
+            {
+              "ltr": "@media (prefers-color-scheme: dark){:root{--xay5bfx:lightblue;--xptvf7g:rgba(0, 0, 0, 0.8);}}",
+              "rtl": undefined,
+            },
+            0.1,
+          ],
+          [
+            "x1t4wu1b-bdddrq",
+            {
+              "ltr": "@media print{:root{--xay5bfx:white;}}",
+              "rtl": undefined,
+            },
+            0.1,
+          ],
+        ]
+      `);
+    });
   });
 });

--- a/packages/shared/src/types/index.js
+++ b/packages/shared/src/types/index.js
@@ -73,19 +73,20 @@ export const isCSSType = (value: mixed): value is CSSType<string | number> => {
   );
 };
 
-type AnguleValue = string;
-export class Angle<+T: AnguleValue> extends BaseCSSType implements CSSType<T> {
+type AngleValue = string;
+export class Angle<+T: AngleValue> extends BaseCSSType implements CSSType<T> {
   +value: ValueWithDefault;
   +syntax: CSSSyntaxType = '<angle>';
   static +syntax: CSSSyntaxType = '<angle>';
 
-  static create<T: AnguleValue = AnguleValue>(
-    value: ValueWithDefault,
-  ): Angle<T> {
+  static create<T: AngleValue = AngleValue>(value: ValueWithDefault): Angle<T> {
     return new Angle(value);
   }
 }
-export const angle = Angle.create;
+export const angle: <T: AngleValue = AngleValue>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => Angle<T> = Angle.create;
 
 type ColorValue = string;
 export class Color<+T: ColorValue> extends BaseCSSType implements CSSType<T> {
@@ -96,7 +97,10 @@ export class Color<+T: ColorValue> extends BaseCSSType implements CSSType<T> {
     return new Color(value);
   }
 }
-export const color = Color.create;
+export const color: <T: ColorValue = ColorValue>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => Color<T> = Color.create;
 
 type URLValue = string;
 
@@ -108,7 +112,9 @@ export class Url<+T: URLValue> extends BaseCSSType implements CSSType<T> {
     return new Url(value);
   }
 }
-export const url = Url.create;
+export const url: <T: URLValue = URLValue>(value: ValueWithDefault) => Url<T> =
+  // $FlowIgnore[method-unbinding]
+  Url.create;
 
 type ImageValue = string;
 
@@ -125,7 +131,10 @@ export class Image<+T: ImageValue> extends Url<T> implements CSSType<T> {
     return new Image(value);
   }
 }
-export const image = Image.create;
+export const image: <T: ImageValue = ImageValue>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => Image<T> = Image.create;
 
 type IntegerValue = number;
 
@@ -140,7 +149,9 @@ export class Integer<+T: IntegerValue>
     return new Integer(convertNumberToStringUsing(String, '0')(value));
   }
 }
-export const integer = Integer.create;
+export const integer: <T: IntegerValue = IntegerValue>(value: T) => Integer<T> =
+  // $FlowIgnore[method-unbinding]
+  Integer.create;
 
 type LengthPercentageValue = string;
 
@@ -163,7 +174,10 @@ export class LengthPercentage<+_T: LengthPercentageValue>
     return new LengthPercentage(convertNumberToPercentage(value));
   }
 }
-export const lengthPercentage = LengthPercentage.createLength;
+export const lengthPercentage: <_T: LengthPercentageValue | number>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => LengthPercentage<string> = LengthPercentage.createLength;
 
 type LengthValue = number | string;
 
@@ -180,7 +194,10 @@ export class Length<+_T: LengthValue>
     return new Length(convertNumberToLength(value));
   }
 }
-export const length = Length.create;
+export const length: <T: LengthValue = LengthValue>(
+  value: NestedWithNumbers,
+  // $FlowIgnore[method-unbinding]
+) => Length<T> = Length.create;
 
 type PercentageValue = string | number;
 
@@ -197,7 +214,10 @@ export class Percentage<+_T: PercentageValue>
     return new Percentage(convertNumberToPercentage(value));
   }
 }
-export const percentage = Percentage.create;
+export const percentage: <T: PercentageValue = PercentageValue>(
+  value: NestedWithNumbers,
+  // $FlowIgnore[method-unbinding]
+) => Percentage<T> = Percentage.create;
 
 type NumberValue = number;
 
@@ -211,7 +231,10 @@ export class Num<+T: NumberValue> extends BaseCSSType implements CSSType<T> {
     return new Num(convertNumberToBareString(value));
   }
 }
-export const number = Num.create;
+export const number: <T: NumberValue = NumberValue>(
+  value: NestedWithNumbers,
+  // $FlowIgnore[method-unbinding]
+) => Num<T> = Num.create;
 
 type ResolutionValue = string | 0;
 
@@ -228,7 +251,10 @@ export class Resolution<+T: ResolutionValue>
     return new Resolution(value);
   }
 }
-export const resolution = Resolution.create;
+export const resolution: <T: ResolutionValue = ResolutionValue>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => Resolution<T> = Resolution.create;
 
 type TimeValue = string | 0;
 
@@ -240,7 +266,10 @@ export class Time<+T: TimeValue> extends BaseCSSType implements CSSType<T> {
     return new Time(value);
   }
 }
-export const time = Time.create;
+export const time: <T: TimeValue = TimeValue>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => Time<T> = Time.create;
 
 type TransformFunctionValue = string;
 
@@ -257,7 +286,12 @@ export class TransformFunction<+T: TransformFunctionValue>
     return new TransformFunction(value);
   }
 }
-export const transformFunction = TransformFunction.create;
+export const transformFunction: <
+  T: TransformFunctionValue = TransformFunctionValue,
+>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => TransformFunction<T> = TransformFunction.create;
 
 type TransformListValue = string;
 
@@ -274,7 +308,10 @@ export class TransformList<T: TransformListValue>
     return new TransformList(value);
   }
 }
-export const transformList = TransformList.create;
+export const transformList: <T: TransformListValue = TransformListValue>(
+  value: ValueWithDefault,
+  // $FlowIgnore[method-unbinding]
+) => TransformList<T> = TransformList.create;
 
 const convertNumberToStringUsing =
   (


### PR DESCRIPTION
Following up from the previous PR, this PR adds documentation for the `stylex.types.*` functions and adds a new blog post with release notes for `v0.6.1`.
