### PR TITLE
fix: Fix improper variable handing in css-shorthand-expand by pre-processing whitespace

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -121,6 +121,17 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       })
     `,
     },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          borderColor: 'rgb(0, 0, 0)',
+          borderWidth: 'var(--border-width, 10)',
+        },
+      })
+    `,
+    },
   ],
   invalid: [
     {
@@ -152,55 +163,117 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            borderWidth: '1px 2px 3px 4px',
-            borderStyle: 'solid dashed dotted double',
-            borderColor: 'red green blue yellow',
-            borderTop: '2px solid red',
-            borderRight: '3px dashed green',
-            borderBottom: '4px dotted blue',
-            borderLeft: '5px double yellow',
-            borderRadius: '10px 20px 30px 40px'
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              borderColor: 'rgb(0, 0, 0), rgb(5, 5, 5)',
+              borderWidth: 'var(--vertical-border-width, 10) var(--horizontal-border-width, 15)',
+            },
+          })
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            borderTopWidth: '1px',
-            borderRightWidth: '2px',
-            borderBottomWidth: '3px',
-            borderLeftWidth: '4px',
-            borderTopStyle: 'solid',
-            borderRightStyle: 'dashed',
-            borderBottomStyle: 'dotted',
-            borderLeftStyle: 'double',
-            borderTopColor: 'red',
-            borderRightColor: 'green',
-            borderBottomColor: 'blue',
-            borderLeftColor: 'yellow',
-            borderTopWidth: '2px',
-            borderTopStyle: 'solid',
-            borderTopColor: 'red',
-            borderRightWidth: '3px',
-            borderRightStyle: 'dashed',
-            borderRightColor: 'green',
-            borderBottomWidth: '4px',
-            borderBottomStyle: 'dotted',
-            borderBottomColor: 'blue',
-            borderLeftWidth: '5px',
-            borderLeftStyle: 'double',
-            borderLeftColor: 'yellow',
-            borderTopLeftRadius: '10px',
-            borderTopRightRadius: '20px',
-            borderBottomRightRadius: '30px',
-            borderBottomLeftRadius: '40px'
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              borderTopColor: 'rgb(0, 0, 0),',
+              borderRightColor: 'rgb(5, 5, 5)',
+              borderBottomColor: 'rgb(0, 0, 0),',
+              borderLeftColor: 'rgb(5, 5, 5)',
+              borderTopWidth: 'var(--vertical-border-width, 10)',
+              borderRightWidth: 'var(--horizontal-border-width, 15)',
+              borderBottomWidth: 'var(--vertical-border-width, 10)',
+              borderLeftWidth: 'var(--horizontal-border-width, 15)',
+            },
+          })
+        `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "borderColor: rgb(0, 0, 0), rgb(5, 5, 5)" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderWidth: var(--vertical-border-width, 10) var(--horizontal-border-width, 15)" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              borderWidth: 'calc(100% - 20px) calc(90% - 20px)',
+              borderColor: 'var(--test-color, #ccc) linear-gradient(to right, #ff7e5f, #feb47b)',
+              background: 'no-repeat center/cover, linear-gradient(to right, #ff7e5f, #feb47b)'
+            },
+          })
+        `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "borderWidth: calc(100% - 20px) calc(90% - 20px)" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderColor: var(--test-color, #ccc) linear-gradient(to right, #ff7e5f, #feb47b)" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "background: no-repeat center/cover, linear-gradient(to right, #ff7e5f, #feb47b)" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              borderWidth: '1px 2px 3px 4px',
+              borderStyle: 'solid dashed dotted double',
+              borderColor: 'red green blue yellow',
+              borderTop: '2px solid red',
+              borderRight: '3px dashed green',
+              borderBottom: '4px dotted blue',
+              borderLeft: '5px double yellow',
+              borderRadius: '10px 20px 30px 40px'
+            },
+          });
+        `,
+      output: `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              borderTopWidth: '1px',
+              borderRightWidth: '2px',
+              borderBottomWidth: '3px',
+              borderLeftWidth: '4px',
+              borderTopStyle: 'solid',
+              borderRightStyle: 'dashed',
+              borderBottomStyle: 'dotted',
+              borderLeftStyle: 'double',
+              borderTopColor: 'red',
+              borderRightColor: 'green',
+              borderBottomColor: 'blue',
+              borderLeftColor: 'yellow',
+              borderTopWidth: '2px',
+              borderTopStyle: 'solid',
+              borderTopColor: 'red',
+              borderRightWidth: '3px',
+              borderRightStyle: 'dashed',
+              borderRightColor: 'green',
+              borderBottomWidth: '4px',
+              borderBottomStyle: 'dotted',
+              borderBottomColor: 'blue',
+              borderLeftWidth: '5px',
+              borderLeftStyle: 'double',
+              borderLeftColor: 'yellow',
+              borderTopLeftRadius: '10px',
+              borderTopRightRadius: '20px',
+              borderBottomRightRadius: '30px',
+              borderBottomLeftRadius: '40px'
+            },
+          });
+        `,
       errors: [
         {
           message:
@@ -264,26 +337,26 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            background: '#ff0 url("image.jpg") no-repeat fixed center / cover !important',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              background: '#ff0 url("image.jpg") no-repeat fixed center / cover !important',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            backgroundColor: '#ff0',
-            backgroundImage: 'url("image.jpg")',
-            backgroundRepeat: 'no-repeat',
-            backgroundAttachment: 'fixed',
-            backgroundPosition: 'center',
-            backgroundSize: 'cover',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              backgroundColor: '#ff0',
+              backgroundImage: 'url("image.jpg")',
+              backgroundRepeat: 'no-repeat',
+              backgroundAttachment: 'fixed',
+              backgroundPosition: 'center',
+              backgroundSize: 'cover',
+            },
+          });
+        `,
       errors: [
         {
           message:
@@ -294,26 +367,26 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     {
       options: [{ allowImportant: true }],
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            background: '#ff0 url("image.jpg") no-repeat fixed center / cover !important',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              background: '#ff0 url("image.jpg") no-repeat fixed center / cover !important',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            backgroundColor: '#ff0 !important',
-            backgroundImage: 'url("image.jpg") !important',
-            backgroundRepeat: 'no-repeat !important',
-            backgroundAttachment: 'fixed !important',
-            backgroundPosition: 'center !important',
-            backgroundSize: 'cover !important',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              backgroundColor: '#ff0 !important',
+              backgroundImage: 'url("image.jpg") !important',
+              backgroundRepeat: 'no-repeat !important',
+              backgroundAttachment: 'fixed !important',
+              backgroundPosition: 'center !important',
+              backgroundSize: 'cover !important',
+            },
+          });
+        `,
       errors: [
         {
           message:
@@ -323,30 +396,30 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            margin: '0px',
-            font: 'italic small-caps bold 16px/1.5 "Helvetica Neue"',
-            color: 'white',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              margin: '0px',
+              font: 'italic small-caps bold 16px/1.5 "Helvetica Neue"',
+              color: 'white',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            margin: '0px',
-            fontFamily: '"Helvetica Neue"',
-            fontStyle: 'italic',
-            fontVariant: 'small-caps',
-            fontWeight: 'bold',
-            fontSize: '16px',
-            lineHeight: '1.5',
-            color: 'white',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              margin: '0px',
+              fontFamily: '"Helvetica Neue"',
+              fontStyle: 'italic',
+              fontVariant: 'small-caps',
+              fontWeight: 'bold',
+              fontSize: '16px',
+              lineHeight: '1.5',
+              color: 'white',
+            },
+          });
+        `,
       errors: [
         {
           message:
@@ -357,24 +430,24 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     {
       options: [{ allowImportant: true }],
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            margin: '10px 12px 13px 14px !important',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              margin: '10px 12px 13px 14px !important',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            marginTop: '10px !important',
-            marginRight: '12px !important',
-            marginBottom: '13px !important',
-            marginLeft: '14px !important',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              marginTop: '10px !important',
+              marginRight: '12px !important',
+              marginBottom: '13px !important',
+              marginLeft: '14px !important',
+            },
+          });
+        `,
       errors: [
         {
           message:
@@ -384,24 +457,24 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            margin: '10px 12px 13px 14px !important',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              margin: '10px 12px 13px 14px !important',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            marginTop: '10px',
-            marginRight: '12px',
-            marginBottom: '13px',
-            marginLeft: '14px',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              marginTop: '10px',
+              marginRight: '12px',
+              marginBottom: '13px',
+              marginLeft: '14px',
+            },
+          });
+        `,
       errors: [
         {
           message:
@@ -439,22 +512,22 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            margin: '10em 1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              margin: '10em 1em',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            marginBlock: '10em',
-            marginInline: '1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              marginBlock: '10em',
+              marginInline: '1em',
+            },
+          });
+        `,
       errors: [
         {
           message:
@@ -464,22 +537,22 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            marginInline: '10em 1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              marginInline: '10em 1em',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            marginInlineStart: '10em',
-            marginInlineEnd: '1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              marginInlineStart: '10em',
+              marginInlineEnd: '1em',
+            },
+          });
+        `,
       errors: [
         {
           message:
@@ -489,22 +562,22 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            marginBlock: '10em 1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              marginBlock: '10em 1em',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            marginBlockStart: '10em',
-            marginBlockEnd: '1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              marginBlockStart: '10em',
+              marginBlockEnd: '1em',
+            },
+          });
+        `,
       errors: [
         {
           message:
@@ -514,22 +587,22 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            paddingBlock: '10em 1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              paddingBlock: '10em 1em',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            paddingBlockStart: '10em',
-            paddingBlockEnd: '1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              paddingBlockStart: '10em',
+              paddingBlockEnd: '1em',
+            },
+          });
+        `,
       errors: [
         {
           message:
@@ -539,31 +612,31 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            paddingTop: '10em',
-            paddingBottom: '1em',
-            marginStart: '20em',
-            marginEnd: '20em',
-            paddingStart: '10em',
-            paddingEnd: '1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              paddingTop: '10em',
+              paddingBottom: '1em',
+              marginStart: '20em',
+              marginEnd: '20em',
+              paddingStart: '10em',
+              paddingEnd: '1em',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            paddingTop: '10em',
-            paddingBottom: '1em',
-            marginInlineStart: '20em',
-            marginInlineEnd: '20em',
-            paddingInlineStart: '10em',
-            paddingInlineEnd: '1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              paddingTop: '10em',
+              paddingBottom: '1em',
+              marginInlineStart: '20em',
+              marginInlineEnd: '20em',
+              paddingInlineStart: '10em',
+              paddingInlineEnd: '1em',
+            },
+          });
+        `,
       errors: [
         {
           message:
@@ -585,22 +658,22 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            padding: '10em 1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              padding: '10em 1em',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            paddingBlock: '10em',
-            paddingInline: '1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              paddingBlock: '10em',
+              paddingInline: '1em',
+            },
+          });
+        `,
       errors: [
         {
           message:

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -25,6 +25,8 @@ import {
   splitDirectionalShorthands,
 } from './utils/splitShorthands.js';
 
+import { CANNOT_FIX } from './utils/splitShorthands.js';
+
 /*:: import { Rule } from 'eslint'; */
 
 const legacyNameMapping = {
@@ -380,7 +382,10 @@ const stylexValidShorthands = {
         preferInline,
       );
 
-      if (!newValues || newValues.length === 1) {
+      const isUnfixableError =
+        newValues.length === 1 && newValues[0]?.[1] === CANNOT_FIX;
+
+      if ((!newValues || newValues.length === 1) && !isUnfixableError) {
         // Single values do not need to be split
         return;
       }
@@ -391,32 +396,37 @@ const stylexValidShorthands = {
         data: {
           property: key,
         },
-        fix: (fixer) => {
-          // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
-          const sourceCode =
-            context.sourceCode ||
-            (typeof context.getSourceCode === 'function'
-              ? context.getSourceCode()
-              : null);
+        fix: !isUnfixableError
+          ? (fixer) => {
+              // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
+              const sourceCode =
+                context.sourceCode ||
+                (typeof context.getSourceCode === 'function'
+                  ? context.getSourceCode()
+                  : null);
 
-          if (!sourceCode) {
-            throw new Error(
-              'ESLint context does not provide source code access. Please update ESLint to v>=8.40.0. See: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/',
-            );
-          }
+              if (!sourceCode) {
+                throw new Error(
+                  'ESLint context does not provide source code access. Please update ESLint to v>=8.40.0. See: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/',
+                );
+              }
 
-          const startNodeIndentation = getNodeIndentation(sourceCode, property);
-          const newLineAndIndent = `\n${startNodeIndentation}`;
+              const startNodeIndentation = getNodeIndentation(
+                sourceCode,
+                property,
+              );
+              const newLineAndIndent = `\n${startNodeIndentation}`;
 
-          const newPropertiesText = newValues
-            .map(
-              ([key, value], index) =>
-                `${index > 0 ? newLineAndIndent : ''}${key}: ${typeof value === 'string' ? `'${value}'` : value}`,
-            )
-            .join(',');
+              const newPropertiesText = newValues
+                .map(
+                  ([key, value], index) =>
+                    `${index > 0 ? newLineAndIndent : ''}${key}: ${typeof value === 'string' ? `'${value}'` : value}`,
+                )
+                .join(',');
 
-          return fixer.replaceText(property, newPropertiesText);
-        },
+              return fixer.replaceText(property, newPropertiesText);
+            }
+          : null,
       });
     }
 

--- a/packages/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/eslint-plugin/src/utils/splitShorthands.js
@@ -10,6 +10,8 @@
 import parser from 'postcss-value-parser';
 import cssExpand from 'css-shorthand-expand';
 
+export const CANNOT_FIX = 'CANNOT_FIX';
+
 function printNode(node: PostCSSValueASTNode): string {
   switch (node.type) {
     case 'word':
@@ -26,6 +28,46 @@ const toCamelCase = (str: string) => {
   return str.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());
 };
 
+/* The css-shorthands-expand library does not handle spaces within variables like `rgb(0, 0, 0) or var(-test-var, 0) properly. 
+In cases with simple spaces between comma-separated parameters, we can preprocess the values by stripping the spaces.
+If there are still spaces remaining, such as in edge cases involving `calc()` or gradient values, we won't provide an auto-fix. */
+function processWhitespacesinFunctions(str: string) {
+  // Strip spaces after commas within parentheses
+  const strippedValue = str.replace(/\(\s*([^)]+?)\s*\)/g, (match, p1) => {
+    const strippedContent = p1.replace(/,\s+/g, ',');
+    return `(${strippedContent})`;
+  });
+
+  // If there are remaining spaces within the parentheses, we won't auto-fix
+  const canFix = !/\([^()]*\s+[^()]*\)/.test(strippedValue);
+
+  // Strip all spaces within the parentheses to determine if multivalue shorthand
+  const fullyStripped = strippedValue.replace(
+    /\(\s*([^)]+?)\s*\)/g,
+    (match, p1) => {
+      const strippedContent = p1.replace(/\s+/g, '');
+      return `(${strippedContent})`;
+    },
+  );
+
+  const isInvalidShorthand = /\s/.test(fullyStripped);
+
+  return {
+    strippedValue,
+    canFix,
+    isInvalidShorthand,
+  };
+}
+
+/* The css-shorthands-expand library does not handle spaces within variables like `rgb(0, 0, 0) or var(-test-var, 0) properly. 
+After stripping the spaces, let's post-process the values to add back the missing whitespaces between parentheses after a comma */
+function addSpacesAfterCommasInParentheses(str: string) {
+  return str.replace(/\(([^)]+)\)/g, (match, p1) => {
+    const correctedContent = p1.replace(/,\s*/g, ', ');
+    return `(${correctedContent})`;
+  });
+}
+
 const stripImportant = (cssProperty: string | number) =>
   cssProperty
     .toString()
@@ -37,7 +79,14 @@ export function splitSpecificShorthands(
   value: string,
   allowImportant: boolean = false,
 ): $ReadOnlyArray<$ReadOnlyArray<mixed>> {
-  const longform = cssExpand(property, value);
+  const { strippedValue, canFix, isInvalidShorthand } =
+    processWhitespacesinFunctions(value);
+
+  if (!canFix && isInvalidShorthand) {
+    return [[property, CANNOT_FIX]];
+  }
+
+  const longform = cssExpand(property, strippedValue);
 
   // If the longform is empty or all values are the same, no need to expand
   // Relevant for properties like `borderColor` or `borderStyle`
@@ -53,9 +102,10 @@ export function splitSpecificShorthands(
   } = {};
 
   Object.entries(longform).forEach(([key, val]) => {
+    const correctedVal = addSpacesAfterCommasInParentheses(val);
     longformStyle[toCamelCase(key)] = allowImportant
-      ? val
-      : stripImportant(val);
+      ? correctedVal
+      : stripImportant(correctedVal);
   });
 
   return Object.entries(longformStyle);


### PR DESCRIPTION
## Context
The `css-shorthand-expand` library (https://www.npmjs.com/package/css-shorthand-expand) does not handle variable spacing correctly. Property values like `rgb(0, 0, 0` and `var(--example-var, 0)` are incorrectly being split (see: D61342957). Font values with quotations perform fine.

See: [D61342957](https://www.internalfb.com/diff/D61342957)

## Implementation

Let's preprocess the values to strip the whitespace in between parentheses that occur within comma separated parameters:
- `rgb(0, 0, 0)` -> `rgb(0,0,0)`
- `var(--example-var, 0)` -> `var(--example-var,0)`

We'll add back whitespaces after the commas within parentheses after splitting values if they are absent. (Prettier should handle this as well, but just for safety)
- `rgb(0,0,0)` -> `rgb(0, 0, 0)`
- `var(--example-var,0)` -> `var(--example-var, 0)`

In cases where there are whitespaces remaining (such as in `calc(5px - 2px)` or `linear-gradient(to right, #ff7e5f, #feb47b)`), let's avoid providing an autofix for simplicity. We achieve this by checking for leftover spaces between parentheses after stripping. 

Ideally I would open a PR on the [repo](https://github.com/kapetan/css-shorthand-expand), but it has not been updated in a few years. The repo license is MIT, so another option would be to port over the code and maintain it in StyleX itself.

## Testing
Added in test cases to ensure that:
1) Single values like `borderColor: rgb(0, 0, 0)` and `borderWidth: var(--example-var, 0)`are ignored 
2) Multi-value shorthands like `borderColor: rgb(0, 0, 0) rgb(10, 10, 10)` are split appropriately
2) Multi-value shorthands like `calc(100% - 20px) calc(90% - 20px)` are marked as errors but exempt from autofix

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code