### PR TITLE
fix: process duplicated single shorthands

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -163,6 +163,42 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            margin: '10px 10px 10px',
+            marginInline: '15px 15px',
+            padding: '20px 20px 20px 20px',
+          },
+        });
+      `,
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            margin: '10px',
+            marginInline: '15px',
+            padding: '20px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "margin: 10px 10px 10px" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "marginInline: 15px 15px" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "padding: 20px 20px 20px 20px" are not supported in StyleX. Separate into individual properties.',
+        }
+      ],
+    },
+    {
+      code: `
           import stylex from 'stylex';
           const styles = stylex.create({
             main: {

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -21,8 +21,11 @@ import type { SourceCode } from 'eslint/eslint-rule';
 import type { Token } from 'eslint/eslint-ast';
 
 import {
+  createBlockInlineTransformer,
+  createSpecificShorthandTransformer,
+  createDirectionalTransformer,
   splitSpecificShorthands,
-  splitDirectionalShorthands,
+  splitDirectionalShorthands
 } from './utils/splitShorthands.js';
 
 import { CANNOT_FIX } from './utils/splitShorthands.js';
@@ -37,261 +40,24 @@ const legacyNameMapping = {
 };
 
 const shorthandAliases = {
-  background: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'background',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  font: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands('font', rawValue.toString(), allowImportant);
-  },
-  border: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderColor: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-color',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderWidth: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-width',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderStyle: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-style',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderTop: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-top',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderRight: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-right',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderBottom: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-bottom',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderLeft: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-left',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderRadius: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-radius',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  outline: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'outline',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  marginInline: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['marginInline', rawValue]];
-    }
-    const [top, right = top, _ = top, __ = right] = splitValues;
-    return [
-      ['marginInlineStart', top],
-      ['marginInlineEnd', right],
-    ];
-  },
-  marginBlock: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['marginBlock', rawValue]];
-    }
-    const [top, right = top, _ = top, __ = right] = splitValues;
-    return [
-      ['marginBlockStart', top],
-      ['marginBlockEnd', right],
-    ];
-  },
-  margin: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['margin', rawValue]];
-    }
-
-    const [top, right = top, bottom = top, left = right] = splitValues;
-
-    if (splitValues.length === 2) {
-      return [
-        ['marginBlock', top],
-        ['marginInline', right],
-      ];
-    }
-
-    return preferInline
-      ? [
-          ['marginTop', top],
-          ['marginInlineEnd', right],
-          ['marginBottom', bottom],
-          ['marginInlineStart', left],
-        ]
-      : [
-          ['marginTop', top],
-          ['marginRight', right],
-          ['marginBottom', bottom],
-          ['marginLeft', left],
-        ];
-  },
-  padding: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['padding', rawValue]];
-    }
-
-    const [top, right = top, bottom = top, left = right] =
-      splitDirectionalShorthands(rawValue, allowImportant);
-
-    if (splitValues.length === 2) {
-      return [
-        ['paddingBlock', top],
-        ['paddingInline', right],
-      ];
-    }
-
-    return preferInline
-      ? [
-          ['paddingTop', top],
-          ['paddingInlineEnd', right],
-          ['paddingBottom', bottom],
-          ['paddingInlineStart', left],
-        ]
-      : [
-          ['paddingTop', top],
-          ['paddingRight', right],
-          ['paddingBottom', bottom],
-          ['paddingLeft', left],
-        ];
-  },
-  paddingInline: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['paddingInline', rawValue]];
-    }
-    const [top, right = top, _ = top, __ = right] = splitValues;
-    return [
-      ['paddingInlineStart', top],
-      ['paddingInlineEnd', right],
-    ];
-  },
-  paddingBlock: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['paddingBlock', rawValue]];
-    }
-    const [top, right = top, _ = top, __ = right] = splitValues;
-    return [
-      ['paddingBlockStart', top],
-      ['paddingBlockEnd', right],
-    ];
-  },
+  background: createSpecificShorthandTransformer('background'),
+  font: createSpecificShorthandTransformer('font'),
+  border: createSpecificShorthandTransformer('border'),
+  borderColor: createSpecificShorthandTransformer('border-color'),
+  borderWidth: createSpecificShorthandTransformer('border-width'),
+  borderStyle: createSpecificShorthandTransformer('border-style'),
+  borderTop: createSpecificShorthandTransformer('border-top'),
+  borderRight: createSpecificShorthandTransformer('border-right'),
+  borderBottom: createSpecificShorthandTransformer('border-bottom'),
+  borderLeft: createSpecificShorthandTransformer('border-left'),
+  borderRadius: createSpecificShorthandTransformer('border-radius'),
+  outline: createSpecificShorthandTransformer('outline'),
+  margin: createDirectionalTransformer('margin', 'Block', 'Inline'),
+  padding: createDirectionalTransformer('padding', 'Block', 'Inline'),
+  marginBlock: createBlockInlineTransformer('margin', 'Block', ''),
+  marginInline: createBlockInlineTransformer('margin', 'Inline', ''),
+  paddingBlock: createBlockInlineTransformer('padding', 'Block', ''),
+  paddingInline: createBlockInlineTransformer('padding', 'Inline', ''),
 };
 
 const stylexValidShorthands = {
@@ -385,7 +151,8 @@ const stylexValidShorthands = {
       const isUnfixableError =
         newValues.length === 1 && newValues[0]?.[1] === CANNOT_FIX;
 
-      if ((!newValues || newValues.length === 1) && !isUnfixableError) {
+
+      if ((!newValues || (newValues.length === 1 && newValues[0][1] === (property.value.value || property.value.value.toString()))) && !isUnfixableError) {
         // Single values do not need to be split
         return;
       }

--- a/packages/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/eslint-plugin/src/utils/splitShorthands.js
@@ -12,6 +12,58 @@ import cssExpand from 'css-shorthand-expand';
 
 export const CANNOT_FIX = 'CANNOT_FIX';
 
+export const createSpecificShorthandTransformer = (property) => {
+  return (rawValue: number | string, allowImportant: boolean = false, _preferInline: boolean = false) => {
+    return splitSpecificShorthands(property, rawValue.toString(), allowImportant);
+  };
+};
+
+export const createDirectionalTransformer = (baseProperty, blockSuffix, inlineSuffix) => {
+  return (rawValue: number | string, allowImportant: boolean = false, preferInline: boolean = false) => {
+    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
+    const [top, right = top, bottom = top, left = right] = splitValues;
+
+    if (splitValues.length === 1) {
+      return [[`${baseProperty}`, top]];
+    }
+
+    if (splitValues.length === 2) {
+      return [
+        [`${baseProperty}${blockSuffix}`, top],
+        [`${baseProperty}${inlineSuffix}`, right],
+      ];
+    }
+
+    return preferInline
+      ? [
+          [`${baseProperty}Top`, top],
+          [`${baseProperty}${inlineSuffix}End`, right],
+          [`${baseProperty}Bottom`, bottom],
+          [`${baseProperty}${inlineSuffix}Start`, left],
+        ]
+      : [
+          [`${baseProperty}Top`, top],
+          [`${baseProperty}Right`, right],
+          [`${baseProperty}Bottom`, bottom],
+          [`${baseProperty}Left`, left],
+        ];
+  };
+};
+
+export const createBlockInlineTransformer = (baseProperty, blockSuffix, inlineSuffix) => {
+  return (rawValue: number | string, allowImportant: boolean = false) => {
+    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
+    if (splitValues.length === 1) {
+      return [[`${baseProperty}${blockSuffix}${inlineSuffix}`, splitValues[0]]];
+    }
+    const [start, end = start] = splitValues;
+    return [
+      [`${baseProperty}${blockSuffix}Start`, start],
+      [`${baseProperty}${blockSuffix}End`, end],
+    ];
+  };
+};
+
 function printNode(node: PostCSSValueASTNode): string {
   switch (node.type) {
     case 'word':
@@ -28,7 +80,7 @@ const toCamelCase = (str: string) => {
   return str.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());
 };
 
-/* The css-shorthands-expand library does not handle spaces within variables like `rgb(0, 0, 0) or var(-test-var, 0) properly. 
+/* The css-shorthands-expand library does not handle spaces within variables like `rgb(0, 0, 0) or var(-test-var, 0) properly.
 In cases with simple spaces between comma-separated parameters, we can preprocess the values by stripping the spaces.
 If there are still spaces remaining, such as in edge cases involving `calc()` or gradient values, we won't provide an auto-fix. */
 function processWhitespacesinFunctions(str: string) {
@@ -59,7 +111,7 @@ function processWhitespacesinFunctions(str: string) {
   };
 }
 
-/* The css-shorthands-expand library does not handle spaces within variables like `rgb(0, 0, 0) or var(-test-var, 0) properly. 
+/* The css-shorthands-expand library does not handle spaces within variables like `rgb(0, 0, 0) or var(-test-var, 0) properly.
 After stripping the spaces, let's post-process the values to add back the missing whitespaces between parentheses after a comma */
 function addSpacesAfterCommasInParentheses(str: string) {
   return str.replace(/\(([^)]+)\)/g, (match, p1) => {
@@ -141,6 +193,7 @@ export function splitDirectionalShorthands(
 
   if (typeof str === 'number') {
     // if originally a number, let's preserve that here
+    console.log('nodesNUMBER', nodes)
     const processedNodes = nodes.map(parseFloat);
     return processedNodes;
   }
@@ -151,6 +204,13 @@ export function splitDirectionalShorthands(
     allowImportant
   ) {
     return nodes.slice(0, nodes.length - 1).map((node) => node + ' !important');
+  }
+
+  console.log('nodes', nodes);
+
+  if (nodes.length > 1 && new Set(nodes).size === 1) {
+    // If all values are the same, no need to expand
+    return [nodes[0]];
   }
 
   return nodes;


### PR DESCRIPTION
## Context
Processing properties with 2-4 duplicate values like `margin: "10px 10px 10px"`

Implementation:
-  Take the set of split values and check if length is 1
- Previously we filtered out single returns from erroring by default. Now we check if the value matches the original

## Testing
Added tests for these use cases:
- margin: "10px 10px 10px"
- paddingInline: "20px 20px"
- padding: "25px 25px 25px 25px"

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code