### PR TITLE
fix: big refactor to enable cleaner dynamic styles within conditional…

### DIFF
--- a/packages/babel-plugin/__tests__/evaluation/stylex-fn-obj-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-fn-obj-evaluation-test.js
@@ -110,7 +110,7 @@ describe('custom path evaluation works as expected', () => {
     expect(result.value).toEqual({
       default: {
         borderStyle: 'dashed',
-        borderWidth: 'var(--borderWidth, revert)',
+        borderWidth: 'var(--borderWidth)',
         overflow: 'hidden',
       },
     });
@@ -240,7 +240,7 @@ describe('custom path evaluation works as expected', () => {
       default: {
         overflow: 'hidden',
         borderStyle: 'dashed',
-        borderWidth: 'var(--borderWidth, revert)',
+        borderWidth: 'var(--borderWidth)',
       },
     });
     expect(removeLoc(result.fns)).toMatchInlineSnapshot(`

--- a/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
@@ -329,10 +329,10 @@ describe('Evaluation of imported values works based on configuration', () => {
         import stylex from 'stylex';
         import 'otherFile.stylex';
         import { MyTheme } from 'otherFile.stylex';
-        _inject2(".__hashed_var__15x39w1{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb,revert)}", 1);
+        _inject2(".__hashed_var__b69i2g{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb)}", 1);
         const styles = {
           color: color => [{
-            "--__hashed_var__1jqb1tb": color == null ? null : "__hashed_var__15x39w1",
+            "--__hashed_var__1jqb1tb": color == null ? null : "__hashed_var__b69i2g",
             $$css: true
           }, {
             "----__hashed_var__1jqb1tb": color != null ? color : undefined
@@ -343,9 +343,9 @@ describe('Evaluation of imported values works based on configuration', () => {
       expect(transformation.metadata.stylex).toMatchInlineSnapshot(`
         [
           [
-            "__hashed_var__15x39w1",
+            "__hashed_var__b69i2g",
             {
-              "ltr": ".__hashed_var__15x39w1{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb,revert)}",
+              "ltr": ".__hashed_var__b69i2g{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb)}",
               "rtl": null,
             },
             1,

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -1189,11 +1189,11 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject2(".xfx01vb{color:var(--color)}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: color == null ? null : "x19dipnz",
+            color: color == null ? null : "xfx01vb",
             $$css: true
           }, {
             "--color": color != null ? color : undefined
@@ -1218,11 +1218,11 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x17fnjtu{width:var(--width,revert)}", 4000);
+        _inject2(".x1bl4301{width:var(--width)}", 4000);
         export const styles = {
           default: width => [{
             backgroundColor: "xrkmrrc",
-            width: width == null ? null : "x17fnjtu",
+            width: width == null ? null : "x1bl4301",
             $$css: true
           }, {
             "--width": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
@@ -1250,12 +1250,12 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject2(".xfx01vb{color:var(--color)}", 3000);
         _inject2(".x1mqxbix{color:black}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: color == null ? null : "x19dipnz",
+            color: color == null ? null : "xfx01vb",
             $$css: true
           }, {
             "--color": color != null ? color : undefined
@@ -1282,10 +1282,10 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
+        _inject2(".x15mgraa{--background-color:var(----background-color)}", 1);
         export const styles = {
           default: bgColor => [{
-            "--background-color": bgColor == null ? null : "xyv4n8w",
+            "--background-color": bgColor == null ? null : "x15mgraa",
             $$css: true
           }, {
             "----background-color": bgColor != null ? bgColor : undefined
@@ -1311,11 +1311,11 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x1gykpug:hover{background-color:red}", 3130);
-        _inject2(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
+        _inject2(".xtyu0qe:hover{color:var(--1ijzsae)}", 3130);
         export const styles = {
           default: color => [{
             ":hover_backgroundColor": "x1gykpug",
-            ":hover_color": color == null ? null : "x11bf1mc",
+            ":hover_color": color == null ? null : "xtyu0qe",
             $$css: true
           }, {
             "--1ijzsae": color != null ? color : undefined
@@ -1342,12 +1342,12 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject2(".xfx01vb{color:var(--color)}", 3000);
         _inject2(".x1mqxbix{color:black}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: color == null ? null : "x19dipnz",
+            color: color == null ? null : "xfx01vb",
             $$css: true
           }, {
             "--color": color != null ? color : undefined
@@ -1374,10 +1374,10 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
+        _inject2(".x15mgraa{--background-color:var(----background-color)}", 1);
         export const styles = {
           default: bgColor => [{
-            "--background-color": bgColor == null ? null : "xyv4n8w",
+            "--background-color": bgColor == null ? null : "x15mgraa",
             $$css: true
           }, {
             "----background-color": bgColor != null ? bgColor : undefined
@@ -1407,13 +1407,13 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x9lz66z{color:var(--4xs81a,revert)}", 3000);
+        _inject2(".x1n25116{color:var(--4xs81a)}", 3000);
         _inject2("@media (min-width: 1000px){.xtljkjt.xtljkjt:hover{color:green}}", 3330);
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: (color == null ? "" : "x9lz66z ") + "xtljkjt " + "x17z2mba",
+            color: (color == null ? "" : "x1n25116 ") + "xtljkjt " + "x17z2mba",
             $$css: true
           }, {
             "--4xs81a": color != null ? color : undefined
@@ -1443,17 +1443,64 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x9lz66z{color:var(--4xs81a,revert)}", 3000);
+        _inject2(".x1n25116{color:var(--4xs81a)}", 3000);
         _inject2("@media (min-width: 1000px){.xtljkjt.xtljkjt:hover{color:green}}", 3330);
-        _inject2(".x1pgt9tt:hover{color:var(--w5m4kq,revert)}", 3130);
+        _inject2(".x1d4gdy3:hover{color:var(--w5m4kq)}", 3130);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: (color == null ? "" : "x9lz66z ") + "xtljkjt " + ('color-mix(' + color + ', blue)' == null ? "" : "x1pgt9tt"),
+            color: (color == null ? "" : "x1n25116 ") + "xtljkjt " + ('color-mix(' + color + ', blue)' == null ? "" : "x1d4gdy3"),
             $$css: true
           }, {
             "--4xs81a": color != null ? color : undefined,
             "--w5m4kq": 'color-mix(' + color + ', blue)' != null ? 'color-mix(' + color + ', blue)' : undefined
+          }]
+        };"
+      `);
+    });
+
+    test('transforms shorthands in legacy-expand-shorthands mode', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            default: (margin) => ({
+              backgroundColor: 'red',
+              margin: {
+                default: margin,
+                ':hover': margin + 4,
+              },
+              marginTop: margin - 4,
+            })
+          });
+        `,
+          { styleResolution: 'legacy-expand-shorthands' },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".x1ie72y1{margin-right:var(--14mfytm)}", 3000, ".x1ie72y1{margin-left:var(--14mfytm)}");
+        _inject2(".x128459:hover{margin-right:var(--yepcm9)}", 3130, ".x128459:hover{margin-left:var(--yepcm9)}");
+        _inject2(".x1hvr6ea{margin-bottom:var(--14mfytm)}", 4000);
+        _inject2(".x3skgmg:hover{margin-bottom:var(--yepcm9)}", 4130);
+        _inject2(".x1k44ad6{margin-left:var(--14mfytm)}", 3000, ".x1k44ad6{margin-right:var(--14mfytm)}");
+        _inject2(".x10ktymb:hover{margin-left:var(--yepcm9)}", 3130, ".x10ktymb:hover{margin-right:var(--yepcm9)}");
+        _inject2(".x17zef60{margin-top:var(--marginTop)}", 4000);
+        export const styles = {
+          default: margin => [{
+            backgroundColor: "xrkmrrc",
+            marginEnd: (margin == null ? "" : "x1ie72y1 ") + (margin + 4 == null ? "" : "x128459"),
+            marginBottom: (margin == null ? "" : "x1hvr6ea ") + (margin + 4 == null ? "" : "x3skgmg"),
+            marginStart: (margin == null ? "" : "x1k44ad6 ") + (margin + 4 == null ? "" : "x10ktymb"),
+            marginTop: margin - 4 == null ? null : "x17zef60",
+            $$css: true
+          }, {
+            "--14mfytm": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin),
+            "--yepcm9": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin + 4),
+            "--marginTop": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin - 4)
           }]
         };"
       `);

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -847,12 +847,12 @@ describe('@stylexjs/babel-plugin', () => {
         _inject2(".xbsl7fq{border-style:dashed}", 2000);
         _inject2(".xn43iik{border-width:0 0 2px 0}", 2000);
         _inject2(".xmkeg23{border-width:1px}", 2000);
-        _inject2(".xa309fb{border-bottom-width:5px}", 4000);
         _inject2(".x1y0btm7{border-style:solid}", 2000);
-        _inject2(".x1q0q8m5{border-bottom-style:solid}", 4000);
         _inject2(".x1lh7sze{border-color:var(--divider)}", 2000);
-        _inject2(".xud65wk{border-bottom-color:red}", 4000);
         _inject2(".x12oqio5{border-radius:4px}", 2000);
+        _inject2(".xa309fb{border-bottom-width:5px}", 4000);
+        _inject2(".x1q0q8m5{border-bottom-style:solid}", 4000);
+        _inject2(".xud65wk{border-bottom-color:red}", 4000);
         _inject2(".x1lmef92{padding:calc((100% - 50px) * .5) var(--rightpadding,20px)}", 1000);
         _inject2(".xexx8yu{padding-top:0}", 4000);
         _inject2(".x1bg2uv5{border-color:green}", 2000);"
@@ -988,7 +988,6 @@ describe('@stylexjs/babel-plugin', () => {
             borderRightWidth: null,
             borderBlockWidth: null,
             borderTopWidth: null,
-            borderBottomWidth: "xa309fb",
             borderStyle: "x1y0btm7",
             borderInlineStyle: null,
             borderInlineStartStyle: null,
@@ -997,7 +996,6 @@ describe('@stylexjs/babel-plugin', () => {
             borderRightStyle: null,
             borderBlockStyle: null,
             borderTopStyle: null,
-            borderBottomStyle: "x1q0q8m5",
             borderColor: "x1lh7sze",
             borderInlineColor: null,
             borderInlineStartColor: null,
@@ -1006,7 +1004,6 @@ describe('@stylexjs/babel-plugin', () => {
             borderRightColor: null,
             borderBlockColor: null,
             borderTopColor: null,
-            borderBottomColor: "xud65wk",
             borderRadius: "x12oqio5",
             borderStartStartRadius: null,
             borderStartEndRadius: null,
@@ -1016,6 +1013,9 @@ describe('@stylexjs/babel-plugin', () => {
             borderTopRightRadius: null,
             borderBottomLeftRadius: null,
             borderBottomRightRadius: null,
+            borderBottomWidth: "xa309fb",
+            borderBottomStyle: "x1q0q8m5",
+            borderBottomColor: "xud65wk",
             $$css: true
           },
           short: {
@@ -1026,12 +1026,11 @@ describe('@stylexjs/babel-plugin', () => {
             paddingEnd: null,
             paddingRight: null,
             paddingBlock: null,
-            paddingTop: "xexx8yu",
             paddingBottom: null,
+            paddingTop: "xexx8yu",
             $$css: true
           },
           shortReversed: {
-            paddingTop: null,
             padding: "x1lmef92",
             paddingInline: null,
             paddingStart: null,
@@ -1039,6 +1038,7 @@ describe('@stylexjs/babel-plugin', () => {
             paddingEnd: null,
             paddingRight: null,
             paddingBlock: null,
+            paddingTop: null,
             paddingBottom: null,
             $$css: true
           },
@@ -1413,10 +1413,47 @@ describe('@stylexjs/babel-plugin', () => {
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: "x9lz66z xtljkjt x17z2mba",
+            color: [color == null ? null : "x9lz66z", "xtljkjt", "x17z2mba"].filter(Boolean).join(" "),
             $$css: true
           }, {
             "--4xs81a": color != null ? color : undefined
+          }]
+        };"
+      `);
+    });
+    test('transforms functions with multiple dynamic values within conditional values', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            default: (color) => ({
+              backgroundColor: 'red',
+              color: {
+                default: color,
+                ':hover': {
+                  '@media (min-width: 1000px)': 'green',
+                  default: 'color-mix(' + color + ', blue)',
+                }
+              },
+            }),
+          });
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".x9lz66z{color:var(--4xs81a,revert)}", 3000);
+        _inject2("@media (min-width: 1000px){.xtljkjt.xtljkjt:hover{color:green}}", 3330);
+        _inject2(".x1pgt9tt:hover{color:var(--w5m4kq,revert)}", 3130);
+        export const styles = {
+          default: color => [{
+            backgroundColor: "xrkmrrc",
+            color: [color == null ? null : "x9lz66z", "xtljkjt", 'color-mix(' + color + ', blue)' == null ? null : "x1pgt9tt"].filter(Boolean).join(" "),
+            $$css: true
+          }, {
+            "--4xs81a": color != null ? color : undefined,
+            "--w5m4kq": 'color-mix(' + color + ', blue)' != null ? 'color-mix(' + color + ', blue)' : undefined
           }]
         };"
       `);

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -1413,7 +1413,7 @@ describe('@stylexjs/babel-plugin', () => {
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: [color == null ? null : "x9lz66z", "xtljkjt", "x17z2mba"].filter(Boolean).join(" "),
+            color: (color == null ? "" : "x9lz66z ") + "xtljkjt " + "x17z2mba",
             $$css: true
           }, {
             "--4xs81a": color != null ? color : undefined
@@ -1449,7 +1449,7 @@ describe('@stylexjs/babel-plugin', () => {
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: [color == null ? null : "x9lz66z", "xtljkjt", 'color-mix(' + color + ', blue)' == null ? null : "x1pgt9tt"].filter(Boolean).join(" "),
+            color: (color == null ? "" : "x9lz66z ") + "xtljkjt " + ('color-mix(' + color + ', blue)' == null ? "" : "x1pgt9tt"),
             $$css: true
           }, {
             "--4xs81a": color != null ? color : undefined,

--- a/packages/babel-plugin/__tests__/stylex-transform-legacy-shorthands-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-legacy-shorthands-test.js
@@ -92,9 +92,9 @@ describe('Legacy-shorthand-expansion resolution', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
-        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);
         _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".x1nn3v0j{padding-top:2px}", 4000);
         _inject2(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
         _inject2(".x1120s5i{padding-bottom:2px}", 4000);
@@ -124,9 +124,9 @@ describe('Legacy-shorthand-expansion resolution', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
-        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);
         _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".x1nn3v0j{padding-top:2px}", 4000);
         _inject2(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
         _inject2(".x1120s5i{padding-bottom:2px}", 4000);
@@ -155,9 +155,9 @@ describe('Legacy-shorthand-expansion resolution', () => {
         export const styles = {
           foo: {
             paddingStart: "x1t2a60a",
+            paddingEnd: "x1mpkggp",
             paddingLeft: null,
             paddingRight: null,
-            paddingEnd: "x1mpkggp",
             $$css: true
           }
         };
@@ -186,9 +186,9 @@ describe('Legacy-shorthand-expansion resolution', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
-        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);
         _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".x1nn3v0j{padding-top:2px}", 4000);
         _inject2(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
         _inject2(".x1120s5i{padding-bottom:2px}", 4000);
@@ -218,9 +218,9 @@ describe('Legacy-shorthand-expansion resolution', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x123j3cw{padding-top:5px}", 4000);
-        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".xs9asl8{padding-bottom:5px}", 4000);
         _inject2(".x1t2a60a{padding-left:5px}", 3000, ".x1t2a60a{padding-right:5px}");
+        _inject2(".x1iji9kk{padding-right:10px}", 3000, ".x1iji9kk{padding-left:10px}");
         _inject2(".x1nn3v0j{padding-top:2px}", 4000);
         _inject2(".xg83lxy{padding-right:2px}", 3000, ".xg83lxy{padding-left:2px}");
         _inject2(".x1120s5i{padding-bottom:2px}", 4000);

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -69,10 +69,6 @@ export default function transformStyleXCreate(
     > = path.get('arguments');
     const firstArg = args[0];
 
-    // TODO: This should be removed soon since we should disallow spreads without
-    // `stylex.include` in the future.
-    // preProcessStyleArg(firstArg, state);
-
     state.inStyleXCreate = true;
 
     const injectedKeyframes: { [animationName: string]: InjectableStyle } = {};
@@ -214,7 +210,7 @@ export default function transformStyleXCreate(
                   const dynamicMatch = dynamicStyles.filter(
                     ({ key }) => key === propKey,
                   );
-                  if (dynamicMatch.length !== 0) {
+                  if (dynamicMatch.length > 0) {
                     const value = objProp.value;
                     if (t.isStringLiteral(value)) {
                       const classList = value.value.split(' ');

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -29,6 +29,7 @@ import {
 import { messages } from '@stylexjs/shared';
 import * as pathUtils from '../../babel-path-utils';
 import { evaluateStyleXCreateArg } from './parse-stylex-create-arg';
+import flatMapExpandedShorthands from '@stylexjs/shared/lib/preprocess-rules';
 
 /// This function looks for `stylex.create` calls and transforms them.
 /// 1. It finds the first argument to `stylex.create` and validates it.
@@ -171,7 +172,7 @@ export default function transformStyleXCreate(
               origClassPaths[className] = classPaths.join('_');
             }
 
-            const dynamicStyles: $ReadOnlyArray<{
+            let dynamicStyles: $ReadOnlyArray<{
               +expression: t.Expression,
               +key: string,
               path: string,
@@ -187,6 +188,10 @@ export default function transformStyleXCreate(
                 .join('_'),
               path: v.path.join('_'),
             }));
+
+            if (state.options.styleResolution === 'legacy-expand-shorthands') {
+              dynamicStyles = legacyExpandShorthands(dynamicStyles);
+            }
 
             if (t.isObjectExpression(prop.value)) {
               const value: t.ObjectExpression = prop.value;
@@ -332,4 +337,43 @@ function findNearestStatementAncestor(path: NodePath<>): NodePath<t.Statement> {
     throw new Error('Unexpected Path found that is not part of the AST.');
   }
   return findNearestStatementAncestor(path.parentPath);
+}
+
+function legacyExpandShorthands(
+  dynamicStyles: $ReadOnlyArray<{
+    +expression: t.Expression,
+    +key: string,
+    path: string,
+  }>,
+): $ReadOnlyArray<{
+  +expression: t.Expression,
+  +key: string,
+  path: string,
+}> {
+  const expandedKeysToKeyPaths = dynamicStyles
+    .flatMap(({ key }, i) => {
+      return flatMapExpandedShorthands([key, 'p' + i], {
+        styleResolution: 'legacy-expand-shorthands',
+      });
+    })
+    .map(([key, value]) => {
+      if (typeof value !== 'string') {
+        return null;
+      }
+      const index = parseInt(value.slice(1), 10);
+      const thatDynStyle = dynamicStyles[index];
+      return {
+        ...thatDynStyle,
+        key,
+        path:
+          thatDynStyle.path === thatDynStyle.key
+            ? key
+            : thatDynStyle.path.includes(thatDynStyle.key + '_')
+              ? thatDynStyle.path.replace(thatDynStyle.key + '_', key + '_')
+              : thatDynStyle.path.replace('_' + thatDynStyle.key, '_' + key),
+      };
+    })
+    .filter(Boolean);
+
+  return expandedKeysToKeyPaths;
 }

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -237,32 +237,33 @@ export default function transformStyleXCreate(
                           ),
                         )
                       ) {
-                        const arrExpr = t.arrayExpression(
-                          classList.map((cls) => {
+                        const exprArray: $ReadOnlyArray<t.Expression> =
+                          classList.map((cls, index) => {
                             const expr = dynamicMatch.find(
                               ({ path }) => origClassPaths[cls] === path,
                             )?.expression;
+                            const suffix =
+                              index === classList.length - 1 ? '' : ' ';
                             if (expr != null) {
                               return t.conditionalExpression(
                                 t.binaryExpression('==', expr, t.nullLiteral()),
-                                t.nullLiteral(),
-                                t.stringLiteral(cls),
+                                t.stringLiteral(''),
+                                t.stringLiteral(cls + suffix),
                               );
                             }
-                            return t.stringLiteral(cls);
-                          }),
-                        );
-                        const filteredArrExpr = t.callExpression(
-                          t.memberExpression(arrExpr, t.identifier('filter')),
-                          [t.identifier('Boolean')],
-                        );
+                            return t.stringLiteral(cls + suffix);
+                          });
 
-                        objProp.value = t.callExpression(
-                          t.memberExpression(
-                            filteredArrExpr,
-                            t.identifier('join'),
-                          ),
-                          [t.stringLiteral(' ')],
+                        const [first, ...rest] = exprArray;
+
+                        objProp.value = rest.reduce(
+                          (
+                            acc: t.Expression,
+                            curr: t.Expression,
+                          ): t.Expression => {
+                            return t.binaryExpression('+', acc, curr);
+                          },
+                          first as t.Expression,
                         );
                       }
                     }

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -188,9 +188,6 @@ export default function transformStyleXCreate(
               path: v.path.join('_'),
             }));
 
-            // console.log('dynamicStyles', dynamicStyles);
-            // console.log('origClassPaths', origClassPaths);
-
             if (t.isObjectExpression(prop.value)) {
               const value: t.ObjectExpression = prop.value;
 

--- a/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
@@ -169,21 +169,28 @@ function evaluatePartialObjectRecursively(
       } else {
         const result = evaluate(valuePath, traversalState, functions);
         if (!result.confident) {
+          const fullKeyPath = [...keyPath, key];
           const varName =
             '--' +
             (keyPath.length > 0
               ? utils.hash([...keyPath, key].join('_'))
               : key);
-          obj[key] = `var(${varName}, revert)`;
+          obj[key] = `var(${varName})`;
           const node = valuePath.node;
           if (!t.isExpression(node)) {
             throw new Error('Expected expression as style value');
           }
           const expression: t.Expression = node as $FlowFixMe;
 
+          const propName =
+            fullKeyPath.find(
+              (k) =>
+                !k.startsWith(':') && !k.startsWith('@') && k !== 'default',
+            ) ?? key;
+
           const unit =
-            timeUnits.has(key) || lengthUnits.has(key)
-              ? getNumberSuffix(key)
+            timeUnits.has(propName) || lengthUnits.has(propName)
+              ? getNumberSuffix(propName)
               : '';
 
           const inlineStyleExpression =

--- a/packages/shared/__tests__/flatten-raw-style-objects/legacy-shorthand-expansion-test.js
+++ b/packages/shared/__tests__/flatten-raw-style-objects/legacy-shorthand-expansion-test.js
@@ -51,8 +51,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['rowGap', new PreRule('rowGap', 10)],
-        ['columnGap', new PreRule('columnGap', 10)],
+        ['rowGap', new PreRule('rowGap', 10, ['gap'])],
+        ['columnGap', new PreRule('columnGap', 10, ['gap'])],
       ]);
     });
 
@@ -65,8 +65,14 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['containIntrinsicWidth', new PreRule('containIntrinsicWidth', 10)],
-        ['containIntrinsicHeight', new PreRule('containIntrinsicHeight', 10)],
+        [
+          'containIntrinsicWidth',
+          new PreRule('containIntrinsicWidth', 10, ['containIntrinsicSize']),
+        ],
+        [
+          'containIntrinsicHeight',
+          new PreRule('containIntrinsicHeight', 10, ['containIntrinsicSize']),
+        ],
       ]);
     });
 
@@ -128,8 +134,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['rowGap', new PreRule('rowGap', '10px')],
-        ['columnGap', new PreRule('columnGap', '20px')],
+        ['rowGap', new PreRule('rowGap', '10px', ['gap'])],
+        ['columnGap', new PreRule('columnGap', '20px', ['gap'])],
       ]);
     });
 
@@ -144,8 +150,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, '10px')],
-        [h, new PreRule(h, '20px')],
+        [w, new PreRule(w, '10px', ['containIntrinsicSize'])],
+        [h, new PreRule(h, '20px', ['containIntrinsicSize'])],
       ]);
       expect(
         flattenRawStyleObject(
@@ -155,8 +161,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, 'auto 10px')],
-        [h, new PreRule(h, '20px')],
+        [w, new PreRule(w, 'auto 10px', ['containIntrinsicSize'])],
+        [h, new PreRule(h, '20px', ['containIntrinsicSize'])],
       ]);
       expect(
         flattenRawStyleObject(
@@ -166,8 +172,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, '10px')],
-        [h, new PreRule(h, 'auto 20px')],
+        [w, new PreRule(w, '10px', ['containIntrinsicSize'])],
+        [h, new PreRule(h, 'auto 20px', ['containIntrinsicSize'])],
       ]);
       expect(
         flattenRawStyleObject(
@@ -177,8 +183,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, 'auto 10px')],
-        [h, new PreRule(h, 'auto 20px')],
+        [w, new PreRule(w, 'auto 10px', ['containIntrinsicSize'])],
+        [h, new PreRule(h, 'auto 20px', ['containIntrinsicSize'])],
       ]);
     });
 

--- a/packages/shared/__tests__/flatten-raw-style-objects/legacy-shorthand-expansion-test.js
+++ b/packages/shared/__tests__/flatten-raw-style-objects/legacy-shorthand-expansion-test.js
@@ -51,8 +51,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['rowGap', new PreRule('rowGap', 10, ['gap'])],
-        ['columnGap', new PreRule('columnGap', 10, ['gap'])],
+        ['rowGap', new PreRule('rowGap', 10, ['rowGap'])],
+        ['columnGap', new PreRule('columnGap', 10, ['columnGap'])],
       ]);
     });
 
@@ -67,30 +67,30 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
       ).toEqual([
         [
           'containIntrinsicWidth',
-          new PreRule('containIntrinsicWidth', 10, ['containIntrinsicSize']),
+          new PreRule('containIntrinsicWidth', 10, ['containIntrinsicWidth']),
         ],
         [
           'containIntrinsicHeight',
-          new PreRule('containIntrinsicHeight', 10, ['containIntrinsicSize']),
+          new PreRule('containIntrinsicHeight', 10, ['containIntrinsicHeight']),
         ],
       ]);
     });
 
     test('should expand simple shorthands', () => {
       expect(flattenRawStyleObject({ margin: 10 }, options)).toEqual([
-        ['marginTop', new PreRule('marginTop', 10, ['margin'])],
-        ['marginEnd', new PreRule('marginEnd', 10, ['margin'])],
-        ['marginBottom', new PreRule('marginBottom', 10, ['margin'])],
-        ['marginStart', new PreRule('marginStart', 10, ['margin'])],
+        ['marginTop', new PreRule('marginTop', 10, ['marginTop'])],
+        ['marginEnd', new PreRule('marginEnd', 10, ['marginEnd'])],
+        ['marginBottom', new PreRule('marginBottom', 10, ['marginBottom'])],
+        ['marginStart', new PreRule('marginStart', 10, ['marginStart'])],
       ]);
 
       expect(
         flattenRawStyleObject({ margin: 10, marginBottom: 20 }, options),
       ).toEqual([
-        ['marginTop', new PreRule('marginTop', 10, ['margin'])],
-        ['marginEnd', new PreRule('marginEnd', 10, ['margin'])],
-        ['marginBottom', new PreRule('marginBottom', 10, ['margin'])],
-        ['marginStart', new PreRule('marginStart', 10, ['margin'])],
+        ['marginTop', new PreRule('marginTop', 10, ['marginTop'])],
+        ['marginEnd', new PreRule('marginEnd', 10, ['marginEnd'])],
+        ['marginBottom', new PreRule('marginBottom', 10, ['marginBottom'])],
+        ['marginStart', new PreRule('marginStart', 10, ['marginStart'])],
         ['marginBottom', new PreRule('marginBottom', 20, ['marginBottom'])],
       ]);
     });
@@ -102,25 +102,25 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['marginTop', new PreRule('marginTop', '10px', ['margin'])],
-        ['marginEnd', new PreRule('marginEnd', '20px', ['margin'])],
-        ['marginBottom', new PreRule('marginBottom', '10px', ['margin'])],
-        ['marginStart', new PreRule('marginStart', '20px', ['margin'])],
+        ['marginTop', new PreRule('marginTop', '10px', ['marginTop'])],
+        ['marginEnd', new PreRule('marginEnd', '20px', ['marginEnd'])],
+        ['marginBottom', new PreRule('marginBottom', '10px', ['marginBottom'])],
+        ['marginStart', new PreRule('marginStart', '20px', ['marginStart'])],
         [
           'borderTopColor',
-          new PreRule('borderTopColor', 'red', ['borderColor']),
+          new PreRule('borderTopColor', 'red', ['borderTopColor']),
         ],
         [
           'borderEndColor',
-          new PreRule('borderEndColor', 'red', ['borderColor']),
+          new PreRule('borderEndColor', 'red', ['borderEndColor']),
         ],
         [
           'borderBottomColor',
-          new PreRule('borderBottomColor', 'red', ['borderColor']),
+          new PreRule('borderBottomColor', 'red', ['borderBottomColor']),
         ],
         [
           'borderStartColor',
-          new PreRule('borderStartColor', 'red', ['borderColor']),
+          new PreRule('borderStartColor', 'red', ['borderStartColor']),
         ],
       ]);
     });
@@ -134,8 +134,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['rowGap', new PreRule('rowGap', '10px', ['gap'])],
-        ['columnGap', new PreRule('columnGap', '20px', ['gap'])],
+        ['rowGap', new PreRule('rowGap', '10px', ['rowGap'])],
+        ['columnGap', new PreRule('columnGap', '20px', ['columnGap'])],
       ]);
     });
 
@@ -150,8 +150,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, '10px', ['containIntrinsicSize'])],
-        [h, new PreRule(h, '20px', ['containIntrinsicSize'])],
+        [w, new PreRule(w, '10px', [w])],
+        [h, new PreRule(h, '20px', [h])],
       ]);
       expect(
         flattenRawStyleObject(
@@ -161,8 +161,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, 'auto 10px', ['containIntrinsicSize'])],
-        [h, new PreRule(h, '20px', ['containIntrinsicSize'])],
+        [w, new PreRule(w, 'auto 10px', [w])],
+        [h, new PreRule(h, '20px', [h])],
       ]);
       expect(
         flattenRawStyleObject(
@@ -172,8 +172,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, '10px', ['containIntrinsicSize'])],
-        [h, new PreRule(h, 'auto 20px', ['containIntrinsicSize'])],
+        [w, new PreRule(w, '10px', [w])],
+        [h, new PreRule(h, 'auto 20px', [h])],
       ]);
       expect(
         flattenRawStyleObject(
@@ -183,8 +183,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, 'auto 10px', ['containIntrinsicSize'])],
-        [h, new PreRule(h, 'auto 20px', ['containIntrinsicSize'])],
+        [w, new PreRule(w, 'auto 10px', [w])],
+        [h, new PreRule(h, 'auto 20px', [h])],
       ]);
     });
 
@@ -192,13 +192,16 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
       expect(
         flattenRawStyleObject({ margin: ['10vh 20px', '10dvh 20px'] }, options),
       ).toEqual([
-        ['marginTop', new PreRule('marginTop', ['10vh', '10dvh'], ['margin'])],
-        ['marginEnd', new PreRule('marginEnd', '20px', ['margin'])],
+        [
+          'marginTop',
+          new PreRule('marginTop', ['10vh', '10dvh'], ['marginTop']),
+        ],
+        ['marginEnd', new PreRule('marginEnd', '20px', ['marginEnd'])],
         [
           'marginBottom',
-          new PreRule('marginBottom', ['10vh', '10dvh'], ['margin']),
+          new PreRule('marginBottom', ['10vh', '10dvh'], ['marginBottom']),
         ],
-        ['marginStart', new PreRule('marginStart', '20px', ['margin'])],
+        ['marginStart', new PreRule('marginStart', '20px', ['marginStart'])],
       ]);
     });
   });
@@ -297,29 +300,29 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'marginTop',
           PreRuleSet.create([
-            new PreRule('marginTop', 0, ['margin', 'default']),
-            new PreRule('marginTop', 10, ['margin', ':hover']),
+            new PreRule('marginTop', 0, ['marginTop', 'default']),
+            new PreRule('marginTop', 10, ['marginTop', ':hover']),
           ]),
         ],
         [
           'marginEnd',
           PreRuleSet.create([
-            new PreRule('marginEnd', 0, ['margin', 'default']),
-            new PreRule('marginEnd', 10, ['margin', ':hover']),
+            new PreRule('marginEnd', 0, ['marginEnd', 'default']),
+            new PreRule('marginEnd', 10, ['marginEnd', ':hover']),
           ]),
         ],
         [
           'marginBottom',
           PreRuleSet.create([
-            new PreRule('marginBottom', 0, ['margin', 'default']),
-            new PreRule('marginBottom', 10, ['margin', ':hover']),
+            new PreRule('marginBottom', 0, ['marginBottom', 'default']),
+            new PreRule('marginBottom', 10, ['marginBottom', ':hover']),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', 0, ['margin', 'default']),
-            new PreRule('marginStart', 10, ['margin', ':hover']),
+            new PreRule('marginStart', 0, ['marginStart', 'default']),
+            new PreRule('marginStart', 10, ['marginStart', ':hover']),
           ]),
         ],
       ]);
@@ -350,29 +353,29 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'marginTop',
           PreRuleSet.create([
-            new PreRule('marginTop', '1px', ['margin', 'default']),
-            new PreRule('marginTop', '10px', ['margin', ':hover']),
+            new PreRule('marginTop', '1px', ['marginTop', 'default']),
+            new PreRule('marginTop', '10px', ['marginTop', ':hover']),
           ]),
         ],
         [
           'marginEnd',
           PreRuleSet.create([
-            new PreRule('marginEnd', '2px', ['margin', 'default']),
-            new PreRule('marginEnd', '20px', ['margin', ':hover']),
+            new PreRule('marginEnd', '2px', ['marginEnd', 'default']),
+            new PreRule('marginEnd', '20px', ['marginEnd', ':hover']),
           ]),
         ],
         [
           'marginBottom',
           PreRuleSet.create([
-            new PreRule('marginBottom', '3px', ['margin', 'default']),
-            new PreRule('marginBottom', '10px', ['margin', ':hover']),
+            new PreRule('marginBottom', '3px', ['marginBottom', 'default']),
+            new PreRule('marginBottom', '10px', ['marginBottom', ':hover']),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', '4px', ['margin', 'default']),
-            new PreRule('marginStart', '20px', ['margin', ':hover']),
+            new PreRule('marginStart', '4px', ['marginStart', 'default']),
+            new PreRule('marginStart', '20px', ['marginStart', ':hover']),
           ]),
         ],
       ]);
@@ -439,29 +442,37 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'marginTop',
           PreRuleSet.create([
-            new PreRule('marginTop', '1px', ['margin', 'default']),
-            new PreRule('marginTop', ['10px', '1dvh'], ['margin', ':hover']),
+            new PreRule('marginTop', '1px', ['marginTop', 'default']),
+            new PreRule('marginTop', ['10px', '1dvh'], ['marginTop', ':hover']),
           ]),
         ],
         [
           'marginEnd',
           PreRuleSet.create([
-            new PreRule('marginEnd', '2px', ['margin', 'default']),
-            new PreRule('marginEnd', ['20px', '2dvw'], ['margin', ':hover']),
+            new PreRule('marginEnd', '2px', ['marginEnd', 'default']),
+            new PreRule('marginEnd', ['20px', '2dvw'], ['marginEnd', ':hover']),
           ]),
         ],
         [
           'marginBottom',
           PreRuleSet.create([
-            new PreRule('marginBottom', '3px', ['margin', 'default']),
-            new PreRule('marginBottom', ['10px', '1dvh'], ['margin', ':hover']),
+            new PreRule('marginBottom', '3px', ['marginBottom', 'default']),
+            new PreRule(
+              'marginBottom',
+              ['10px', '1dvh'],
+              ['marginBottom', ':hover'],
+            ),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', '4px', ['margin', 'default']),
-            new PreRule('marginStart', ['20px', '2dvw'], ['margin', ':hover']),
+            new PreRule('marginStart', '4px', ['marginStart', 'default']),
+            new PreRule(
+              'marginStart',
+              ['20px', '2dvw'],
+              ['marginStart', ':hover'],
+            ),
           ]),
         ],
       ]);

--- a/packages/shared/__tests__/flatten-raw-style-objects/legacy-shorthand-expansion-test.js
+++ b/packages/shared/__tests__/flatten-raw-style-objects/legacy-shorthand-expansion-test.js
@@ -35,8 +35,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['color', new PreRule('color', 'red')],
-        ['marginStart', new PreRule('marginStart', 10)],
+        ['color', new PreRule('color', 'red', ['color'])],
+        ['marginStart', new PreRule('marginStart', 10, ['marginStart'])],
         ['marginLeft', new NullPreRule()],
         ['marginRight', new NullPreRule()],
       ]);
@@ -72,20 +72,20 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
 
     test('should expand simple shorthands', () => {
       expect(flattenRawStyleObject({ margin: 10 }, options)).toEqual([
-        ['marginTop', new PreRule('marginTop', 10)],
-        ['marginEnd', new PreRule('marginEnd', 10)],
-        ['marginBottom', new PreRule('marginBottom', 10)],
-        ['marginStart', new PreRule('marginStart', 10)],
+        ['marginTop', new PreRule('marginTop', 10, ['margin'])],
+        ['marginEnd', new PreRule('marginEnd', 10, ['margin'])],
+        ['marginBottom', new PreRule('marginBottom', 10, ['margin'])],
+        ['marginStart', new PreRule('marginStart', 10, ['margin'])],
       ]);
 
       expect(
         flattenRawStyleObject({ margin: 10, marginBottom: 20 }, options),
       ).toEqual([
-        ['marginTop', new PreRule('marginTop', 10)],
-        ['marginEnd', new PreRule('marginEnd', 10)],
-        ['marginBottom', new PreRule('marginBottom', 10)],
-        ['marginStart', new PreRule('marginStart', 10)],
-        ['marginBottom', new PreRule('marginBottom', 20)],
+        ['marginTop', new PreRule('marginTop', 10, ['margin'])],
+        ['marginEnd', new PreRule('marginEnd', 10, ['margin'])],
+        ['marginBottom', new PreRule('marginBottom', 10, ['margin'])],
+        ['marginStart', new PreRule('marginStart', 10, ['margin'])],
+        ['marginBottom', new PreRule('marginBottom', 20, ['marginBottom'])],
       ]);
     });
 
@@ -96,14 +96,26 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['marginTop', new PreRule('marginTop', '10px')],
-        ['marginEnd', new PreRule('marginEnd', '20px')],
-        ['marginBottom', new PreRule('marginBottom', '10px')],
-        ['marginStart', new PreRule('marginStart', '20px')],
-        ['borderTopColor', new PreRule('borderTopColor', 'red')],
-        ['borderEndColor', new PreRule('borderEndColor', 'red')],
-        ['borderBottomColor', new PreRule('borderBottomColor', 'red')],
-        ['borderStartColor', new PreRule('borderStartColor', 'red')],
+        ['marginTop', new PreRule('marginTop', '10px', ['margin'])],
+        ['marginEnd', new PreRule('marginEnd', '20px', ['margin'])],
+        ['marginBottom', new PreRule('marginBottom', '10px', ['margin'])],
+        ['marginStart', new PreRule('marginStart', '20px', ['margin'])],
+        [
+          'borderTopColor',
+          new PreRule('borderTopColor', 'red', ['borderColor']),
+        ],
+        [
+          'borderEndColor',
+          new PreRule('borderEndColor', 'red', ['borderColor']),
+        ],
+        [
+          'borderBottomColor',
+          new PreRule('borderBottomColor', 'red', ['borderColor']),
+        ],
+        [
+          'borderStartColor',
+          new PreRule('borderStartColor', 'red', ['borderColor']),
+        ],
       ]);
     });
 
@@ -174,10 +186,13 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
       expect(
         flattenRawStyleObject({ margin: ['10vh 20px', '10dvh 20px'] }, options),
       ).toEqual([
-        ['marginTop', new PreRule('marginTop', ['10vh', '10dvh'])],
-        ['marginEnd', new PreRule('marginEnd', '20px')],
-        ['marginBottom', new PreRule('marginBottom', ['10vh', '10dvh'])],
-        ['marginStart', new PreRule('marginStart', '20px')],
+        ['marginTop', new PreRule('marginTop', ['10vh', '10dvh'], ['margin'])],
+        ['marginEnd', new PreRule('marginEnd', '20px', ['margin'])],
+        [
+          'marginBottom',
+          new PreRule('marginBottom', ['10vh', '10dvh'], ['margin']),
+        ],
+        ['marginStart', new PreRule('marginStart', '20px', ['margin'])],
       ]);
     });
   });
@@ -197,12 +212,15 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['color', new PreRule('color', 'blue')],
-        ['marginStart', new PreRule('marginStart', 0)],
+        ['color', new PreRule('color', 'blue', ['color'])],
+        ['marginStart', new PreRule('marginStart', 0, ['marginStart'])],
         ['marginLeft', new NullPreRule()],
         ['marginRight', new NullPreRule()],
-        [':hover_color', new PreRule('color', 'red', [':hover'], [])],
-        [':hover_marginStart', new PreRule('marginStart', 10, [':hover'], [])],
+        [':hover_color', new PreRule('color', 'red', [':hover', 'color'])],
+        [
+          ':hover_marginStart',
+          new PreRule('marginStart', 10, [':hover', 'marginStart']),
+        ],
         [':hover_marginLeft', new NullPreRule()],
         [':hover_marginRight', new NullPreRule()],
       ]);
@@ -226,15 +244,15 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'color',
           PreRuleSet.create([
-            new PreRule('color', 'blue'),
-            new PreRule('color', 'red', [':hover'], []),
+            new PreRule('color', 'blue', ['color', 'default']),
+            new PreRule('color', 'red', ['color', ':hover']),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', 0),
-            new PreRule('marginStart', 10, [':hover'], []),
+            new PreRule('marginStart', 0, ['marginStart', 'default']),
+            new PreRule('marginStart', 10, ['marginStart', ':hover']),
           ]),
         ],
         [
@@ -266,36 +284,36 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'color',
           PreRuleSet.create([
-            new PreRule('color', 'blue'),
-            new PreRule('color', 'red', [':hover'], []),
+            new PreRule('color', 'blue', ['color', 'default']),
+            new PreRule('color', 'red', ['color', ':hover']),
           ]),
         ],
         [
           'marginTop',
           PreRuleSet.create([
-            new PreRule('marginTop', 0),
-            new PreRule('marginTop', 10, [':hover'], []),
+            new PreRule('marginTop', 0, ['margin', 'default']),
+            new PreRule('marginTop', 10, ['margin', ':hover']),
           ]),
         ],
         [
           'marginEnd',
           PreRuleSet.create([
-            new PreRule('marginEnd', 0),
-            new PreRule('marginEnd', 10, [':hover'], []),
+            new PreRule('marginEnd', 0, ['margin', 'default']),
+            new PreRule('marginEnd', 10, ['margin', ':hover']),
           ]),
         ],
         [
           'marginBottom',
           PreRuleSet.create([
-            new PreRule('marginBottom', 0),
-            new PreRule('marginBottom', 10, [':hover'], []),
+            new PreRule('marginBottom', 0, ['margin', 'default']),
+            new PreRule('marginBottom', 10, ['margin', ':hover']),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', 0),
-            new PreRule('marginStart', 10, [':hover'], []),
+            new PreRule('marginStart', 0, ['margin', 'default']),
+            new PreRule('marginStart', 10, ['margin', ':hover']),
           ]),
         ],
       ]);
@@ -319,36 +337,36 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'color',
           PreRuleSet.create([
-            new PreRule('color', 'blue'),
-            new PreRule('color', 'red', [':hover'], []),
+            new PreRule('color', 'blue', ['color', 'default']),
+            new PreRule('color', 'red', ['color', ':hover']),
           ]),
         ],
         [
           'marginTop',
           PreRuleSet.create([
-            new PreRule('marginTop', '1px'),
-            new PreRule('marginTop', '10px', [':hover'], []),
+            new PreRule('marginTop', '1px', ['margin', 'default']),
+            new PreRule('marginTop', '10px', ['margin', ':hover']),
           ]),
         ],
         [
           'marginEnd',
           PreRuleSet.create([
-            new PreRule('marginEnd', '2px'),
-            new PreRule('marginEnd', '20px', [':hover'], []),
+            new PreRule('marginEnd', '2px', ['margin', 'default']),
+            new PreRule('marginEnd', '20px', ['margin', ':hover']),
           ]),
         ],
         [
           'marginBottom',
           PreRuleSet.create([
-            new PreRule('marginBottom', '3px'),
-            new PreRule('marginBottom', '10px', [':hover'], []),
+            new PreRule('marginBottom', '3px', ['margin', 'default']),
+            new PreRule('marginBottom', '10px', ['margin', ':hover']),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', '4px'),
-            new PreRule('marginStart', '20px', [':hover'], []),
+            new PreRule('marginStart', '4px', ['margin', 'default']),
+            new PreRule('marginStart', '20px', ['margin', ':hover']),
           ]),
         ],
       ]);
@@ -373,16 +391,19 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'color',
           PreRuleSet.create([
-            new PreRule('color', 'blue'),
-            new PreRule('color', 'red', [':hover'], []),
-            new PreRule('color', 'green', [], ['@media (min-width: 300px)']),
+            new PreRule('color', 'blue', ['color', 'default']),
+            new PreRule('color', 'red', ['color', ':hover']),
+            new PreRule('color', 'green', [
+              'color',
+              '@media (min-width: 300px)',
+            ]),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', 0),
-            new PreRule('marginStart', 10, [':hover'], []),
+            new PreRule('marginStart', 0, ['marginStart', 'default']),
+            new PreRule('marginStart', 10, ['marginStart', ':hover']),
           ]),
         ],
         [
@@ -412,29 +433,29 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'marginTop',
           PreRuleSet.create([
-            new PreRule('marginTop', '1px'),
-            new PreRule('marginTop', ['10px', '1dvh'], [':hover'], []),
+            new PreRule('marginTop', '1px', ['margin', 'default']),
+            new PreRule('marginTop', ['10px', '1dvh'], ['margin', ':hover']),
           ]),
         ],
         [
           'marginEnd',
           PreRuleSet.create([
-            new PreRule('marginEnd', '2px'),
-            new PreRule('marginEnd', ['20px', '2dvw'], [':hover'], []),
+            new PreRule('marginEnd', '2px', ['margin', 'default']),
+            new PreRule('marginEnd', ['20px', '2dvw'], ['margin', ':hover']),
           ]),
         ],
         [
           'marginBottom',
           PreRuleSet.create([
-            new PreRule('marginBottom', '3px'),
-            new PreRule('marginBottom', ['10px', '1dvh'], [':hover'], []),
+            new PreRule('marginBottom', '3px', ['margin', 'default']),
+            new PreRule('marginBottom', ['10px', '1dvh'], ['margin', ':hover']),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', '4px'),
-            new PreRule('marginStart', ['20px', '2dvw'], [':hover'], []),
+            new PreRule('marginStart', '4px', ['margin', 'default']),
+            new PreRule('marginStart', ['20px', '2dvw'], ['margin', ':hover']),
           ]),
         ],
       ]);
@@ -455,12 +476,11 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           '@media (min-width: 300px)_:hover_color',
           PreRuleSet.create([
-            new PreRule(
+            new PreRule('color', 'red', [
+              '@media (min-width: 300px)',
+              ':hover',
               'color',
-              'red',
-              [':hover'],
-              ['@media (min-width: 300px)'],
-            ),
+            ]),
           ]),
         ],
       ]);
@@ -484,23 +504,22 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           '@media (min-width: 300px)_:hover_color',
           PreRuleSet.create([
-            new PreRule(
+            new PreRule('color', 'pink', [
+              '@media (min-width: 300px)',
+              ':hover',
               'color',
-              'pink',
-              [':hover'],
-              ['@media (min-width: 300px)'],
-            ),
+            ]),
           ]),
         ],
         [
           '@media (min-width: 300px)_:hover_:active_color',
           PreRuleSet.create([
-            new PreRule(
+            new PreRule('color', 'red', [
+              '@media (min-width: 300px)',
+              ':hover',
+              ':active',
               'color',
-              'red',
-              [':active', ':hover'],
-              ['@media (min-width: 300px)'],
-            ),
+            ]),
           ]),
         ],
       ]);
@@ -522,13 +541,12 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'color',
           PreRuleSet.create([
-            new PreRule('color', 'blue', [], []),
-            new PreRule(
+            new PreRule('color', 'blue', ['color', 'default']),
+            new PreRule('color', 'red', [
               'color',
-              'red',
-              [':hover'],
-              ['@media (min-width: 300px)'],
-            ),
+              '@media (min-width: 300px)',
+              ':hover',
+            ]),
           ]),
         ],
       ]);
@@ -553,19 +571,19 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'color',
           PreRuleSet.create([
-            new PreRule('color', 'blue', [], []),
-            new PreRule(
+            new PreRule('color', 'blue', ['color', 'default']),
+            new PreRule('color', 'red', [
               'color',
-              'red',
-              [':hover'],
-              ['@media (min-width: 300px)'],
-            ),
-            new PreRule(
+              '@media (min-width: 300px)',
+              ':hover',
+              'default',
+            ]),
+            new PreRule('color', 'maroon', [
               'color',
-              'maroon',
-              [':hover', ':active'],
-              ['@media (min-width: 300px)'],
-            ),
+              '@media (min-width: 300px)',
+              ':hover',
+              ':active',
+            ]),
           ]),
         ],
       ]);

--- a/packages/shared/__tests__/gen-css-test.js
+++ b/packages/shared/__tests__/gen-css-test.js
@@ -20,18 +20,23 @@ const options = {
 
 describe('Converting PreRule to CSS', () => {
   test('should convert a PreRule to CSS', () => {
-    expect(new PreRule('color', 'red').compiled(options))
+    expect(new PreRule('color', 'red', ['color']).compiled(options))
       .toMatchInlineSnapshot(`
+      [
         [
-          [
-            "x1e2nbdu",
-            {
-              "ltr": ".x1e2nbdu{color:red}",
-              "priority": 3000,
-              "rtl": null,
-            },
-          ],
-        ]
-      `);
+          "x1e2nbdu",
+          {
+            "ltr": ".x1e2nbdu{color:red}",
+            "priority": 3000,
+            "rtl": null,
+          },
+          {
+            "x1e2nbdu": [
+              "color",
+            ],
+          },
+        ],
+      ]
+    `);
   });
 });

--- a/packages/shared/__tests__/stylex-create-test.js
+++ b/packages/shared/__tests__/stylex-create-test.js
@@ -39,6 +39,16 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "xju2f9n": [
+              "color",
+            ],
+            "xrkmrrc": [
+              "backgroundColor",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -69,6 +79,13 @@ describe('stylex-create-test', () => {
             "ltr": ".x1cfch2b{transition-property:margin-top}",
             "priority": 3000,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "x1cfch2b": [
+              "transitionProperty",
+            ],
           },
         },
       ]
@@ -103,6 +120,13 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "x1a6dnx1": [
+              "willChange",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -129,6 +153,13 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "x17389it": [
+              "transitionProperty",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -153,6 +184,13 @@ describe('stylex-create-test', () => {
             "ltr": ".x1lxaxzv{will-change:--foo}",
             "priority": 3000,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "x1lxaxzv": [
+              "willChange",
+            ],
           },
         },
       ]
@@ -185,6 +223,13 @@ describe('stylex-create-test', () => {
             "ltr": ".x95ccmk{transition-property:opacity,margin-top}",
             "priority": 3000,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "x95ccmk": [
+              "transitionProperty",
+            ],
           },
         },
       ]
@@ -227,6 +272,16 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "short": {
+            "x1lmef92": [
+              "padding",
+            ],
+            "xexx8yu": [
+              "paddingTop",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -253,6 +308,13 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "xgau0yw": [
+              "--background-color",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -277,6 +339,13 @@ describe('stylex-create-test', () => {
             "ltr": ".x13tgbkp{--final-color:var(--background-color)}",
             "priority": 1,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "x13tgbkp": [
+              "--final-color",
+            ],
           },
         },
       ]
@@ -318,6 +387,18 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "xrkmrrc": [
+              "backgroundColor",
+            ],
+          },
+          "default2": {
+            "xju2f9n": [
+              "color",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -344,6 +425,13 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "xd71okc": [
+              "content",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -368,6 +456,13 @@ describe('stylex-create-test', () => {
             "ltr": ".xwzgxvi{--foo:500}",
             "priority": 1,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "xwzgxvi": [
+              "--foo",
+            ],
           },
         },
       ]
@@ -405,6 +500,18 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "x17z2mba": [
+              ":hover",
+              "color",
+            ],
+            "x1gykpug": [
+              ":hover",
+              "backgroundColor",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -430,6 +537,13 @@ describe('stylex-create-test', () => {
             "ltr": ".x1ruww2u{position:sticky;position:fixed}",
             "priority": 3000,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "x1ruww2u": [
+              "position",
+            ],
           },
         },
       ]
@@ -490,6 +604,19 @@ describe('stylex-create-test', () => {
             "rtl": null,
           },
         },
+        {
+          "default": {
+            "xb3r6kr": [
+              "overflow",
+            ],
+            "xbsl7fq": [
+              "borderStyle",
+            ],
+            "xmkeg23": [
+              "borderWidth",
+            ],
+          },
+        },
       ]
     `);
   });
@@ -533,6 +660,21 @@ describe('stylex-create-test', () => {
             "ltr": ".xrkmrrc{background-color:red}",
             "priority": 3000,
             "rtl": null,
+          },
+        },
+        {
+          "default": {
+            "x1ssfqz5": [
+              "@media (min-width: 2000px)",
+              "backgroundColor",
+            ],
+            "xc445zv": [
+              "@media (min-width: 1000px)",
+              "backgroundColor",
+            ],
+            "xrkmrrc": [
+              "backgroundColor",
+            ],
           },
         },
       ]

--- a/packages/shared/src/preprocess-rules/PreRule.js
+++ b/packages/shared/src/preprocess-rules/PreRule.js
@@ -13,7 +13,13 @@ import type { IncludedStyles } from '../stylex-include';
 import { convertStyleToClassName } from '../convert-to-className';
 import { arrayEquals, arraySort } from '../utils/object-utils';
 
-export type ComputedStyle = null | $ReadOnly<[string, InjectableStyle]>;
+export type ClassesToOriginalPaths = {
+  +[className: string]: $ReadOnlyArray<string>,
+};
+
+export type ComputedStyle = null | $ReadOnly<
+  [string, InjectableStyle, ClassesToOriginalPaths],
+>;
 
 // The classes in this file are used to represent objects that
 // can be compiled into one or CSS rules.
@@ -74,29 +80,38 @@ const stringComparator = (a: string, b: string): number => {
 export class PreRule implements IPreRule {
   +property: string;
   +value: string | number | $ReadOnlyArray<string | number>;
-  +pseudos: $ReadOnlyArray<string>;
-  +atRules: $ReadOnlyArray<string>;
+  +keyPath: $ReadOnlyArray<string>;
 
   constructor(
     property: string,
     value: string | number | $ReadOnlyArray<string | number>,
-    pseudos?: ?$ReadOnlyArray<string>,
-    atRules?: ?$ReadOnlyArray<string>,
+    keyPath: $ReadOnlyArray<string>,
   ) {
     this.property = property;
+    this.keyPath = keyPath;
     this.value = value;
-    this.pseudos = pseudos ? arraySort(pseudos, stringComparator) : [];
-    this.atRules = atRules ? arraySort(atRules) : [];
   }
 
-  compiled(options: StyleXOptions): $ReadOnlyArray<[string, InjectableStyle]> {
+  get pseudos(): $ReadOnlyArray<string> {
+    const unsortedPseudos = this.keyPath.filter((key) => key.startsWith(':'));
+    return arraySort(unsortedPseudos, stringComparator);
+  }
+
+  get atRules(): $ReadOnlyArray<string> {
+    const unsortedAtRules = this.keyPath.filter((key) => key.startsWith('@'));
+    return arraySort(unsortedAtRules);
+  }
+
+  compiled(
+    options: StyleXOptions,
+  ): $ReadOnlyArray<[string, InjectableStyle, ClassesToOriginalPaths]> {
     const [_key, className, rule] = convertStyleToClassName(
       [this.property, this.value],
       this.pseudos ?? [],
       this.atRules ?? [],
       options,
     );
-    return [[className, rule]];
+    return [[className, rule, { [className]: this.keyPath }]];
   }
 
   equals(other: IPreRule): boolean {

--- a/packages/shared/src/preprocess-rules/PreRule.js
+++ b/packages/shared/src/preprocess-rules/PreRule.js
@@ -85,10 +85,10 @@ export class PreRule implements IPreRule {
   constructor(
     property: string,
     value: string | number | $ReadOnlyArray<string | number>,
-    keyPath: $ReadOnlyArray<string>,
+    keyPath?: $ReadOnlyArray<string>,
   ) {
     this.property = property;
-    this.keyPath = keyPath;
+    this.keyPath = keyPath ?? [];
     this.value = value;
   }
 

--- a/packages/shared/src/preprocess-rules/flatten-raw-style-obj.js
+++ b/packages/shared/src/preprocess-rules/flatten-raw-style-obj.js
@@ -64,7 +64,9 @@ export function _flattenRawStyleObject(
             new PreRule(
               property,
               value,
-              keyPath.includes(key) ? keyPath : [...keyPath, key],
+              keyPath.includes(key)
+                ? keyPath.map((k) => (k === key ? property : k))
+                : [...keyPath, property],
             ),
           ]);
         }
@@ -118,7 +120,9 @@ export function _flattenRawStyleObject(
               new PreRule(
                 property,
                 value,
-                keyPath.includes(_key) ? keyPath : [...keyPath, _key],
+                keyPath.includes(_key)
+                  ? keyPath.map((k) => (k === _key ? property : k))
+                  : [...keyPath, property],
               ),
             ]);
           }

--- a/packages/shared/src/preprocess-rules/flatten-raw-style-obj.js
+++ b/packages/shared/src/preprocess-rules/flatten-raw-style-obj.js
@@ -74,7 +74,7 @@ export function _flattenRawStyleObject(
 
     // Fallback Styles
     if (Array.isArray(value)) {
-      // Step 1: Expand properties to its consituent parts
+      // Step 1: Expand properties to its constituent parts
       // Collect the various values for each value in the array
       // that belongs to the same property.
       const equivalentPairs: {

--- a/packages/shared/src/preprocess-rules/flatten-raw-style-obj.js
+++ b/packages/shared/src/preprocess-rules/flatten-raw-style-obj.js
@@ -24,13 +24,12 @@ export function flattenRawStyleObject(
   style: RawStyles,
   options: StyleXOptions,
 ): $ReadOnlyArray<$ReadOnly<[string, IPreRule]>> {
-  return _flattenRawStyleObject(style, [], [], options);
+  return _flattenRawStyleObject(style, [], options);
 }
 
 export function _flattenRawStyleObject(
   style: RawStyles,
-  pseudos: $ReadOnlyArray<string>,
-  atRules: $ReadOnlyArray<string>,
+  keyPath: $ReadOnlyArray<string>,
   options: StyleXOptions,
 ): Array<$ReadOnly<[string, AnyPreRule | PreIncludedStylesRule]>> {
   const flattened: Array<
@@ -62,7 +61,11 @@ export function _flattenRawStyleObject(
         } else {
           flattened.push([
             property,
-            new PreRule(property, value, pseudos, atRules),
+            new PreRule(
+              property,
+              value,
+              keyPath.includes(key) ? keyPath : [...keyPath, key],
+            ),
           ]);
         }
       }
@@ -71,6 +74,9 @@ export function _flattenRawStyleObject(
 
     // Fallback Styles
     if (Array.isArray(value)) {
+      // Step 1: Expand properties to its consituent parts
+      // Collect the various values for each value in the array
+      // that belongs to the same property.
       const equivalentPairs: {
         [string]: Array<null | string | number>,
       } = {};
@@ -109,7 +115,11 @@ export function _flattenRawStyleObject(
           } else {
             flattened.push([
               property,
-              new PreRule(property, value, pseudos, atRules),
+              new PreRule(
+                property,
+                value,
+                keyPath.includes(_key) ? keyPath : [...keyPath, _key],
+              ),
             ]);
           }
         });
@@ -126,18 +136,9 @@ export function _flattenRawStyleObject(
       for (const condition in value) {
         const innerValue = value[condition];
 
-        const pseudosToPassDown = [...pseudos];
-        const atRulesToPassDown = [...atRules];
-        if (condition.startsWith(':')) {
-          pseudosToPassDown.push(condition);
-        } else if (condition.startsWith('@')) {
-          atRulesToPassDown.push(condition);
-        }
-
         const pairs = _flattenRawStyleObject(
           { [key]: innerValue },
-          pseudosToPassDown,
-          atRulesToPassDown,
+          keyPath.length > 0 ? [...keyPath, condition] : [key, condition],
           options,
         );
         for (const [property, preRule] of pairs) {
@@ -169,19 +170,7 @@ export function _flattenRawStyleObject(
       typeof value === 'object' &&
       (key.startsWith(':') || key.startsWith('@'))
     ) {
-      const pseudosToPassDown = [...pseudos];
-      const atRulesToPassDown = [...atRules];
-      if (key.startsWith(':')) {
-        pseudosToPassDown.push(key);
-      } else if (key.startsWith('@')) {
-        atRulesToPassDown.push(key);
-      }
-      const pairs = _flattenRawStyleObject(
-        value,
-        pseudosToPassDown,
-        atRulesToPassDown,
-        options,
-      );
+      const pairs = _flattenRawStyleObject(value, [...keyPath, _key], options);
       for (const [property, preRule] of pairs) {
         flattened.push([key + '_' + property, preRule]);
       }

--- a/packages/shared/src/preprocess-rules/index.js
+++ b/packages/shared/src/preprocess-rules/index.js
@@ -29,7 +29,10 @@ export function getExpandedKeys(
 
 export default function flatMapExpandedShorthands(
   objEntry: $ReadOnly<[string, TStyleValue]>,
-  options: StyleXOptions,
+  options: $ReadOnly<{
+    styleResolution: StyleXOptions['styleResolution'],
+    ...
+  }>,
 ): $ReadOnlyArray<[string, TStyleValue]> {
   // eslint-disable-next-line prefer-const
   let [key, value] = objEntry;

--- a/packages/shared/src/stylex-create.js
+++ b/packages/shared/src/stylex-create.js
@@ -94,10 +94,6 @@ export default function styleXCreateSet(
           .map((v) => (Array.isArray(v) ? v : null))
           .filter(Boolean);
 
-        // if (classNameTuples.length > 1) {
-        //   namespaceObj[key] = null;
-        //   continue;
-        // }
         classNameTuples.forEach(([_className, _, classesToOriginalPath]) => {
           Object.assign(classPathsInNamespace, classesToOriginalPath);
         });

--- a/packages/shared/src/stylex-create.js
+++ b/packages/shared/src/stylex-create.js
@@ -14,12 +14,22 @@ import type {
   FlatCompiledStyles,
 } from './common-types';
 
-import { objFromEntries } from './utils/object-utils';
 import { IncludedStyles } from './stylex-include';
 import { defaultOptions } from './utils/default-options';
 import { flattenRawStyleObject } from './preprocess-rules/flatten-raw-style-obj';
-import type { ComputedStyle } from './preprocess-rules/PreRule';
+import type { ComputedStyle, IPreRule } from './preprocess-rules/PreRule';
 import { validateNamespace } from './preprocess-rules/basic-validation';
+
+type TPropTuple = [
+  +key: string,
+  +styles: IncludedStyles | $ReadOnlyArray<ComputedStyle>,
+];
+
+type ClassPathsInNamespace = {
+  +[className: string]: $ReadOnlyArray<string>,
+};
+
+type TClassNameTuples = $NonMaybeType<ComputedStyle>;
 
 // This takes the object of styles passed to `stylex.create` and transforms it.
 //   The transformation replaces style values with classNames.
@@ -34,38 +44,68 @@ import { validateNamespace } from './preprocess-rules/basic-validation';
 export default function styleXCreateSet(
   namespaces: { +[string]: RawStyles },
   options?: StyleXOptions = defaultOptions,
-): [{ [string]: FlatCompiledStyles }, { [string]: InjectableStyle }] {
+): [
+  { [string]: FlatCompiledStyles },
+  { [string]: InjectableStyle },
+  { +[string]: ClassPathsInNamespace },
+] {
   const resolvedNamespaces: { [string]: FlatCompiledStyles } = {};
   const injectedStyles: { [string]: InjectableStyle } = {};
+  const namespaceToClassPaths: { [string]: ClassPathsInNamespace } = {};
 
   for (const namespaceName of Object.keys(namespaces)) {
     const namespace = namespaces[namespaceName];
+    const classPathsInNamespace: { [string]: $ReadOnlyArray<string> } = {};
 
     validateNamespace(namespace);
 
-    const flattenedNamespace = flattenRawStyleObject(namespace, options);
-    const compiledNamespaceTuples = flattenedNamespace.map(([key, value]) => {
-      return [key, value.compiled(options)];
-    });
+    // filterReverse to remove duplicate keys and keep the last one always.
+    // This is the same behaviour as Object.fromEntries, except it maintains
+    // order correctly and is more efficient.
+    const seenProperties = new Set<string>();
+    const flattenedNamespace: $ReadOnlyArray<$ReadOnly<[string, IPreRule]>> =
+      flattenRawStyleObject(namespace, options).reduceRight(
+        (arr, curr) => {
+          if (seenProperties.has(curr[0])) {
+            return arr;
+          }
+          seenProperties.add(curr[0]);
+          arr.unshift(curr);
+          return arr;
+        },
+        [] as Array<$ReadOnly<[string, IPreRule]>>,
+      );
 
-    const compiledNamespace = objFromEntries<
-      string,
-      IncludedStyles | $ReadOnlyArray<ComputedStyle>,
-    >(compiledNamespaceTuples);
+    const compiledNamespaceTuples: $ReadOnlyArray<TPropTuple> =
+      flattenedNamespace.map(([key, value]) => {
+        return [key, value.compiled(options)];
+      });
 
     const namespaceObj: {
       [string]: null | string | IncludedStyles,
     } = {};
-    for (const key of Object.keys(compiledNamespace)) {
-      const value = compiledNamespace[key];
+    for (const [key, value] of compiledNamespaceTuples) {
       if (value instanceof IncludedStyles) {
+        // stylex.include calls are passed through as-is.
         namespaceObj[key] = value;
       } else {
-        const classNameTuples: Array<$ReadOnly<[string, InjectableStyle]>> =
-          value.map((v) => (Array.isArray(v) ? v : null)).filter(Boolean);
+        // Remove nulls
+        const classNameTuples: $ReadOnlyArray<TClassNameTuples> = value
+          .map((v) => (Array.isArray(v) ? v : null))
+          .filter(Boolean);
+
+        // if (classNameTuples.length > 1) {
+        //   namespaceObj[key] = null;
+        //   continue;
+        // }
+        classNameTuples.forEach(([_className, _, classesToOriginalPath]) => {
+          Object.assign(classPathsInNamespace, classesToOriginalPath);
+        });
+
         const className =
           classNameTuples.map(([className]) => className).join(' ') || null;
         namespaceObj[key] = className;
+
         for (const [className, injectable] of classNameTuples) {
           if (injectedStyles[className] == null) {
             injectedStyles[className] = injectable;
@@ -74,7 +114,8 @@ export default function styleXCreateSet(
       }
     }
     resolvedNamespaces[namespaceName] = { ...namespaceObj, $$css: true };
+    namespaceToClassPaths[namespaceName] = classPathsInNamespace;
   }
 
-  return [resolvedNamespaces, injectedStyles];
+  return [resolvedNamespaces, injectedStyles, namespaceToClassPaths];
 }

--- a/packages/shared/src/transform-value.js
+++ b/packages/shared/src/transform-value.js
@@ -141,7 +141,6 @@ export const lengthUnits: Set<string> = new Set([
   'borderBottomWidth',
   'borderEndEndRadius',
   'borderEndStartRadius',
-  // 'borderImageWidth', // can be a unitless number
   'borderInlineEndWidth',
   'borderEndWidth',
   'borderInlineStartWidth',
@@ -185,8 +184,6 @@ export const lengthUnits: Set<string> = new Set([
   'marginLeft',
   'marginRight',
   'marginTop',
-  'maskBorderOutset',
-  'maskBorderWidth',
   'maxBlockSize',
   'maxHeight',
   'maxInlineSize',


### PR DESCRIPTION
The previous PR did not correctly handle space-separated classNames that are applied to a single CSS property as the information to know *which* className in the list should be applied conditionally was lost.

This  PR does a big refactor to collect and report that information to connect classNames to their original object paths so any className that resolves to a dynamic style value (via a variable) will be applied conditionally *only* if the dynamic value is not `null` or `undefined`.

This even fixes a bug where if a dynamic value for, say `color` in a `:hover` style resolved to `null`, instead of having no `:hover` styles as is expected, hover styles are applied and set to an undefined variable which resolves to a "default" value for the given property. In practice this means that even if the default `color` value is `red`, instead of the color remaining `red` on `:hover` as well, it would become `black` as that is the default color value.

This issue has been fixed as part of this PR.

### One remaining bug

There is still one remaining bug specifically when using the `legacy-expand-shorthands` config option. Any classNames with dynamic values used for a shorthand will not be applied conditionally.