### PR TITLE
fix: Add legacy support for context.sourceCode

### DIFF
--- a/packages/eslint-plugin/src/stylex-sort-keys.js
+++ b/packages/eslint-plugin/src/stylex-sort-keys.js
@@ -218,12 +218,24 @@ const stylexSortKeys = {
           return;
         }
 
-        const sourceCode = context.sourceCode;
         const prevName = stack.prevName;
         const prevNode = stack?.prevNode;
         const numKeys = stack.numKeys;
         const currName = getPropertyName(node);
         let isBlankLineBetweenNodes = stack?.prevBlankLine;
+
+        // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
+        const sourceCode =
+          context.sourceCode ||
+          (typeof context.getSourceCode === 'function'
+            ? context.getSourceCode()
+            : null);
+
+        if (!sourceCode) {
+          throw new Error(
+            'ESLint context does not provide source code access. Please update ESLint to v>=8.40.0. See: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/',
+          );
+        }
 
         const tokens =
           stack?.prevNode &&

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -279,7 +279,19 @@ const stylexValidShorthands = {
           property: key,
         },
         fix: (fixer) => {
-          const sourceCode = context.sourceCode;
+          // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
+          const sourceCode =
+            context.sourceCode ||
+            (typeof context.getSourceCode === 'function'
+              ? context.getSourceCode()
+              : null);
+
+          if (!sourceCode) {
+            throw new Error(
+              'ESLint context does not provide source code access. Please update ESLint to v>=8.40.0. See: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/',
+            );
+          }
+
           const startNodeIndentation = getNodeIndentation(sourceCode, property);
           const newLineAndIndent = `\n${startNodeIndentation}`;
 


### PR DESCRIPTION
## Context
In v8.40.0 several properties on `context` were introduced as alternatives to a few methods (see: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/). Accessing properties like `context.sourceCode`  is not backwards compatible with the older versions of eslint currently used in WWW, causing eslint to fail when either `sort-keys` or `valid-shorthands` is added ([D60950492](https://www.internalfb.com/diff/D60950492))

Ideally we should migrate WWW over to a newer version of eslint, but this would be a longer term fix that may involve other breaking changes with pre-existing lint rules.

## Fix
Fixes # (issue)

## Testing
1) Lint rule works in WWW
2) Shorthands test pass.
```
% npx jest shorthands

Test Suites: 1 passed, 1 total
Tests:       22 passed, 22 total
Snapshots:   0 total
Time:        1.751 s, estimated 2 s
Ran all test suites matching shorthands.
```

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code