### PR TITLE
fix: Add missing CSS pseudo elements to types and ESLint

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -156,7 +156,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
           '100%': {
             opacity: 1,
           },
-        }); 
+        });
         const styles = create({
           main: {
             animationName: fadeIn,
@@ -174,7 +174,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
           '100%': {
             opacity: 1,
           },
-        }); 
+        });
         const styles = create({
           main: {
             animationName: fadeIn,
@@ -250,6 +250,28 @@ eslintTester.run('stylex-valid-styles', rule.default, {
            appearance: 'none',
          },
          '::-webkit-search-results-decoration': {
+           appearance: 'none',
+         },
+       },
+     })`,
+    // test for input ranges
+    `import stylex from "stylex";
+     stylex.create({
+       default: {
+         'WebkitAppearance': 'textfield',
+         '::-webkit-slider-thumb': {
+           appearance: 'none',
+         },
+         '::-webkit-slider-runnable-track': {
+           appearance: 'none',
+         },
+         '::-moz-range-thumb': {
+           appearance: 'none',
+         },
+         '::-moz-range-track': {
+           appearance: 'none',
+         },
+         '::-moz-range-progress': {
            appearance: 'none',
          },
        },

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -2245,6 +2245,13 @@ const pseudoElements = makeUnionRule(
   makeLiteralRule('::-webkit-scrollbar-track-piece'),
   makeLiteralRule('::-webkit-scrollbar-corner'),
   makeLiteralRule('::-webkit-resizer'),
+  // For input ranges in Chromium
+  makeLiteralRule('::-webkit-slider-thumb'),
+  makeLiteralRule('::-webkit-slider-runnable-track'),
+  // For input ranges in Firefox
+  makeLiteralRule('::-moz-range-thumb'),
+  makeLiteralRule('::-moz-range-track'),
+  makeLiteralRule('::-moz-range-progress'),
 );
 
 const pseudoClassesAndAtRules = makeUnionRule(

--- a/packages/stylex/src/StyleXTypes.d.ts
+++ b/packages/stylex/src/StyleXTypes.d.ts
@@ -67,6 +67,13 @@ type CSSPropertiesWithExtras = Partial<
       '::-webkit-search-cancel-button'?: CSSProperties;
       '::-webkit-search-results-button'?: CSSProperties;
       '::-webkit-search-results-decoration'?: CSSProperties;
+      // For input ranges in Chromium
+      '::-webkit-slider-thumb'?: CSSProperties;
+      '::-webkit-slider-runnable-track'?: CSSProperties;
+      // For input ranges in Firefox
+      '::-moz-range-thumb'?: CSSProperties;
+      '::-moz-range-track'?: CSSProperties;
+      '::-moz-range-progress'?: CSSProperties;
     }
   >
 >;


### PR DESCRIPTION
## What changed / motivation?
Found some missing pseudo classes while commenting on #137.

## Linked PR/Issues
Probably falls somewhere under #135.

## Additional Context
See diff.

Refs on pseudo elements:
- https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-slider-thumb
- https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-slider-runnable-track
- https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-range-thumb
- https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-range-track
- https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-range-progress
- https://www.smashingmagazine.com/2021/12/create-custom-range-input-consistent-browsers/
- https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/
- https://stackoverflow.com/questions/18389224/how-to-style-html5-range-input-to-have-different-color-before-and-after-slider

Sadly, there doesn't seem to be a standardized version without a prefix.

## Pre-flight checklist
- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code