### PR TITLE
fix: Handle deletion of files gracefully on compile

### DIFF
--- a/packages/cli/src/transform.js
+++ b/packages/cli/src/transform.js
@@ -42,7 +42,7 @@ export async function compileDirectory(
         try {
           fs.rmSync(outputPath);
         } catch (err) {
-          console.error('[stylex] failed to delete file: ', error);
+          console.error('[stylex] failed to delete file: ', err);
         }
       }
     });

--- a/packages/cli/src/transform.js
+++ b/packages/cli/src/transform.js
@@ -39,7 +39,11 @@ export async function compileDirectory(
       config.state.styleXRules.delete(file);
       const outputPath = path.join(config.output, file);
       if (fs.existsSync(outputPath)) {
-        fs.rmSync(outputPath);
+        try {
+          fs.rmSync(outputPath);
+        } catch (err) {
+          console.error('[stylex] failed to delete file: ', error);
+        }
       }
     });
   }


### PR DESCRIPTION
Catch and display error when `compileDirectory` fails to delete a file.

## What changed / motivation ?

When running the CLI on watch mode and making file system changes to the watched folder, the CLI consistently fails to delete a missing file. This causes the CLI to exit and not restart drastically reducing the usability of the tool during active development. 

## Linked PR/Issues

<!-- Fixes # (issue) -->

## Additional Context

Old error:

```
Error: ENOENT: no such file or directory, lstat '<project-file>'
     at Object.rmSync (node:fs:1261:13)
     at <project-path>/node_modules/@stylexjs/cli/lib/index.js:199:12
     at Array.forEach (<anonymous>)
     at compileDirectory (<project-path>/node_modules/@stylexjs/cli/lib/index.js:196:19)
     at Client.<anonymous> (<project-path>/node_modules/@stylexjs/cli/lib/index.js:350:5)
     at Client.emit (node:events:519:28)
     at BunserBuf.<anonymous> (<project-path>/node_modules/fb-watchman/index.js:94:14)
     at BunserBuf.emit (node:events:519:28)
     at BunserBuf.process (<project-path>/node_modules/bser/index.js:292:10)
     at <project-path>/node_modules/bser/index.js:247:12 {
   errno: -2,
   code: 'ENOENT',
   syscall: 'lstat',
   path: '<project-file>'
 }
```


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code