### PR TITLE
RFC: Maintain variable names for keys that start with "--"

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-create-theme-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-theme-test.js
@@ -63,7 +63,7 @@ const createThemeWithDifferentOrder = `{
   cornerRadius: '6px',
 }`;
 
-describe('@stylexjs/babel-plugin', () => {
+describe('@stylexjs/babel-plugin stylex.createTheme', () => {
   beforeEach(() => {
     defineVarsOutput = transform(`
       import stylex from 'stylex';
@@ -588,6 +588,76 @@ describe('@stylexjs/babel-plugin', () => {
           TestTheme__buttonThemePositive: "TestTheme__buttonThemePositive",
           $$css: true,
           x568ih9: "x41sqjo"
+        };"
+      `);
+    });
+  });
+});
+
+describe('@stylexjs/babel-plugin stylex.createTheme with literals', () => {
+  beforeEach(() => {
+    defineVarsOutput = transform(`
+      import stylex from 'stylex';
+      export const buttonTheme = stylex.defineVars({
+        '--bgColor': {
+          default: 'blue',
+          '@media (prefers-color-scheme: dark)': 'lightblue',
+          '@media print': 'white',
+        },
+        '--bgColorDisabled': {
+          default: 'grey',
+          '@media (prefers-color-scheme: dark)': 'rgba(0, 0, 0, 0.8)',
+        },
+        '--cornerRadius': 10,
+        '--fgColor': {
+          default: 'pink',
+        },
+      });
+    `);
+  });
+  test('output of stylex.defineVars()', () => {
+    expect(defineVarsOutput).toMatchInlineSnapshot(`
+      "import stylex from 'stylex';
+      export const buttonTheme = {
+        "--bgColor": "var(--bgColor)",
+        "--bgColorDisabled": "var(--bgColorDisabled)",
+        "--cornerRadius": "var(--cornerRadius)",
+        "--fgColor": "var(--fgColor)",
+        __themeName__: "x568ih9"
+      };"
+    `);
+  });
+  describe('[transform] stylex.createTheme()', () => {
+    test('transforms variables object', () => {
+      expect(
+        transform(`
+          ${defineVarsOutput}
+          const buttonThemePositive = stylex.createTheme(buttonTheme, {
+            '--bgColor': {
+              default: 'green',
+              '@media (prefers-color-scheme: dark)': 'lightgreen',
+              '@media print': 'transparent',
+            },
+            '--bgColorDisabled': {
+              default: 'antiquewhite',
+              '@media (prefers-color-scheme: dark)': 'floralwhite',
+            },
+            '--cornerRadius': { default: '6px' },
+            '--fgColor': 'coral',
+          });
+        `),
+      ).toMatchInlineSnapshot(`
+        "import stylex from 'stylex';
+        export const buttonTheme = {
+          "--bgColor": "var(--bgColor)",
+          "--bgColorDisabled": "var(--bgColorDisabled)",
+          "--cornerRadius": "var(--cornerRadius)",
+          "--fgColor": "var(--fgColor)",
+          __themeName__: "x568ih9"
+        };
+        const buttonThemePositive = {
+          $$css: true,
+          x568ih9: "x4znj40"
         };"
       `);
     });

--- a/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
@@ -67,6 +67,38 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
+    test('transforms literal variables object', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          export const buttonTheme = stylex.defineVars({
+            '--bgColor': {
+              default: 'blue',
+              '@media (prefers-color-scheme: dark)': 'lightblue',
+              '@media print': 'white',
+            },
+            '--bgColorDisabled': {
+              default: 'grey',
+              '@media (prefers-color-scheme: dark)': 'rgba(0, 0, 0, 0.8)',
+            },
+            '--cornerRadius': 10,
+            '--fgColor': {
+              default: 'pink',
+            },
+          });
+        `),
+      ).toMatchInlineSnapshot(`
+        "import stylex from 'stylex';
+        export const buttonTheme = {
+          "--bgColor": "var(--bgColor)",
+          "--bgColorDisabled": "var(--bgColorDisabled)",
+          "--cornerRadius": "var(--cornerRadius)",
+          "--fgColor": "var(--fgColor)",
+          __themeName__: "x568ih9"
+        };"
+      `);
+    });
+
     test('transforms variables object with import *', () => {
       expect(
         transform(`

--- a/packages/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/babel-plugin/src/utils/evaluate-path.js
@@ -158,7 +158,9 @@ function evaluateThemeRef(
     const strToHash =
       key === '__themeName__'
         ? utils.genFileBasedIdentifier({ fileName, exportName })
-        : utils.genFileBasedIdentifier({ fileName, exportName, key });
+        : key.startsWith('--')
+          ? `var(${key})`
+          : utils.genFileBasedIdentifier({ fileName, exportName, key });
 
     const varName =
       state.traversalState.options.classNamePrefix + utils.hash(strToHash);

--- a/packages/shared/__tests__/stylex-create-theme-test.js
+++ b/packages/shared/__tests__/stylex-create-theme-test.js
@@ -49,6 +49,44 @@ describe('stylex-create-theme test', () => {
     `);
   });
 
+  test('overrides set of literal vars with CSS class', () => {
+    const defaultVars = {
+      __themeName__: 'TestTheme.stylex.js//buttonTheme',
+      '--bgColor': 'var(--bgColor)',
+      '--bgColorDisabled': 'var(--bgColorDisabled)',
+      '--cornerRadius': 'var(--cornerRadius)',
+      '--fgColor': 'var(--fgColor)',
+    };
+
+    const createTheme = {
+      '--bgColor': {
+        default: 'green',
+        '@media (prefers-color-scheme: dark)': 'lightgreen',
+        '@media print': 'transparent',
+      },
+      '--bgColorDisabled': {
+        default: 'antiquewhite',
+        '@media (prefers-color-scheme: dark)': 'floralwhite',
+      },
+      '--cornerRadius': { default: '6px' },
+      '--fgColor': 'coral',
+    };
+
+    const [classNameOutput, cssOutput] = stylexCreateTheme(
+      defaultVars,
+      createTheme,
+    );
+
+    expect(cssOutput[classNameOutput[defaultVars.__themeName__]])
+      .toMatchInlineSnapshot(`
+      {
+        "ltr": ".x4znj40{--bgColor:green;--bgColorDisabled:antiquewhite;--cornerRadius:6px;--fgColor:coral;}",
+        "priority": 0.5,
+        "rtl": null,
+      }
+    `);
+  });
+
   test('variables order does not change the hash', () => {
     const defaultVars = {
       __themeName__: 'TestTheme.stylex.js//buttonTheme',

--- a/packages/shared/__tests__/stylex-define-vars-test.js
+++ b/packages/shared/__tests__/stylex-define-vars-test.js
@@ -65,6 +65,55 @@ describe('stylex-define-vars test', () => {
     `);
   });
 
+  test('maintains literal var names in CSS', () => {
+    const themeName = 'TestTheme.stylex.js//buttonTheme';
+    const classNamePrefix = 'x';
+    const defaultVars = {
+      '--bgColor': {
+        default: 'blue',
+        '@media (prefers-color-scheme: dark)': 'lightblue',
+        '@media print': 'white',
+      },
+      '--bgColorDisabled': {
+        default: 'grey',
+        '@media (prefers-color-scheme: dark)': 'rgba(0, 0, 0, 0.8)',
+      },
+      '--cornerRadius': '10px',
+      '--fgColor': {
+        default: 'pink',
+      },
+    };
+    const [jsOutput, cssOutput] = styleXDefineVars(defaultVars, { themeName });
+
+    expect(jsOutput).toEqual({
+      __themeName__: classNamePrefix + createHash(themeName),
+      '--bgColor': 'var(--bgColor)',
+      '--bgColorDisabled': 'var(--bgColorDisabled)',
+      '--cornerRadius': 'var(--cornerRadius)',
+      '--fgColor': 'var(--fgColor)',
+    });
+
+    expect(cssOutput).toMatchInlineSnapshot(`
+      {
+        "x568ih9": {
+          "ltr": ":root{--bgColor:blue;--bgColorDisabled:grey;--cornerRadius:10px;--fgColor:pink;}",
+          "priority": 0,
+          "rtl": null,
+        },
+        "x568ih9-1lveb7": {
+          "ltr": "@media (prefers-color-scheme: dark){:root{--bgColor:lightblue;--bgColorDisabled:rgba(0, 0, 0, 0.8);}}",
+          "priority": 0.1,
+          "rtl": null,
+        },
+        "x568ih9-bdddrq": {
+          "ltr": "@media print{:root{--bgColor:white;}}",
+          "priority": 0.1,
+          "rtl": null,
+        },
+      }
+    `);
+  });
+
   test('converts set of vars with nested at rules to CSS', () => {
     const themeName = 'TestTheme.stylex.js//buttonTheme';
     const classNamePrefix = 'x';

--- a/packages/shared/src/stylex-define-vars.js
+++ b/packages/shared/src/stylex-define-vars.js
@@ -48,7 +48,9 @@ export default function styleXDefineVars<Vars: VarsConfig>(
 
   const variablesMap = objMap(variables, (value, key) => {
     // Created hashed variable names with fileName//themeName//key
-    const nameHash = classNamePrefix + createHash(`${themeName}.${key}`);
+    const nameHash = key.startsWith('--')
+      ? key.slice(2)
+      : classNamePrefix + createHash(`${themeName}.${key}`);
     if (isCSSType(value)) {
       const v: CSSType<> = value;
       typedVariables[nameHash] = {


### PR DESCRIPTION
# RFC - Variable name literals for keys that that start with "--"

The main change proposed is to opt out of automatic variable name generation when the object keys used within `stylex.defineVars` starts with `--`.

## Motivations

### 1. Using variables across StyleX and global `.css` files

There is often a desire to use variables defined within StyleX to be usable within a raw CSS file to set global styles. However, since the actual generated variable names created by StyleX are unknown until compile time, this process isn't developer friendly.

The only escape hatch today is to fallback to strings for using variables within StyleX and CSS. This means losing *all* the benefits provided by StyleX's theming APIs, such as type-safety and guaranteed default values.

### 2. Migrating from CSS strings to StyleX theming APIs

There existing codebases that use CSS variable names as strings today and don't have a clear migration path to adopt StyleX's theming APIs. While it is easier to move to StyleX's APIs for new variables, it is usually a non-starter to migrate existing variables. This new feature provides an escape hatch to make migration possible.

A typical migration process might look like:
1. Define all existing CSS variables as literals with a `stylex.defineVars` call with the default value set to `null`
2. Update all usages of that variable to use the object created with `stylex.defineVars`
3. Define the default values for the variables within StyleX
4. Define any Themes within StyleX
5. Delete the old patterns for defining the variables to make StyleX the exclusive way to define variables.
6. Optionally, if no uses of the variables exist outside of StyleX anymore, rename the keys to drop the `--`.

## Caveat

There is one major caveat or risk of this proposal. Unlike variables generated by StyleX itself, there is no way to guarantee that a variable name isn't accidentally duplicated. If the same variable name is used in two separate `stylex.defineVars` calls, it will result in the same variable being defined twice in the generated CSS file.

Ideally, in a follow-up, we should be able to *detect* such a conflict at compile time.