### PR TITLE
add esm resolver

### DIFF
--- a/apps/docs/docs/learn/03-installation.mdx
+++ b/apps/docs/docs/learn/03-installation.mdx
@@ -243,7 +243,7 @@ provides (experimental) plugins for Webpack, Rollup, Next.js and esbuild.
         stylexImports: ['@stylexjs/stylex'],
         // Required for CSS variable support
         unstable_moduleResolution: {
-          // type: 'commonJS' | 'ESModules' | 'haste'
+          // type: 'commonJS' | 'haste'
           // default: 'commonJS'
           type: 'commonJS',
           // The absolute path to the root of your project

--- a/package-lock.json
+++ b/package-lock.json
@@ -12609,6 +12609,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esm-resolve": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/esm-resolve/-/esm-resolve-1.0.11.tgz",
+      "integrity": "sha512-LxF0wfUQm3ldUDHkkV2MIbvvY0TgzIpJ420jHSV1Dm+IlplBEWiJTKWM61GtxUfvjV6iD4OtTYFGAGM2uuIUWg=="
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -26313,7 +26318,8 @@
         "@babel/traverse": "^7.23.6",
         "@babel/types": "^7.23.6",
         "@stylexjs/shared": "0.8.0",
-        "@stylexjs/stylex": "0.8.0"
+        "@stylexjs/stylex": "0.8.0",
+        "esm-resolve": "^1.0.11"
       }
     },
     "packages/cli": {
@@ -31289,7 +31295,8 @@
         "@babel/traverse": "^7.23.6",
         "@babel/types": "^7.23.6",
         "@stylexjs/shared": "0.8.0",
-        "@stylexjs/stylex": "0.8.0"
+        "@stylexjs/stylex": "0.8.0",
+        "esm-resolve": "^1.0.11"
       }
     },
     "@stylexjs/cli": {
@@ -35240,6 +35247,11 @@
     "eslint-visitor-keys": {
       "version": "2.1.0",
       "dev": true
+    },
+    "esm-resolve": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/esm-resolve/-/esm-resolve-1.0.11.tgz",
+      "integrity": "sha512-LxF0wfUQm3ldUDHkkV2MIbvvY0TgzIpJ420jHSV1Dm+IlplBEWiJTKWM61GtxUfvjV6iD4OtTYFGAGM2uuIUWg=="
     },
     "espree": {
       "version": "9.6.1",

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -18,7 +18,8 @@
     "@stylexjs/stylex": "0.8.0",
     "@babel/core": "^7.23.6",
     "@babel/traverse": "^7.23.6",
-    "@babel/types": "^7.23.6"
+    "@babel/types": "^7.23.6",
+    "esm-resolve": "^1.0.11"
   },
   "jest": {
     "verbose": true,

--- a/packages/esbuild-plugin/README.md
+++ b/packages/esbuild-plugin/README.md
@@ -38,7 +38,7 @@ esbuild.build({
       stylexImports: ['@stylexjs/stylex'],
       // Required for CSS variable support
       unstable_moduleResolution: {
-        // type: 'commonJS' | 'ESModules' | 'haste'
+        // type: 'commonJS' | 'haste'
         // default: 'commonJS'
         type: 'commonJS',
         // The absolute path to the root of your project


### PR DESCRIPTION
## What changed / motivation ?

I author esm and the babel plugin wasn't recognizing my imports.

## Additional Context

I tested this in my app and it resolves the files now.

The package I use is pretty lenient when It comes to imports. It might be able to be used instead of the other file path resolvers too.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code