### PR TITLE
fix: add `babel-plugin-syntax-hermes-parser` dependency to esbuild plugin

### DIFF
--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -25,6 +25,7 @@
     "@babel/plugin-syntax-typescript": "^7.23.3",
     "@stylexjs/babel-plugin": "^0.6.1",
     "@stylexjs/shared": "^0.6.1",
+    "babel-plugin-syntax-hermes-parser": "^0.21.1",
     "esbuild": "^0.19.12"
   },
   "devDependencies": {


### PR DESCRIPTION
## What changed / motivation ?

Adds missing `babel-plugin-syntax-hermes-parser` dependency to esbuild plugin.

## Linked PR/Issues

Fixes #576 

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code