### PR TITLE
feat: allow using firstThatWorks for variable fallbacks

### DIFF
--- a/packages/shared/__tests__/stylex-first-that-works-test.js
+++ b/packages/shared/__tests__/stylex-first-that-works-test.js
@@ -13,4 +13,21 @@ describe('stylex-first-that-works test', () => {
   test('reverses simple array of values', () => {
     expect(firstThatWorks('a', 'b', 'c')).toEqual(['c', 'b', 'a']);
   });
+  test('creates fallbacks for variables', () => {
+    expect(firstThatWorks('var(--accent)', 'blue')).toEqual(
+      'var(--accent, blue)',
+    );
+  });
+  test('Allow variables to be fallbacks too', () => {
+    expect(
+      firstThatWorks(
+        'color-mix(in srgb, currentColor 20%, transparent)',
+        'var(--accent)',
+        'blue',
+      ),
+    ).toEqual([
+      'var(--accent, blue)',
+      'color-mix(in srgb, currentColor 20%, transparent)',
+    ]);
+  });
 });

--- a/packages/shared/__tests__/stylex-first-that-works-test.js
+++ b/packages/shared/__tests__/stylex-first-that-works-test.js
@@ -11,11 +11,19 @@ import firstThatWorks from '../src/stylex-first-that-works';
 
 describe('stylex-first-that-works test', () => {
   test('reverses simple array of values', () => {
+    expect(firstThatWorks('a', 'b')).toEqual(['b', 'a']);
     expect(firstThatWorks('a', 'b', 'c')).toEqual(['c', 'b', 'a']);
   });
   test('creates fallbacks for variables', () => {
     expect(firstThatWorks('var(--accent)', 'blue')).toEqual(
       'var(--accent, blue)',
+    );
+    expect(firstThatWorks('blue', 'var(--accent)')).toEqual([
+      'var(--accent)',
+      'blue',
+    ]);
+    expect(firstThatWorks('var(--primary)', 'var(--accent)')).toEqual(
+      'var(--primary, var(--accent))',
     );
   });
   test('Allow variables to be fallbacks too', () => {
@@ -28,6 +36,24 @@ describe('stylex-first-that-works test', () => {
     ).toEqual([
       'var(--accent, blue)',
       'color-mix(in srgb, currentColor 20%, transparent)',
+    ]);
+  });
+  test('Omit all but first fallback after the last variable', () => {
+    expect(
+      firstThatWorks(
+        'color-mix(in oklch, currentColor 20%, transparent)',
+        'color-mix(in srgb, currentColor 20%, transparent)',
+        'var(--accent)',
+        'var(--primary)',
+        'var(--secondary)',
+        'red',
+        'blue',
+        'green',
+      ),
+    ).toEqual([
+      'var(--accent, var(--primary, var(--secondary, red)))',
+      'color-mix(in srgb, currentColor 20%, transparent)',
+      'color-mix(in oklch, currentColor 20%, transparent)',
     ]);
   });
 });

--- a/packages/shared/src/stylex-first-that-works.js
+++ b/packages/shared/src/stylex-first-that-works.js
@@ -7,8 +7,40 @@
  * @flow strict
  */
 
-export default function stylexFirstThatWorks<T: string>(
-  ...args: $ReadOnlyArray<T>
-): $ReadOnlyArray<T> {
-  return [...args].reverse();
+const isVar = (arg: string) =>
+  typeof arg === 'string' && arg.match(/^var\(--[a-zA-Z0-9-_]+\)$/);
+
+export default function stylexFirstThatWorks(
+  ...args: $ReadOnlyArray<string>
+): $ReadOnlyArray<string> | string {
+  const firstVar = args.findIndex(isVar);
+
+  if (firstVar === -1) {
+    return [...args].reverse();
+  }
+  const priorities = args.slice(0, firstVar).reverse();
+  const rest = args.slice(firstVar);
+  const firstNonVar = rest.findIndex((arg) => !isVar(arg));
+  const varParts = rest
+    .slice(0, firstNonVar === -1 ? rest.length : firstNonVar + 1)
+    .reverse();
+
+  const vars = varParts.map((arg) => (isVar(arg) ? arg.slice(4, -1) : arg));
+
+  const returnValue = [
+    vars.reduce<string>(
+      (soFar, varName) =>
+        soFar
+          ? `var(${varName}, ${String(soFar)})`
+          : varName.startsWith('--')
+            ? `var(${varName})`
+            : varName,
+      '',
+    ),
+    ...priorities,
+  ];
+  if (returnValue.length === 1) {
+    return returnValue[0];
+  }
+  return returnValue;
 }


### PR DESCRIPTION
Fixes #432 

Update `stylex.firstThatWorks` to work with variables and generate fallback values for variables.

Handles various edge-cases.