### PR TITLE
fix: Stop polyfilling logical text-align

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-logical-values-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-logical-values-test.js
@@ -109,7 +109,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xp4054r{text-align:right}", 3000, ".xp4054r{text-align:left}");
+        _inject2(".xp4054r{text-align:end}", 3000);
         const classnames = "xp4054r";"
       `);
     });
@@ -125,7 +125,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1yc453h{text-align:left}", 3000, ".x1yc453h{text-align:right}");
+        _inject2(".x1yc453h{text-align:start}", 3000);
         const classnames = "x1yc453h";"
       `);
     });

--- a/packages/shared/src/physical-rtl/generate-ltr.js
+++ b/packages/shared/src/physical-rtl/generate-ltr.js
@@ -75,10 +75,6 @@ const propertyToLTR = {
     val,
   ],
   // 'border-end-end-radius': ([key, val]: [string, string]) => ['border-bottom-right-radius', val],
-  'text-align': ([key, val]: [string, string]) => [
-    key,
-    logicalToPhysical[val] ?? val,
-  ],
   float: ([key, val]: [string, string]) => [key, logicalToPhysical[val] ?? val],
   clear: ([key, val]: [string, string]) => [key, logicalToPhysical[val] ?? val],
   start: ([_key, val]: [string, string]) => ['left', val],

--- a/packages/shared/src/physical-rtl/generate-rtl.js
+++ b/packages/shared/src/physical-rtl/generate-rtl.js
@@ -156,8 +156,6 @@ const propertyToRTL = {
     val,
   ],
   // 'border-end-end-radius': ([key, val]: [string, string]) => ['border-bottom-left-radius', val],
-  'text-align': ([key, val]: [string, string]) =>
-    logicalToPhysical[val] != null ? [key, logicalToPhysical[val]] : null,
   float: ([key, val]: [string, string]) =>
     logicalToPhysical[val] != null ? [key, logicalToPhysical[val]] : null,
   clear: ([key, val]: [string, string]) =>


### PR DESCRIPTION
Fixes #627 

The `styleResolution: 'legacy-expand-shorthands'` configuration also converts logical properties to physical properties for supporting very old browsers.

Turns out that logical `text-align` has been supported in even the oldest browsers, so deleting the code that converts those logical values to physical ones.