### PR TITLE
chore: using ansis replace chalk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9087,6 +9087,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/ansis": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.2.0.tgz",
+      "integrity": "sha512-Yk3BkHH9U7oPyCN3gL5Tc7CpahG/+UFv/6UG03C311Vy9lzRmA5uoxDTpU9CO3rGHL6KzJz/pdDeXZCZ5Mu/Sg==",
+      "engines": {
+        "node": ">=15"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.2",
       "license": "ISC",
@@ -31356,6 +31364,7 @@
         "@babel/plugin-syntax-typescript": "^7.23.3",
         "@stylexjs/babel-plugin": "0.6.1",
         "@stylexjs/scripts": "0.6.1",
+        "ansis": "^3.2.0",
         "fb-watchman": "^2.0.2",
         "json5": "^2.2.3",
         "mkdirp": "^3.0.1"
@@ -31383,11 +31392,33 @@
         "@babel/plugin-syntax-typescript": "^7.23.3",
         "@stylexjs/babel-plugin": "^0.6.1",
         "@stylexjs/shared": "^0.6.1",
+        "babel-plugin-syntax-hermes-parser": "^0.21.1",
         "esbuild": "^0.19.12"
       },
       "devDependencies": {
         "@stylexjs/stylex": "^0.6.1",
         "eslint": "^8.55.0"
+      }
+    },
+    "packages/esbuild-plugin/node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.21.1.tgz",
+      "integrity": "sha512-tUCEa+EykZx3oJXc+PolKz2iwDscCJ2hCONMvEqjAb4jIQH5ZapDd5Brs2Nk4TQpSJ/1Ykz53ksQbevXbF0wxg==",
+      "dependencies": {
+        "hermes-parser": "0.21.1"
+      }
+    },
+    "packages/esbuild-plugin/node_modules/hermes-estree": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.21.1.tgz",
+      "integrity": "sha512-ayfESdfG0wZM32uGw0CMfcW6pW6RM8htLXZI56A4rr7hIOjmKw+wd3+71wUc1uQfn90ZyY1NMCbQeMnunrIidg=="
+    },
+    "packages/esbuild-plugin/node_modules/hermes-parser": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.21.1.tgz",
+      "integrity": "sha512-ANsRSBqQHzca7AXbsuwKApSQhAdljPip63MgqLebSVzNUI+A3NDzfiH9Ny4df4fA7Ndso3kPR1V/x1YEc7BYxA==",
+      "dependencies": {
+        "hermes-estree": "0.21.1"
       }
     },
     "packages/eslint-plugin": {
@@ -36429,6 +36460,7 @@
         "@babel/plugin-syntax-typescript": "^7.23.3",
         "@stylexjs/babel-plugin": "0.6.1",
         "@stylexjs/scripts": "0.6.1",
+        "ansis": "^3.2.0",
         "fb-watchman": "^2.0.2",
         "json5": "^2.2.3",
         "mkdirp": "^3.0.1"
@@ -36450,8 +36482,32 @@
         "@stylexjs/babel-plugin": "^0.6.1",
         "@stylexjs/shared": "^0.6.1",
         "@stylexjs/stylex": "^0.6.1",
+        "babel-plugin-syntax-hermes-parser": "^0.21.1",
         "esbuild": "^0.19.12",
         "eslint": "^8.55.0"
+      },
+      "dependencies": {
+        "babel-plugin-syntax-hermes-parser": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.21.1.tgz",
+          "integrity": "sha512-tUCEa+EykZx3oJXc+PolKz2iwDscCJ2hCONMvEqjAb4jIQH5ZapDd5Brs2Nk4TQpSJ/1Ykz53ksQbevXbF0wxg==",
+          "requires": {
+            "hermes-parser": "0.21.1"
+          }
+        },
+        "hermes-estree": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.21.1.tgz",
+          "integrity": "sha512-ayfESdfG0wZM32uGw0CMfcW6pW6RM8htLXZI56A4rr7hIOjmKw+wd3+71wUc1uQfn90ZyY1NMCbQeMnunrIidg=="
+        },
+        "hermes-parser": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.21.1.tgz",
+          "integrity": "sha512-ANsRSBqQHzca7AXbsuwKApSQhAdljPip63MgqLebSVzNUI+A3NDzfiH9Ny4df4fA7Ndso3kPR1V/x1YEc7BYxA==",
+          "requires": {
+            "hermes-estree": "0.21.1"
+          }
+        }
       }
     },
     "@stylexjs/eslint-plugin": {
@@ -37499,6 +37555,11 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "ansis": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.2.0.tgz",
+      "integrity": "sha512-Yk3BkHH9U7oPyCN3gL5Tc7CpahG/+UFv/6UG03C311Vy9lzRmA5uoxDTpU9CO3rGHL6KzJz/pdDeXZCZ5Mu/Sg=="
     },
     "anymatch": {
       "version": "3.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,8 @@
     "@stylexjs/scripts": "0.6.1",
     "fb-watchman": "^2.0.2",
     "json5": "^2.2.3",
-    "mkdirp": "^3.0.1"
+    "mkdirp": "^3.0.1",
+    "ansis": "^3.2.0"
   },
   "bin": {
     "stylex": "./lib/index.js"

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -12,9 +12,8 @@ import type { Argv } from 'yargs';
 import type { Rule } from '@stylexjs/babel-plugin';
 import yargs from 'yargs';
 import path from 'path';
-import chalk from 'chalk';
+import ansis from 'ansis';
 import JSON5 from 'json5';
-
 import { isDir } from './files';
 import { compileDirectory } from './transform';
 import options from './options';
@@ -28,15 +27,15 @@ const primary = '#5B45DE';
 const secondary = '#D573DD';
 
 console.log(
-  chalk.hex(primary).bold(`\n
-   .d8888b.  888             888         ${chalk.hex(secondary).bold('Y88b   d88P')} 
-  d88P  Y88b 888             888          ${chalk.hex(secondary).bold('Y88b d88P')}  
-  Y88b.      888             888           ${chalk.hex(secondary).bold('Y88o88P')}   
-   "Y888b.   888888 888  888 888  .d88b.    ${chalk.hex(secondary).bold('Y888P')}    
-      "Y88b. 888    888  888 888 d8P  Y8b   ${chalk.hex(secondary).bold('d888b')}    
-        "888 888    888  888 888 88888888  ${chalk.hex(secondary).bold('d88888b')}   
-  Y88b  d88P Y88b.  Y88b 888 888 Y8b.     ${chalk.hex(secondary).bold('d88P Y88b')}  
-   "Y8888P"   "Y888  "Y88888 888  "Y8888 ${chalk.hex(secondary).bold('cd88P   Y88b')} 
+  ansis.hex(primary).bold(`\n
+   .d8888b.  888             888         ${ansis.hex(secondary).bold('Y88b   d88P')} 
+  d88P  Y88b 888             888          ${ansis.hex(secondary).bold('Y88b d88P')}  
+  Y88b.      888             888           ${ansis.hex(secondary).bold('Y88o88P')}   
+   "Y888b.   888888 888  888 888  .d88b.    ${ansis.hex(secondary).bold('Y888P')}    
+      "Y88b. 888    888  888 888 d8P  Y8b   ${ansis.hex(secondary).bold('d888b')}    
+        "888 888    888  888 888 88888888  ${ansis.hex(secondary).bold('d88888b')}   
+  Y88b  d88P Y88b.  Y88b 888 888 Y8b.     ${ansis.hex(secondary).bold('d88P Y88b')}  
+   "Y8888P"   "Y888  "Y88888 888  "Y8888 ${ansis.hex(secondary).bold('cd88P   Y88b')} 
                          888                         
                     Y8b d88P                         
                      "Y88P"          

--- a/packages/cli/src/transform.js
+++ b/packages/cli/src/transform.js
@@ -21,7 +21,7 @@ import {
   getRelativePath,
 } from './files';
 import type { TransformConfig } from './config';
-import chalk from 'chalk';
+import ansis from 'ansis';
 import fs from 'fs';
 import {
   createImportPlugin,
@@ -46,7 +46,7 @@ export async function compileDirectory(
       const parsed = path.parse(filePath);
       if (isJSFile(filePath) && !parsed.dir.startsWith('node_modules')) {
         console.log(
-          `${chalk.green('[stylex]')} transforming ${path.join(config.input, filePath)}`,
+          `${ansis.green('[stylex]')} transforming ${path.join(config.input, filePath)}`,
         );
         await compileFile(filePath, config);
       } else {

--- a/packages/cli/src/watcher.js
+++ b/packages/cli/src/watcher.js
@@ -11,7 +11,7 @@ import type { TransformConfig } from './config';
 
 import { compileDirectory } from './transform';
 
-import chalk from 'chalk';
+import ansis from 'ansis';
 import watchman from 'fb-watchman';
 
 type Subscription = {
@@ -72,7 +72,7 @@ export default function watch(config: TransformConfig) {
           subscribe(watchmanClient, resp.watch, resp.relative_path, config);
           console.log(
             'Watching for style changes in',
-            chalk.green(resp.relative_path),
+            ansis.green(resp.relative_path),
           );
         },
       );


### PR DESCRIPTION
## What changed / motivation ?

The cli package is using `chalk` as a terminal output. However this package doesn't declare equivalent dependencies which risks ghost dependencies. And the most important ting is that the `chalk` doesn't support cjs. So we should find a package support esm/cjs. `picocolors` looks well but has too few features. So i think we can using `ansis` replace `chalk` and it will be smaller and faster.

## Linked PR/Issues

None

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code