### PR TITLE
Adds next@15 and next@15rc to the nextjs plugin's peer dependencies

### DIFF
--- a/packages/nextjs-plugin/package.json
+++ b/packages/nextjs-plugin/package.json
@@ -13,7 +13,7 @@
     "@stylexjs/babel-plugin": "^0.6.1"
   },
   "peerDependencies": {
-    "next": ">=14.0.1"
+    "next": ">=14.0.1 || >=15.0.0 || 15.0.0-rc.0"
   },
   "devDependencies": {
     "next": "^14.0.1",


### PR DESCRIPTION
## What changed / motivation ?

NextJS 15 has released a RC that depends upon this change.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code