### PR TITLE
fix: Ensure themes have higher specificity than default var values

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-create-theme-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-theme-test.js
@@ -123,9 +123,9 @@ describe('@stylexjs/babel-plugin stylex.createTheme', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject2(".xtrlmmh{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
-        _inject2("@media (prefers-color-scheme: dark){.xtrlmmh{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
-        _inject2("@media print{.xtrlmmh{--xgck17p:transparent;}}", 0.6);
+        _inject2(".xtrlmmh, .xtrlmmh:root{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
+        _inject2("@media (prefers-color-scheme: dark){.xtrlmmh, .xtrlmmh:root{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
+        _inject2("@media print{.xtrlmmh, .xtrlmmh:root{--xgck17p:transparent;}}", 0.6);
         const buttonThemePositive = {
           TestTheme__buttonThemePositive: "TestTheme__buttonThemePositive",
           $$css: true,
@@ -177,9 +177,9 @@ describe('@stylexjs/babel-plugin stylex.createTheme', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject2(".xtrlmmh{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
-        _inject2("@media (prefers-color-scheme: dark){.xtrlmmh{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
-        _inject2("@media print{.xtrlmmh{--xgck17p:transparent;}}", 0.6);
+        _inject2(".xtrlmmh, .xtrlmmh:root{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
+        _inject2("@media (prefers-color-scheme: dark){.xtrlmmh, .xtrlmmh:root{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
+        _inject2("@media print{.xtrlmmh, .xtrlmmh:root{--xgck17p:transparent;}}", 0.6);
         const buttonThemePositive = {
           TestTheme__buttonThemePositive: "TestTheme__buttonThemePositive",
           $$css: true,
@@ -240,9 +240,9 @@ describe('@stylexjs/babel-plugin stylex.createTheme', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject2(".xtrlmmh{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
-        _inject2("@media (prefers-color-scheme: dark){.xtrlmmh{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
-        _inject2("@media print{.xtrlmmh{--xgck17p:transparent;}}", 0.6);
+        _inject2(".xtrlmmh, .xtrlmmh:root{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
+        _inject2("@media (prefers-color-scheme: dark){.xtrlmmh, .xtrlmmh:root{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
+        _inject2("@media print{.xtrlmmh, .xtrlmmh:root{--xgck17p:transparent;}}", 0.6);
         const buttonThemePositive = {
           TestTheme__buttonThemePositive: "TestTheme__buttonThemePositive",
           $$css: true,
@@ -312,15 +312,15 @@ describe('@stylexjs/babel-plugin stylex.createTheme', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject2(".xtrlmmh{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
-        _inject2("@media (prefers-color-scheme: dark){.xtrlmmh{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
-        _inject2("@media print{.xtrlmmh{--xgck17p:transparent;}}", 0.6);
+        _inject2(".xtrlmmh, .xtrlmmh:root{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
+        _inject2("@media (prefers-color-scheme: dark){.xtrlmmh, .xtrlmmh:root{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
+        _inject2("@media print{.xtrlmmh, .xtrlmmh:root{--xgck17p:transparent;}}", 0.6);
         const buttonThemePositive = {
           TestTheme__buttonThemePositive: "TestTheme__buttonThemePositive",
           $$css: true,
           x568ih9: "xtrlmmh"
         };
-        _inject2(".x1awrdae{--xgck17p:white;--xpegid5:black;--xrqfjmn:0px;}", 0.5);
+        _inject2(".x1awrdae, .x1awrdae:root{--xgck17p:white;--xpegid5:black;--xrqfjmn:0px;}", 0.5);
         const buttonThemeMonochromatic = {
           TestTheme__buttonThemeMonochromatic: "TestTheme__buttonThemeMonochromatic",
           $$css: true,
@@ -363,9 +363,9 @@ describe('@stylexjs/babel-plugin stylex.createTheme', () => {
           __themeName__: "x568ih9"
         };
         const RADIUS = 10;
-        _inject2(".xi7kglk{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:10;--x4y59db:coral;}", 0.5);
-        _inject2("@media (prefers-color-scheme: dark){.xi7kglk{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
-        _inject2("@media print{.xi7kglk{--xgck17p:transparent;}}", 0.6);
+        _inject2(".xi7kglk, .xi7kglk:root{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:10;--x4y59db:coral;}", 0.5);
+        _inject2("@media (prefers-color-scheme: dark){.xi7kglk, .xi7kglk:root{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
+        _inject2("@media print{.xi7kglk, .xi7kglk:root{--xgck17p:transparent;}}", 0.6);
         const buttonThemePositive = {
           TestTheme__buttonThemePositive: "TestTheme__buttonThemePositive",
           $$css: true,
@@ -408,9 +408,9 @@ describe('@stylexjs/babel-plugin stylex.createTheme', () => {
           __themeName__: "x568ih9"
         };
         const COLOR = 'coral';
-        _inject2(".xtrlmmh{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
-        _inject2("@media (prefers-color-scheme: dark){.xtrlmmh{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
-        _inject2("@media print{.xtrlmmh{--xgck17p:transparent;}}", 0.6);
+        _inject2(".xtrlmmh, .xtrlmmh:root{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
+        _inject2("@media (prefers-color-scheme: dark){.xtrlmmh, .xtrlmmh:root{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
+        _inject2("@media print{.xtrlmmh, .xtrlmmh:root{--xgck17p:transparent;}}", 0.6);
         const buttonThemePositive = {
           TestTheme__buttonThemePositive: "TestTheme__buttonThemePositive",
           $$css: true,
@@ -453,9 +453,9 @@ describe('@stylexjs/babel-plugin stylex.createTheme', () => {
           __themeName__: "x568ih9"
         };
         const name = 'light';
-        _inject2(".x143z4bu{--xgck17p:lightgreen;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
-        _inject2("@media (prefers-color-scheme: dark){.x143z4bu{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
-        _inject2("@media print{.x143z4bu{--xgck17p:transparent;}}", 0.6);
+        _inject2(".x143z4bu, .x143z4bu:root{--xgck17p:lightgreen;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
+        _inject2("@media (prefers-color-scheme: dark){.x143z4bu, .x143z4bu:root{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
+        _inject2("@media print{.x143z4bu, .x143z4bu:root{--xgck17p:transparent;}}", 0.6);
         const buttonThemePositive = {
           TestTheme__buttonThemePositive: "TestTheme__buttonThemePositive",
           $$css: true,
@@ -498,9 +498,9 @@ describe('@stylexjs/babel-plugin stylex.createTheme', () => {
           __themeName__: "x568ih9"
         };
         const RADIUS = 2;
-        _inject2(".x64jqcx{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4;--x4y59db:coral;}", 0.5);
-        _inject2("@media (prefers-color-scheme: dark){.x64jqcx{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
-        _inject2("@media print{.x64jqcx{--xgck17p:transparent;}}", 0.6);
+        _inject2(".x64jqcx, .x64jqcx:root{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4;--x4y59db:coral;}", 0.5);
+        _inject2("@media (prefers-color-scheme: dark){.x64jqcx, .x64jqcx:root{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
+        _inject2("@media print{.x64jqcx, .x64jqcx:root{--xgck17p:transparent;}}", 0.6);
         const buttonThemePositive = {
           TestTheme__buttonThemePositive: "TestTheme__buttonThemePositive",
           $$css: true,
@@ -536,9 +536,9 @@ describe('@stylexjs/babel-plugin stylex.createTheme', () => {
           fgColor: "var(--x4y59db)",
           __themeName__: "x568ih9"
         };
-        _inject2(".xtrlmmh{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
-        _inject2("@media (prefers-color-scheme: dark){.xtrlmmh{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
-        _inject2("@media print{.xtrlmmh{--xgck17p:transparent;}}", 0.6);
+        _inject2(".xtrlmmh, .xtrlmmh:root{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}", 0.5);
+        _inject2("@media (prefers-color-scheme: dark){.xtrlmmh, .xtrlmmh:root{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
+        _inject2("@media print{.xtrlmmh, .xtrlmmh:root{--xgck17p:transparent;}}", 0.6);
         const buttonThemePositive = {
           NestedTheme__buttonThemePositive: "NestedTheme__buttonThemePositive",
           $$css: true,
@@ -581,9 +581,9 @@ describe('@stylexjs/babel-plugin stylex.createTheme', () => {
           __themeName__: "x568ih9"
         };
         const RADIUS = 2;
-        _inject2(".x41sqjo{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4px;--x4y59db:coral;}", 0.5);
-        _inject2("@media (prefers-color-scheme: dark){.x41sqjo{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
-        _inject2("@media print{.x41sqjo{--xgck17p:transparent;}}", 0.6);
+        _inject2(".x41sqjo, .x41sqjo:root{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:4px;--x4y59db:coral;}", 0.5);
+        _inject2("@media (prefers-color-scheme: dark){.x41sqjo, .x41sqjo:root{--xgck17p:lightgreen;--xpegid5:floralwhite;}}", 0.6);
+        _inject2("@media print{.x41sqjo, .x41sqjo:root{--xgck17p:transparent;}}", 0.6);
         const buttonThemePositive = {
           TestTheme__buttonThemePositive: "TestTheme__buttonThemePositive",
           $$css: true,

--- a/packages/dev-runtime/__tests__/stylex-transform-create-theme-test.js
+++ b/packages/dev-runtime/__tests__/stylex-transform-create-theme-test.js
@@ -63,7 +63,7 @@ describe('Development Plugin Transformation', () => {
           [
             "xtrlmmh",
             {
-              "ltr": ".xtrlmmh{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}",
+              "ltr": ".xtrlmmh, .xtrlmmh:root{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}",
               "rtl": undefined,
             },
             0.5,
@@ -71,7 +71,7 @@ describe('Development Plugin Transformation', () => {
           [
             "xtrlmmh-1lveb7",
             {
-              "ltr": "@media (prefers-color-scheme: dark){.xtrlmmh{--xgck17p:lightgreen;--xpegid5:floralwhite;}}",
+              "ltr": "@media (prefers-color-scheme: dark){.xtrlmmh, .xtrlmmh:root{--xgck17p:lightgreen;--xpegid5:floralwhite;}}",
               "rtl": undefined,
             },
             0.6,
@@ -79,7 +79,7 @@ describe('Development Plugin Transformation', () => {
           [
             "xtrlmmh-bdddrq",
             {
-              "ltr": "@media print{.xtrlmmh{--xgck17p:transparent;}}",
+              "ltr": "@media print{.xtrlmmh, .xtrlmmh:root{--xgck17p:transparent;}}",
               "rtl": undefined,
             },
             0.6,
@@ -123,7 +123,7 @@ describe('Development Plugin Transformation', () => {
           [
             "xtrlmmh",
             {
-              "ltr": ".xtrlmmh{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}",
+              "ltr": ".xtrlmmh, .xtrlmmh:root{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}",
               "rtl": undefined,
             },
             0.5,
@@ -131,7 +131,7 @@ describe('Development Plugin Transformation', () => {
           [
             "xtrlmmh-1lveb7",
             {
-              "ltr": "@media (prefers-color-scheme: dark){.xtrlmmh{--xgck17p:lightgreen;--xpegid5:floralwhite;}}",
+              "ltr": "@media (prefers-color-scheme: dark){.xtrlmmh, .xtrlmmh:root{--xgck17p:lightgreen;--xpegid5:floralwhite;}}",
               "rtl": undefined,
             },
             0.6,
@@ -139,7 +139,7 @@ describe('Development Plugin Transformation', () => {
           [
             "xtrlmmh-bdddrq",
             {
-              "ltr": "@media print{.xtrlmmh{--xgck17p:transparent;}}",
+              "ltr": "@media print{.xtrlmmh, .xtrlmmh:root{--xgck17p:transparent;}}",
               "rtl": undefined,
             },
             0.6,

--- a/packages/shared/__tests__/stylex-create-theme-test.js
+++ b/packages/shared/__tests__/stylex-create-theme-test.js
@@ -42,7 +42,7 @@ describe('stylex-create-theme test', () => {
     expect(cssOutput[classNameOutput[defaultVars.__themeName__]])
       .toMatchInlineSnapshot(`
       {
-        "ltr": ".xtrlmmh{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}",
+        "ltr": ".xtrlmmh, .xtrlmmh:root{--xgck17p:green;--xpegid5:antiquewhite;--xrqfjmn:6px;--x4y59db:coral;}",
         "priority": 0.5,
         "rtl": null,
       }
@@ -80,7 +80,7 @@ describe('stylex-create-theme test', () => {
     expect(cssOutput[classNameOutput[defaultVars.__themeName__]])
       .toMatchInlineSnapshot(`
       {
-        "ltr": ".x4znj40{--bgColor:green;--bgColorDisabled:antiquewhite;--cornerRadius:6px;--fgColor:coral;}",
+        "ltr": ".x4znj40, .x4znj40:root{--bgColor:green;--bgColorDisabled:antiquewhite;--cornerRadius:6px;--fgColor:coral;}",
         "priority": 0.5,
         "rtl": null,
       }
@@ -186,22 +186,22 @@ describe('stylex-create-theme test', () => {
     expect(cssOutput).toMatchInlineSnapshot(`
       {
         "x2y918k": {
-          "ltr": ".x2y918k{--xgck17p:green;}",
+          "ltr": ".x2y918k, .x2y918k:root{--xgck17p:green;}",
           "priority": 0.5,
           "rtl": null,
         },
         "x2y918k-1e6ryz3": {
-          "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){.x2y918k{--xgck17p:oklab(0.7 -0.2 -0.4);}}}",
+          "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){.x2y918k, .x2y918k:root{--xgck17p:oklab(0.7 -0.2 -0.4);}}}",
           "priority": 0.7,
           "rtl": null,
         },
         "x2y918k-1lveb7": {
-          "ltr": "@media (prefers-color-scheme: dark){.x2y918k{--xgck17p:lightgreen;}}",
+          "ltr": "@media (prefers-color-scheme: dark){.x2y918k, .x2y918k:root{--xgck17p:lightgreen;}}",
           "priority": 0.6,
           "rtl": null,
         },
         "x2y918k-kpd015": {
-          "ltr": "@supports (color: oklab(0 0 0)){.x2y918k{--xgck17p:oklab(0.7 -0.3 -0.4);}}",
+          "ltr": "@supports (color: oklab(0 0 0)){.x2y918k, .x2y918k:root{--xgck17p:oklab(0.7 -0.3 -0.4);}}",
           "priority": 0.6,
           "rtl": null,
         },
@@ -236,22 +236,22 @@ describe('stylex-create-theme test', () => {
     expect(cssOutput).toMatchInlineSnapshot(`
       {
         "x2y918k": {
-          "ltr": ".x2y918k{--xgck17p:green;}",
+          "ltr": ".x2y918k, .x2y918k:root{--xgck17p:green;}",
           "priority": 0.5,
           "rtl": null,
         },
         "x2y918k-1e6ryz3": {
-          "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){.x2y918k{--xgck17p:oklab(0.7 -0.2 -0.4);}}}",
+          "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){.x2y918k, .x2y918k:root{--xgck17p:oklab(0.7 -0.2 -0.4);}}}",
           "priority": 0.7,
           "rtl": null,
         },
         "x2y918k-1lveb7": {
-          "ltr": "@media (prefers-color-scheme: dark){.x2y918k{--xgck17p:lightgreen;}}",
+          "ltr": "@media (prefers-color-scheme: dark){.x2y918k, .x2y918k:root{--xgck17p:lightgreen;}}",
           "priority": 0.6,
           "rtl": null,
         },
         "x2y918k-kpd015": {
-          "ltr": "@supports (color: oklab(0 0 0)){.x2y918k{--xgck17p:oklab(0.7 -0.3 -0.4);}}",
+          "ltr": "@supports (color: oklab(0 0 0)){.x2y918k, .x2y918k:root{--xgck17p:oklab(0.7 -0.3 -0.4);}}",
           "priority": 0.6,
           "rtl": null,
         },

--- a/packages/shared/src/stylex-create-theme.js
+++ b/packages/shared/src/stylex-create-theme.js
@@ -65,7 +65,7 @@ export default function styleXCreateTheme(
 
   for (const atRule of sortedAtRules) {
     const decls = rulesByAtRule[atRule].join('');
-    const rule = `.${overrideClassName}{${decls}}`;
+    const rule = `.${overrideClassName}, .${overrideClassName}:root{${decls}}`;
 
     if (atRule === 'default') {
       stylesToInject[overrideClassName] = {


### PR DESCRIPTION
Simple bug-fix for cases where we can't enforce a single CSS bundle for defining variables.