### PR TITLE
fix: (eslint) Add fieldSizing as a valid prop

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -380,6 +380,23 @@ eslintTester.run('stylex-valid-styles', rule.default, {
         fontWeight: red,
       },
     })`,
+    // test for field-sizing
+    `
+    import stylex from "stylex";
+    const red = 'var(--🔴)';
+    stylex.create({
+      default: {
+        fieldSizing: 'fixed',
+      },
+    })`,
+    `
+    import stylex from "stylex";
+    const red = 'var(--🔴)';
+    stylex.create({
+      default: {
+        fieldSizing: 'content',
+      },
+    })`,
     // test for stylex create vars tokens
     `
     import stylex from'stylex';

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -1847,6 +1847,9 @@ const CSSProperties = {
   fontVariationSettings: isString,
   fontWeight: fontWeight,
   forcedColorAdjust: makeUnionRule('auto', 'none'),
+
+  fieldSizing: makeUnionRule('content', 'fixed'),
+
   gap: gap,
   glyphOrientationHorizontal: glyphOrientationHorizontal,
   glyphOrientationVertical: glyphOrientationVertical,


### PR DESCRIPTION
A very small change to allow `fieldSizing` in the ESLint rule.