### PR TITLE
feat: Process font, background, and outline in shorthand lint rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,6 @@
         "packages/*",
         "apps/*"
       ],
-      "dependencies": {
-        "css-shorthand-expand": "^1.2.0"
-      },
       "devDependencies": {
         "@babel/cli": "^7.23.9",
         "@babel/core": "^7.23.9",
@@ -31504,6 +31501,7 @@
       "version": "0.7.5",
       "license": "MIT",
       "dependencies": {
+        "css-shorthand-expand": "^1.2.0",
         "micromatch": "^4.0.5"
       }
     },
@@ -36602,6 +36600,7 @@
     "@stylexjs/eslint-plugin": {
       "version": "file:packages/eslint-plugin",
       "requires": {
+        "css-shorthand-expand": "^1.2.0",
         "micromatch": "^4.0.5"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
         "packages/*",
         "apps/*"
       ],
+      "dependencies": {
+        "css-shorthand-expand": "^1.2.0"
+      },
       "devDependencies": {
         "@babel/cli": "^7.23.9",
         "@babel/core": "^7.23.9",
@@ -10919,6 +10922,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-color-names": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.1.tgz",
+      "integrity": "sha512-i7o8lqlrmiG/EUzlBftBncsrkYgBCfCI9X6plNxdyXMZlMNd4hPX7u/o7YLH9vwXPPPAr+BUs3R0oto+lzjbyA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/css-declaration-sorter": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
@@ -11092,6 +11103,31 @@
       "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
       "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g=="
     },
+    "node_modules/css-shorthand-expand": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-shorthand-expand/-/css-shorthand-expand-1.2.0.tgz",
+      "integrity": "sha512-L3RS1VNYuXgMOfVGX4WzP9AFK6KL0JuioSoO8661egEac2eHX9/s4yFO8mgK6QEtm8UmU8IvuKzPgdQpU0DhpQ==",
+      "dependencies": {
+        "css-color-names": "0.0.1",
+        "css-url-regex": "0.0.1",
+        "hex-color-regex": "^1.0.1",
+        "hsl-regex": "^1.0.0",
+        "hsla-regex": "^1.0.0",
+        "map-obj": "^1.0.0",
+        "repeat-element": "^1.1.0",
+        "rgb-regex": "^1.0.1",
+        "rgba-regex": "^1.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/css-shorthand-expand/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/css-tree": {
       "version": "1.1.3",
       "license": "MIT",
@@ -11102,6 +11138,11 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/css-url-regex": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-0.0.1.tgz",
+      "integrity": "sha512-nFtRgFyJUwz9pyMpyscglpHEFdEJ+y2Q8pK33I99gzhUV1OFzS3t5DtIop3VWLIoGFr4mWcM4hJuWPLXn1NXgA=="
     },
     "node_modules/css-what": {
       "version": "6.1.0",
@@ -14881,6 +14922,11 @@
         "prettier-plugin-hermes-parser": "0.19.2"
       }
     },
+    "node_modules/hex-color-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+      "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
     "node_modules/highlight.js": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -14964,6 +15010,16 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/hsl-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
+      "integrity": "sha512-M5ezZw4LzXbBKMruP+BNANf0k+19hDQMgpzBIYnya//Al+fjNct9Wf3b1WedLqdEs2hKBvxq/jh+DsHJLj0F9A=="
+    },
+    "node_modules/hsla-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
+      "integrity": "sha512-7Wn5GMLuHBjZCb2bTmnDOycho0p/7UVaAeqXZGbHrBCl6Yd/xDhQJAXe6Ga9AXJH2I5zY1dEdYw2u1UptnSBJA=="
     },
     "node_modules/htm": {
       "version": "3.1.1",
@@ -27599,6 +27655,14 @@
         "entities": "^2.0.0"
       }
     },
+    "node_modules/repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
@@ -27712,6 +27776,16 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rgb-regex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
+      "integrity": "sha512-gDK5mkALDFER2YLqH6imYvK6g02gpNGM4ILDZ472EwWfXZnC2ZEpoB2ECXTyOVUKuk/bPJZMzwQPBYICzP+D3w=="
+    },
+    "node_modules/rgba-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "integrity": "sha512-zgn5OjNQXLUTdq8m17KdaicF6w89TZs8ZU8y0AYENIU6wG8GG6LLm0yLSiPY8DmaYmHdgRW8rnApjoT0fQRfMg=="
     },
     "node_modules/rimraf": {
       "version": "5.0.5",
@@ -31466,6 +31540,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -31481,6 +31556,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -31496,6 +31572,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31511,6 +31588,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31526,6 +31604,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31541,6 +31620,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31556,6 +31636,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -31571,6 +31652,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -31586,6 +31668,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -38827,6 +38910,11 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
+    "css-color-names": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.1.tgz",
+      "integrity": "sha512-i7o8lqlrmiG/EUzlBftBncsrkYgBCfCI9X6plNxdyXMZlMNd4hPX7u/o7YLH9vwXPPPAr+BUs3R0oto+lzjbyA=="
+    },
     "css-declaration-sorter": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
@@ -38930,12 +39018,41 @@
       "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
       "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g=="
     },
+    "css-shorthand-expand": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-shorthand-expand/-/css-shorthand-expand-1.2.0.tgz",
+      "integrity": "sha512-L3RS1VNYuXgMOfVGX4WzP9AFK6KL0JuioSoO8661egEac2eHX9/s4yFO8mgK6QEtm8UmU8IvuKzPgdQpU0DhpQ==",
+      "requires": {
+        "css-color-names": "0.0.1",
+        "css-url-regex": "0.0.1",
+        "hex-color-regex": "^1.0.1",
+        "hsl-regex": "^1.0.0",
+        "hsla-regex": "^1.0.0",
+        "map-obj": "^1.0.0",
+        "repeat-element": "^1.1.0",
+        "rgb-regex": "^1.0.1",
+        "rgba-regex": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg=="
+        }
+      }
+    },
     "css-tree": {
       "version": "1.1.3",
       "requires": {
         "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
       }
+    },
+    "css-url-regex": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-0.0.1.tgz",
+      "integrity": "sha512-nFtRgFyJUwz9pyMpyscglpHEFdEJ+y2Q8pK33I99gzhUV1OFzS3t5DtIop3VWLIoGFr4mWcM4hJuWPLXn1NXgA=="
     },
     "css-what": {
       "version": "6.1.0"
@@ -41897,6 +42014,11 @@
         "hermes-parser": "0.19.2"
       }
     },
+    "hex-color-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+      "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
     "highlight.js": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -41978,6 +42100,16 @@
           }
         }
       }
+    },
+    "hsl-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
+      "integrity": "sha512-M5ezZw4LzXbBKMruP+BNANf0k+19hDQMgpzBIYnya//Al+fjNct9Wf3b1WedLqdEs2hKBvxq/jh+DsHJLj0F9A=="
+    },
+    "hsla-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
+      "integrity": "sha512-7Wn5GMLuHBjZCb2bTmnDOycho0p/7UVaAeqXZGbHrBCl6Yd/xDhQJAXe6Ga9AXJH2I5zY1dEdYw2u1UptnSBJA=="
     },
     "htm": {
       "version": "3.1.1",
@@ -51090,6 +51222,11 @@
         }
       }
     },
+    "repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ=="
+    },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
@@ -51161,6 +51298,16 @@
     },
     "reusify": {
       "version": "1.0.4"
+    },
+    "rgb-regex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
+      "integrity": "sha512-gDK5mkALDFER2YLqH6imYvK6g02gpNGM4ILDZ472EwWfXZnC2ZEpoB2ECXTyOVUKuk/bPJZMzwQPBYICzP+D3w=="
+    },
+    "rgba-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "integrity": "sha512-zgn5OjNQXLUTdq8m17KdaicF6w89TZs8ZU8y0AYENIU6wG8GG6LLm0yLSiPY8DmaYmHdgRW8rnApjoT0fQRfMg=="
     },
     "rimraf": {
       "version": "5.0.5",
@@ -53723,60 +53870,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
       "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
-    },
-    "@next/swc-darwin-arm64": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.1.tgz",
-      "integrity": "sha512-JyxnGCS4qT67hdOKQ0CkgFTp+PXub5W1wsGvIq98TNbF3YEIN7iDekYhYsZzc8Ov0pWEsghQt+tANdidITCLaw==",
-      "optional": true
-    },
-    "@next/swc-darwin-x64": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.1.tgz",
-      "integrity": "sha512-625Z7bb5AyIzswF9hvfZWa+HTwFZw+Jn3lOBNZB87lUS0iuCYDHqk3ujuHCkiyPtSC0xFBtYDLcrZ11mF/ap3w==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-gnu": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.1.tgz",
-      "integrity": "sha512-iVpn3KG3DprFXzVHM09kvb//4CNNXBQ9NB/pTm8LO+vnnnaObnzFdS5KM+w1okwa32xH0g8EvZIhoB3fI3mS1g==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-musl": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.1.tgz",
-      "integrity": "sha512-mVsGyMxTLWZXyD5sen6kGOTYVOO67lZjLApIj/JsTEEohDDt1im2nkspzfV5MvhfS7diDw6Rp/xvAQaWZTv1Ww==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-gnu": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.1.tgz",
-      "integrity": "sha512-wMqf90uDWN001NqCM/auRl3+qVVeKfjJdT9XW+RMIOf+rhUzadmYJu++tp2y+hUbb6GTRhT+VjQzcgg/QTD9NQ==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-musl": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.1.tgz",
-      "integrity": "sha512-ol1X1e24w4j4QwdeNjfX0f+Nza25n+ymY0T2frTyalVczUmzkVD7QGgPTZMHfR1aLrO69hBs0G3QBYaj22J5GQ==",
-      "optional": true
-    },
-    "@next/swc-win32-arm64-msvc": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.1.tgz",
-      "integrity": "sha512-WEmTEeWs6yRUEnUlahTgvZteh5RJc4sEjCQIodJlZZ5/VJwVP8p2L7l6VhzQhT4h7KvLx/Ed4UViBdne6zpIsw==",
-      "optional": true
-    },
-    "@next/swc-win32-ia32-msvc": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.1.tgz",
-      "integrity": "sha512-oFpHphN4ygAgZUKjzga7SoH2VGbEJXZa/KL8bHCAwCjDWle6R1SpiGOdUdA8EJ9YsG1TYWpzY6FTbUA+iAJeww==",
-      "optional": true
-    },
-    "@next/swc-win32-x64-msvc": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.1.tgz",
-      "integrity": "sha512-FFp3nOJ/5qSpeWT0BZQ+YE1pSMk4IMpkME/1DwKBwhg4mJLB9L+6EXuJi4JEwaJdl5iN+UUlmUD3IsR1kx5fAg==",
-      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,8 +76,5 @@
         }
       }
     ]
-  },
-  "dependencies": {
-    "css-shorthand-expand": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
         }
       }
     ]
+  },
+  "dependencies": {
+    "css-shorthand-expand": "^1.2.0"
   }
 }

--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -138,6 +138,124 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       ],
     },
     {
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            outline: '2px dashed red',
+          },
+        });
+      `,
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            outlineWidth: '2px',
+            outlineStyle: 'dashed',
+            outlineColor: 'red',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "outline: 2px dashed red" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            background: '#ff0 url("image.jpg") no-repeat fixed center / cover !important',
+          },
+        });
+      `,
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            backgroundColor: '#ff0',
+            backgroundImage: 'url("image.jpg")',
+            backgroundRepeat: 'no-repeat',
+            backgroundAttachment: 'fixed',
+            backgroundPosition: 'center',
+            backgroundSize: 'cover',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "background: #ff0 url("image.jpg") no-repeat fixed center / cover !important" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      options: [{ allowImportant: true }],
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            background: '#ff0 url("image.jpg") no-repeat fixed center / cover !important',
+          },
+        });
+      `,
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            backgroundColor: '#ff0 !important',
+            backgroundImage: 'url("image.jpg") !important',
+            backgroundRepeat: 'no-repeat !important',
+            backgroundAttachment: 'fixed !important',
+            backgroundPosition: 'center !important',
+            backgroundSize: 'cover !important',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "background: #ff0 url("image.jpg") no-repeat fixed center / cover !important" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            margin: '0px',
+            font: 'italic small-caps bold 16px/1.5 "Helvetica Neue"',
+            color: 'white',
+          },
+        });
+      `,
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            margin: '0px',
+            fontFamily: '"Helvetica Neue"',
+            fontStyle: 'italic',
+            fontVariant: 'small-caps',
+            fontWeight: 'bold',
+            fontSize: '16px',
+            lineHeight: '1.5',
+            color: 'white',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "font: italic small-caps bold 16px/1.5 "Helvetica Neue"" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
       options: [{ allowImportant: true }],
       code: `
         import stylex from 'stylex';

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -13,6 +13,7 @@
     "test": "jest --detectOpenHandles"
   },
   "dependencies": {
+    "css-shorthand-expand": "^1.2.0",
     "micromatch": "^4.0.5"
   },
   "files": [

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -20,7 +20,10 @@ import type { SourceCode } from 'eslint/eslint-rule';
 
 import type { Token } from 'eslint/eslint-ast';
 
-import splitValue from './utils/splitShorthands.js';
+import {
+  splitSpecificShorthands,
+  splitDirectionalShorthands,
+} from './utils/splitShorthands.js';
 
 /*:: import { Rule } from 'eslint'; */
 
@@ -32,12 +35,41 @@ const legacyNameMapping = {
 };
 
 const shorthandAliases = {
+  background: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'background',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  font: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands('font', rawValue.toString(), allowImportant);
+  },
+  outline: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'outline',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
   marginInline: (
     rawValue: number | string,
     allowImportant: boolean = false,
     _preferInline: boolean = false,
   ) => {
-    const splitValues = splitValue(rawValue, allowImportant);
+    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
     if (splitValues.length === 1) {
       return [['marginInline', rawValue]];
     }
@@ -52,7 +84,7 @@ const shorthandAliases = {
     allowImportant: boolean = false,
     _preferInline: boolean = false,
   ) => {
-    const splitValues = splitValue(rawValue, allowImportant);
+    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
     if (splitValues.length === 1) {
       return [['marginBlock', rawValue]];
     }
@@ -67,7 +99,7 @@ const shorthandAliases = {
     allowImportant: boolean = false,
     preferInline: boolean = false,
   ) => {
-    const splitValues = splitValue(rawValue, allowImportant);
+    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
     if (splitValues.length === 1) {
       return [['margin', rawValue]];
     }
@@ -93,15 +125,13 @@ const shorthandAliases = {
     allowImportant: boolean = false,
     preferInline: boolean = false,
   ) => {
-    const splitValues = splitValue(rawValue, allowImportant);
+    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
     if (splitValues.length === 1) {
       return [['padding', rawValue]];
     }
 
-    const [top, right = top, bottom = top, left = right] = splitValue(
-      rawValue,
-      allowImportant,
-    );
+    const [top, right = top, bottom = top, left = right] =
+      splitDirectionalShorthands(rawValue, allowImportant);
 
     return preferInline
       ? [
@@ -122,7 +152,7 @@ const shorthandAliases = {
     allowImportant: boolean = false,
     _preferInline: boolean = false,
   ) => {
-    const splitValues = splitValue(rawValue, allowImportant);
+    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
     if (splitValues.length === 1) {
       return [['paddingInline', rawValue]];
     }
@@ -137,7 +167,7 @@ const shorthandAliases = {
     allowImportant: boolean = false,
     _preferInline: boolean = false,
   ) => {
-    const splitValues = splitValue(rawValue, allowImportant);
+    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
     if (splitValues.length === 1) {
       return [['paddingBlock', rawValue]];
     }

--- a/packages/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/eslint-plugin/src/utils/splitShorthands.js
@@ -8,6 +8,7 @@
  */
 
 import parser from 'postcss-value-parser';
+import cssExpand from 'css-shorthand-expand';
 
 function printNode(node: PostCSSValueASTNode): string {
   switch (node.type) {
@@ -21,7 +22,34 @@ function printNode(node: PostCSSValueASTNode): string {
   }
 }
 
-export default function splitValue(
+const toCamelCase = (str: string) => {
+  return str.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());
+};
+
+const stripImportant = (cssProperty: string | number) =>
+  cssProperty
+    .toString()
+    .replace(/\s*!important\s*$/, '')
+    .trim();
+
+export function splitSpecificShorthands(
+  property: string,
+  value: string,
+  allowImportant: boolean = false,
+): $ReadOnlyArray<$ReadOnlyArray<mixed>> {
+  const longform = cssExpand(property, value);
+  const longformJsx: {
+    [key: string]: number | string,
+  } = {};
+
+  Object.entries(longform).forEach(([key, val]) => {
+    longformJsx[toCamelCase(key)] = allowImportant ? val : stripImportant(val);
+  });
+
+  return Object.entries(longformJsx);
+}
+
+export function splitDirectionalShorthands(
   str: number | string,
   allowImportant: boolean = false,
 ): $ReadOnlyArray<number | string> {

--- a/packages/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/eslint-plugin/src/utils/splitShorthands.js
@@ -38,15 +38,17 @@ export function splitSpecificShorthands(
   allowImportant: boolean = false,
 ): $ReadOnlyArray<$ReadOnlyArray<mixed>> {
   const longform = cssExpand(property, value);
-  const longformJsx: {
+  const longformStyle: {
     [key: string]: number | string,
   } = {};
 
   Object.entries(longform).forEach(([key, val]) => {
-    longformJsx[toCamelCase(key)] = allowImportant ? val : stripImportant(val);
+    longformStyle[toCamelCase(key)] = allowImportant
+      ? val
+      : stripImportant(val);
   });
 
-  return Object.entries(longformJsx);
+  return Object.entries(longformStyle);
 }
 
 export function splitDirectionalShorthands(


### PR DESCRIPTION
## Implementation

This PR iterates on a new lint rule for the handling of shorthands in stylex. 
- Here we are processing `background`, 'font' and `outline` properties.
- Because of the limitations of the parser in mapping exact styles, I'm leveraging https://www.npmjs.com/package/css-shorthand-expand to perform some of the parsing logic
- The output is transformed to stylex compatible syntax via regex parsing (stripping !important, camelCase)

## Context
On a broader scale, we want to add this fix within the js1 upgrade codemod. For the border styles, I'll explore leveraging the existing codemod instead of including it in this lint rule explicitly to avoid duplicate work.

This is a follow up to https://github.com/facebook/stylex/pull/614. 

## Testing

Added tests to cover the following:
- Style objects with `background`, `font`, and `outline`
- Above styles in isolation, as well as with other styles
- Tested !important flag, which we strip by default

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code