### PR TITLE
Add focus-within

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -1362,6 +1362,18 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
         });
       `,
     },
+    {
+      code: `
+        import stylex from'stylex';
+        const styles = stylex.create({
+          base: {
+            backgroundColor: {
+              default: 'blue',
+              ':focus-within': 'red',
+            },
+          },
+        });`
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -1372,7 +1372,7 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
               ':focus-within': 'red',
             },
           },
-        });`
+        });`,
     },
   ],
   invalid: [

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -2272,6 +2272,7 @@ const pseudoClassesAndAtRules = makeUnionRule(
   makeLiteralRule(':hover'),
   makeLiteralRule(':focus'),
   makeLiteralRule(':focus-visible'),
+  makeLiteralRule(':focus-within'),
   makeLiteralRule(':active'),
   makeLiteralRule(':visited'),
   makeLiteralRule(':disabled'),


### PR DESCRIPTION
For some reason the valid-styles tests don't actually fail even if they are invalid.