### PR TITLE
support font-stretch percentage values

### DIFF
--- a/packages/stylex/src/StyleXCSSTypes.js
+++ b/packages/stylex/src/StyleXCSSTypes.js
@@ -332,7 +332,8 @@ type fontStretch =
   | 'semi-expanded'
   | 'expanded'
   | 'extra-expanded'
-  | 'ultra-expanded';
+  | 'ultra-expanded'
+  | string;
 type fontStyle = 'normal' | 'italic' | 'oblique';
 type fontSynthesis = 'none' | string;
 type fontVariant = 'normal' | 'none' | string;


### PR DESCRIPTION
## What changed / motivation ?

possible values can be a percentage from 50% to 200% https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch#values

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code