### PR TITLE
fix: handle watch mode errors and transform external module imports when options are specified

### DIFF
--- a/packages/cli/src/transform.js
+++ b/packages/cli/src/transform.js
@@ -133,7 +133,7 @@ export async function transformFile(
     ],
   });
   if (result == null) {
-    throw new Error(`Failed to transform file ${inputFilePath}`);
+    throw new Error(`[stylex] failed to transform file ${inputFilePath}`);
   }
   const { code, metadata } = result;
 

--- a/packages/cli/src/transform.js
+++ b/packages/cli/src/transform.js
@@ -19,6 +19,7 @@ import {
   writeCompiledCSS,
   writeCompiledJS,
   getRelativePath,
+  isDir,
 } from './files';
 import type { TransformConfig } from './config';
 import ansis from 'ansis';
@@ -27,7 +28,6 @@ import {
   createImportPlugin,
   createModuleImportModifierPlugin,
 } from './plugins';
-import { clearInputModuleDir } from './modules';
 
 export async function compileDirectory(
   config: TransformConfig,
@@ -37,44 +37,51 @@ export async function compileDirectory(
   if (filesToDelete) {
     filesToDelete.forEach((file) => {
       config.state.styleXRules.delete(file);
-      fs.rmSync(path.join(config.output, file));
+      const outputPath = path.join(config.output, file);
+      if (fs.existsSync(outputPath)) {
+        fs.rmSync(outputPath);
+      }
     });
   }
-  try {
-    const dirFiles = filesToCompile ?? getInputDirectoryFiles(config.input);
-    for (const filePath of dirFiles) {
-      const parsed = path.parse(filePath);
-      if (isJSFile(filePath) && !parsed.dir.startsWith('node_modules')) {
-        console.log(
-          `${ansis.green('[stylex]')} transforming ${path.join(config.input, filePath)}`,
-        );
+  const dirFiles = filesToCompile ?? getInputDirectoryFiles(config.input);
+  for (const filePath of dirFiles) {
+    const parsed = path.parse(filePath);
+    if (isJSFile(filePath) && !parsed.dir.startsWith('node_modules')) {
+      console.log(
+        `${ansis.green('[stylex]')} transforming ${path.join(config.input, filePath)}`,
+      );
+      try {
         await compileFile(filePath, config);
-      } else {
-        const src = path.join(config.input, filePath);
-        const dst = path.join(config.output, filePath);
+      } catch (transformError) {
+        throw transformError;
+      }
+    } else {
+      const src = path.join(config.input, filePath);
+      const dst = path.join(config.output, filePath);
+      if (!isDir(src)) {
+        console.log(
+          `${ansis.green('[stylex]')} copying ${path.join(config.input, filePath)}`,
+        );
         copyFile(src, dst);
       }
     }
-    const compiledCSS = await styleXPlugin.processStylexRules(
-      Array.from(config.state.styleXRules.values()).flat(),
-      config.useCSSLayers,
-    );
-
-    const cssBundlePath = path.join(config.output, config.styleXBundleName);
-    if (config.state.compiledCSSDir == null) {
-      config.state.compiledCSSDir = cssBundlePath;
-    }
-    writeCompiledCSS(
-      config.state.compiledCSSDir != null
-        ? config.state.compiledCSSDir
-        : cssBundlePath,
-      compiledCSS,
-    );
-  } catch (err) {
-    fs.rmSync(config.output, { recursive: true, force: true });
-    clearInputModuleDir(config);
-    throw err;
   }
+
+  const compiledCSS = await styleXPlugin.processStylexRules(
+    Array.from(config.state.styleXRules.values()).flat(),
+    config.useCSSLayers,
+  );
+
+  const cssBundlePath = path.join(config.output, config.styleXBundleName);
+  if (config.state.compiledCSSDir == null) {
+    config.state.compiledCSSDir = cssBundlePath;
+  }
+  writeCompiledCSS(
+    config.state.compiledCSSDir != null
+      ? config.state.compiledCSSDir
+      : cssBundlePath,
+    compiledCSS,
+  );
 }
 
 export async function compileFile(

--- a/packages/cli/src/watcher.js
+++ b/packages/cli/src/watcher.js
@@ -63,7 +63,7 @@ export function startWatcher(config: TransformConfig) {
         ['watch-project', config.input],
         function (error, resp) {
           if (error) {
-            console.error('Error initiating watch:', error);
+            console.error('[stylex] error initiating watch:', error);
             return;
           }
           if ('warning' in resp) {
@@ -97,7 +97,7 @@ function subscribe(
     ['subscribe', watcher, 'jsFileChanged', subscription],
     function (error: string, _resp: Response) {
       if (error) {
-        console.error('failed to subscribe: ', error);
+        console.error('[stylex] failed to subscribe with watch mode: ', error);
         return;
       }
     },


### PR DESCRIPTION
Currently the CLI when used in watch mode has 3 issues.

1. If you have babel transform errors (such as when you made a type error with the typescript plugin), then the CLI will kill itself and exit.
2. Because we copy (and the subsequently delete) the modules_experimental to the input directory, this inadvertently triggers changes in watchman.
3. The only files initially picked up when started in watch mode are JavaScript files (or typescript, etc), which means existing non-JavaScript files are not copied over.

This PR fixes the issues by adding a catch to the function that compiles the input directory, excluding external node modules from recompiling via watchman, and ensuring that the CLI will recompile on changes to non-js files.