### PR TITLE
fix: pass caller to babel within rollup plugin

### DIFF
--- a/packages/rollup-plugin/src/index.js
+++ b/packages/rollup-plugin/src/index.js
@@ -96,6 +96,13 @@ export default function stylexPlugin({
             unstable_moduleResolution,
           }),
         ],
+        caller: {
+          name: '@stylexjs/rollup-plugin',
+          supportsStaticESM: true,
+          supportsDynamicImport: true,
+          supportsTopLevelAwait: !inputCode.includes('require('),
+          supportsExportNamespaceFrom: true,
+        },
       });
       if (result == null) {
         console.warn('stylex: transformAsync returned null');


### PR DESCRIPTION
Fixes #402

There has been reports of the Rollup Plugin not playing well with `babel-env`. A fix was suggested in the issue above which is what this PR implements.

Still trying to reproduce the bug, but putting up this PR in the meantime for review.