### PR TITLE
docs: ecosystem add `@stylex-extend/babel-plugin`

### DIFF
--- a/apps/docs/docs/learn/07-ecosystem.mdx
+++ b/apps/docs/docs/learn/07-ecosystem.mdx
@@ -39,6 +39,8 @@ Custom babel plugins can be used before using the StyleX babel plugin or as the
 
 * [tailwind-to-stylex](https://www.npmjs.com/package/tailwind-to-stylex) converts
   Tailwind CSS used within `className` attributes or `tw()` calls to StyleX.
+* [@stylex-extend/babel-plugin](https://github.com/nonzzz/stylex-extend/tree/main/packages/babel-plugin) allows you
+to use JSXAttribute to define StyleX.
 
 ## Starter templates
 


### PR DESCRIPTION
## What changed / motivation ?

Added babel plugin that i maintain to the ecosystem docs. The plugin allows user using `JSXAttribute` stylex to define inline style. might look like #534 

## Linked PR/Issues

Fixes # (issue)

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code