### PR TITLE
fix: [CLI] Handle errors while deleting files gracefully

### DIFF
--- a/packages/cli/src/transform.js
+++ b/packages/cli/src/transform.js
@@ -39,7 +39,11 @@ export async function compileDirectory(
       config.state.styleXRules.delete(file);
       const outputPath = path.join(config.output, file);
       if (fs.existsSync(outputPath)) {
-        fs.rmSync(outputPath);
+        try {
+          fs.rmSync(outputPath);
+        } catch (err) {
+          console.error('[stylex] failed to delete file: ', err);
+        }
       }
     });
   }


### PR DESCRIPTION
A previous PR #680 had mysterious CI errors. This is a second attempt at the same change.