### PR TITLE
Install Lightning CSS dependency and process rollup-plugin CSS using …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "flow-bin": "^0.245.2",
         "hermes-eslint": "^0.23.1",
         "jest": "^30.0.0-alpha.6",
-        "lightningcss": "^1.27.0",
         "prettier": "^3.3.3",
         "prettier-plugin-hermes-parser": "^0.23.1",
         "rimraf": "^5.0.5",
@@ -11750,7 +11749,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -20295,7 +20293,6 @@
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.27.0.tgz",
       "integrity": "sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==",
-      "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -20326,7 +20323,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -20346,7 +20342,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -20366,7 +20361,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -20386,7 +20380,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -20406,7 +20399,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -20426,7 +20418,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -20446,7 +20437,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -20466,7 +20456,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -20486,7 +20475,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -20506,7 +20494,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -32345,7 +32332,8 @@
         "@babel/plugin-syntax-flow": "^7.23.3",
         "@babel/plugin-syntax-jsx": "^7.23.3",
         "@babel/plugin-syntax-typescript": "^7.23.3",
-        "@stylexjs/babel-plugin": "0.7.5"
+        "@stylexjs/babel-plugin": "0.7.5",
+        "lightningcss": "^1.27.0"
       }
     },
     "packages/scripts": {
@@ -37359,7 +37347,8 @@
         "@babel/plugin-syntax-flow": "^7.23.3",
         "@babel/plugin-syntax-jsx": "^7.23.3",
         "@babel/plugin-syntax-typescript": "^7.23.3",
-        "@stylexjs/babel-plugin": "0.7.5"
+        "@stylexjs/babel-plugin": "0.7.5",
+        "lightningcss": "^1.27.0"
       }
     },
     "@stylexjs/scripts": {
@@ -39945,8 +39934,7 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -46273,7 +46261,6 @@
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.27.0.tgz",
       "integrity": "sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==",
-      "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
         "lightningcss-darwin-arm64": "1.27.0",
@@ -46292,70 +46279,60 @@
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz",
       "integrity": "sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==",
-      "dev": true,
       "optional": true
     },
     "lightningcss-darwin-x64": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.27.0.tgz",
       "integrity": "sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==",
-      "dev": true,
       "optional": true
     },
     "lightningcss-freebsd-x64": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.27.0.tgz",
       "integrity": "sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==",
-      "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm-gnueabihf": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.27.0.tgz",
       "integrity": "sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==",
-      "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm64-gnu": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.27.0.tgz",
       "integrity": "sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==",
-      "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm64-musl": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.27.0.tgz",
       "integrity": "sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==",
-      "dev": true,
       "optional": true
     },
     "lightningcss-linux-x64-gnu": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.27.0.tgz",
       "integrity": "sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==",
-      "dev": true,
       "optional": true
     },
     "lightningcss-linux-x64-musl": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.27.0.tgz",
       "integrity": "sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==",
-      "dev": true,
       "optional": true
     },
     "lightningcss-win32-arm64-msvc": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.27.0.tgz",
       "integrity": "sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==",
-      "dev": true,
       "optional": true
     },
     "lightningcss-win32-x64-msvc": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.27.0.tgz",
       "integrity": "sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==",
-      "dev": true,
       "optional": true
     },
     "lilconfig": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32010,7 +32010,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -32026,7 +32025,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -32042,7 +32040,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -32058,7 +32055,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -32074,7 +32070,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -32090,7 +32085,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -32106,7 +32100,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -32122,7 +32115,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -32138,7 +32130,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -54608,6 +54599,60 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
       "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
+    },
+    "@next/swc-darwin-arm64": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.1.tgz",
+      "integrity": "sha512-JyxnGCS4qT67hdOKQ0CkgFTp+PXub5W1wsGvIq98TNbF3YEIN7iDekYhYsZzc8Ov0pWEsghQt+tANdidITCLaw==",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.1.tgz",
+      "integrity": "sha512-625Z7bb5AyIzswF9hvfZWa+HTwFZw+Jn3lOBNZB87lUS0iuCYDHqk3ujuHCkiyPtSC0xFBtYDLcrZ11mF/ap3w==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.1.tgz",
+      "integrity": "sha512-iVpn3KG3DprFXzVHM09kvb//4CNNXBQ9NB/pTm8LO+vnnnaObnzFdS5KM+w1okwa32xH0g8EvZIhoB3fI3mS1g==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.1.tgz",
+      "integrity": "sha512-mVsGyMxTLWZXyD5sen6kGOTYVOO67lZjLApIj/JsTEEohDDt1im2nkspzfV5MvhfS7diDw6Rp/xvAQaWZTv1Ww==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.1.tgz",
+      "integrity": "sha512-wMqf90uDWN001NqCM/auRl3+qVVeKfjJdT9XW+RMIOf+rhUzadmYJu++tp2y+hUbb6GTRhT+VjQzcgg/QTD9NQ==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.1.tgz",
+      "integrity": "sha512-ol1X1e24w4j4QwdeNjfX0f+Nza25n+ymY0T2frTyalVczUmzkVD7QGgPTZMHfR1aLrO69hBs0G3QBYaj22J5GQ==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.1.tgz",
+      "integrity": "sha512-WEmTEeWs6yRUEnUlahTgvZteh5RJc4sEjCQIodJlZZ5/VJwVP8p2L7l6VhzQhT4h7KvLx/Ed4UViBdne6zpIsw==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.1.tgz",
+      "integrity": "sha512-oFpHphN4ygAgZUKjzga7SoH2VGbEJXZa/KL8bHCAwCjDWle6R1SpiGOdUdA8EJ9YsG1TYWpzY6FTbUA+iAJeww==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.1.tgz",
+      "integrity": "sha512-FFp3nOJ/5qSpeWT0BZQ+YE1pSMk4IMpkME/1DwKBwhg4mJLB9L+6EXuJi4JEwaJdl5iN+UUlmUD3IsR1kx5fAg==",
+      "optional": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "flow-bin": "^0.245.2",
         "hermes-eslint": "^0.23.1",
         "jest": "^30.0.0-alpha.6",
+        "lightningcss": "^1.27.0",
         "prettier": "^3.3.3",
         "prettier-plugin-hermes-parser": "^0.23.1",
         "rimraf": "^5.0.5",
@@ -11745,6 +11746,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -20276,6 +20289,234 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.27.0.tgz",
+      "integrity": "sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "1.27.0",
+        "lightningcss-darwin-x64": "1.27.0",
+        "lightningcss-freebsd-x64": "1.27.0",
+        "lightningcss-linux-arm-gnueabihf": "1.27.0",
+        "lightningcss-linux-arm64-gnu": "1.27.0",
+        "lightningcss-linux-arm64-musl": "1.27.0",
+        "lightningcss-linux-x64-gnu": "1.27.0",
+        "lightningcss-linux-x64-musl": "1.27.0",
+        "lightningcss-win32-arm64-msvc": "1.27.0",
+        "lightningcss-win32-x64-msvc": "1.27.0"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz",
+      "integrity": "sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.27.0.tgz",
+      "integrity": "sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.27.0.tgz",
+      "integrity": "sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.27.0.tgz",
+      "integrity": "sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.27.0.tgz",
+      "integrity": "sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.27.0.tgz",
+      "integrity": "sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.27.0.tgz",
+      "integrity": "sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.27.0.tgz",
+      "integrity": "sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.27.0.tgz",
+      "integrity": "sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.27.0.tgz",
+      "integrity": "sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -39701,6 +39942,12 @@
         "repeat-string": "^1.5.4"
       }
     },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -46021,6 +46268,95 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
+    },
+    "lightningcss": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.27.0.tgz",
+      "integrity": "sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "lightningcss-darwin-arm64": "1.27.0",
+        "lightningcss-darwin-x64": "1.27.0",
+        "lightningcss-freebsd-x64": "1.27.0",
+        "lightningcss-linux-arm-gnueabihf": "1.27.0",
+        "lightningcss-linux-arm64-gnu": "1.27.0",
+        "lightningcss-linux-arm64-musl": "1.27.0",
+        "lightningcss-linux-x64-gnu": "1.27.0",
+        "lightningcss-linux-x64-musl": "1.27.0",
+        "lightningcss-win32-arm64-msvc": "1.27.0",
+        "lightningcss-win32-x64-msvc": "1.27.0"
+      }
+    },
+    "lightningcss-darwin-arm64": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz",
+      "integrity": "sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-darwin-x64": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.27.0.tgz",
+      "integrity": "sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-freebsd-x64": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.27.0.tgz",
+      "integrity": "sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm-gnueabihf": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.27.0.tgz",
+      "integrity": "sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm64-gnu": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.27.0.tgz",
+      "integrity": "sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm64-musl": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.27.0.tgz",
+      "integrity": "sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-x64-gnu": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.27.0.tgz",
+      "integrity": "sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-x64-musl": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.27.0.tgz",
+      "integrity": "sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-win32-arm64-msvc": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.27.0.tgz",
+      "integrity": "sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-win32-x64-msvc": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.27.0.tgz",
+      "integrity": "sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==",
+      "dev": true,
+      "optional": true
     },
     "lilconfig": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "flow-bin": "^0.245.2",
     "hermes-eslint": "^0.23.1",
     "jest": "^30.0.0-alpha.6",
+    "lightningcss": "^1.27.0",
     "prettier": "^3.3.3",
     "prettier-plugin-hermes-parser": "^0.23.1",
     "rimraf": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "flow-bin": "^0.245.2",
     "hermes-eslint": "^0.23.1",
     "jest": "^30.0.0-alpha.6",
-    "lightningcss": "^1.27.0",
     "prettier": "^3.3.3",
     "prettier-plugin-hermes-parser": "^0.23.1",
     "rimraf": "^5.0.5",

--- a/packages/rollup-plugin/__tests__/__fixtures__/index.js
+++ b/packages/rollup-plugin/__tests__/__fixtures__/index.js
@@ -34,6 +34,7 @@ const styles = stylex.create({
     ':hover': {
       background: 'red',
     },
+    borderStartStartRadius: 7.5
   },
 });
 

--- a/packages/rollup-plugin/__tests__/__fixtures__/index.js
+++ b/packages/rollup-plugin/__tests__/__fixtures__/index.js
@@ -34,7 +34,7 @@ const styles = stylex.create({
     ':hover': {
       background: 'red',
     },
-    borderStartStartRadius: 7.5
+    borderStartStartRadius: 7.5,
   },
 });
 

--- a/packages/rollup-plugin/__tests__/index-test.js
+++ b/packages/rollup-plugin/__tests__/index-test.js
@@ -20,7 +20,7 @@ import { browserslistToTargets } from 'lightningcss';
 
 describe('rollup-plugin-stylex', () => {
   async function runStylex(options) {
-    let targets = browserslistToTargets(browserslist('>= 0.25%'));
+    const targets = browserslistToTargets(browserslist('>= 0.25%'));
 
     // Configure a rollup bundle
     const bundle = await rollup.rollup({

--- a/packages/rollup-plugin/__tests__/index-test.js
+++ b/packages/rollup-plugin/__tests__/index-test.js
@@ -61,66 +61,9 @@ describe('rollup-plugin-stylex', () => {
   it('extracts CSS and removes stylex.inject calls', async () => {
     const { css, js } = await runStylex({ fileName: 'stylex.css' });
 
-    expect(css).toMatchInlineSnapshot(`
-      "@layer priority1 {
-        @keyframes xgnty7z-B {
-          0% {
-            opacity: .25;
-          }
-
-          100% {
-            opacity: 1;
-          }
-        }
-      }
-
-      @layer priority2 {
-        .x1oz5o6v:hover {
-          background: red;
-        }
-      }
-
-      @layer priority3 {
-        .xeuoslp {
-          animation-name: xgnty7z-B;
-        }
-
-        .x1lliihq {
-          display: block;
-        }
-
-        .x78zum5 {
-          display: flex;
-        }
-
-        .xt0psk2 {
-          display: inline;
-        }
-
-        .x1hm9lzh {
-          margin-inline-start: 10px;
-        }
-      }
-
-      @layer priority4 {
-        .x1egiwwb {
-          height: 500px;
-        }
-
-        .xlrshdv {
-          margin-top: 99px;
-        }
-
-        .xh8yej3 {
-          width: 100%;
-        }
-
-        .x3hqpx7 {
-          width: 50%;
-        }
-      }
-      "
-    `);
+    expect(css).toMatchInlineSnapshot(
+      `"@layer priority1{@keyframes xgnty7z-B{0%{opacity:.25}to{opacity:1}}}@layer priority2{.x1oz5o6v:hover{background:red}}@layer priority3{.xeuoslp{animation-name:xgnty7z-B}.x1lliihq{display:block}.x78zum5{display:flex}.xt0psk2{display:inline}.x1hm9lzh{margin-inline-start:10px}}@layer priority4{.x1egiwwb{height:500px}.xlrshdv{margin-top:99px}.xh8yej3{width:100%}.x3hqpx7{width:50%}}"`,
+    );
 
     expect(js).toMatchInlineSnapshot(`
       "import stylex from 'stylex';

--- a/packages/rollup-plugin/__tests__/index-test.js
+++ b/packages/rollup-plugin/__tests__/index-test.js
@@ -61,9 +61,66 @@ describe('rollup-plugin-stylex', () => {
   it('extracts CSS and removes stylex.inject calls', async () => {
     const { css, js } = await runStylex({ fileName: 'stylex.css' });
 
-    expect(css).toMatchInlineSnapshot(
-      `"@layer priority1{@keyframes xgnty7z-B{0%{opacity:.25}to{opacity:1}}}@layer priority2{.x1oz5o6v:hover{background:red}}@layer priority3{.xeuoslp{animation-name:xgnty7z-B}.x1lliihq{display:block}.x78zum5{display:flex}.xt0psk2{display:inline}.x1hm9lzh{margin-inline-start:10px}}@layer priority4{.x1egiwwb{height:500px}.xlrshdv{margin-top:99px}.xh8yej3{width:100%}.x3hqpx7{width:50%}}"`,
-    );
+    expect(css).toMatchInlineSnapshot(`
+      "@layer priority1 {
+        @keyframes xgnty7z-B {
+          0% {
+            opacity: .25;
+          }
+
+          100% {
+            opacity: 1;
+          }
+        }
+      }
+
+      @layer priority2 {
+        .x1oz5o6v:hover {
+          background: red;
+        }
+      }
+
+      @layer priority3 {
+        .xeuoslp {
+          animation-name: xgnty7z-B;
+        }
+
+        .x1lliihq {
+          display: block;
+        }
+
+        .x78zum5 {
+          display: flex;
+        }
+
+        .xt0psk2 {
+          display: inline;
+        }
+
+        .x1hm9lzh {
+          margin-inline-start: 10px;
+        }
+      }
+
+      @layer priority4 {
+        .x1egiwwb {
+          height: 500px;
+        }
+
+        .xlrshdv {
+          margin-top: 99px;
+        }
+
+        .xh8yej3 {
+          width: 100%;
+        }
+
+        .x3hqpx7 {
+          width: 50%;
+        }
+      }
+      "
+    `);
 
     expect(js).toMatchInlineSnapshot(`
       "import stylex from 'stylex';

--- a/packages/rollup-plugin/__tests__/index-test.js
+++ b/packages/rollup-plugin/__tests__/index-test.js
@@ -15,9 +15,13 @@ import { babel } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import stylexPlugin from '../src/index';
+import browserslist from 'browserslist';
+import { browserslistToTargets } from 'lightningcss';
 
 describe('rollup-plugin-stylex', () => {
   async function runStylex(options) {
+    let targets = browserslistToTargets(browserslist('>= 0.25%'));
+
     // Configure a rollup bundle
     const bundle = await rollup.rollup({
       // Remove stylex runtime from bundle
@@ -35,7 +39,11 @@ describe('rollup-plugin-stylex', () => {
           configFile: path.resolve(__dirname, '__fixtures__/.babelrc.json'),
           exclude: [/npmStyles\.js/],
         }),
-        stylexPlugin({ useCSSLayers: true, ...options }),
+        stylexPlugin({
+          useCSSLayers: true,
+          ...options,
+          lightningcssOptions: { minify: false, targets },
+        }),
       ],
     });
 
@@ -97,8 +105,12 @@ describe('rollup-plugin-stylex', () => {
           display: inline;
         }
 
-        .x1hm9lzh {
-          margin-inline-start: 10px;
+        .x1hm9lzh:not(:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
+          margin-left: 10px;
+        }
+
+        .x1hm9lzh:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
+          margin-right: 10px;
         }
       }
 

--- a/packages/rollup-plugin/__tests__/index-test.js
+++ b/packages/rollup-plugin/__tests__/index-test.js
@@ -62,27 +62,64 @@ describe('rollup-plugin-stylex', () => {
     const { css, js } = await runStylex({ fileName: 'stylex.css' });
 
     expect(css).toMatchInlineSnapshot(`
+      "@layer priority1 {
+        @keyframes xgnty7z-B {
+          0% {
+            opacity: .25;
+          }
+
+          100% {
+            opacity: 1;
+          }
+        }
+      }
+
+      @layer priority2 {
+        .x1oz5o6v:hover {
+          background: red;
+        }
+      }
+
+      @layer priority3 {
+        .xeuoslp {
+          animation-name: xgnty7z-B;
+        }
+
+        .x1lliihq {
+          display: block;
+        }
+
+        .x78zum5 {
+          display: flex;
+        }
+
+        .xt0psk2 {
+          display: inline;
+        }
+
+        .x1hm9lzh {
+          margin-inline-start: 10px;
+        }
+      }
+
+      @layer priority4 {
+        .x1egiwwb {
+          height: 500px;
+        }
+
+        .xlrshdv {
+          margin-top: 99px;
+        }
+
+        .xh8yej3 {
+          width: 100%;
+        }
+
+        .x3hqpx7 {
+          width: 50%;
+        }
+      }
       "
-      @layer priority1, priority2, priority3, priority4;
-      @layer priority1{
-      @keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}
-      }
-      @layer priority2{
-      .x1oz5o6v:hover{background:red}
-      }
-      @layer priority3{
-      .xeuoslp{animation-name:xgnty7z-B}
-      .x1lliihq{display:block}
-      .x78zum5{display:flex}
-      .xt0psk2{display:inline}
-      .x1hm9lzh{margin-inline-start:10px}
-      }
-      @layer priority4{
-      .x1egiwwb{height:500px}
-      .xlrshdv{margin-top:99px}
-      .xh8yej3{width:100%}
-      .x3hqpx7{width:50%}
-      }"
     `);
 
     expect(js).toMatchInlineSnapshot(`

--- a/packages/rollup-plugin/__tests__/index-test.js
+++ b/packages/rollup-plugin/__tests__/index-test.js
@@ -20,8 +20,6 @@ import { browserslistToTargets } from 'lightningcss';
 
 describe('rollup-plugin-stylex', () => {
   async function runStylex(options) {
-    const targets = browserslistToTargets(browserslist('>= 0.25%'));
-
     // Configure a rollup bundle
     const bundle = await rollup.rollup({
       // Remove stylex runtime from bundle
@@ -42,7 +40,7 @@ describe('rollup-plugin-stylex', () => {
         stylexPlugin({
           useCSSLayers: true,
           ...options,
-          lightningcssOptions: { minify: false, targets },
+          lightningcssOptions: { minify: false },
         }),
       ],
     });
@@ -93,6 +91,10 @@ describe('rollup-plugin-stylex', () => {
           animation-name: xgnty7z-B;
         }
 
+        .xu4yf9m {
+          border-start-start-radius: 7.5px;
+        }
+
         .x1lliihq {
           display: block;
         }
@@ -105,12 +107,8 @@ describe('rollup-plugin-stylex', () => {
           display: inline;
         }
 
-        .x1hm9lzh:not(:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
-          margin-left: 10px;
-        }
-
-        .x1hm9lzh:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
-          margin-right: 10px;
+        .x1hm9lzh {
+          margin-inline-start: 10px;
         }
       }
 
@@ -201,6 +199,9 @@ describe('rollup-plugin-stylex', () => {
           ":hover_backgroundPositionY": null,
           ":hover_backgroundRepeat": null,
           ":hover_backgroundSize": null,
+          borderStartStartRadius: "xu4yf9m",
+          borderTopLeftRadius: null,
+          borderTopRightRadius: null,
           $$css: true
         }
       };
@@ -286,6 +287,7 @@ describe('rollup-plugin-stylex', () => {
         _inject2(".xlrshdv{margin-top:99px}", 4000);
         _inject2(".x1egiwwb{height:500px}", 4000);
         _inject2(".x1oz5o6v:hover{background:red}", 1130);
+        _inject2(".xu4yf9m{border-start-start-radius:7.5px}", 3000);
         var styles = {
           foo: {
             "index__styles.foo": "index__styles.foo",
@@ -307,6 +309,9 @@ describe('rollup-plugin-stylex', () => {
             ":hover_backgroundPositionY": null,
             ":hover_backgroundRepeat": null,
             ":hover_backgroundSize": null,
+            borderStartStartRadius: "xu4yf9m",
+            borderTopLeftRadius: null,
+            borderTopRightRadius: null,
             $$css: true
           }
         };

--- a/packages/rollup-plugin/__tests__/index-test.js
+++ b/packages/rollup-plugin/__tests__/index-test.js
@@ -15,8 +15,6 @@ import { babel } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import stylexPlugin from '../src/index';
-import browserslist from 'browserslist';
-import { browserslistToTargets } from 'lightningcss';
 
 describe('rollup-plugin-stylex', () => {
   async function runStylex(options) {

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -32,10 +32,11 @@
   },
   "dependencies": {
     "@babel/core": "^7.23.9",
-    "@stylexjs/babel-plugin": "0.7.5",
     "@babel/plugin-syntax-flow": "^7.23.3",
     "@babel/plugin-syntax-jsx": "^7.23.3",
-    "@babel/plugin-syntax-typescript": "^7.23.3"
+    "@babel/plugin-syntax-typescript": "^7.23.3",
+    "@stylexjs/babel-plugin": "0.7.5",
+    "lightningcss": "^1.27.0"
   },
   "files": [
     "flow_modules/*",

--- a/packages/rollup-plugin/src/index.js
+++ b/packages/rollup-plugin/src/index.js
@@ -15,6 +15,7 @@ import typescriptSyntaxPlugin from '@babel/plugin-syntax-typescript';
 import path from 'path';
 import type { Options, Rule } from '@stylexjs/babel-plugin';
 import { transform } from 'lightningcss';
+import type { Targets } from 'lightningcss';
 import type {
   Plugin,
   PluginContext,
@@ -26,6 +27,11 @@ const IS_DEV_ENV =
   process.env.NODE_ENV === 'development' ||
   process.env.BABEL_ENV === 'development';
 
+type LightningcssTransformOptions = $ReadOnly<{
+  minify?: boolean,
+  targets?: Targets,
+}>;
+
 export type PluginOptions = $ReadOnly<{
   ...Partial<Options>,
   fileName?: string,
@@ -34,6 +40,7 @@ export type PluginOptions = $ReadOnly<{
     presets?: $ReadOnlyArray<PluginItem>,
   }>,
   useCSSLayers?: boolean,
+  lightningcssOptions?: LightningcssTransformOptions,
   ...
 }>;
 
@@ -44,6 +51,7 @@ export default function stylexPlugin({
   babelConfig: { plugins = [], presets = [] } = {},
   importSources = ['stylex', '@stylexjs/stylex'],
   useCSSLayers = false,
+  lightningcssOptions,
   ...options
 }: PluginOptions = {}): Plugin<> {
   let stylexRules: { [string]: $ReadOnlyArray<Rule> } = {};
@@ -62,8 +70,9 @@ export default function stylexPlugin({
 
         // Process the CSS using lightningcss
         const { code } = transform({
-          filename: 'stylex.css',
+          filename: fileName,
           code: Buffer.from(collectedCSS),
+          ...lightningcssOptions,
         });
 
         // Convert the Buffer back to a string

--- a/packages/rollup-plugin/src/index.js
+++ b/packages/rollup-plugin/src/index.js
@@ -64,7 +64,6 @@ export default function stylexPlugin({
         const { code } = transform({
           filename: 'stylex.css',
           code: Buffer.from(collectedCSS),
-          minify: true,
         });
 
         // Convert the Buffer back to a string

--- a/packages/rollup-plugin/src/index.js
+++ b/packages/rollup-plugin/src/index.js
@@ -16,7 +16,6 @@ import path from 'path';
 import type { Options, Rule } from '@stylexjs/babel-plugin';
 import { transform } from 'lightningcss';
 import type { TransformOptions } from 'lightningcss';
-import type { Targets } from 'lightningcss';
 import type {
   Plugin,
   PluginContext,

--- a/packages/rollup-plugin/src/index.js
+++ b/packages/rollup-plugin/src/index.js
@@ -64,6 +64,7 @@ export default function stylexPlugin({
         const { code } = transform({
           filename: 'stylex.css',
           code: Buffer.from(collectedCSS),
+          minify: true,
         });
 
         // Convert the Buffer back to a string

--- a/packages/rollup-plugin/src/index.js
+++ b/packages/rollup-plugin/src/index.js
@@ -14,6 +14,7 @@ import jsxSyntaxPlugin from '@babel/plugin-syntax-jsx';
 import typescriptSyntaxPlugin from '@babel/plugin-syntax-typescript';
 import path from 'path';
 import type { Options, Rule } from '@stylexjs/babel-plugin';
+import { transform } from 'lightningcss';
 import type {
   Plugin,
   PluginContext,
@@ -59,11 +60,20 @@ export default function stylexPlugin({
           useCSSLayers,
         );
 
+        // Process the CSS using lightningcss
+        const { code } = transform({
+          filename: 'stylex.css',
+          code: Buffer.from(collectedCSS),
+        });
+
+        // Convert the Buffer back to a string
+        const processedCSS = code.toString();
+
         // This is the intended API, but Flow doesn't support this pattern.
         // $FlowExpectedError[object-this-reference]
         this.emitFile({
           fileName,
-          source: collectedCSS,
+          source: processedCSS,
           type: 'asset',
         });
       }

--- a/packages/rollup-plugin/src/index.js
+++ b/packages/rollup-plugin/src/index.js
@@ -15,6 +15,7 @@ import typescriptSyntaxPlugin from '@babel/plugin-syntax-typescript';
 import path from 'path';
 import type { Options, Rule } from '@stylexjs/babel-plugin';
 import { transform } from 'lightningcss';
+import type { TransformOptions } from 'lightningcss';
 import type { Targets } from 'lightningcss';
 import type {
   Plugin,
@@ -22,15 +23,12 @@ import type {
   TransformResult,
   TransformPluginContext,
 } from 'rollup';
+import browserslist from 'browserslist';
+import { browserslistToTargets } from 'lightningcss';
 
 const IS_DEV_ENV =
   process.env.NODE_ENV === 'development' ||
   process.env.BABEL_ENV === 'development';
-
-type LightningcssTransformOptions = $ReadOnly<{
-  minify?: boolean,
-  targets?: Targets,
-}>;
 
 export type PluginOptions = $ReadOnly<{
   ...Partial<Options>,
@@ -40,7 +38,7 @@ export type PluginOptions = $ReadOnly<{
     presets?: $ReadOnlyArray<PluginItem>,
   }>,
   useCSSLayers?: boolean,
-  lightningcssOptions?: LightningcssTransformOptions,
+  lightningcssOptions?: Omit<TransformOptions<{}>, 'code' | 'filename' | 'visitor'>,
   ...
 }>;
 
@@ -70,9 +68,10 @@ export default function stylexPlugin({
 
         // Process the CSS using lightningcss
         const { code } = transform({
+          targets: browserslistToTargets(browserslist('>= 1%')),
+          ...lightningcssOptions,
           filename: fileName,
           code: Buffer.from(collectedCSS),
-          ...lightningcssOptions,
         });
 
         // Convert the Buffer back to a string

--- a/packages/rollup-plugin/src/index.js
+++ b/packages/rollup-plugin/src/index.js
@@ -37,7 +37,10 @@ export type PluginOptions = $ReadOnly<{
     presets?: $ReadOnlyArray<PluginItem>,
   }>,
   useCSSLayers?: boolean,
-  lightningcssOptions?: Omit<TransformOptions<{}>, 'code' | 'filename' | 'visitor'>,
+  lightningcssOptions?: Omit<
+    TransformOptions<{}>,
+    'code' | 'filename' | 'visitor',
+  >,
   ...
 }>;
 

--- a/packages/webpack-plugin/__tests__/index-test.js
+++ b/packages/webpack-plugin/__tests__/index-test.js
@@ -154,8 +154,8 @@ describe('webpack-plugin-stylex', () => {
         var _otherStyles = _interopRequireDefault(__webpack_require__("./otherStyles.js"));
         var _npmStyles = _interopRequireDefault(__webpack_require__("./npmStyles.js"));
         function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
-        var fadeAnimation = "xgnty7z-B";
-        var styles = {
+        const fadeAnimation = "xgnty7z-B";
+        const styles = {
           foo: {
             animationName: "xeuoslp",
             display: "x78zum5",
@@ -206,7 +206,7 @@ describe('webpack-plugin-stylex', () => {
         exports["default"] = void 0;
         var _stylex = _interopRequireDefault(__webpack_require__("stylex"));
         function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
-        var styles = {
+        const styles = {
           bar: {
             display: "x1lliihq",
             width: "xh8yej3",
@@ -552,14 +552,14 @@ describe('webpack-plugin-stylex', () => {
           function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
           var _inject2 = _stylexInject.default;
           _inject2("@keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}", 1);
-          var fadeAnimation = "xgnty7z-B";
+          const fadeAnimation = "xgnty7z-B";
           _inject2(".xeuoslp{animation-name:xgnty7z-B}", 3000);
           _inject2(".x78zum5{display:flex}", 3000);
           _inject2(".x1hm9lzh{margin-inline-start:10px}", 3000);
           _inject2(".xlrshdv{margin-top:99px}", 4000);
           _inject2(".x1egiwwb{height:500px}", 4000);
           _inject2(".x1oz5o6v:hover{background:red}", 1130);
-          var styles = {
+          const styles = {
             foo: {
               "index__styles.foo": "index__styles.foo",
               animationName: "xeuoslp",
@@ -615,7 +615,7 @@ describe('webpack-plugin-stylex', () => {
           var _inject2 = _stylexInject.default;
           _inject2(".x1lliihq{display:block}", 3000);
           _inject2(".xh8yej3{width:100%}", 4000);
-          var styles = {
+          const styles = {
             bar: {
               "otherStyles__styles.bar": "otherStyles__styles.bar",
               display: "x1lliihq",

--- a/packages/webpack-plugin/__tests__/index-test.js
+++ b/packages/webpack-plugin/__tests__/index-test.js
@@ -154,8 +154,8 @@ describe('webpack-plugin-stylex', () => {
         var _otherStyles = _interopRequireDefault(__webpack_require__("./otherStyles.js"));
         var _npmStyles = _interopRequireDefault(__webpack_require__("./npmStyles.js"));
         function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
-        const fadeAnimation = "xgnty7z-B";
-        const styles = {
+        var fadeAnimation = "xgnty7z-B";
+        var styles = {
           foo: {
             animationName: "xeuoslp",
             display: "x78zum5",
@@ -206,7 +206,7 @@ describe('webpack-plugin-stylex', () => {
         exports["default"] = void 0;
         var _stylex = _interopRequireDefault(__webpack_require__("stylex"));
         function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
-        const styles = {
+        var styles = {
           bar: {
             display: "x1lliihq",
             width: "xh8yej3",
@@ -552,14 +552,14 @@ describe('webpack-plugin-stylex', () => {
           function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
           var _inject2 = _stylexInject.default;
           _inject2("@keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}", 1);
-          const fadeAnimation = "xgnty7z-B";
+          var fadeAnimation = "xgnty7z-B";
           _inject2(".xeuoslp{animation-name:xgnty7z-B}", 3000);
           _inject2(".x78zum5{display:flex}", 3000);
           _inject2(".x1hm9lzh{margin-inline-start:10px}", 3000);
           _inject2(".xlrshdv{margin-top:99px}", 4000);
           _inject2(".x1egiwwb{height:500px}", 4000);
           _inject2(".x1oz5o6v:hover{background:red}", 1130);
-          const styles = {
+          var styles = {
             foo: {
               "index__styles.foo": "index__styles.foo",
               animationName: "xeuoslp",
@@ -615,7 +615,7 @@ describe('webpack-plugin-stylex', () => {
           var _inject2 = _stylexInject.default;
           _inject2(".x1lliihq{display:block}", 3000);
           _inject2(".xh8yej3{width:100%}", 4000);
-          const styles = {
+          var styles = {
             bar: {
               "otherStyles__styles.bar": "otherStyles__styles.bar",
               display: "x1lliihq",


### PR DESCRIPTION
## What changed / motivation ?
Using Lightning CSS to process the output of `stylexBabelPlugin.processStylexRules`, which outputs CSS rules. As a starting point, I've installed the package as dependency, and currently only being used in `rollup-plugin`.

## Additional Context
Using Lightning CSS `transform` function helps with:
- optimizing CSS for performance by minifying and reducing file sizes
- ensuring cross-browser compatibility through automatic prefixing and polyfilling.

Screenshots, Tests, Anything Else
The tests `packages/rollup-plugin/__tests__/index-test.js` is updated with the new output from `transform()` function, and successfully passes.
<img width="517" alt="image" src="https://github.com/user-attachments/assets/7a30cc81-02a7-4fde-b56e-9ede6eada88f">

## Resources
1. Lightning CSS Documentation: https://lightningcss.dev/docs.html
2. Github: https://github.com/parcel-bundler/lightningcss