### PR TITLE
fix: Fix check for single value shorthands

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -40,6 +40,16 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       import stylex from 'stylex';
       const styles = stylex.create({
         main: {
+          borderRadius: 5,
+        },
+      })
+    `,
+    },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
           margin: 10,
         },
       })
@@ -50,7 +60,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       import stylex from 'stylex';
       const styles = stylex.create({
         main: {
-          marginInline: 10,
+          marginInline: 0,
         },
       })
     `,
@@ -60,7 +70,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       import stylex from 'stylex';
       const styles = stylex.create({
         main: {
-          paddingInline: 10,
+          paddingInline: 0,
         },
       })
     `,

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -149,10 +149,11 @@ const stylexValidShorthands = {
       const isUnfixableError =
         newValues.length === 1 && newValues[0]?.[1] === CANNOT_FIX;
 
-      if ((!newValues || newValues.length === 1) && !isUnfixableError) {
-        // Single values do not need to be split
-        return;
-      }
+        if (!newValues ||
+          (newValues.length === 1 && newValues[0][1] === property.value.value || newValues[0][1] === property.value?.value?.toString() || newValues[0][1] === parseInt(property.value?.value, 10))
+          && !isUnfixableError) {
+          return;
+        }
 
       context.report({
         node: property,


### PR DESCRIPTION
## What changed / motivation ?
Improper or check causing numeric values to trigger false positives: replacing `if A == (x || y || z)` with `if (A == x || A == y || A == z)`.

Also, added number -> string -> number reconversion. This is hard to capture on tests, discovered when linting on WWW (borderRadius: 5 -> borderRadius: '5') 

## Testing
Manually ported over changes into WWW and tested

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code