### PR TITLE
fix(cli): when modules experimental item is string should be copy

### DIFF
--- a/apps/cli-example/.stylex.json
+++ b/apps/cli-example/.stylex.json
@@ -3,7 +3,7 @@
     "output": ["./src"],
     "cssBundleName": "stylex_bundle.css",
     "babelPresets": [
-      ["@babel/preset-typescript", { "allExtensions": "true", "isTSX": "true" }],
+      ["@babel/preset-typescript", { "allExtensions": true, "isTSX": true }],
       "@babel/preset-react"
     ],
     "modules_EXPERIMENTAL": ["@stylexjs/open-props"],

--- a/packages/cli/src/modules.js
+++ b/packages/cli/src/modules.js
@@ -96,6 +96,7 @@ export function fetchModule(
           return !ignorePaths.some((p: string) => src.startsWith(p));
         }
       }
+      return true;
     },
   });
   config.state.compiledNodeModuleDir = path.join(


### PR DESCRIPTION
## What changed / motivation ?

Fix cli fetchModule can't not working as expected.

## Linked PR/Issues

None

## Additional Context

- I notice cli has been in the main branch. So i based on the example directory to test the cli without json5. And i meet some bug when the `modules_EXPERIMENTAL` children is string literal. It will break `fetchModule` logic. According [fs.cpsync](https://nodejs.org/api/fs.html#fscpsyncsrc-dest-options) so we should set a state for filter option. 
- Fix cli example incorrect babel option.


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code