### PR TITLE
fix(babel-plugin): apply the right context for string static methods

### DIFF
--- a/packages/babel-plugin/__tests__/evaluation/stylex-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-evaluation-test.js
@@ -231,10 +231,15 @@ describe('custom path evaluation works as expected', () => {
     });
 
     test('Methods called by string should be bind', () => {
-      expect(evaluateFirstStatement('const x = "".concat("10px"," ").concat("10px");', {})).toBe(
-        '10px 10px',
+      expect(
+        evaluateFirstStatement(
+          'const x = "".concat("10px"," ").concat("10px");',
+          {},
+        ),
+      ).toBe('10px 10px');
+      expect(evaluateFirstStatement('const x = "abc".charCodeAt(0);', {})).toBe(
+        97,
       );
-      expect(evaluateFirstStatement('const x = "abc".charCodeAt(0);', {})).toBe(97);
     });
   });
 });

--- a/packages/babel-plugin/__tests__/evaluation/stylex-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-evaluation-test.js
@@ -229,5 +229,12 @@ describe('custom path evaluation works as expected', () => {
         c: 4,
       });
     });
+
+    test('Methods called by string should be bind', () => {
+      expect(evaluateFirstStatement('const x = "".concat("10px"," ").concat("10px");', {})).toBe(
+        '10px 10px',
+      );
+      expect(evaluateFirstStatement('const x = "abc".charCodeAt(0);', {})).toBe(97);
+    });
   });
 });

--- a/packages/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/babel-plugin/src/utils/evaluate-path.js
@@ -690,6 +690,9 @@ function _evaluate(path: NodePath<>, state: State): any {
       ) {
         const val: number | string = object.node.value;
         func = (val as $FlowFixMe)[property.node.name];
+        if (typeof val === 'string') {
+          context = object.node.value;
+        }
       }
 
       if (func == null) {


### PR DESCRIPTION
## What changed / motivation ?

Ensure the correctly binds the context when evaluating strings called with static method.

## Linked PR/Issues

Fixes #555 

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code