### PR TITLE
CLI - add option to use CSS layers in the generated CSS file

### DIFF
--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -21,6 +21,7 @@ export type CliConfig = {
   watch: boolean,
   babelPresets: $ReadOnlyArray<any>,
   modules_EXPERIMENTAL: $ReadOnlyArray<ModuleType>,
+  useCSSLayers?: boolean,
 };
 
 export type TransformConfig = {

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -68,6 +68,7 @@ const styleXBundleName: string = args.styleXBundleName;
 const modules_EXPERIMENTAL: $ReadOnlyArray<ModuleType> =
   args.modules_EXPERIMENTAL;
 const babelPresets: Array<any> = args.babelPresets;
+const useCSSLayers: boolean = args.useCSSLayers;
 
 const cliArgsConfig: CliConfig = {
   input,
@@ -76,6 +77,7 @@ const cliArgsConfig: CliConfig = {
   watch,
   styleXBundleName,
   babelPresets,
+  useCSSLayers,
 };
 
 styleXCompile(cliArgsConfig);

--- a/packages/cli/src/options.js
+++ b/packages/cli/src/options.js
@@ -35,6 +35,12 @@ const options: { [$Keys<CliConfig>]: Options } = {
     type: 'boolean',
     default: false,
   },
+  useCSSLayers: {
+    alias: 'l',
+    describe: 'Use CSS layers to optimize CSS rendering',
+    type: 'boolean',
+    default: false,
+  },
   babelPresets: {
     describe:
       'A list of babel presets to pass to the babel transform when compiling StyleX',

--- a/packages/cli/src/transform.js
+++ b/packages/cli/src/transform.js
@@ -57,6 +57,7 @@ export async function compileDirectory(
     }
     const compiledCSS = await styleXPlugin.processStylexRules(
       Array.from(config.state.styleXRules.values()).flat(),
+      config.useCSSLayers,
     );
 
     const cssBundlePath = path.join(config.output, config.styleXBundleName);


### PR DESCRIPTION
Added the `useCSSLayers` option to the CLI which, when `true`, generates a CSS bundle that uses CSS layers instead of the `:not(#\#)` polyfill.