### PR TITLE
Revert "fix: Keep units for 0 values (#532)"

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-metadata-test.js
+++ b/packages/babel-plugin/__tests__/stylex-metadata-test.js
@@ -88,9 +88,9 @@ describe('@stylexjs/babel-plugin', () => {
               3200,
             ],
             [
-              "x1g85oeb-B",
+              "xqv9ub1-B",
               {
-                "ltr": "@keyframes x1g85oeb-B{from{inset-inline-start:0px;}to{inset-inline-start:100px;}}",
+                "ltr": "@keyframes xqv9ub1-B{from{inset-inline-start:0;}to{inset-inline-start:100px;}}",
                 "rtl": null,
               },
               1,

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -445,7 +445,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x8crwfo{box-shadow:0px 2px 4px var(--shadow-1)}", 3000, ".x8crwfo{box-shadow:-0px 2px 4px var(--shadow-1)}");"
+        _inject2(".xxnfx33{box-shadow:0 2px 4px var(--shadow-1)}", 3000);"
       `);
     });
 
@@ -817,7 +817,7 @@ describe('@stylexjs/babel-plugin', () => {
         _inject2(".xud65wk{border-bottom-color:red}", 4000);
         _inject2(".x12oqio5{border-radius:4px}", 2000);
         _inject2(".x1lmef92{padding:calc((100% - 50px) * .5) var(--rightpadding,20px)}", 1000);
-        _inject2(".x1uu4ab4{padding-top:0px}", 4000);
+        _inject2(".xexx8yu{padding-top:0}", 4000);
         _inject2(".x1bg2uv5{border-color:green}", 2000);"
       `);
     });
@@ -850,8 +850,8 @@ describe('@stylexjs/babel-plugin', () => {
         _inject2(".x1sa5p1d{margin-inline-end:10px}", 3000);
         _inject2(".x1fqp7bg{margin-bottom:15px}", 4000);
         _inject2(".xqsn43r{margin-inline-start:20px}", 3000);
-        _inject2(".x1q9hu08{margin:0px}", 1000);
-        "x1q9hu08";"
+        _inject2(".x1ghz6dp{margin:0}", 1000);
+        "x1ghz6dp";"
       `);
     });
 
@@ -989,7 +989,7 @@ describe('@stylexjs/babel-plugin', () => {
             paddingEnd: null,
             paddingRight: null,
             paddingBlock: null,
-            paddingTop: "x1uu4ab4",
+            paddingTop: "xexx8yu",
             paddingBottom: null,
             $$css: true
           },
@@ -1092,7 +1092,7 @@ describe('@stylexjs/babel-plugin', () => {
           default: {
             marginTop: "xxsse2n",
             marginRight: "x1wh8b8d",
-            marginBottom: "x1du4iog",
+            marginBottom: "xat24cr",
             $$css: true
           },
           error: {
@@ -1115,11 +1115,11 @@ describe('@stylexjs/babel-plugin', () => {
           short: {
             paddingBlock: "x190pm2f",
             paddingInline: "x1n86tx6",
-            paddingTop: "x1uu4ab4",
+            paddingTop: "xexx8yu",
             $$css: true
           },
           shortReversed: {
-            paddingTop: "x1uu4ab4",
+            paddingTop: "xexx8yu",
             paddingBlock: "x190pm2f",
             paddingInline: "x1n86tx6",
             $$css: true

--- a/packages/babel-plugin/__tests__/stylex-transform-keyframes-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-keyframes-test.js
@@ -175,12 +175,12 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2("@keyframes x1id2van-B{from{inset-inline-start:0px;}to{inset-inline-start:500px;}}", 1);
-        const name = "x1id2van-B";
-        _inject2(".x1phmjlw{animation-name:x1id2van-B}", 3000);
+        _inject2("@keyframes x1jkcf39-B{from{inset-inline-start:0;}to{inset-inline-start:500px;}}", 1);
+        const name = "x1jkcf39-B";
+        _inject2(".x1vfi257{animation-name:x1jkcf39-B}", 3000);
         export const styles = {
           root: {
-            animationName: "x1phmjlw",
+            animationName: "x1vfi257",
             $$css: true
           }
         };"

--- a/packages/babel-plugin/__tests__/stylex-transform-logical-properties-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-logical-properties-test.js
@@ -43,8 +43,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1ed0pl6{border-block-color:0px}", 3000);
-        const classnames = "x1ed0pl6";"
+        _inject2(".x1lkbs04{border-block-color:0}", 3000);
+        const classnames = "x1lkbs04";"
       `);
     });
 
@@ -59,8 +59,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1g2d423{border-top-color:0px}", 3000);
-        const classnames = "x1g2d423";"
+        _inject2(".x4q076{border-top-color:0}", 3000);
+        const classnames = "x4q076";"
       `);
     });
 
@@ -75,8 +75,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1uxq421{border-bottom-color:0px}", 4000);
-        const classnames = "x1uxq421";"
+        _inject2(".x1ylptbq{border-bottom-color:0}", 4000);
+        const classnames = "x1ylptbq";"
       `);
     });
 
@@ -91,8 +91,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1mdkzvo{border-inline-color:0px}", 2000);
-        const classnames = "x1mdkzvo";"
+        _inject2(".x1v09clb{border-inline-color:0}", 2000);
+        const classnames = "x1v09clb";"
       `);
     });
 
@@ -107,8 +107,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x9qt5s6{border-inline-start-color:0px}", 3000);
-        const classnames = "x9qt5s6";"
+        _inject2(".x1t19a1o{border-inline-start-color:0}", 3000);
+        const classnames = "x1t19a1o";"
       `);
     });
 
@@ -123,8 +123,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xmt3h97{border-inline-end-color:0px}", 3000);
-        const classnames = "xmt3h97";"
+        _inject2(".x14mj1wy{border-inline-end-color:0}", 3000);
+        const classnames = "x14mj1wy";"
       `);
     });
 
@@ -141,8 +141,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xyinpli{border-block-style:0px}", 3000);
-        const classnames = "xyinpli";"
+        _inject2(".x7mea6a{border-block-style:0}", 3000);
+        const classnames = "x7mea6a";"
       `);
     });
 
@@ -157,8 +157,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1vwv6rm{border-top-style:0px}", 3000);
-        const classnames = "x1vwv6rm";"
+        _inject2(".x1d917x0{border-top-style:0}", 3000);
+        const classnames = "x1d917x0";"
       `);
     });
 
@@ -173,8 +173,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xpdgvxk{border-bottom-style:0px}", 4000);
-        const classnames = "xpdgvxk";"
+        _inject2(".x1nmap2y{border-bottom-style:0}", 4000);
+        const classnames = "x1nmap2y";"
       `);
     });
 
@@ -189,8 +189,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xn5gpj6{border-inline-style:0px}", 2000);
-        const classnames = "xn5gpj6";"
+        _inject2(".xt8kkye{border-inline-style:0}", 2000);
+        const classnames = "xt8kkye";"
       `);
     });
 
@@ -205,8 +205,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1jac53v{border-inline-start-style:0px}", 3000);
-        const classnames = "x1jac53v";"
+        _inject2(".xl8mozw{border-inline-start-style:0}", 3000);
+        const classnames = "xl8mozw";"
       `);
     });
 
@@ -221,8 +221,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xepdarh{border-inline-end-style:0px}", 3000);
-        const classnames = "xepdarh";"
+        _inject2(".x10o505a{border-inline-end-style:0}", 3000);
+        const classnames = "x10o505a";"
       `);
     });
 
@@ -239,8 +239,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1of20wf{border-block-width:0px}", 3000);
-        const classnames = "x1of20wf";"
+        _inject2(".x1616tdu{border-block-width:0}", 3000);
+        const classnames = "x1616tdu";"
       `);
     });
 
@@ -255,8 +255,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1ptnzft{border-top-width:0px}", 3000);
-        const classnames = "x1ptnzft";"
+        _inject2(".x972fbf{border-top-width:0}", 3000);
+        const classnames = "x972fbf";"
       `);
     });
 
@@ -271,8 +271,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1n5ok7h{border-bottom-width:0px}", 4000);
-        const classnames = "x1n5ok7h";"
+        _inject2(".x1qhh985{border-bottom-width:0}", 4000);
+        const classnames = "x1qhh985";"
       `);
     });
 
@@ -287,8 +287,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1p0apqc{border-inline-width:0px}", 2000);
-        const classnames = "x1p0apqc";"
+        _inject2(".xuxrje7{border-inline-width:0}", 2000);
+        const classnames = "xuxrje7";"
       `);
     });
 
@@ -303,8 +303,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xt32w6p{border-inline-start-width:0px}", 3000);
-        const classnames = "xt32w6p";"
+        _inject2(".x14e42zd{border-inline-start-width:0}", 3000);
+        const classnames = "x14e42zd";"
       `);
     });
 
@@ -319,8 +319,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1ljmqpl{border-inline-end-width:0px}", 3000);
-        const classnames = "x1ljmqpl";"
+        _inject2(".x10w94by{border-inline-end-width:0}", 3000);
+        const classnames = "x10w94by";"
       `);
     });
 
@@ -337,8 +337,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x9oc6z4{top:0px}", 4000);
-        const classnames = "x9oc6z4";"
+        _inject2(".x13vifvy{top:0}", 4000);
+        const classnames = "x13vifvy";"
       `);
     });
 
@@ -353,8 +353,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1yutot1{inset-block:0px}", 2000);
-        const classnames = "x1yutot1";"
+        _inject2(".x10no89f{inset-block:0}", 2000);
+        const classnames = "x10no89f";"
       `);
     });
 
@@ -369,8 +369,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1sh2tzk{bottom:0px}", 4000);
-        const classnames = "x1sh2tzk";"
+        _inject2(".x1ey2m1c{bottom:0}", 4000);
+        const classnames = "x1ey2m1c";"
       `);
     });
 
@@ -385,8 +385,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x9oc6z4{top:0px}", 4000);
-        const classnames = "x9oc6z4";"
+        _inject2(".x13vifvy{top:0}", 4000);
+        const classnames = "x13vifvy";"
       `);
     });
 
@@ -401,8 +401,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xl33w4x{inset-inline:0px}", 2000);
-        const classnames = "xl33w4x";"
+        _inject2(".x17y0mx6{inset-inline:0}", 2000);
+        const classnames = "x17y0mx6";"
       `);
     });
 
@@ -417,8 +417,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xhw0b42{inset-inline-end:0px}", 3000);
-        const classnames = "xhw0b42";"
+        _inject2(".xtijo5x{inset-inline-end:0}", 3000);
+        const classnames = "xtijo5x";"
       `);
     });
 
@@ -433,8 +433,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1at4hj2{inset-inline-start:0px}", 3000);
-        const classnames = "x1at4hj2";"
+        _inject2(".x1o0tod{inset-inline-start:0}", 3000);
+        const classnames = "x1o0tod";"
       `);
     });
 
@@ -451,8 +451,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1yslrto{margin-block:0px}", 2000);
-        const classnames = "x1yslrto";"
+        _inject2(".x10im51j{margin-block:0}", 2000);
+        const classnames = "x10im51j";"
       `);
     });
 
@@ -467,8 +467,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1du4iog{margin-bottom:0px}", 4000);
-        const classnames = "x1du4iog";"
+        _inject2(".xat24cr{margin-bottom:0}", 4000);
+        const classnames = "xat24cr";"
       `);
     });
 
@@ -483,8 +483,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1q12cbh{margin-top:0px}", 4000);
-        const classnames = "x1q12cbh";"
+        _inject2(".xdj266r{margin-top:0}", 4000);
+        const classnames = "xdj266r";"
       `);
     });
 
@@ -499,8 +499,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xmbzetd{margin-inline:0px}", 2000);
-        const classnames = "xmbzetd";"
+        _inject2(".xrxpjvj{margin-inline:0}", 2000);
+        const classnames = "xrxpjvj";"
       `);
     });
 
@@ -515,8 +515,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xfbia9g{margin-inline-end:0px}", 3000);
-        const classnames = "xfbia9g";"
+        _inject2(".x14z9mp{margin-inline-end:0}", 3000);
+        const classnames = "x14z9mp";"
       `);
     });
 
@@ -531,8 +531,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1tt3wx9{margin-inline-start:0px}", 3000);
-        const classnames = "x1tt3wx9";"
+        _inject2(".x1lziwak{margin-inline-start:0}", 3000);
+        const classnames = "x1lziwak";"
       `);
     });
 
@@ -549,8 +549,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xa87odg{padding-block:0px}", 2000);
-        const classnames = "xa87odg";"
+        _inject2(".xt970qd{padding-block:0}", 2000);
+        const classnames = "xt970qd";"
       `);
     });
 
@@ -565,8 +565,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xw0v6cn{padding-bottom:0px}", 4000);
-        const classnames = "xw0v6cn";"
+        _inject2(".x18d9i69{padding-bottom:0}", 4000);
+        const classnames = "x18d9i69";"
       `);
     });
 
@@ -581,8 +581,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1uu4ab4{padding-top:0px}", 4000);
-        const classnames = "x1uu4ab4";"
+        _inject2(".xexx8yu{padding-top:0}", 4000);
+        const classnames = "xexx8yu";"
       `);
     });
 
@@ -597,8 +597,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1270q1i{padding-inline:0px}", 2000);
-        const classnames = "x1270q1i";"
+        _inject2(".xnjsko4{padding-inline:0}", 2000);
+        const classnames = "xnjsko4";"
       `);
     });
 
@@ -613,8 +613,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1ib0srb{padding-inline-end:0px}", 3000);
-        const classnames = "x1ib0srb";"
+        _inject2(".xyri2b{padding-inline-end:0}", 3000);
+        const classnames = "xyri2b";"
       `);
     });
 
@@ -629,8 +629,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x167wa4d{padding-inline-start:0px}", 3000);
-        const classnames = "x167wa4d";"
+        _inject2(".x1c1uobl{padding-inline-start:0}", 3000);
+        const classnames = "x1c1uobl";"
       `);
     });
 
@@ -665,8 +665,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xfbia9g{margin-inline-end:0px}", 3000);
-        const classnames = "xfbia9g";"
+        _inject2(".x14z9mp{margin-inline-end:0}", 3000);
+        const classnames = "x14z9mp";"
       `);
     });
 
@@ -681,8 +681,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xmbzetd{margin-inline:0px}", 2000);
-        const classnames = "xmbzetd";"
+        _inject2(".xrxpjvj{margin-inline:0}", 2000);
+        const classnames = "xrxpjvj";"
       `);
     });
 
@@ -697,8 +697,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1tt3wx9{margin-inline-start:0px}", 3000);
-        const classnames = "x1tt3wx9";"
+        _inject2(".x1lziwak{margin-inline-start:0}", 3000);
+        const classnames = "x1lziwak";"
       `);
     });
 
@@ -713,8 +713,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1yslrto{margin-block:0px}", 2000);
-        const classnames = "x1yslrto";"
+        _inject2(".x10im51j{margin-block:0}", 2000);
+        const classnames = "x10im51j";"
       `);
     });
 
@@ -729,8 +729,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1ib0srb{padding-inline-end:0px}", 3000);
-        const classnames = "x1ib0srb";"
+        _inject2(".xyri2b{padding-inline-end:0}", 3000);
+        const classnames = "xyri2b";"
       `);
     });
 
@@ -745,8 +745,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1270q1i{padding-inline:0px}", 2000);
-        const classnames = "x1270q1i";"
+        _inject2(".xnjsko4{padding-inline:0}", 2000);
+        const classnames = "xnjsko4";"
       `);
     });
 
@@ -761,8 +761,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x167wa4d{padding-inline-start:0px}", 3000);
-        const classnames = "x167wa4d";"
+        _inject2(".x1c1uobl{padding-inline-start:0}", 3000);
+        const classnames = "x1c1uobl";"
       `);
     });
 
@@ -777,8 +777,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xa87odg{padding-block:0px}", 2000);
-        const classnames = "xa87odg";"
+        _inject2(".xt970qd{padding-block:0}", 2000);
+        const classnames = "xt970qd";"
       `);
     });
 

--- a/packages/babel-plugin/__tests__/stylex-transform-value-normalize-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-value-normalize-test.js
@@ -81,7 +81,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1q9hu08{margin:0px}", 1000);
+        _inject2(".x1ghz6dp{margin:0}", 1000);
         _inject2(".xgsvwom{margin-left:1px}", 4000);"
       `);
     });
@@ -114,9 +114,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1hbt0ae{transform:0rad}", 3000);
-        _inject2(".xr5m4w3{transform:0turn}", 3000);
-        _inject2(".x17dlbb3{transform:0grad}", 3000);"
+        _inject2(".x1jpfit1{transform:0deg}", 3000);"
       `);
     });
 

--- a/packages/dev-runtime/__tests__/stylex-metadata-test.js
+++ b/packages/dev-runtime/__tests__/stylex-metadata-test.js
@@ -85,9 +85,9 @@ describe('Development Plugin Metadata', () => {
             3200,
           ],
           [
-            "x1g85oeb-B",
+            "xqv9ub1-B",
             {
-              "ltr": "@keyframes x1g85oeb-B{from{inset-inline-start:0px;}to{inset-inline-start:100px;}}",
+              "ltr": "@keyframes xqv9ub1-B{from{inset-inline-start:0;}to{inset-inline-start:100px;}}",
               "rtl": null,
             },
             1,

--- a/packages/dev-runtime/__tests__/stylex-transform-create-test.js
+++ b/packages/dev-runtime/__tests__/stylex-transform-create-test.js
@@ -348,7 +348,7 @@ describe('Development Plugin Transformation', () => {
         {
           "default": {
             "$$css": true,
-            "boxShadow": "x8crwfo",
+            "boxShadow": "xxnfx33",
           },
         }
       `);
@@ -356,10 +356,10 @@ describe('Development Plugin Transformation', () => {
       expect(metadata).toMatchInlineSnapshot(`
         [
           [
-            "x8crwfo",
+            "xxnfx33",
             {
-              "ltr": ".x8crwfo{box-shadow:0px 2px 4px var(--shadow-1)}",
-              "rtl": ".x8crwfo{box-shadow:-0px 2px 4px var(--shadow-1)}",
+              "ltr": ".xxnfx33{box-shadow:0 2px 4px var(--shadow-1)}",
+              "rtl": null,
             },
             3000,
           ],

--- a/packages/dev-runtime/__tests__/stylex-transform-keyframes-test.js
+++ b/packages/dev-runtime/__tests__/stylex-transform-keyframes-test.js
@@ -80,7 +80,7 @@ describe('Development Runtime Transformation', () => {
           start: 500,
         },
       });
-      expect(name).toMatchInlineSnapshot(`"x1id2van-B"`);
+      expect(name).toMatchInlineSnapshot(`"x1jkcf39-B"`);
 
       expect(
         stylex.create({
@@ -92,7 +92,7 @@ describe('Development Runtime Transformation', () => {
         {
           "root": {
             "$$css": true,
-            "animationName": "x1phmjlw",
+            "animationName": "x1vfi257",
           },
         }
       `);
@@ -100,17 +100,17 @@ describe('Development Runtime Transformation', () => {
       expect(metadata).toMatchInlineSnapshot(`
         [
           [
-            "x1id2van-B",
+            "x1jkcf39-B",
             {
-              "ltr": "@keyframes x1id2van-B{from{inset-inline-start:0px;}to{inset-inline-start:500px;}}",
+              "ltr": "@keyframes x1jkcf39-B{from{inset-inline-start:0;}to{inset-inline-start:500px;}}",
               "rtl": null,
             },
             1,
           ],
           [
-            "x1phmjlw",
+            "x1vfi257",
             {
-              "ltr": ".x1phmjlw{animation-name:x1id2van-B}",
+              "ltr": ".x1vfi257{animation-name:x1jkcf39-B}",
               "rtl": null,
             },
             3000,

--- a/packages/shared/__tests__/stylex-create-test.js
+++ b/packages/shared/__tests__/stylex-create-test.js
@@ -212,7 +212,7 @@ describe('stylex-create-test', () => {
             "paddingLeft": null,
             "paddingRight": null,
             "paddingStart": null,
-            "paddingTop": "x1uu4ab4",
+            "paddingTop": "xexx8yu",
           },
         },
         {
@@ -221,8 +221,8 @@ describe('stylex-create-test', () => {
             "priority": 1000,
             "rtl": null,
           },
-          "x1uu4ab4": {
-            "ltr": ".x1uu4ab4{padding-top:0px}",
+          "xexx8yu": {
+            "ltr": ".xexx8yu{padding-top:0}",
             "priority": 4000,
             "rtl": null,
           },

--- a/packages/shared/__tests__/stylex-keyframes-test.js
+++ b/packages/shared/__tests__/stylex-keyframes-test.js
@@ -46,9 +46,9 @@ describe('stylex-keyframes test', () => {
       }),
     ).toMatchInlineSnapshot(`
       [
-        "x1id2van-B",
+        "x1jkcf39-B",
         {
-          "ltr": "@keyframes x1id2van-B{from{inset-inline-start:0px;}to{inset-inline-start:500px;}}",
+          "ltr": "@keyframes x1jkcf39-B{from{inset-inline-start:0;}to{inset-inline-start:500px;}}",
           "priority": 1,
           "rtl": null,
         },

--- a/packages/shared/src/utils/normalize-value.js
+++ b/packages/shared/src/utils/normalize-value.js
@@ -14,6 +14,7 @@ import normalizeLeadingZero from './normalizers/leading-zero';
 import normalizeQuotes from './normalizers/quotes';
 import normalizeTimings from './normalizers/timings';
 import normalizeWhitespace from './normalizers/whitespace';
+import normalizeZeroDimensions from './normalizers/zero-dimensions';
 
 import detectUnclosedFns from './normalizers/detect-unclosed-fns';
 import parser from 'postcss-value-parser';
@@ -26,6 +27,7 @@ const normalizers = [
   detectUnclosedFns,
   normalizeWhitespace,
   normalizeTimings,
+  normalizeZeroDimensions,
   normalizeLeadingZero,
   normalizeQuotes,
   convertCamelCaseValues,

--- a/packages/shared/src/utils/normalizers/zero-dimensions.js
+++ b/packages/shared/src/utils/normalizers/zero-dimensions.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+import parser from 'postcss-value-parser';
+
+const angles = ['deg', 'grad', 'turn', 'rad'];
+const timings = ['ms', 's'];
+const fraction = 'fr';
+const percentage = '%';
+
+/**
+ * Remove units in zero values, except when required: in angles, timings, fractions, and percentages,
+ * in which case make them consistent 0deg, 0s, 0fr, and 0%.
+ */
+
+export default function normalizeZeroDimensions(
+  ast: PostCSSValueAST,
+  _: mixed,
+): PostCSSValueAST {
+  let endFunction = 0;
+
+  ast.walk((node) => {
+    if (node.type === 'function' && !endFunction) {
+      endFunction = node.sourceEndIndex ?? 0;
+    }
+    if (endFunction > 0 && node.sourceIndex > endFunction) {
+      endFunction = 0;
+    }
+    if (node.type !== 'word') {
+      return;
+    }
+    const dimension = parser.unit(node.value);
+    if (!dimension || dimension.number !== '0') {
+      return;
+    }
+    if (angles.indexOf(dimension.unit) !== -1) {
+      node.value = '0deg';
+    } else if (timings.indexOf(dimension.unit) !== -1) {
+      node.value = '0s';
+    } else if (dimension.unit === fraction) {
+      node.value = '0fr';
+    } else if (dimension.unit === percentage) {
+      node.value = '0%';
+    } else if (!endFunction) {
+      node.value = '0';
+    }
+  });
+  return ast;
+}


### PR DESCRIPTION
Not dropping units for various `0` values leads to a significant increase in the size of the generated CSS file.

So this PR, brings back this particular strategy to drop units from `0` values while keeping the `fr` and `%` units and taking a more measured approach. If any other unit needs to be maintained, we can work on that in the future.