### PR TITLE
feat: new lint rule to enforce stylex file extension

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-enforce-extension-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-enforce-extension-test.js
@@ -16,6 +16,13 @@ const ruleTester = new RuleTester({
   parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
+const invalidFilenameWithDefineVars =
+  'Files that export StyleX variables defined with `stylex.defineVars()` must end with the `.stylex.jsx` or `.stylex.tsx` extension.';
+const invalidFilenameWithoutDefineVars =
+  'Only StyleX variables defined with `stylex.defineVars()` can be exported from a file with the `.stylex.jsx` or `.stylex.tsx` extension.';
+const invalidExportWithDefineVars =
+  'Files that export `stylex.defineVars()` must not export anything else.';
+
 ruleTester.run('stylex-enforce-extension', rule.default, {
   valid: [
     {
@@ -49,48 +56,80 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
       filename: 'testComponent.jsx',
       options: [{ themeFileExtension: '.custom.jsx' }],
     },
+    {
+      code: `
+        export const vars = stylex.defineVars({ color: 'red' });
+        export default stylex.defineVars({ background: 'blue' });
+      `,
+      filename: 'myComponent.stylex.jsx',
+    },
   ],
 
   invalid: [
     {
       code: 'export const vars = stylex.defineVars({});',
       filename: 'testComponent.jsx',
+      errors: [{ message: invalidFilenameWithDefineVars }],
+    },
+    {
+      code: `
+        export const vars = stylex.defineVars({ color: 'red' });
+        export const somethingElse = someFunction();
+        export default stylex.defineVars({ background: 'blue' });
+      `,
+      filename: 'myComponent.stylex.jsx',
       errors: [
-        {
-          message:
-            'Files that export `stylex.defineVars` must have a `.stylex.jsx` or `.stylex.tsx` extension.',
-        },
+        { message: invalidExportWithDefineVars },
+        { message: invalidExportWithDefineVars },
       ],
+    },
+    {
+      code: `
+        export const vars = someFunction();
+        export const somethingElse = someFunction();
+        export default stylex.defineVars({ background: 'blue' });
+      `,
+      filename: 'myComponent.stylex.jsx',
+      errors: [
+        { message: invalidFilenameWithoutDefineVars },
+        { message: invalidFilenameWithoutDefineVars },
+        { message: invalidExportWithDefineVars },
+      ],
+    },
+    {
+      code: `
+        export const vars = stylex.defineVars({
+          color: 'blue',
+        });
+        export const somethingElse = someFunction();
+      `,
+      filename: 'myComponent.stylex.tsx',
+      errors: [{ message: invalidExportWithDefineVars }],
+    },
+    {
+      code: `
+        export const vars = stylex.defineVars({
+          color: 'red',
+        });
+        export const somethingElse = someFunction();
+      `,
+      filename: 'myComponent.stylex.jsx',
+      errors: [{ message: invalidExportWithDefineVars }],
     },
     {
       code: 'export const vars = stylex.defineVars({});',
       filename: 'testComponent.tsx',
-      errors: [
-        {
-          message:
-            'Files that export `stylex.defineVars` must have a `.stylex.jsx` or `.stylex.tsx` extension.',
-        },
-      ],
+      errors: [{ message: invalidFilenameWithDefineVars }],
     },
     {
       code: 'export const somethingElse = {};',
       filename: 'testComponent.stylex.jsx',
-      errors: [
-        {
-          message:
-            'Files that do not export `stylex.defineVars` must not have a `.stylex.jsx` or `.stylex.tsx` extension.',
-        },
-      ],
+      errors: [{ message: invalidFilenameWithoutDefineVars }],
     },
     {
       code: 'export const somethingElse = {};',
       filename: 'testComponent.stylex.tsx',
-      errors: [
-        {
-          message:
-            'Files that do not export `stylex.defineVars` must not have a `.stylex.jsx` or `.stylex.tsx` extension.',
-        },
-      ],
+      errors: [{ message: invalidFilenameWithoutDefineVars }],
     },
     {
       code: 'export const vars = stylex.defineVars({});',
@@ -99,7 +138,7 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
       errors: [
         {
           message:
-            'Files that export `stylex.defineVars` must have a `.custom.jsx` or `.custom.tsx` extension.',
+            'Files that export StyleX variables defined with `stylex.defineVars()` must end with the `.custom.jsx` or `.custom.tsx` extension.',
         },
       ],
     },
@@ -110,7 +149,7 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
       errors: [
         {
           message:
-            'Files that do not export `stylex.defineVars` must not have a `.custom.jsx` or `.custom.tsx` extension.',
+            'Only StyleX variables defined with `stylex.defineVars()` can be exported from a file with the `.custom.jsx` or `.custom.tsx` extension.',
         },
       ],
     },

--- a/packages/eslint-plugin/__tests__/stylex-enforce-extension-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-enforce-extension-test.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../src/stylex-enforce-extension');
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+});
+
+ruleTester.run('stylex-enforce-extension', rule.default, {
+  valid: [
+    {
+      code: 'export const vars = stylex.defineVars({});',
+      filename: 'testComponent.stylex.jsx',
+    },
+    {
+      code: 'export const vars = stylex.defineVars({});',
+      filename: 'testComponent.stylex.tsx',
+    },
+    {
+      code: 'export const somethingElse = {};',
+      filename: 'testComponent.jsx',
+    },
+    {
+      code: 'export const somethingElse = {};',
+      filename: 'testComponent.tsx',
+    },
+    {
+      code: 'export const vars = stylex.defineVars({});',
+      filename: 'testComponent.custom.jsx',
+      options: [{ themeFileExtension: '.custom.jsx' }],
+    },
+    {
+      code: 'export const vars = stylex.defineVars({});',
+      filename: 'testComponent.custom.tsx',
+      options: [{ themeFileExtension: '.custom.jsx' }],
+    },
+    {
+      code: 'export const somethingElse = {};',
+      filename: 'testComponent.jsx',
+      options: [{ themeFileExtension: '.custom.jsx' }],
+    },
+  ],
+
+  invalid: [
+    {
+      code: 'export const vars = stylex.defineVars({});',
+      filename: 'testComponent.jsx',
+      errors: [
+        {
+          message:
+            'Files that export `stylex.defineVars` must have a `.stylex.jsx` or `.stylex.tsx` extension.',
+        },
+      ],
+    },
+    {
+      code: 'export const vars = stylex.defineVars({});',
+      filename: 'testComponent.tsx',
+      errors: [
+        {
+          message:
+            'Files that export `stylex.defineVars` must have a `.stylex.jsx` or `.stylex.tsx` extension.',
+        },
+      ],
+    },
+    {
+      code: 'export const somethingElse = {};',
+      filename: 'testComponent.stylex.jsx',
+      errors: [
+        {
+          message:
+            'Files that do not export `stylex.defineVars` must not have a `.stylex.jsx` or `.stylex.tsx` extension.',
+        },
+      ],
+    },
+    {
+      code: 'export const somethingElse = {};',
+      filename: 'testComponent.stylex.tsx',
+      errors: [
+        {
+          message:
+            'Files that do not export `stylex.defineVars` must not have a `.stylex.jsx` or `.stylex.tsx` extension.',
+        },
+      ],
+    },
+    {
+      code: 'export const vars = stylex.defineVars({});',
+      filename: 'testComponent.jsx',
+      options: [{ themeFileExtension: '.custom.jsx' }],
+      errors: [
+        {
+          message:
+            'Files that export `stylex.defineVars` must have a `.custom.jsx` or `.custom.tsx` extension.',
+        },
+      ],
+    },
+    {
+      code: 'export const somethingElse = {};',
+      filename: 'testComponent.custom.jsx',
+      options: [{ themeFileExtension: '.custom.jsx' }],
+      errors: [
+        {
+          message:
+            'Files that do not export `stylex.defineVars` must not have a `.custom.jsx` or `.custom.tsx` extension.',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/stylex-enforce-extension.js
+++ b/packages/eslint-plugin/src/stylex-enforce-extension.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+import type { Node } from 'estree';
+
+/*:: import { Rule } from 'eslint'; */
+
+const stylexEnforceExtension = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        "Ensure that files exporting `stylex.defineVars` end with a specified extension (default `.stylex.jsx` or `.stylex.tsx`), and those that don't must not.",
+      category: 'Possible Errors',
+      recommended: false,
+    },
+    messages: {
+      invalidFilenameWithDefineVars:
+        'Files that export `stylex.defineVars` must have a `{{ extension }}` or `{{ tsxExtension }}` extension.',
+      invalidFilenameWithoutDefineVars:
+        'Files that do not export `stylex.defineVars` must not have a `{{ extension }}` or `{{ tsxExtension }}` extension.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          themeFileExtension: {
+            type: 'string',
+            default: '.stylex.jsx',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context: Rule.RuleContext): { ... } {
+    let hasDefineVarsExport = false;
+    const fileName = context.getFilename();
+    const options = context.options[0] || {};
+    const themeFileExtension = options.themeFileExtension || '.stylex.jsx';
+    const themeTsxExtension = themeFileExtension.replace('.jsx', '.tsx');
+
+    return {
+      ExportNamedDeclaration(node: Node) {
+        if (node.declaration && node.declaration.declarations) {
+          node.declaration.declarations.forEach((declaration) => {
+            const init = declaration.init;
+
+            if (
+              init &&
+              init.callee &&
+              init.callee.object &&
+              init.callee.object.name === 'stylex' &&
+              init.callee.property &&
+              init.callee.property.name === 'defineVars'
+            ) {
+              hasDefineVarsExport = true;
+            }
+          });
+        }
+      },
+      'Program:exit'(node: Node) {
+        const isStylexFile =
+          fileName.endsWith(themeFileExtension) ||
+          fileName.endsWith(themeTsxExtension);
+
+        if (hasDefineVarsExport && !isStylexFile) {
+          context.report({
+            node,
+            message: `Files that export \`stylex.defineVars\` must have a \`${themeFileExtension}\` or \`${themeTsxExtension}\` extension.`,
+          });
+        } else if (!hasDefineVarsExport && isStylexFile) {
+          context.report({
+            node,
+            message: `Files that do not export \`stylex.defineVars\` must not have a \`${themeFileExtension}\` or \`${themeTsxExtension}\` extension.`,
+          });
+        }
+      },
+    };
+  },
+};
+
+export default stylexEnforceExtension as typeof stylexEnforceExtension;

--- a/packages/shared/src/preprocess-rules/flatten-raw-style-obj.js
+++ b/packages/shared/src/preprocess-rules/flatten-raw-style-obj.js
@@ -116,7 +116,7 @@ export function _flattenRawStyleObject(
       continue;
     }
 
-    // Object Values for propetiies. e.g. { color: { hover: 'red', default: 'blue' } }
+    // Object Values for properties. e.g. { color: { hover: 'red', default: 'blue' } }
     if (
       typeof value === 'object' &&
       !key.startsWith(':') &&


### PR DESCRIPTION
## Context
This ESLint rule ensures consistency in file naming conventions when exporting `stylex.defineVars`. 

Specifically:
- Files that export `stylex.defineVars` must end with `.stylex.jsx` or `.stylex.tsx` 
- Files that do not export `stylex.defineVars` must not use the `.stylex.jsx` or `.stylex.tsx` extensions
- Users can configure the file extension via a themeFileExtension option (e.g., `.custom.jsx`), defaulting to `.stylex.jsx`.
## Test Cases:
Valid cases:
- Files with `stylex.defineVars` export correctly using `.stylex.jsx`, `.stylex.tsx`, or custom extensions.
- Files without `stylex.defineVars` export using non-.stylex extensions.

Invalid cases:
- Files exporting `stylex.defineVars` without the correct extension.
- Files not exporting `stylex.defineVars` but using `.stylex.jsx/.tsx` or custom extensions incorrectly.


- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code