### PR TITLE
docs: fix stylex import source in code example

### DIFF
--- a/apps/docs/docs/learn/02-thinking-in-stylex.mdx
+++ b/apps/docs/docs/learn/02-thinking-in-stylex.mdx
@@ -80,7 +80,7 @@ compiles away `stylex.props` calls when possible.
 So,
 
 ```tsx
-import * as stylex from 'stylex';
+import * as stylex from '@stylexjs/stylex';
 const styles = stylex.create({
   red: {color: 'red'},
 });
@@ -93,7 +93,7 @@ Compiles down to:
 <TabItem label="JS Output" value="js-output">
 
 ```tsx
-import * as stylex from 'stylex';
+import * as stylex from '@stylexjs/stylex';
 
 let a = {className: 'x1e2nbdu'};
 ```


### PR DESCRIPTION
## What changed / motivation ?

I tried to copy-paste and run this code snippet from "Thinking in StyleX", and found that the import source in the snippet seems incorrect.

Instead of `import * as stylex from 'stylex';`, it should be `import * as stylex from '@stylexjs/stylex';`.

## Linked PR/Issues

N/A

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Did a search for `import * as stylex from 'stylex';` in the codebase and did not find any other matches in `.mdx` files. 

All are `import * as stylex from '@stylexjs/stylex';`, including other code snippets in the same file. So I think this may be a mistake.

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code