### PR TITLE
fix: process duplicated single shorthands

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -108,6 +108,19 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       })
     `,
     },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          borderWidth: '1px',
+          borderStyle: 'solid',
+          borderColor: 'black',
+          borderRadius: '4px'
+        },
+      })
+    `,
+    },
   ],
   invalid: [
     {
@@ -134,6 +147,92 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         {
           message:
             'Property shorthands using multiple values like "margin: 10px 12px 13px 14px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            borderWidth: '1px 2px 3px 4px',
+            borderStyle: 'solid dashed dotted double',
+            borderColor: 'red green blue yellow',
+            borderTop: '2px solid red',
+            borderRight: '3px dashed green',
+            borderBottom: '4px dotted blue',
+            borderLeft: '5px double yellow',
+            borderRadius: '10px 20px 30px 40px'
+          },
+        });
+      `,
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            borderTopWidth: '1px',
+            borderRightWidth: '2px',
+            borderBottomWidth: '3px',
+            borderLeftWidth: '4px',
+            borderTopStyle: 'solid',
+            borderRightStyle: 'dashed',
+            borderBottomStyle: 'dotted',
+            borderLeftStyle: 'double',
+            borderTopColor: 'red',
+            borderRightColor: 'green',
+            borderBottomColor: 'blue',
+            borderLeftColor: 'yellow',
+            borderTopWidth: '2px',
+            borderTopStyle: 'solid',
+            borderTopColor: 'red',
+            borderRightWidth: '3px',
+            borderRightStyle: 'dashed',
+            borderRightColor: 'green',
+            borderBottomWidth: '4px',
+            borderBottomStyle: 'dotted',
+            borderBottomColor: 'blue',
+            borderLeftWidth: '5px',
+            borderLeftStyle: 'double',
+            borderLeftColor: 'yellow',
+            borderTopLeftRadius: '10px',
+            borderTopRightRadius: '20px',
+            borderBottomRightRadius: '30px',
+            borderBottomLeftRadius: '40px'
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "borderWidth: 1px 2px 3px 4px" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderStyle: solid dashed dotted double" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderColor: red green blue yellow" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderTop: 2px solid red" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderRight: 3px dashed green" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderBottom: 4px dotted blue" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderLeft: 5px double yellow" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderRadius: 10px 20px 30px 40px" are not supported in StyleX. Separate into individual properties.',
         },
       ],
     },

--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -163,6 +163,42 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            margin: '10px 10px 10px',
+            marginInline: '15px 15px',
+            padding: '20px 20px 20px 20px',
+          },
+        });
+      `,
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            margin: '10px',
+            marginInline: '15px',
+            padding: '20px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "margin: 10px 10px 10px" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "marginInline: 15px 15px" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "padding: 20px 20px 20px 20px" are not supported in StyleX. Separate into individual properties.',
+        }
+      ],
+    },
+    {
+      code: `
           import stylex from 'stylex';
           const styles = stylex.create({
             main: {

--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -412,28 +412,28 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     {
       options: [{ preferInline: true }],
       code: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            margin: '10em 1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              margin: '10em 1em 5em 2em',
+            },
+          });
+        `,
       output: `
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          main: {
-            marginTop: '10em',
-            marginInlineEnd: '1em',
-            marginBottom: '10em',
-            marginInlineStart: '1em',
-          },
-        });
-      `,
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            main: {
+              marginTop: '10em',
+              marginInlineEnd: '1em',
+              marginBottom: '5em',
+              marginInlineStart: '2em',
+            },
+          });
+        `,
       errors: [
         {
           message:
-            'Property shorthands using multiple values like "margin: 10em 1em" are not supported in StyleX. Separate into individual properties.',
+            'Property shorthands using multiple values like "margin: 10em 1em 5em 2em" are not supported in StyleX. Separate into individual properties.',
         },
       ],
     },
@@ -450,10 +450,8 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         import stylex from 'stylex';
         const styles = stylex.create({
           main: {
-            marginTop: '10em',
-            marginRight: '1em',
-            marginBottom: '10em',
-            marginLeft: '1em',
+            marginBlock: '10em',
+            marginInline: '1em',
           },
         });
       `,
@@ -598,10 +596,8 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         import stylex from 'stylex';
         const styles = stylex.create({
           main: {
-            paddingTop: '10em',
-            paddingRight: '1em',
-            paddingBottom: '10em',
-            paddingLeft: '1em',
+            paddingBlock: '10em',
+            paddingInline: '1em',
           },
         });
       `,

--- a/packages/eslint-plugin/src/stylex-sort-keys.js
+++ b/packages/eslint-plugin/src/stylex-sort-keys.js
@@ -218,12 +218,24 @@ const stylexSortKeys = {
           return;
         }
 
-        const sourceCode = context.sourceCode;
         const prevName = stack.prevName;
         const prevNode = stack?.prevNode;
         const numKeys = stack.numKeys;
         const currName = getPropertyName(node);
         let isBlankLineBetweenNodes = stack?.prevBlankLine;
+
+        // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
+        const sourceCode =
+          context.sourceCode ||
+          (typeof context.getSourceCode === 'function'
+            ? context.getSourceCode()
+            : null);
+
+        if (!sourceCode) {
+          throw new Error(
+            'ESLint context does not provide source code access. Please update ESLint to v>=8.40.0. See: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/',
+          );
+        }
 
         const tokens =
           stack?.prevNode &&

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -21,8 +21,11 @@ import type { SourceCode } from 'eslint/eslint-rule';
 import type { Token } from 'eslint/eslint-ast';
 
 import {
+  createBlockInlineTransformer,
+  createSpecificShorthandTransformer,
+  createDirectionalTransformer,
   splitSpecificShorthands,
-  splitDirectionalShorthands,
+  splitDirectionalShorthands
 } from './utils/splitShorthands.js';
 
 import { CANNOT_FIX } from './utils/splitShorthands.js';
@@ -37,261 +40,24 @@ const legacyNameMapping = {
 };
 
 const shorthandAliases = {
-  background: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'background',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  font: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands('font', rawValue.toString(), allowImportant);
-  },
-  border: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderColor: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-color',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderWidth: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-width',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderStyle: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-style',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderTop: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-top',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderRight: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-right',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderBottom: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-bottom',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderLeft: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-left',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  borderRadius: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'border-radius',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  outline: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    return splitSpecificShorthands(
-      'outline',
-      rawValue.toString(),
-      allowImportant,
-    );
-  },
-  marginInline: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['marginInline', rawValue]];
-    }
-    const [top, right = top, _ = top, __ = right] = splitValues;
-    return [
-      ['marginInlineStart', top],
-      ['marginInlineEnd', right],
-    ];
-  },
-  marginBlock: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['marginBlock', rawValue]];
-    }
-    const [top, right = top, _ = top, __ = right] = splitValues;
-    return [
-      ['marginBlockStart', top],
-      ['marginBlockEnd', right],
-    ];
-  },
-  margin: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['margin', rawValue]];
-    }
-
-    const [top, right = top, bottom = top, left = right] = splitValues;
-
-    if (splitValues.length === 2) {
-      return [
-        ['marginBlock', top],
-        ['marginInline', right],
-      ];
-    }
-
-    return preferInline
-      ? [
-          ['marginTop', top],
-          ['marginInlineEnd', right],
-          ['marginBottom', bottom],
-          ['marginInlineStart', left],
-        ]
-      : [
-          ['marginTop', top],
-          ['marginRight', right],
-          ['marginBottom', bottom],
-          ['marginLeft', left],
-        ];
-  },
-  padding: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['padding', rawValue]];
-    }
-
-    const [top, right = top, bottom = top, left = right] =
-      splitDirectionalShorthands(rawValue, allowImportant);
-
-    if (splitValues.length === 2) {
-      return [
-        ['paddingBlock', top],
-        ['paddingInline', right],
-      ];
-    }
-
-    return preferInline
-      ? [
-          ['paddingTop', top],
-          ['paddingInlineEnd', right],
-          ['paddingBottom', bottom],
-          ['paddingInlineStart', left],
-        ]
-      : [
-          ['paddingTop', top],
-          ['paddingRight', right],
-          ['paddingBottom', bottom],
-          ['paddingLeft', left],
-        ];
-  },
-  paddingInline: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['paddingInline', rawValue]];
-    }
-    const [top, right = top, _ = top, __ = right] = splitValues;
-    return [
-      ['paddingInlineStart', top],
-      ['paddingInlineEnd', right],
-    ];
-  },
-  paddingBlock: (
-    rawValue: number | string,
-    allowImportant: boolean = false,
-    _preferInline: boolean = false,
-  ) => {
-    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
-    if (splitValues.length === 1) {
-      return [['paddingBlock', rawValue]];
-    }
-    const [top, right = top, _ = top, __ = right] = splitValues;
-    return [
-      ['paddingBlockStart', top],
-      ['paddingBlockEnd', right],
-    ];
-  },
+  background: createSpecificShorthandTransformer('background'),
+  font: createSpecificShorthandTransformer('font'),
+  border: createSpecificShorthandTransformer('border'),
+  borderColor: createSpecificShorthandTransformer('border-color'),
+  borderWidth: createSpecificShorthandTransformer('border-width'),
+  borderStyle: createSpecificShorthandTransformer('border-style'),
+  borderTop: createSpecificShorthandTransformer('border-top'),
+  borderRight: createSpecificShorthandTransformer('border-right'),
+  borderBottom: createSpecificShorthandTransformer('border-bottom'),
+  borderLeft: createSpecificShorthandTransformer('border-left'),
+  borderRadius: createSpecificShorthandTransformer('border-radius'),
+  outline: createSpecificShorthandTransformer('outline'),
+  margin: createDirectionalTransformer('margin', 'Block', 'Inline'),
+  padding: createDirectionalTransformer('padding', 'Block', 'Inline'),
+  marginBlock: createBlockInlineTransformer('margin', 'Block', ''),
+  marginInline: createBlockInlineTransformer('margin', 'Inline', ''),
+  paddingBlock: createBlockInlineTransformer('padding', 'Block', ''),
+  paddingInline: createBlockInlineTransformer('padding', 'Inline', ''),
 };
 
 const stylexValidShorthands = {

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -279,7 +279,19 @@ const stylexValidShorthands = {
           property: key,
         },
         fix: (fixer) => {
-          const sourceCode = context.sourceCode;
+          // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
+          const sourceCode =
+            context.sourceCode ||
+            (typeof context.getSourceCode === 'function'
+              ? context.getSourceCode()
+              : null);
+
+          if (!sourceCode) {
+            throw new Error(
+              'ESLint context does not provide source code access. Please update ESLint to v>=8.40.0. See: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/',
+            );
+          }
+
           const startNodeIndentation = getNodeIndentation(sourceCode, property);
           const newLineAndIndent = `\n${startNodeIndentation}`;
 

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -205,6 +205,13 @@ const shorthandAliases = {
 
     const [top, right = top, bottom = top, left = right] = splitValues;
 
+    if (splitValues.length === 2) {
+      return [
+        ['marginBlock', top],
+        ['marginInline', right],
+      ];
+    }
+
     return preferInline
       ? [
           ['marginTop', top],
@@ -231,6 +238,13 @@ const shorthandAliases = {
 
     const [top, right = top, bottom = top, left = right] =
       splitDirectionalShorthands(rawValue, allowImportant);
+
+    if (splitValues.length === 2) {
+      return [
+        ['paddingBlock', top],
+        ['paddingInline', right],
+      ];
+    }
 
     return preferInline
       ? [

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -24,8 +24,6 @@ import {
   createBlockInlineTransformer,
   createSpecificShorthandTransformer,
   createDirectionalTransformer,
-  splitSpecificShorthands,
-  splitDirectionalShorthands
 } from './utils/splitShorthands.js';
 
 import { CANNOT_FIX } from './utils/splitShorthands.js';
@@ -151,7 +149,8 @@ const stylexValidShorthands = {
       const isUnfixableError =
         newValues.length === 1 && newValues[0]?.[1] === CANNOT_FIX;
 
-      if ((!newValues || newValues.length === 1) && !isUnfixableError) {
+
+      if ((!newValues || (newValues.length === 1 && newValues[0][1] === (property.value.value || property.value.value.toString()))) && !isUnfixableError) {
         // Single values do not need to be split
         return;
       }

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -53,6 +53,105 @@ const shorthandAliases = {
   ) => {
     return splitSpecificShorthands('font', rawValue.toString(), allowImportant);
   },
+  border: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderColor: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-color',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderWidth: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-width',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderStyle: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-style',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderTop: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-top',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderRight: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-right',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderBottom: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-bottom',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderLeft: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-left',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
+  borderRadius: (
+    rawValue: number | string,
+    allowImportant: boolean = false,
+    _preferInline: boolean = false,
+  ) => {
+    return splitSpecificShorthands(
+      'border-radius',
+      rawValue.toString(),
+      allowImportant,
+    );
+  },
   outline: (
     rawValue: number | string,
     allowImportant: boolean = false,
@@ -267,7 +366,7 @@ const stylexValidShorthands = {
         preferInline,
       );
 
-      if (newValues.length === 1) {
+      if (!newValues || newValues.length === 1) {
         // Single values do not need to be split
         return;
       }

--- a/packages/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/eslint-plugin/src/utils/splitShorthands.js
@@ -205,5 +205,10 @@ export function splitDirectionalShorthands(
     return nodes.slice(0, nodes.length - 1).map((node) => node + ' !important');
   }
 
+  if (nodes.length > 1 && new Set(nodes).size === 1) {
+    // If all values are the same, no need to expand
+    return [nodes[0]];
+  }
+
   return nodes;
 }

--- a/packages/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/eslint-plugin/src/utils/splitShorthands.js
@@ -12,6 +12,58 @@ import cssExpand from 'css-shorthand-expand';
 
 export const CANNOT_FIX = 'CANNOT_FIX';
 
+export const createSpecificShorthandTransformer = (property) => {
+  return (rawValue: number | string, allowImportant: boolean = false, _preferInline: boolean = false) => {
+    return splitSpecificShorthands(property, rawValue.toString(), allowImportant);
+  };
+};
+
+export const createDirectionalTransformer = (baseProperty, blockSuffix, inlineSuffix) => {
+  return (rawValue: number | string, allowImportant: boolean = false, preferInline: boolean = false) => {
+    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
+    const [top, right = top, bottom = top, left = right] = splitValues;
+
+    if (splitValues.length === 1) {
+      return [[`${baseProperty}`, top]];
+    }
+
+    if (splitValues.length === 2) {
+      return [
+        [`${baseProperty}${blockSuffix}`, top],
+        [`${baseProperty}${inlineSuffix}`, right],
+      ];
+    }
+
+    return preferInline
+      ? [
+          [`${baseProperty}Top`, top],
+          [`${baseProperty}${inlineSuffix}End`, right],
+          [`${baseProperty}Bottom`, bottom],
+          [`${baseProperty}${inlineSuffix}Start`, left],
+        ]
+      : [
+          [`${baseProperty}Top`, top],
+          [`${baseProperty}Right`, right],
+          [`${baseProperty}Bottom`, bottom],
+          [`${baseProperty}Left`, left],
+        ];
+  };
+};
+
+export const createBlockInlineTransformer = (baseProperty, blockSuffix, inlineSuffix) => {
+  return (rawValue: number | string, allowImportant: boolean = false) => {
+    const splitValues = splitDirectionalShorthands(rawValue, allowImportant);
+    if (splitValues.length === 1) {
+      return [[`${baseProperty}${blockSuffix}${inlineSuffix}`, splitValues[0]]];
+    }
+    const [start, end = start] = splitValues;
+    return [
+      [`${baseProperty}${blockSuffix}Start`, start],
+      [`${baseProperty}${blockSuffix}End`, end],
+    ];
+  };
+};
+
 function printNode(node: PostCSSValueASTNode): string {
   switch (node.type) {
     case 'word':
@@ -28,7 +80,7 @@ const toCamelCase = (str: string) => {
   return str.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());
 };
 
-/* The css-shorthands-expand library does not handle spaces within variables like `rgb(0, 0, 0) or var(-test-var, 0) properly. 
+/* The css-shorthands-expand library does not handle spaces within variables like `rgb(0, 0, 0) or var(-test-var, 0) properly.
 In cases with simple spaces between comma-separated parameters, we can preprocess the values by stripping the spaces.
 If there are still spaces remaining, such as in edge cases involving `calc()` or gradient values, we won't provide an auto-fix. */
 function processWhitespacesinFunctions(str: string) {
@@ -59,7 +111,7 @@ function processWhitespacesinFunctions(str: string) {
   };
 }
 
-/* The css-shorthands-expand library does not handle spaces within variables like `rgb(0, 0, 0) or var(-test-var, 0) properly. 
+/* The css-shorthands-expand library does not handle spaces within variables like `rgb(0, 0, 0) or var(-test-var, 0) properly.
 After stripping the spaces, let's post-process the values to add back the missing whitespaces between parentheses after a comma */
 function addSpacesAfterCommasInParentheses(str: string) {
   return str.replace(/\(([^)]+)\)/g, (match, p1) => {

--- a/packages/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/eslint-plugin/src/utils/splitShorthands.js
@@ -38,6 +38,16 @@ export function splitSpecificShorthands(
   allowImportant: boolean = false,
 ): $ReadOnlyArray<$ReadOnlyArray<mixed>> {
   const longform = cssExpand(property, value);
+
+  // If the longform is empty or all values are the same, no need to expand
+  // Relevant for properties like `borderColor` or `borderStyle`
+  if (
+    Object.values(longform).length === 0 ||
+    Object.values(longform).every((val) => val === Object.values(longform)[0])
+  ) {
+    return [[property, value]];
+  }
+
   const longformStyle: {
     [key: string]: number | string,
   } = {};


### PR DESCRIPTION
## Context
Last change hopefully 🤞 WWW sync is still blocked so may as well get this all in

Processing properties with 2-4 duplicate values like `margin: "10px 10px 10px"`

Implementation:
-  Take the set of split values and check if length is 1
- Previously we filtered out shorthands where the input returned singular shorthand values by default. Now we check if the value matches the original to account for this edge case

## Testing
Added tests for these use cases:
- margin: "10px 10px 10px"
- paddingInline: "20px 20px"
- padding: "25px 25px 25px 25px"

```
$ npx jest shorthands

Test Suites: 1 passed, 1 total
Tests:       27 passed, 27 total
Snapshots:   0 total
Time:        1.866 s, estimated 2 s
Ran all test suites matching shorthands.
```

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code