### PR TITLE
feat: add namespaceToDevClassName as option of babel-plugin

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-call-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-call-test.js
@@ -1164,6 +1164,36 @@ describe('@stylexjs/babel-plugin', () => {
           stylex(styles.default, isActive && styles.active);"
         `);
       });
+
+      test('stylex call produces dev class name with namespaceToDevClassName option', () => {
+        const options = {
+          filename: '/html/js/FooBar.react.js',
+          dev: true,
+          namespaceToDevClassName(namespace, varName, fileName) {
+            return `${varName}__${fileName}--${namespace}`
+          }
+        };
+        expect(
+          transform(
+            `
+              import stylex from 'stylex';
+              const styles = stylex.create({
+                default: {
+                  color: 'red',
+                },
+              });
+              stylex(styles.default);
+            `,
+            options,
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import stylex from 'stylex';
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          "styles__/html/js/FooBar.react.js--default x1e2nbdu";"
+        `);
+      });
     });
   });
   describe('Keep stylex.create when needed', () => {

--- a/packages/babel-plugin/__tests__/stylex-transform-stylex-attrs-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-stylex-attrs-test.js
@@ -967,6 +967,38 @@ describe('@stylexjs/babel-plugin', () => {
           })[!!isActive << 0];"
         `);
       });
+
+      test('stylex call produces dev class name with namespaceToDevClassName option', () => {
+        const options = {
+          filename: '/html/js/FooBar.react.js',
+          dev: true,
+          namespaceToDevClassName(namespace, varName, fileName) {
+            return `${varName}__${fileName}--${namespace}`
+          }
+        };
+        expect(
+          transform(
+            `
+              import stylex from 'stylex';
+              const styles = stylex.create({
+                default: {
+                  color: 'red',
+                },
+              });
+              stylex.attrs(styles.default);
+            `,
+            options,
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import stylex from 'stylex';
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          ({
+            class: "styles__/html/js/FooBar.react.js--default x1e2nbdu"
+          });"
+        `);
+      });
     });
   });
   describe('Keep stylex.create when needed', () => {

--- a/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
@@ -967,6 +967,38 @@ describe('@stylexjs/babel-plugin', () => {
           })[!!isActive << 0];"
         `);
       });
+
+      test('stylex call produces dev class name with namespaceToDevClassName option', () => {
+        const options = {
+          filename: '/html/js/FooBar.react.js',
+          dev: true,
+          namespaceToDevClassName(namespace, varName, fileName) {
+            return `${varName}__${fileName}--${namespace}`
+          }
+        };
+        expect(
+          transform(
+            `
+              import stylex from 'stylex';
+              const styles = stylex.create({
+                default: {
+                  color: 'red',
+                },
+              });
+              stylex.props(styles.default);
+            `,
+            options,
+          ),
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import stylex from 'stylex';
+          _inject2(".x1e2nbdu{color:red}", 3000);
+          ({
+            className: "styles__/html/js/FooBar.react.js--default x1e2nbdu"
+          });"
+        `);
+      });
     });
   });
   describe('Keep stylex.create when needed', () => {

--- a/packages/babel-plugin/src/utils/dev-classname.js
+++ b/packages/babel-plugin/src/utils/dev-classname.js
@@ -11,23 +11,8 @@ import type {
   CompiledNamespaces,
   MutableCompiledNamespaces,
 } from '@stylexjs/shared';
-import path from 'path';
 import StateManager from './state-manager';
 
-// TODO: We will need to maintain the full path to the file eventually
-// Perhaps this can be an option that is passed in.
-export function namespaceToDevClassName(
-  namespace: string,
-  varName: null | string,
-  filename: string,
-): string {
-  // Get the basename of the file without the extension
-  const basename = path.basename(filename).split('.')[0];
-
-  // Build up the class name, and sanitize it of disallowed characters
-  const className = `${basename}__${varName ? `${varName}.` : ''}${namespace}`;
-  return className.replace(/[^.a-zA-Z0-9_-]/g, '');
-}
 
 export function injectDevClassNames(
   obj: CompiledNamespaces,
@@ -36,7 +21,7 @@ export function injectDevClassNames(
 ): CompiledNamespaces {
   const result: MutableCompiledNamespaces = {};
   for (const [key, value] of Object.entries(obj)) {
-    const devClassName = namespaceToDevClassName(
+    const devClassName = state.options.namespaceToDevClassName(
       key,
       varName,
       state.filename ?? 'UnknownFile',
@@ -56,7 +41,7 @@ export function convertToTestStyles(
 ): CompiledNamespaces {
   const result: MutableCompiledNamespaces = {};
   for (const [key, _value] of Object.entries(obj)) {
-    const devClassName = namespaceToDevClassName(
+    const devClassName = state.options.namespaceToDevClassName(
       key,
       varName,
       state.filename ?? 'UnknownFile',

--- a/packages/babel-plugin/src/utils/validate.js
+++ b/packages/babel-plugin/src/utils/validate.js
@@ -124,6 +124,16 @@ export const array: <T>(Check<T>, msg?: Msg) => Check<$ReadOnlyArray<T>> =
     );
   };
 
+// HAVE TO ENSURE THIS FUNCTION TYPE
+export const func: PrimitiveChecker<Function> =
+  (message = defaultMessage('a function')) =>
+  (value, name) => {
+    if (typeof value !== 'function') {
+      return new Error(message(value, name));
+    }
+    return value;
+  }
+
 type ObjOfChecks<T: { +[string]: Check<mixed> }> = $ReadOnly<{
   [K in keyof T]: InferCheckType<T[K]>,
 }>;


### PR DESCRIPTION
## What changed / motivation ?
**Changed:** Now namespaceToDevClassName has become part of babel-plugin so user can modify the output of dev class names to their need.

> I'll add more details like docs changes for above change once this PR is approved.

## Linked PR/Issues

Fixes https://github.com/facebook/stylex/issues/487

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code