### PR TITLE
chore: dynamically generate shorthands property handlers

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -412,28 +412,28 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     {
       options: [{ preferInline: true }],
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            margin: '10em 1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              margin: '10em 1em 5em 2em',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            marginTop: '10em',
-            marginInlineEnd: '1em',
-            marginBottom: '10em',
-            marginInlineStart: '1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              marginTop: '10em',
+              marginInlineEnd: '1em',
+              marginBottom: '5em',
+              marginInlineStart: '2em',
+            },
+          });
+        `,
       errors: [
         {
           message:
-            'Property shorthands using multiple values like "margin: 10em 1em" are not supported in StyleX. Separate into individual properties.',
+            'Property shorthands using multiple values like "margin: 10em 1em 5em 2em" are not supported in StyleX. Separate into individual properties.',
         },
       ],
     },
@@ -450,10 +450,8 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         import stylex from 'stylex';
         const styles = stylex.create({
           main: {
-            marginTop: '10em',
-            marginRight: '1em',
-            marginBottom: '10em',
-            marginLeft: '1em',
+            marginBlock: '10em',
+            marginInline: '1em',
           },
         });
       `,
@@ -598,10 +596,8 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         import stylex from 'stylex';
         const styles = stylex.create({
           main: {
-            paddingTop: '10em',
-            paddingRight: '1em',
-            paddingBottom: '10em',
-            paddingLeft: '1em',
+            paddingBlock: '10em',
+            paddingInline: '1em',
           },
         });
       `,

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -21,8 +21,9 @@ import type { SourceCode } from 'eslint/eslint-rule';
 import type { Token } from 'eslint/eslint-ast';
 
 import {
-  splitSpecificShorthands,
-  splitDirectionalShorthands,
+  createBlockInlineTransformer,
+  createSpecificTransformer,
+  createDirectionalTransformer,
 } from './utils/splitShorthands.js';
 
 import { CANNOT_FIX } from './utils/splitShorthands.js';
@@ -37,261 +38,24 @@ const legacyNameMapping = {
 };
 
 const shorthandAliases = {
-  background: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'background',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  font: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands('font', rawValue.toString(), allowImportant);
-  },
-  border: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderColor: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-color',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderWidth: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-width',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderStyle: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-style',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderTop: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-top',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderRight: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-right',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderBottom: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-bottom',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderLeft: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-left',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderRadius: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-radius',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  outline: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'outline',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  marginInline: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['marginInline', rawValue]];
-    }
-    const [top, right = top, _ = top, __ = right] = splitValues;
-    return [
-      ['marginInlineStart', top],
-      ['marginInlineEnd', right],
-    ];
-  },
-  marginBlock: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['marginBlock', rawValue]];
-    }
-    const [top, right = top, _ = top, __ = right] = splitValues;
-    return [
-      ['marginBlockStart', top],
-      ['marginBlockEnd', right],
-    ];
-  },
-  margin: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['margin', rawValue]];
-    }
-
-    const [top, right = top, bottom = top, left = right] = splitValues;
-
-    if (splitValues.length === 2) {
-      return [
-        ['marginBlock', top],
-        ['marginInline', right],
-      ];
-    }
-
-    return preferInline
-      ? [
-          ['marginTop', top],
-          ['marginInlineEnd', right],
-          ['marginBottom', bottom],
-          ['marginInlineStart', left],
-        ]
-      : [
-          ['marginTop', top],
-          ['marginRight', right],
-          ['marginBottom', bottom],
-          ['marginLeft', left],
-        ];
-  },
-  padding: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['padding', rawValue]];
-    }
-
-    const [top, right = top, bottom = top, left = right] =
-      splitDirectionalShorthands(rawValue, allowImportant);
-
-    if (splitValues.length === 2) {
-      return [
-        ['paddingBlock', top],
-        ['paddingInline', right],
-      ];
-    }
-
-    return preferInline
-      ? [
-          ['paddingTop', top],
-          ['paddingInlineEnd', right],
-          ['paddingBottom', bottom],
-          ['paddingInlineStart', left],
-        ]
-      : [
-          ['paddingTop', top],
-          ['paddingRight', right],
-          ['paddingBottom', bottom],
-          ['paddingLeft', left],
-        ];
-  },
-  paddingInline: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['paddingInline', rawValue]];
-    }
-    const [top, right = top, _ = top, __ = right] = splitValues;
-    return [
-      ['paddingInlineStart', top],
-      ['paddingInlineEnd', right],
-    ];
-  },
-  paddingBlock: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['paddingBlock', rawValue]];
-    }
-    const [top, right = top, _ = top, __ = right] = splitValues;
-    return [
-      ['paddingBlockStart', top],
-      ['paddingBlockEnd', right],
-    ];
-  },
+  background: createSpecificTransformer('background'),
+  font: createSpecificTransformer('font'),
+  border: createSpecificTransformer('border'),
+  borderColor: createSpecificTransformer('border-color'),
+  borderWidth: createSpecificTransformer('border-width'),
+  borderStyle: createSpecificTransformer('border-style'),
+  borderTop: createSpecificTransformer('border-top'),
+  borderRight: createSpecificTransformer('border-right'),
+  borderBottom: createSpecificTransformer('border-bottom'),
+  borderLeft: createSpecificTransformer('border-left'),
+  borderRadius: createSpecificTransformer('border-radius'),
+  outline: createSpecificTransformer('outline'),
+  margin: createDirectionalTransformer('margin', 'Block', 'Inline'),
+  padding: createDirectionalTransformer('padding', 'Block', 'Inline'),
+  marginBlock: createBlockInlineTransformer('margin', 'Block'),
+  marginInline: createBlockInlineTransformer('margin', 'Inline'),
+  paddingBlock: createBlockInlineTransformer('padding', 'Block'),
+  paddingInline: createBlockInlineTransformer('padding', 'Inline'),
 };
 
 const stylexValidShorthands = {

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -205,6 +205,13 @@ const shorthandAliases = {
 
     const [top, right = top, bottom = top, left = right] = splitValues;
 
+    if (splitValues.length === 2) {
+      return [
+        ['marginBlock', top],
+        ['marginInline', right],
+      ];
+    }
+
     return preferInline
       ? [
           ['marginTop', top],
@@ -231,6 +238,13 @@ const shorthandAliases = {
 
     const [top, right = top, bottom = top, left = right] =
       splitDirectionalShorthands(rawValue, allowImportant);
+
+    if (splitValues.length === 2) {
+      return [
+        ['paddingBlock', top],
+        ['paddingInline', right],
+      ];
+    }
 
     return preferInline
       ? [


### PR DESCRIPTION
## Context

As we added more properties, code became hard to maintain. Refactoring repeated logic for readability and ease of modification

## Testing
```
$ npx jest shorthands

Test Suites: 1 passed, 1 total
Tests:       27 passed, 27 total
Snapshots:   0 total
Time:        1.866 s, estimated 2 s
Ran all test suites matching shorthands.
```

## Pre-flight checklist
- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code