### PR TITLE
feat: Add border shorthand handling

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -108,6 +108,19 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       })
     `,
     },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          borderWidth: '1px',
+          borderStyle: 'solid',
+          borderColor: 'black',
+          borderRadius: '4px'
+        },
+      })
+    `,
+    },
   ],
   invalid: [
     {
@@ -134,6 +147,92 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         {
           message:
             'Property shorthands using multiple values like "margin: 10px 12px 13px 14px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            borderWidth: '1px 2px 3px 4px',
+            borderStyle: 'solid dashed dotted double',
+            borderColor: 'red green blue yellow',
+            borderTop: '2px solid red',
+            borderRight: '3px dashed green',
+            borderBottom: '4px dotted blue',
+            borderLeft: '5px double yellow',
+            borderRadius: '10px 20px 30px 40px'
+          },
+        });
+      `,
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            borderTopWidth: '1px',
+            borderRightWidth: '2px',
+            borderBottomWidth: '3px',
+            borderLeftWidth: '4px',
+            borderTopStyle: 'solid',
+            borderRightStyle: 'dashed',
+            borderBottomStyle: 'dotted',
+            borderLeftStyle: 'double',
+            borderTopColor: 'red',
+            borderRightColor: 'green',
+            borderBottomColor: 'blue',
+            borderLeftColor: 'yellow',
+            borderTopWidth: '2px',
+            borderTopStyle: 'solid',
+            borderTopColor: 'red',
+            borderRightWidth: '3px',
+            borderRightStyle: 'dashed',
+            borderRightColor: 'green',
+            borderBottomWidth: '4px',
+            borderBottomStyle: 'dotted',
+            borderBottomColor: 'blue',
+            borderLeftWidth: '5px',
+            borderLeftStyle: 'double',
+            borderLeftColor: 'yellow',
+            borderTopLeftRadius: '10px',
+            borderTopRightRadius: '20px',
+            borderBottomRightRadius: '30px',
+            borderBottomLeftRadius: '40px'
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "borderWidth: 1px 2px 3px 4px" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderStyle: solid dashed dotted double" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderColor: red green blue yellow" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderTop: 2px solid red" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderRight: 3px dashed green" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderBottom: 4px dotted blue" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderLeft: 5px double yellow" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderRadius: 10px 20px 30px 40px" are not supported in StyleX. Separate into individual properties.',
         },
       ],
     },

--- a/packages/eslint-plugin/src/stylex-sort-keys.js
+++ b/packages/eslint-plugin/src/stylex-sort-keys.js
@@ -218,12 +218,24 @@ const stylexSortKeys = {
           return;
         }
 
-        const sourceCode = context.sourceCode;
         const prevName = stack.prevName;
         const prevNode = stack?.prevNode;
         const numKeys = stack.numKeys;
         const currName = getPropertyName(node);
         let isBlankLineBetweenNodes = stack?.prevBlankLine;
+
+        // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
+        const sourceCode =
+          context.sourceCode ||
+          (typeof context.getSourceCode === 'function'
+            ? context.getSourceCode()
+            : null);
+
+        if (!sourceCode) {
+          throw new Error(
+            'ESLint context does not provide source code access. Please update ESLint to v>=8.40.0. See: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/',
+          );
+        }
 
         const tokens =
           stack?.prevNode &&

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -279,7 +279,19 @@ const stylexValidShorthands = {
           property: key,
         },
         fix: (fixer) => {
-          const sourceCode = context.sourceCode;
+          // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
+          const sourceCode =
+            context.sourceCode ||
+            (typeof context.getSourceCode === 'function'
+              ? context.getSourceCode()
+              : null);
+
+          if (!sourceCode) {
+            throw new Error(
+              'ESLint context does not provide source code access. Please update ESLint to v>=8.40.0. See: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/',
+            );
+          }
+
           const startNodeIndentation = getNodeIndentation(sourceCode, property);
           const newLineAndIndent = `\n${startNodeIndentation}`;
 

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -53,6 +53,105 @@ const shorthandAliases = {
   ) => {
     return splitSpecificShorthands('font', rawValue.toString(), allowImportant);
   },
+  border: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderColor: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-color',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderWidth: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-width',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderStyle: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-style',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderTop: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-top',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderRight: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-right',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderBottom: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-bottom',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderLeft: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-left',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderRadius: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-radius',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
   outline: (
     rawValue: number | string,
     allowImportant: boolean = false,
@@ -267,7 +366,7 @@ const stylexValidShorthands = {
         preferInline,
       );
 
-      if (newValues.length === 1) {
+      if (!newValues || newValues.length === 1) {
         // Single values do not need to be split
         return;
       }

--- a/packages/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/eslint-plugin/src/utils/splitShorthands.js
@@ -38,6 +38,16 @@ export function splitSpecificShorthands(
   allowImportant: boolean = false,
 ): $ReadOnlyArray<$ReadOnlyArray<mixed>> {
   const longform = cssExpand(property, value);
+
+  // If the longform is empty or all values are the same, no need to expand
+  // Relevant for properties like `borderColor` or `borderStyle`
+  if (
+    Object.values(longform).length === 0 ||
+    Object.values(longform).every((val) => val === Object.values(longform)[0])
+  ) {
+    return [[property, value]];
+  }
+
   const longformStyle: {
     [key: string]: number | string,
   } = {};


### PR DESCRIPTION
## Implementation
This PR iterates on a new lint rule for the handling of shorthands in stylex. 
- Here we are processing border and related styles
- Original intention was to use the border shorthands codemod, but as there is support in https://www.npmjs.com/package/css-shorthand-expand, is lightweight to add for consistency and to keep all expansions in one rule
- The output is transformed to stylex compatible syntax via regex parsing (stripping !important, camelCase)

## Context
This is a follow up to https://github.com/facebook/stylex/pull/614 and https://github.com/facebook/stylex/pull/637

## Testing

Added tests to cover the following:
- border-top
- border-right
- border-bottom
- border-left
- border-radius

As well as conditionally in these styles, if multi-value shorthand:
- border-width
- border-style
- border-color

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code