### PR TITLE
fix: more efficient dynamic styles

### DIFF
--- a/packages/babel-plugin/__tests__/evaluation/stylex-fn-obj-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-fn-obj-evaluation-test.js
@@ -125,78 +125,99 @@ describe('custom path evaluation works as expected', () => {
           ],
           {
             "--borderWidth": {
-              "arguments": [
-                {
-                  "name": "width",
-                  "type": "Identifier",
-                },
-              ],
-              "callee": {
-                "async": false,
-                "body": {
-                  "alternate": {
+              "expression": {
+                "arguments": [
+                  {
+                    "name": "width",
+                    "type": "Identifier",
+                  },
+                ],
+                "callee": {
+                  "async": false,
+                  "body": {
                     "alternate": {
-                      "type": "StringLiteral",
-                      "value": "initial",
+                      "alternate": {
+                        "name": "undefined",
+                        "type": "Identifier",
+                      },
+                      "consequent": {
+                        "name": "val",
+                        "type": "Identifier",
+                      },
+                      "test": {
+                        "left": {
+                          "name": "val",
+                          "type": "Identifier",
+                        },
+                        "operator": "!=",
+                        "right": {
+                          "type": "NullLiteral",
+                        },
+                        "type": "BinaryExpression",
+                      },
+                      "type": "ConditionalExpression",
                     },
                     "consequent": {
-                      "name": "val",
-                      "type": "Identifier",
-                    },
-                    "test": {
                       "left": {
                         "name": "val",
                         "type": "Identifier",
                       },
-                      "operator": "!=",
+                      "operator": "+",
                       "right": {
-                        "type": "NullLiteral",
+                        "type": "StringLiteral",
+                        "value": "px",
+                      },
+                      "type": "BinaryExpression",
+                    },
+                    "test": {
+                      "left": {
+                        "argument": {
+                          "name": "val",
+                          "type": "Identifier",
+                        },
+                        "operator": "typeof",
+                        "prefix": true,
+                        "type": "UnaryExpression",
+                      },
+                      "operator": "===",
+                      "right": {
+                        "type": "StringLiteral",
+                        "value": "number",
                       },
                       "type": "BinaryExpression",
                     },
                     "type": "ConditionalExpression",
                   },
-                  "consequent": {
-                    "left": {
+                  "expression": null,
+                  "params": [
+                    {
                       "name": "val",
                       "type": "Identifier",
                     },
-                    "operator": "+",
-                    "right": {
-                      "type": "StringLiteral",
-                      "value": "px",
-                    },
-                    "type": "BinaryExpression",
-                  },
-                  "test": {
-                    "left": {
-                      "argument": {
-                        "name": "val",
-                        "type": "Identifier",
-                      },
-                      "operator": "typeof",
-                      "prefix": true,
-                      "type": "UnaryExpression",
-                    },
-                    "operator": "===",
-                    "right": {
-                      "type": "StringLiteral",
-                      "value": "number",
-                    },
-                    "type": "BinaryExpression",
-                  },
-                  "type": "ConditionalExpression",
+                  ],
+                  "type": "ArrowFunctionExpression",
                 },
-                "expression": null,
-                "params": [
-                  {
-                    "name": "val",
-                    "type": "Identifier",
-                  },
-                ],
-                "type": "ArrowFunctionExpression",
+                "type": "CallExpression",
               },
-              "type": "CallExpression",
+              "originalExpression": {
+                "name": "width",
+                "type": "Identifier",
+              },
+              "path": [
+                {
+                  "0": "b",
+                  "1": "o",
+                  "10": "h",
+                  "2": "r",
+                  "3": "d",
+                  "4": "e",
+                  "5": "r",
+                  "6": "W",
+                  "7": "i",
+                  "8": "d",
+                  "9": "t",
+                },
+              ],
             },
           },
         ],
@@ -233,102 +254,147 @@ describe('custom path evaluation works as expected', () => {
           ],
           {
             "--borderWidth": {
-              "arguments": [
-                {
-                  "left": {
+              "expression": {
+                "arguments": [
+                  {
                     "left": {
-                      "name": "width",
-                      "type": "Identifier",
-                    },
-                    "operator": "*",
-                    "right": {
-                      "extra": {
-                        "raw": "2",
-                        "rawValue": 2,
-                      },
-                      "type": "NumericLiteral",
-                      "value": 2,
-                    },
-                    "type": "BinaryExpression",
-                  },
-                  "operator": "+",
-                  "right": {
-                    "extra": {
-                      "raw": "'px'",
-                      "rawValue": "px",
-                    },
-                    "type": "StringLiteral",
-                    "value": "px",
-                  },
-                  "type": "BinaryExpression",
-                },
-              ],
-              "callee": {
-                "async": false,
-                "body": {
-                  "alternate": {
-                    "alternate": {
-                      "type": "StringLiteral",
-                      "value": "initial",
-                    },
-                    "consequent": {
-                      "name": "val",
-                      "type": "Identifier",
-                    },
-                    "test": {
                       "left": {
-                        "name": "val",
+                        "name": "width",
                         "type": "Identifier",
                       },
-                      "operator": "!=",
+                      "operator": "*",
                       "right": {
-                        "type": "NullLiteral",
+                        "extra": {
+                          "raw": "2",
+                          "rawValue": 2,
+                        },
+                        "type": "NumericLiteral",
+                        "value": 2,
                       },
                       "type": "BinaryExpression",
                     },
-                    "type": "ConditionalExpression",
-                  },
-                  "consequent": {
-                    "left": {
-                      "name": "val",
-                      "type": "Identifier",
-                    },
                     "operator": "+",
                     "right": {
+                      "extra": {
+                        "raw": "'px'",
+                        "rawValue": "px",
+                      },
                       "type": "StringLiteral",
                       "value": "px",
                     },
                     "type": "BinaryExpression",
                   },
-                  "test": {
-                    "left": {
-                      "argument": {
+                ],
+                "callee": {
+                  "async": false,
+                  "body": {
+                    "alternate": {
+                      "alternate": {
+                        "name": "undefined",
+                        "type": "Identifier",
+                      },
+                      "consequent": {
                         "name": "val",
                         "type": "Identifier",
                       },
-                      "operator": "typeof",
-                      "prefix": true,
-                      "type": "UnaryExpression",
+                      "test": {
+                        "left": {
+                          "name": "val",
+                          "type": "Identifier",
+                        },
+                        "operator": "!=",
+                        "right": {
+                          "type": "NullLiteral",
+                        },
+                        "type": "BinaryExpression",
+                      },
+                      "type": "ConditionalExpression",
                     },
-                    "operator": "===",
-                    "right": {
-                      "type": "StringLiteral",
-                      "value": "number",
+                    "consequent": {
+                      "left": {
+                        "name": "val",
+                        "type": "Identifier",
+                      },
+                      "operator": "+",
+                      "right": {
+                        "type": "StringLiteral",
+                        "value": "px",
+                      },
+                      "type": "BinaryExpression",
                     },
-                    "type": "BinaryExpression",
+                    "test": {
+                      "left": {
+                        "argument": {
+                          "name": "val",
+                          "type": "Identifier",
+                        },
+                        "operator": "typeof",
+                        "prefix": true,
+                        "type": "UnaryExpression",
+                      },
+                      "operator": "===",
+                      "right": {
+                        "type": "StringLiteral",
+                        "value": "number",
+                      },
+                      "type": "BinaryExpression",
+                    },
+                    "type": "ConditionalExpression",
                   },
-                  "type": "ConditionalExpression",
+                  "expression": null,
+                  "params": [
+                    {
+                      "name": "val",
+                      "type": "Identifier",
+                    },
+                  ],
+                  "type": "ArrowFunctionExpression",
                 },
-                "expression": null,
-                "params": [
-                  {
-                    "name": "val",
+                "type": "CallExpression",
+              },
+              "originalExpression": {
+                "left": {
+                  "left": {
+                    "name": "width",
                     "type": "Identifier",
                   },
-                ],
-                "type": "ArrowFunctionExpression",
+                  "operator": "*",
+                  "right": {
+                    "extra": {
+                      "raw": "2",
+                      "rawValue": 2,
+                    },
+                    "type": "NumericLiteral",
+                    "value": 2,
+                  },
+                  "type": "BinaryExpression",
+                },
+                "operator": "+",
+                "right": {
+                  "extra": {
+                    "raw": "'px'",
+                    "rawValue": "px",
+                  },
+                  "type": "StringLiteral",
+                  "value": "px",
+                },
+                "type": "BinaryExpression",
               },
-              "type": "CallExpression",
+              "path": [
+                {
+                  "0": "b",
+                  "1": "o",
+                  "10": "h",
+                  "2": "r",
+                  "3": "d",
+                  "4": "e",
+                  "5": "r",
+                  "6": "W",
+                  "7": "i",
+                  "8": "d",
+                  "9": "t",
+                },
+              ],
             },
           },
         ],

--- a/packages/babel-plugin/__tests__/evaluation/stylex-fn-obj-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-fn-obj-evaluation-test.js
@@ -110,7 +110,7 @@ describe('custom path evaluation works as expected', () => {
     expect(result.value).toEqual({
       default: {
         borderStyle: 'dashed',
-        borderWidth: 'var(--borderWidth, revert)',
+        borderWidth: 'var(--borderWidth)',
         overflow: 'hidden',
       },
     });
@@ -240,7 +240,7 @@ describe('custom path evaluation works as expected', () => {
       default: {
         overflow: 'hidden',
         borderStyle: 'dashed',
-        borderWidth: 'var(--borderWidth, revert)',
+        borderWidth: 'var(--borderWidth)',
       },
     });
     expect(removeLoc(result.fns)).toMatchInlineSnapshot(`

--- a/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
@@ -332,10 +332,10 @@ describe('Evaluation of imported values works based on configuration', () => {
         _inject2(".__hashed_var__15x39w1{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb,revert)}", 1);
         const styles = {
           color: color => [{
-            "--__hashed_var__1jqb1tb": "__hashed_var__15x39w1",
+            "--__hashed_var__1jqb1tb": color == null ? null : "__hashed_var__15x39w1",
             $$css: true
           }, {
-            "----__hashed_var__1jqb1tb": color != null ? color : "initial"
+            "----__hashed_var__1jqb1tb": color != null ? color : undefined
           }]
         };
         stylex.props(styles.color('red'));"

--- a/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
@@ -329,10 +329,10 @@ describe('Evaluation of imported values works based on configuration', () => {
         import stylex from 'stylex';
         import 'otherFile.stylex';
         import { MyTheme } from 'otherFile.stylex';
-        _inject2(".__hashed_var__15x39w1{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb,revert)}", 1);
+        _inject2(".__hashed_var__b69i2g{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb)}", 1);
         const styles = {
           color: color => [{
-            "--__hashed_var__1jqb1tb": color == null ? null : "__hashed_var__15x39w1",
+            "--__hashed_var__1jqb1tb": color == null ? null : "__hashed_var__b69i2g",
             $$css: true
           }, {
             "----__hashed_var__1jqb1tb": color != null ? color : undefined
@@ -343,9 +343,9 @@ describe('Evaluation of imported values works based on configuration', () => {
       expect(transformation.metadata.stylex).toMatchInlineSnapshot(`
         [
           [
-            "__hashed_var__15x39w1",
+            "__hashed_var__b69i2g",
             {
-              "ltr": ".__hashed_var__15x39w1{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb,revert)}",
+              "ltr": ".__hashed_var__b69i2g{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb)}",
               "rtl": null,
             },
             1,

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -847,12 +847,12 @@ describe('@stylexjs/babel-plugin', () => {
         _inject2(".xbsl7fq{border-style:dashed}", 2000);
         _inject2(".xn43iik{border-width:0 0 2px 0}", 2000);
         _inject2(".xmkeg23{border-width:1px}", 2000);
-        _inject2(".xa309fb{border-bottom-width:5px}", 4000);
         _inject2(".x1y0btm7{border-style:solid}", 2000);
-        _inject2(".x1q0q8m5{border-bottom-style:solid}", 4000);
         _inject2(".x1lh7sze{border-color:var(--divider)}", 2000);
-        _inject2(".xud65wk{border-bottom-color:red}", 4000);
         _inject2(".x12oqio5{border-radius:4px}", 2000);
+        _inject2(".xa309fb{border-bottom-width:5px}", 4000);
+        _inject2(".x1q0q8m5{border-bottom-style:solid}", 4000);
+        _inject2(".xud65wk{border-bottom-color:red}", 4000);
         _inject2(".x1lmef92{padding:calc((100% - 50px) * .5) var(--rightpadding,20px)}", 1000);
         _inject2(".xexx8yu{padding-top:0}", 4000);
         _inject2(".x1bg2uv5{border-color:green}", 2000);"
@@ -988,7 +988,6 @@ describe('@stylexjs/babel-plugin', () => {
             borderRightWidth: null,
             borderBlockWidth: null,
             borderTopWidth: null,
-            borderBottomWidth: "xa309fb",
             borderStyle: "x1y0btm7",
             borderInlineStyle: null,
             borderInlineStartStyle: null,
@@ -997,7 +996,6 @@ describe('@stylexjs/babel-plugin', () => {
             borderRightStyle: null,
             borderBlockStyle: null,
             borderTopStyle: null,
-            borderBottomStyle: "x1q0q8m5",
             borderColor: "x1lh7sze",
             borderInlineColor: null,
             borderInlineStartColor: null,
@@ -1006,7 +1004,6 @@ describe('@stylexjs/babel-plugin', () => {
             borderRightColor: null,
             borderBlockColor: null,
             borderTopColor: null,
-            borderBottomColor: "xud65wk",
             borderRadius: "x12oqio5",
             borderStartStartRadius: null,
             borderStartEndRadius: null,
@@ -1016,6 +1013,9 @@ describe('@stylexjs/babel-plugin', () => {
             borderTopRightRadius: null,
             borderBottomLeftRadius: null,
             borderBottomRightRadius: null,
+            borderBottomWidth: "xa309fb",
+            borderBottomStyle: "x1q0q8m5",
+            borderBottomColor: "xud65wk",
             $$css: true
           },
           short: {
@@ -1026,12 +1026,11 @@ describe('@stylexjs/babel-plugin', () => {
             paddingEnd: null,
             paddingRight: null,
             paddingBlock: null,
-            paddingTop: "xexx8yu",
             paddingBottom: null,
+            paddingTop: "xexx8yu",
             $$css: true
           },
           shortReversed: {
-            paddingTop: null,
             padding: "x1lmef92",
             paddingInline: null,
             paddingStart: null,
@@ -1039,6 +1038,7 @@ describe('@stylexjs/babel-plugin', () => {
             paddingEnd: null,
             paddingRight: null,
             paddingBlock: null,
+            paddingTop: null,
             paddingBottom: null,
             $$css: true
           },
@@ -1189,11 +1189,11 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject2(".xfx01vb{color:var(--color)}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: color == null ? null : "x19dipnz",
+            color: color == null ? null : "xfx01vb",
             $$css: true
           }, {
             "--color": color != null ? color : undefined
@@ -1218,11 +1218,11 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x17fnjtu{width:var(--width,revert)}", 4000);
+        _inject2(".x1bl4301{width:var(--width)}", 4000);
         export const styles = {
           default: width => [{
             backgroundColor: "xrkmrrc",
-            width: width == null ? null : "x17fnjtu",
+            width: width == null ? null : "x1bl4301",
             $$css: true
           }, {
             "--width": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
@@ -1250,12 +1250,12 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject2(".xfx01vb{color:var(--color)}", 3000);
         _inject2(".x1mqxbix{color:black}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: color == null ? null : "x19dipnz",
+            color: color == null ? null : "xfx01vb",
             $$css: true
           }, {
             "--color": color != null ? color : undefined
@@ -1282,10 +1282,10 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
+        _inject2(".x15mgraa{--background-color:var(----background-color)}", 1);
         export const styles = {
           default: bgColor => [{
-            "--background-color": bgColor == null ? null : "xyv4n8w",
+            "--background-color": bgColor == null ? null : "x15mgraa",
             $$css: true
           }, {
             "----background-color": bgColor != null ? bgColor : undefined
@@ -1311,11 +1311,11 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x1gykpug:hover{background-color:red}", 3130);
-        _inject2(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
+        _inject2(".xtyu0qe:hover{color:var(--1ijzsae)}", 3130);
         export const styles = {
           default: color => [{
             ":hover_backgroundColor": "x1gykpug",
-            ":hover_color": color == null ? null : "x11bf1mc",
+            ":hover_color": color == null ? null : "xtyu0qe",
             $$css: true
           }, {
             "--1ijzsae": color != null ? color : undefined
@@ -1342,12 +1342,12 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject2(".xfx01vb{color:var(--color)}", 3000);
         _inject2(".x1mqxbix{color:black}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: color == null ? null : "x19dipnz",
+            color: color == null ? null : "xfx01vb",
             $$css: true
           }, {
             "--color": color != null ? color : undefined
@@ -1374,10 +1374,10 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
+        _inject2(".x15mgraa{--background-color:var(----background-color)}", 1);
         export const styles = {
           default: bgColor => [{
-            "--background-color": bgColor == null ? null : "xyv4n8w",
+            "--background-color": bgColor == null ? null : "x15mgraa",
             $$css: true
           }, {
             "----background-color": bgColor != null ? bgColor : undefined
@@ -1407,16 +1407,100 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x9lz66z{color:var(--4xs81a,revert)}", 3000);
+        _inject2(".x1n25116{color:var(--4xs81a)}", 3000);
         _inject2("@media (min-width: 1000px){.xtljkjt.xtljkjt:hover{color:green}}", 3330);
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: "x9lz66z xtljkjt x17z2mba",
+            color: (color == null ? "" : "x1n25116 ") + "xtljkjt " + "x17z2mba",
             $$css: true
           }, {
             "--4xs81a": color != null ? color : undefined
+          }]
+        };"
+      `);
+    });
+    test('transforms functions with multiple dynamic values within conditional values', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            default: (color) => ({
+              backgroundColor: 'red',
+              color: {
+                default: color,
+                ':hover': {
+                  '@media (min-width: 1000px)': 'green',
+                  default: 'color-mix(' + color + ', blue)',
+                }
+              },
+            }),
+          });
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".x1n25116{color:var(--4xs81a)}", 3000);
+        _inject2("@media (min-width: 1000px){.xtljkjt.xtljkjt:hover{color:green}}", 3330);
+        _inject2(".x1d4gdy3:hover{color:var(--w5m4kq)}", 3130);
+        export const styles = {
+          default: color => [{
+            backgroundColor: "xrkmrrc",
+            color: (color == null ? "" : "x1n25116 ") + "xtljkjt " + ('color-mix(' + color + ', blue)' == null ? "" : "x1d4gdy3"),
+            $$css: true
+          }, {
+            "--4xs81a": color != null ? color : undefined,
+            "--w5m4kq": 'color-mix(' + color + ', blue)' != null ? 'color-mix(' + color + ', blue)' : undefined
+          }]
+        };"
+      `);
+    });
+
+    test('transforms shorthands in legacy-expand-shorthands mode', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            default: (margin) => ({
+              backgroundColor: 'red',
+              margin: {
+                default: margin,
+                ':hover': margin + 4,
+              },
+              marginTop: margin - 4,
+            })
+          });
+        `,
+          { styleResolution: 'legacy-expand-shorthands' },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".x1ie72y1{margin-right:var(--14mfytm)}", 3000, ".x1ie72y1{margin-left:var(--14mfytm)}");
+        _inject2(".x128459:hover{margin-right:var(--yepcm9)}", 3130, ".x128459:hover{margin-left:var(--yepcm9)}");
+        _inject2(".x1hvr6ea{margin-bottom:var(--14mfytm)}", 4000);
+        _inject2(".x3skgmg:hover{margin-bottom:var(--yepcm9)}", 4130);
+        _inject2(".x1k44ad6{margin-left:var(--14mfytm)}", 3000, ".x1k44ad6{margin-right:var(--14mfytm)}");
+        _inject2(".x10ktymb:hover{margin-left:var(--yepcm9)}", 3130, ".x10ktymb:hover{margin-right:var(--yepcm9)}");
+        _inject2(".x17zef60{margin-top:var(--marginTop)}", 4000);
+        export const styles = {
+          default: margin => [{
+            backgroundColor: "xrkmrrc",
+            marginEnd: (margin == null ? "" : "x1ie72y1 ") + (margin + 4 == null ? "" : "x128459"),
+            marginBottom: (margin == null ? "" : "x1hvr6ea ") + (margin + 4 == null ? "" : "x3skgmg"),
+            marginStart: (margin == null ? "" : "x1k44ad6 ") + (margin + 4 == null ? "" : "x10ktymb"),
+            marginTop: margin - 4 == null ? null : "x17zef60",
+            $$css: true
+          }, {
+            "--14mfytm": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin),
+            "--yepcm9": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin + 4),
+            "--marginTop": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin - 4)
           }]
         };"
       `);

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -1193,10 +1193,10 @@ describe('@stylexjs/babel-plugin', () => {
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: "x19dipnz",
+            color: color == null ? null : "x19dipnz",
             $$css: true
           }, {
-            "--color": color != null ? color : "initial"
+            "--color": color != null ? color : undefined
           }]
         };"
       `);
@@ -1222,10 +1222,10 @@ describe('@stylexjs/babel-plugin', () => {
         export const styles = {
           default: width => [{
             backgroundColor: "xrkmrrc",
-            width: "x17fnjtu",
+            width: width == null ? null : "x17fnjtu",
             $$css: true
           }, {
-            "--width": (val => typeof val === "number" ? val + "px" : val != null ? val : "initial")(width)
+            "--width": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
           }]
         };"
       `);
@@ -1255,10 +1255,10 @@ describe('@stylexjs/babel-plugin', () => {
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: "x19dipnz",
+            color: color == null ? null : "x19dipnz",
             $$css: true
           }, {
-            "--color": color != null ? color : "initial"
+            "--color": color != null ? color : undefined
           }],
           mono: {
             color: "x1mqxbix",
@@ -1285,10 +1285,10 @@ describe('@stylexjs/babel-plugin', () => {
         _inject2(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
         export const styles = {
           default: bgColor => [{
-            "--background-color": "xyv4n8w",
+            "--background-color": bgColor == null ? null : "xyv4n8w",
             $$css: true
           }, {
-            "----background-color": bgColor != null ? bgColor : "initial"
+            "----background-color": bgColor != null ? bgColor : undefined
           }]
         };"
       `);
@@ -1318,7 +1318,7 @@ describe('@stylexjs/babel-plugin', () => {
             ":hover_color": "x11bf1mc",
             $$css: true
           }, {
-            "--1ijzsae": color != null ? color : "initial"
+            "--1ijzsae": color != null ? color : undefined
           }]
         };"
       `);
@@ -1347,10 +1347,10 @@ describe('@stylexjs/babel-plugin', () => {
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: "x19dipnz",
+            color: color == null ? null : "x19dipnz",
             $$css: true
           }, {
-            "--color": color != null ? color : "initial"
+            "--color": color != null ? color : undefined
           }],
           mono: {
             color: "x1mqxbix",
@@ -1377,23 +1377,27 @@ describe('@stylexjs/babel-plugin', () => {
         _inject2(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
         export const styles = {
           default: bgColor => [{
-            "--background-color": "xyv4n8w",
+            "--background-color": bgColor == null ? null : "xyv4n8w",
             $$css: true
           }, {
-            "----background-color": bgColor != null ? bgColor : "initial"
+            "----background-color": bgColor != null ? bgColor : undefined
           }]
         };"
       `);
     });
-    test('transforms functions with nested dynamic values', () => {
+    test('transforms functions with dynamic values within conditional values', () => {
       expect(
         transform(`
           import stylex from 'stylex';
           export const styles = stylex.create({
             default: (color) => ({
-              ':hover': {
-                backgroundColor: 'red',
-                color,
+              backgroundColor: 'red',
+              color: {
+                default: color,
+                ':hover': {
+                  '@media (min-width: 1000px)': 'green',
+                  default: 'blue',
+                }
               },
             }),
           });
@@ -1402,15 +1406,17 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1gykpug:hover{background-color:red}", 3130);
-        _inject2(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".x9lz66z{color:var(--4xs81a,revert)}", 3000);
+        _inject2("@media (min-width: 1000px){.xtljkjt.xtljkjt:hover{color:green}}", 3330);
+        _inject2(".x17z2mba:hover{color:blue}", 3130);
         export const styles = {
           default: color => [{
-            ":hover_backgroundColor": "x1gykpug",
-            ":hover_color": "x11bf1mc",
+            backgroundColor: "xrkmrrc",
+            color: "x9lz66z xtljkjt x17z2mba",
             $$css: true
           }, {
-            "--1ijzsae": color != null ? color : "initial"
+            "--4xs81a": color != null ? color : undefined
           }]
         };"
       `);

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -1315,7 +1315,7 @@ describe('@stylexjs/babel-plugin', () => {
         export const styles = {
           default: color => [{
             ":hover_backgroundColor": "x1gykpug",
-            ":hover_color": "x11bf1mc",
+            ":hover_color": color == null ? null : "x11bf1mc",
             $$css: true
           }, {
             "--1ijzsae": color != null ? color : undefined

--- a/packages/babel-plugin/__tests__/stylex-transform-legacy-shorthands-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-legacy-shorthands-test.js
@@ -92,9 +92,9 @@ describe('Legacy-shorthand-expansion resolution', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
-        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);
         _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".x1nn3v0j{padding-top:2px}", 4000);
         _inject2(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
         _inject2(".x1120s5i{padding-bottom:2px}", 4000);
@@ -124,9 +124,9 @@ describe('Legacy-shorthand-expansion resolution', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
-        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);
         _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".x1nn3v0j{padding-top:2px}", 4000);
         _inject2(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
         _inject2(".x1120s5i{padding-bottom:2px}", 4000);
@@ -155,9 +155,9 @@ describe('Legacy-shorthand-expansion resolution', () => {
         export const styles = {
           foo: {
             paddingStart: "x1t2a60a",
+            paddingEnd: "x1mpkggp",
             paddingLeft: null,
             paddingRight: null,
-            paddingEnd: "x1mpkggp",
             $$css: true
           }
         };
@@ -186,9 +186,9 @@ describe('Legacy-shorthand-expansion resolution', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
-        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);
         _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".x1nn3v0j{padding-top:2px}", 4000);
         _inject2(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
         _inject2(".x1120s5i{padding-bottom:2px}", 4000);
@@ -218,9 +218,9 @@ describe('Legacy-shorthand-expansion resolution', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
-        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);
         _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".x1nn3v0j{padding-top:2px}", 4000);
         _inject2(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
         _inject2(".x1120s5i{padding-bottom:2px}", 4000);

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -169,7 +169,6 @@ export default function transformStyleXCreate(
           if (key != null && Object.keys(fns).includes(key)) {
             const [params, inlineStyles] = fns[key];
 
-            console.log('inlineStyles', inlineStyles);
             const singleValueDynamicStyles: {
               +[string]: t.Expression,
             } = Object.fromEntries(

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -173,8 +173,16 @@ export default function transformStyleXCreate(
               +[string]: t.Expression,
             } = Object.fromEntries(
               Object.entries(inlineStyles)
-                .filter(([_key, v]) => v.path.length === 1)
-                .map(([_key, v]) => [v.path[0], v.originalExpression]),
+                .filter(
+                  ([_key, v]) =>
+                    v.path.length === 1 ||
+                    (v.path.length === 2 &&
+                      (v.path[0].startsWith(':') || v.path[0].startsWith('@'))),
+                )
+                .map(([_key, v]) => [
+                  v.path.length === 1 ? v.path[0] : v.path.join('_'),
+                  v.originalExpression,
+                ]),
             );
 
             if (t.isObjectExpression(prop.value)) {

--- a/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
@@ -169,21 +169,28 @@ function evaluatePartialObjectRecursively(
       } else {
         const result = evaluate(valuePath, traversalState, functions);
         if (!result.confident) {
+          const fullKeyPath = [...keyPath, key];
           const varName =
             '--' +
             (keyPath.length > 0
               ? utils.hash([...keyPath, key].join('_'))
               : key);
-          obj[key] = `var(${varName}, revert)`;
+          obj[key] = `var(${varName})`;
           const node = valuePath.node;
           if (!t.isExpression(node)) {
             throw new Error('Expected expression as style value');
           }
           const expression: t.Expression = node as $FlowFixMe;
 
+          const propName =
+            fullKeyPath.find(
+              (k) =>
+                !k.startsWith(':') && !k.startsWith('@') && k !== 'default',
+            ) ?? key;
+
           const unit =
-            timeUnits.has(key) || lengthUnits.has(key)
-              ? getNumberSuffix(key)
+            timeUnits.has(propName) || lengthUnits.has(propName)
+              ? getNumberSuffix(propName)
               : '';
 
           const inlineStyleExpression =

--- a/packages/shared/__tests__/flatten-raw-style-objects/legacy-shorthand-expansion-test.js
+++ b/packages/shared/__tests__/flatten-raw-style-objects/legacy-shorthand-expansion-test.js
@@ -35,8 +35,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['color', new PreRule('color', 'red')],
-        ['marginStart', new PreRule('marginStart', 10)],
+        ['color', new PreRule('color', 'red', ['color'])],
+        ['marginStart', new PreRule('marginStart', 10, ['marginStart'])],
         ['marginLeft', new NullPreRule()],
         ['marginRight', new NullPreRule()],
       ]);
@@ -51,8 +51,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['rowGap', new PreRule('rowGap', 10)],
-        ['columnGap', new PreRule('columnGap', 10)],
+        ['rowGap', new PreRule('rowGap', 10, ['rowGap'])],
+        ['columnGap', new PreRule('columnGap', 10, ['columnGap'])],
       ]);
     });
 
@@ -65,27 +65,33 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['containIntrinsicWidth', new PreRule('containIntrinsicWidth', 10)],
-        ['containIntrinsicHeight', new PreRule('containIntrinsicHeight', 10)],
+        [
+          'containIntrinsicWidth',
+          new PreRule('containIntrinsicWidth', 10, ['containIntrinsicWidth']),
+        ],
+        [
+          'containIntrinsicHeight',
+          new PreRule('containIntrinsicHeight', 10, ['containIntrinsicHeight']),
+        ],
       ]);
     });
 
     test('should expand simple shorthands', () => {
       expect(flattenRawStyleObject({ margin: 10 }, options)).toEqual([
-        ['marginTop', new PreRule('marginTop', 10)],
-        ['marginEnd', new PreRule('marginEnd', 10)],
-        ['marginBottom', new PreRule('marginBottom', 10)],
-        ['marginStart', new PreRule('marginStart', 10)],
+        ['marginTop', new PreRule('marginTop', 10, ['marginTop'])],
+        ['marginEnd', new PreRule('marginEnd', 10, ['marginEnd'])],
+        ['marginBottom', new PreRule('marginBottom', 10, ['marginBottom'])],
+        ['marginStart', new PreRule('marginStart', 10, ['marginStart'])],
       ]);
 
       expect(
         flattenRawStyleObject({ margin: 10, marginBottom: 20 }, options),
       ).toEqual([
-        ['marginTop', new PreRule('marginTop', 10)],
-        ['marginEnd', new PreRule('marginEnd', 10)],
-        ['marginBottom', new PreRule('marginBottom', 10)],
-        ['marginStart', new PreRule('marginStart', 10)],
-        ['marginBottom', new PreRule('marginBottom', 20)],
+        ['marginTop', new PreRule('marginTop', 10, ['marginTop'])],
+        ['marginEnd', new PreRule('marginEnd', 10, ['marginEnd'])],
+        ['marginBottom', new PreRule('marginBottom', 10, ['marginBottom'])],
+        ['marginStart', new PreRule('marginStart', 10, ['marginStart'])],
+        ['marginBottom', new PreRule('marginBottom', 20, ['marginBottom'])],
       ]);
     });
 
@@ -96,14 +102,26 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['marginTop', new PreRule('marginTop', '10px')],
-        ['marginEnd', new PreRule('marginEnd', '20px')],
-        ['marginBottom', new PreRule('marginBottom', '10px')],
-        ['marginStart', new PreRule('marginStart', '20px')],
-        ['borderTopColor', new PreRule('borderTopColor', 'red')],
-        ['borderEndColor', new PreRule('borderEndColor', 'red')],
-        ['borderBottomColor', new PreRule('borderBottomColor', 'red')],
-        ['borderStartColor', new PreRule('borderStartColor', 'red')],
+        ['marginTop', new PreRule('marginTop', '10px', ['marginTop'])],
+        ['marginEnd', new PreRule('marginEnd', '20px', ['marginEnd'])],
+        ['marginBottom', new PreRule('marginBottom', '10px', ['marginBottom'])],
+        ['marginStart', new PreRule('marginStart', '20px', ['marginStart'])],
+        [
+          'borderTopColor',
+          new PreRule('borderTopColor', 'red', ['borderTopColor']),
+        ],
+        [
+          'borderEndColor',
+          new PreRule('borderEndColor', 'red', ['borderEndColor']),
+        ],
+        [
+          'borderBottomColor',
+          new PreRule('borderBottomColor', 'red', ['borderBottomColor']),
+        ],
+        [
+          'borderStartColor',
+          new PreRule('borderStartColor', 'red', ['borderStartColor']),
+        ],
       ]);
     });
 
@@ -116,8 +134,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['rowGap', new PreRule('rowGap', '10px')],
-        ['columnGap', new PreRule('columnGap', '20px')],
+        ['rowGap', new PreRule('rowGap', '10px', ['rowGap'])],
+        ['columnGap', new PreRule('columnGap', '20px', ['columnGap'])],
       ]);
     });
 
@@ -132,8 +150,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, '10px')],
-        [h, new PreRule(h, '20px')],
+        [w, new PreRule(w, '10px', [w])],
+        [h, new PreRule(h, '20px', [h])],
       ]);
       expect(
         flattenRawStyleObject(
@@ -143,8 +161,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, 'auto 10px')],
-        [h, new PreRule(h, '20px')],
+        [w, new PreRule(w, 'auto 10px', [w])],
+        [h, new PreRule(h, '20px', [h])],
       ]);
       expect(
         flattenRawStyleObject(
@@ -154,8 +172,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, '10px')],
-        [h, new PreRule(h, 'auto 20px')],
+        [w, new PreRule(w, '10px', [w])],
+        [h, new PreRule(h, 'auto 20px', [h])],
       ]);
       expect(
         flattenRawStyleObject(
@@ -165,8 +183,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, 'auto 10px')],
-        [h, new PreRule(h, 'auto 20px')],
+        [w, new PreRule(w, 'auto 10px', [w])],
+        [h, new PreRule(h, 'auto 20px', [h])],
       ]);
     });
 
@@ -174,10 +192,16 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
       expect(
         flattenRawStyleObject({ margin: ['10vh 20px', '10dvh 20px'] }, options),
       ).toEqual([
-        ['marginTop', new PreRule('marginTop', ['10vh', '10dvh'])],
-        ['marginEnd', new PreRule('marginEnd', '20px')],
-        ['marginBottom', new PreRule('marginBottom', ['10vh', '10dvh'])],
-        ['marginStart', new PreRule('marginStart', '20px')],
+        [
+          'marginTop',
+          new PreRule('marginTop', ['10vh', '10dvh'], ['marginTop']),
+        ],
+        ['marginEnd', new PreRule('marginEnd', '20px', ['marginEnd'])],
+        [
+          'marginBottom',
+          new PreRule('marginBottom', ['10vh', '10dvh'], ['marginBottom']),
+        ],
+        ['marginStart', new PreRule('marginStart', '20px', ['marginStart'])],
       ]);
     });
   });
@@ -197,12 +221,15 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['color', new PreRule('color', 'blue')],
-        ['marginStart', new PreRule('marginStart', 0)],
+        ['color', new PreRule('color', 'blue', ['color'])],
+        ['marginStart', new PreRule('marginStart', 0, ['marginStart'])],
         ['marginLeft', new NullPreRule()],
         ['marginRight', new NullPreRule()],
-        [':hover_color', new PreRule('color', 'red', [':hover'], [])],
-        [':hover_marginStart', new PreRule('marginStart', 10, [':hover'], [])],
+        [':hover_color', new PreRule('color', 'red', [':hover', 'color'])],
+        [
+          ':hover_marginStart',
+          new PreRule('marginStart', 10, [':hover', 'marginStart']),
+        ],
         [':hover_marginLeft', new NullPreRule()],
         [':hover_marginRight', new NullPreRule()],
       ]);
@@ -226,15 +253,15 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'color',
           PreRuleSet.create([
-            new PreRule('color', 'blue'),
-            new PreRule('color', 'red', [':hover'], []),
+            new PreRule('color', 'blue', ['color', 'default']),
+            new PreRule('color', 'red', ['color', ':hover']),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', 0),
-            new PreRule('marginStart', 10, [':hover'], []),
+            new PreRule('marginStart', 0, ['marginStart', 'default']),
+            new PreRule('marginStart', 10, ['marginStart', ':hover']),
           ]),
         ],
         [
@@ -266,36 +293,36 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'color',
           PreRuleSet.create([
-            new PreRule('color', 'blue'),
-            new PreRule('color', 'red', [':hover'], []),
+            new PreRule('color', 'blue', ['color', 'default']),
+            new PreRule('color', 'red', ['color', ':hover']),
           ]),
         ],
         [
           'marginTop',
           PreRuleSet.create([
-            new PreRule('marginTop', 0),
-            new PreRule('marginTop', 10, [':hover'], []),
+            new PreRule('marginTop', 0, ['marginTop', 'default']),
+            new PreRule('marginTop', 10, ['marginTop', ':hover']),
           ]),
         ],
         [
           'marginEnd',
           PreRuleSet.create([
-            new PreRule('marginEnd', 0),
-            new PreRule('marginEnd', 10, [':hover'], []),
+            new PreRule('marginEnd', 0, ['marginEnd', 'default']),
+            new PreRule('marginEnd', 10, ['marginEnd', ':hover']),
           ]),
         ],
         [
           'marginBottom',
           PreRuleSet.create([
-            new PreRule('marginBottom', 0),
-            new PreRule('marginBottom', 10, [':hover'], []),
+            new PreRule('marginBottom', 0, ['marginBottom', 'default']),
+            new PreRule('marginBottom', 10, ['marginBottom', ':hover']),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', 0),
-            new PreRule('marginStart', 10, [':hover'], []),
+            new PreRule('marginStart', 0, ['marginStart', 'default']),
+            new PreRule('marginStart', 10, ['marginStart', ':hover']),
           ]),
         ],
       ]);
@@ -319,36 +346,36 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'color',
           PreRuleSet.create([
-            new PreRule('color', 'blue'),
-            new PreRule('color', 'red', [':hover'], []),
+            new PreRule('color', 'blue', ['color', 'default']),
+            new PreRule('color', 'red', ['color', ':hover']),
           ]),
         ],
         [
           'marginTop',
           PreRuleSet.create([
-            new PreRule('marginTop', '1px'),
-            new PreRule('marginTop', '10px', [':hover'], []),
+            new PreRule('marginTop', '1px', ['marginTop', 'default']),
+            new PreRule('marginTop', '10px', ['marginTop', ':hover']),
           ]),
         ],
         [
           'marginEnd',
           PreRuleSet.create([
-            new PreRule('marginEnd', '2px'),
-            new PreRule('marginEnd', '20px', [':hover'], []),
+            new PreRule('marginEnd', '2px', ['marginEnd', 'default']),
+            new PreRule('marginEnd', '20px', ['marginEnd', ':hover']),
           ]),
         ],
         [
           'marginBottom',
           PreRuleSet.create([
-            new PreRule('marginBottom', '3px'),
-            new PreRule('marginBottom', '10px', [':hover'], []),
+            new PreRule('marginBottom', '3px', ['marginBottom', 'default']),
+            new PreRule('marginBottom', '10px', ['marginBottom', ':hover']),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', '4px'),
-            new PreRule('marginStart', '20px', [':hover'], []),
+            new PreRule('marginStart', '4px', ['marginStart', 'default']),
+            new PreRule('marginStart', '20px', ['marginStart', ':hover']),
           ]),
         ],
       ]);
@@ -373,16 +400,19 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'color',
           PreRuleSet.create([
-            new PreRule('color', 'blue'),
-            new PreRule('color', 'red', [':hover'], []),
-            new PreRule('color', 'green', [], ['@media (min-width: 300px)']),
+            new PreRule('color', 'blue', ['color', 'default']),
+            new PreRule('color', 'red', ['color', ':hover']),
+            new PreRule('color', 'green', [
+              'color',
+              '@media (min-width: 300px)',
+            ]),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', 0),
-            new PreRule('marginStart', 10, [':hover'], []),
+            new PreRule('marginStart', 0, ['marginStart', 'default']),
+            new PreRule('marginStart', 10, ['marginStart', ':hover']),
           ]),
         ],
         [
@@ -412,29 +442,37 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'marginTop',
           PreRuleSet.create([
-            new PreRule('marginTop', '1px'),
-            new PreRule('marginTop', ['10px', '1dvh'], [':hover'], []),
+            new PreRule('marginTop', '1px', ['marginTop', 'default']),
+            new PreRule('marginTop', ['10px', '1dvh'], ['marginTop', ':hover']),
           ]),
         ],
         [
           'marginEnd',
           PreRuleSet.create([
-            new PreRule('marginEnd', '2px'),
-            new PreRule('marginEnd', ['20px', '2dvw'], [':hover'], []),
+            new PreRule('marginEnd', '2px', ['marginEnd', 'default']),
+            new PreRule('marginEnd', ['20px', '2dvw'], ['marginEnd', ':hover']),
           ]),
         ],
         [
           'marginBottom',
           PreRuleSet.create([
-            new PreRule('marginBottom', '3px'),
-            new PreRule('marginBottom', ['10px', '1dvh'], [':hover'], []),
+            new PreRule('marginBottom', '3px', ['marginBottom', 'default']),
+            new PreRule(
+              'marginBottom',
+              ['10px', '1dvh'],
+              ['marginBottom', ':hover'],
+            ),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', '4px'),
-            new PreRule('marginStart', ['20px', '2dvw'], [':hover'], []),
+            new PreRule('marginStart', '4px', ['marginStart', 'default']),
+            new PreRule(
+              'marginStart',
+              ['20px', '2dvw'],
+              ['marginStart', ':hover'],
+            ),
           ]),
         ],
       ]);
@@ -455,12 +493,11 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           '@media (min-width: 300px)_:hover_color',
           PreRuleSet.create([
-            new PreRule(
+            new PreRule('color', 'red', [
+              '@media (min-width: 300px)',
+              ':hover',
               'color',
-              'red',
-              [':hover'],
-              ['@media (min-width: 300px)'],
-            ),
+            ]),
           ]),
         ],
       ]);
@@ -484,23 +521,22 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           '@media (min-width: 300px)_:hover_color',
           PreRuleSet.create([
-            new PreRule(
+            new PreRule('color', 'pink', [
+              '@media (min-width: 300px)',
+              ':hover',
               'color',
-              'pink',
-              [':hover'],
-              ['@media (min-width: 300px)'],
-            ),
+            ]),
           ]),
         ],
         [
           '@media (min-width: 300px)_:hover_:active_color',
           PreRuleSet.create([
-            new PreRule(
+            new PreRule('color', 'red', [
+              '@media (min-width: 300px)',
+              ':hover',
+              ':active',
               'color',
-              'red',
-              [':active', ':hover'],
-              ['@media (min-width: 300px)'],
-            ),
+            ]),
           ]),
         ],
       ]);
@@ -522,13 +558,12 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'color',
           PreRuleSet.create([
-            new PreRule('color', 'blue', [], []),
-            new PreRule(
+            new PreRule('color', 'blue', ['color', 'default']),
+            new PreRule('color', 'red', [
               'color',
-              'red',
-              [':hover'],
-              ['@media (min-width: 300px)'],
-            ),
+              '@media (min-width: 300px)',
+              ':hover',
+            ]),
           ]),
         ],
       ]);
@@ -553,19 +588,19 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'color',
           PreRuleSet.create([
-            new PreRule('color', 'blue', [], []),
-            new PreRule(
+            new PreRule('color', 'blue', ['color', 'default']),
+            new PreRule('color', 'red', [
               'color',
-              'red',
-              [':hover'],
-              ['@media (min-width: 300px)'],
-            ),
-            new PreRule(
+              '@media (min-width: 300px)',
+              ':hover',
+              'default',
+            ]),
+            new PreRule('color', 'maroon', [
               'color',
-              'maroon',
-              [':hover', ':active'],
-              ['@media (min-width: 300px)'],
-            ),
+              '@media (min-width: 300px)',
+              ':hover',
+              ':active',
+            ]),
           ]),
         ],
       ]);

--- a/packages/shared/__tests__/gen-css-test.js
+++ b/packages/shared/__tests__/gen-css-test.js
@@ -20,18 +20,23 @@ const options = {
 
 describe('Converting PreRule to CSS', () => {
   test('should convert a PreRule to CSS', () => {
-    expect(new PreRule('color', 'red').compiled(options))
+    expect(new PreRule('color', 'red', ['color']).compiled(options))
       .toMatchInlineSnapshot(`
+      [
         [
-          [
-            "x1e2nbdu",
-            {
-              "ltr": ".x1e2nbdu{color:red}",
-              "priority": 3000,
-              "rtl": null,
-            },
-          ],
-        ]
-      `);
+          "x1e2nbdu",
+          {
+            "ltr": ".x1e2nbdu{color:red}",
+            "priority": 3000,
+            "rtl": null,
+          },
+          {
+            "x1e2nbdu": [
+              "color",
+            ],
+          },
+        ],
+      ]
+    `);
   });
 });

--- a/packages/shared/__tests__/stylex-create-test.js
+++ b/packages/shared/__tests__/stylex-create-test.js
@@ -39,6 +39,16 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "xju2f9n": [
+              "color",
+            ],
+            "xrkmrrc": [
+              "backgroundColor",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -69,6 +79,13 @@ describe('stylex-create-test', () => {
             "ltr": ".x1cfch2b{transition-property:margin-top}",
             "priority": 3000,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "x1cfch2b": [
+              "transitionProperty",
+            ],
           },
         },
       ]
@@ -103,6 +120,13 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "x1a6dnx1": [
+              "willChange",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -129,6 +153,13 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "x17389it": [
+              "transitionProperty",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -153,6 +184,13 @@ describe('stylex-create-test', () => {
             "ltr": ".x1lxaxzv{will-change:--foo}",
             "priority": 3000,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "x1lxaxzv": [
+              "willChange",
+            ],
           },
         },
       ]
@@ -185,6 +223,13 @@ describe('stylex-create-test', () => {
             "ltr": ".x95ccmk{transition-property:opacity,margin-top}",
             "priority": 3000,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "x95ccmk": [
+              "transitionProperty",
+            ],
           },
         },
       ]
@@ -227,6 +272,16 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "short": {
+            "x1lmef92": [
+              "padding",
+            ],
+            "xexx8yu": [
+              "paddingTop",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -253,6 +308,13 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "xgau0yw": [
+              "--background-color",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -277,6 +339,13 @@ describe('stylex-create-test', () => {
             "ltr": ".x13tgbkp{--final-color:var(--background-color)}",
             "priority": 1,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "x13tgbkp": [
+              "--final-color",
+            ],
           },
         },
       ]
@@ -318,6 +387,18 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "xrkmrrc": [
+              "backgroundColor",
+            ],
+          },
+          "default2": {
+            "xju2f9n": [
+              "color",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -344,6 +425,13 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "xd71okc": [
+              "content",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -368,6 +456,13 @@ describe('stylex-create-test', () => {
             "ltr": ".xwzgxvi{--foo:500}",
             "priority": 1,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "xwzgxvi": [
+              "--foo",
+            ],
           },
         },
       ]
@@ -405,6 +500,18 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "x17z2mba": [
+              ":hover",
+              "color",
+            ],
+            "x1gykpug": [
+              ":hover",
+              "backgroundColor",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -430,6 +537,13 @@ describe('stylex-create-test', () => {
             "ltr": ".x1ruww2u{position:sticky;position:fixed}",
             "priority": 3000,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "x1ruww2u": [
+              "position",
+            ],
           },
         },
       ]
@@ -490,6 +604,19 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "xb3r6kr": [
+              "overflow",
+            ],
+            "xbsl7fq": [
+              "borderStyle",
+            ],
+            "xmkeg23": [
+              "borderWidth",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -533,6 +660,21 @@ describe('stylex-create-test', () => {
             "ltr": ".xrkmrrc{background-color:red}",
             "priority": 3000,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "x1ssfqz5": [
+              "@media (min-width: 2000px)",
+              "backgroundColor",
+            ],
+            "xc445zv": [
+              "@media (min-width: 1000px)",
+              "backgroundColor",
+            ],
+            "xrkmrrc": [
+              "backgroundColor",
+            ],
           },
         },
       ]

--- a/packages/shared/src/preprocess-rules/index.js
+++ b/packages/shared/src/preprocess-rules/index.js
@@ -29,7 +29,10 @@ export function getExpandedKeys(
 
 export default function flatMapExpandedShorthands(
   objEntry: $ReadOnly<[string, TStyleValue]>,
-  options: StyleXOptions,
+  options: $ReadOnly<{
+    styleResolution: StyleXOptions['styleResolution'],
+    ...
+  }>,
 ): $ReadOnlyArray<[string, TStyleValue]> {
   // eslint-disable-next-line prefer-const
   let [key, value] = objEntry;

--- a/packages/shared/src/stylex-create.js
+++ b/packages/shared/src/stylex-create.js
@@ -14,12 +14,22 @@ import type {
   FlatCompiledStyles,
 } from './common-types';
 
-import { objFromEntries } from './utils/object-utils';
 import { IncludedStyles } from './stylex-include';
 import { defaultOptions } from './utils/default-options';
 import { flattenRawStyleObject } from './preprocess-rules/flatten-raw-style-obj';
-import type { ComputedStyle } from './preprocess-rules/PreRule';
+import type { ComputedStyle, IPreRule } from './preprocess-rules/PreRule';
 import { validateNamespace } from './preprocess-rules/basic-validation';
+
+type TPropTuple = [
+  +key: string,
+  +styles: IncludedStyles | $ReadOnlyArray<ComputedStyle>,
+];
+
+type ClassPathsInNamespace = {
+  +[className: string]: $ReadOnlyArray<string>,
+};
+
+type TClassNameTuples = $NonMaybeType<ComputedStyle>;
 
 // This takes the object of styles passed to `stylex.create` and transforms it.
 //   The transformation replaces style values with classNames.
@@ -34,38 +44,64 @@ import { validateNamespace } from './preprocess-rules/basic-validation';
 export default function styleXCreateSet(
   namespaces: { +[string]: RawStyles },
   options?: StyleXOptions = defaultOptions,
-): [{ [string]: FlatCompiledStyles }, { [string]: InjectableStyle }] {
+): [
+  { [string]: FlatCompiledStyles },
+  { [string]: InjectableStyle },
+  { +[string]: ClassPathsInNamespace },
+] {
   const resolvedNamespaces: { [string]: FlatCompiledStyles } = {};
   const injectedStyles: { [string]: InjectableStyle } = {};
+  const namespaceToClassPaths: { [string]: ClassPathsInNamespace } = {};
 
   for (const namespaceName of Object.keys(namespaces)) {
     const namespace = namespaces[namespaceName];
+    const classPathsInNamespace: { [string]: $ReadOnlyArray<string> } = {};
 
     validateNamespace(namespace);
 
-    const flattenedNamespace = flattenRawStyleObject(namespace, options);
-    const compiledNamespaceTuples = flattenedNamespace.map(([key, value]) => {
-      return [key, value.compiled(options)];
-    });
+    // filterReverse to remove duplicate keys and keep the last one always.
+    // This is the same behaviour as Object.fromEntries, except it maintains
+    // order correctly and is more efficient.
+    const seenProperties = new Set<string>();
+    const flattenedNamespace: $ReadOnlyArray<$ReadOnly<[string, IPreRule]>> =
+      flattenRawStyleObject(namespace, options).reduceRight(
+        (arr, curr) => {
+          if (seenProperties.has(curr[0])) {
+            return arr;
+          }
+          seenProperties.add(curr[0]);
+          arr.unshift(curr);
+          return arr;
+        },
+        [] as Array<$ReadOnly<[string, IPreRule]>>,
+      );
 
-    const compiledNamespace = objFromEntries<
-      string,
-      IncludedStyles | $ReadOnlyArray<ComputedStyle>,
-    >(compiledNamespaceTuples);
+    const compiledNamespaceTuples: $ReadOnlyArray<TPropTuple> =
+      flattenedNamespace.map(([key, value]) => {
+        return [key, value.compiled(options)];
+      });
 
     const namespaceObj: {
       [string]: null | string | IncludedStyles,
     } = {};
-    for (const key of Object.keys(compiledNamespace)) {
-      const value = compiledNamespace[key];
+    for (const [key, value] of compiledNamespaceTuples) {
       if (value instanceof IncludedStyles) {
+        // stylex.include calls are passed through as-is.
         namespaceObj[key] = value;
       } else {
-        const classNameTuples: Array<$ReadOnly<[string, InjectableStyle]>> =
-          value.map((v) => (Array.isArray(v) ? v : null)).filter(Boolean);
+        // Remove nulls
+        const classNameTuples: $ReadOnlyArray<TClassNameTuples> = value
+          .map((v) => (Array.isArray(v) ? v : null))
+          .filter(Boolean);
+
+        classNameTuples.forEach(([_className, _, classesToOriginalPath]) => {
+          Object.assign(classPathsInNamespace, classesToOriginalPath);
+        });
+
         const className =
           classNameTuples.map(([className]) => className).join(' ') || null;
         namespaceObj[key] = className;
+
         for (const [className, injectable] of classNameTuples) {
           if (injectedStyles[className] == null) {
             injectedStyles[className] = injectable;
@@ -74,7 +110,8 @@ export default function styleXCreateSet(
       }
     }
     resolvedNamespaces[namespaceName] = { ...namespaceObj, $$css: true };
+    namespaceToClassPaths[namespaceName] = classPathsInNamespace;
   }
 
-  return [resolvedNamespaces, injectedStyles];
+  return [resolvedNamespaces, injectedStyles, namespaceToClassPaths];
 }

--- a/packages/shared/src/transform-value.js
+++ b/packages/shared/src/transform-value.js
@@ -141,7 +141,6 @@ export const lengthUnits: Set<string> = new Set([
   'borderBottomWidth',
   'borderEndEndRadius',
   'borderEndStartRadius',
-  // 'borderImageWidth', // can be a unitless number
   'borderInlineEndWidth',
   'borderEndWidth',
   'borderInlineStartWidth',
@@ -185,8 +184,6 @@ export const lengthUnits: Set<string> = new Set([
   'marginLeft',
   'marginRight',
   'marginTop',
-  'maskBorderOutset',
-  'maskBorderWidth',
   'maxBlockSize',
   'maxHeight',
   'maxInlineSize',


### PR DESCRIPTION
# More efficient dynamic styles

Dynamic Styles in StyleX are expressed as minimal arrow functions that return an arrow expression. These styles are then compiled into a function that returns a tuple of two objects — an object of static classNames and an object of inline styles that *only* sets some CSS variables.

The CSS variables defined as inline styles are used in the statically generated CSS as values for the properties that are to have a dynamic value.

## What changed

In this PR, the biggest change is that the object of static classNames is slightly more dynamic than before. Instead of statically returning classNames for all properties, the classNames are now only returned conditionally *when* the dynamic value passed into the function for that particular party is *not* null or undefined.

## What does that mean?

In short this means that after this change, if a property's dynamic value resolves to `null` or `undefined`, no className will be applied for that property at all.

This makes null dynamic values more efficient.

## But also,

Previously, the inline styles would default to `initial` when the dynamic value was `null` or `undefined`. Now they default to `undefined`. This will mean that when a value is `null` or `undefined`, instead of setting a CSS variable to `initial`, we will simply omit it from the inline styles which has the same effect.

This is also a small efficiency improvement.

## ~~What's still missing~~

Not anymore!
