### PR TITLE
fix: conditional classes for dynamic styles for legacy expanded prope…

### DIFF
--- a/packages/babel-plugin/__tests__/evaluation/stylex-fn-obj-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-fn-obj-evaluation-test.js
@@ -110,7 +110,7 @@ describe('custom path evaluation works as expected', () => {
     expect(result.value).toEqual({
       default: {
         borderStyle: 'dashed',
-        borderWidth: 'var(--borderWidth, revert)',
+        borderWidth: 'var(--borderWidth)',
         overflow: 'hidden',
       },
     });
@@ -240,7 +240,7 @@ describe('custom path evaluation works as expected', () => {
       default: {
         overflow: 'hidden',
         borderStyle: 'dashed',
-        borderWidth: 'var(--borderWidth, revert)',
+        borderWidth: 'var(--borderWidth)',
       },
     });
     expect(removeLoc(result.fns)).toMatchInlineSnapshot(`

--- a/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
@@ -329,10 +329,10 @@ describe('Evaluation of imported values works based on configuration', () => {
         import stylex from 'stylex';
         import 'otherFile.stylex';
         import { MyTheme } from 'otherFile.stylex';
-        _inject2(".__hashed_var__15x39w1{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb,revert)}", 1);
+        _inject2(".__hashed_var__b69i2g{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb)}", 1);
         const styles = {
           color: color => [{
-            "--__hashed_var__1jqb1tb": color == null ? null : "__hashed_var__15x39w1",
+            "--__hashed_var__1jqb1tb": color == null ? null : "__hashed_var__b69i2g",
             $$css: true
           }, {
             "----__hashed_var__1jqb1tb": color != null ? color : undefined
@@ -343,9 +343,9 @@ describe('Evaluation of imported values works based on configuration', () => {
       expect(transformation.metadata.stylex).toMatchInlineSnapshot(`
         [
           [
-            "__hashed_var__15x39w1",
+            "__hashed_var__b69i2g",
             {
-              "ltr": ".__hashed_var__15x39w1{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb,revert)}",
+              "ltr": ".__hashed_var__b69i2g{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb)}",
               "rtl": null,
             },
             1,

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -1172,7 +1172,7 @@ describe('@stylexjs/babel-plugin', () => {
     });
   });
 
-  describe.only('[transform] stylex.create() with functions', () => {
+  describe('[transform] stylex.create() with functions', () => {
     test('transforms style object with function', () => {
       expect(
         transform(`

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -1458,5 +1458,52 @@ describe('@stylexjs/babel-plugin', () => {
         };"
       `);
     });
+
+    test('transforms shorthands in legacy-expand-shorthands mode', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            default: (margin) => ({
+              backgroundColor: 'red',
+              margin: {
+                default: margin,
+                ':hover': margin + 4,
+              },
+              marginTop: margin - 4,
+            })
+          });
+        `,
+          { styleResolution: 'legacy-expand-shorthands' },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xrkmrrc{background-color:red}", 3000);
+        _inject2(".xtquba1{margin-right:var(--14mfytm,revert)}", 3000, ".xtquba1{margin-left:var(--14mfytm,revert)}");
+        _inject2(".x1wvyv5g:hover{margin-right:var(--yepcm9,revert)}", 3130, ".x1wvyv5g:hover{margin-left:var(--yepcm9,revert)}");
+        _inject2(".x1lpz8mm{margin-bottom:var(--14mfytm,revert)}", 4000);
+        _inject2(".x5j2iel:hover{margin-bottom:var(--yepcm9,revert)}", 4130);
+        _inject2(".xop2vte{margin-left:var(--14mfytm,revert)}", 3000, ".xop2vte{margin-right:var(--14mfytm,revert)}");
+        _inject2(".x14hq2z5:hover{margin-left:var(--yepcm9,revert)}", 3130, ".x14hq2z5:hover{margin-right:var(--yepcm9,revert)}");
+        _inject2(".x1v67u4u{margin-top:var(--marginTop,revert)}", 4000);
+        export const styles = {
+          default: margin => [{
+            backgroundColor: "xrkmrrc",
+            marginEnd: (margin == null ? "" : "xtquba1 ") + (margin + 4 == null ? "" : "x1wvyv5g"),
+            marginBottom: (margin == null ? "" : "x1lpz8mm ") + (margin + 4 == null ? "" : "x5j2iel"),
+            marginStart: (margin == null ? "" : "xop2vte ") + (margin + 4 == null ? "" : "x14hq2z5"),
+            marginTop: margin - 4 == null ? null : "x1v67u4u",
+            $$css: true
+          }, {
+            "--14mfytm": margin != null ? margin : undefined,
+            "--yepcm9": margin + 4 != null ? margin + 4 : undefined,
+            "--marginTop": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin - 4)
+          }]
+        };"
+      `);
+    });
   });
 });

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -1172,7 +1172,7 @@ describe('@stylexjs/babel-plugin', () => {
     });
   });
 
-  describe('[transform] stylex.create() with functions', () => {
+  describe.only('[transform] stylex.create() with functions', () => {
     test('transforms style object with function', () => {
       expect(
         transform(`
@@ -1498,8 +1498,8 @@ describe('@stylexjs/babel-plugin', () => {
             marginTop: margin - 4 == null ? null : "x1v67u4u",
             $$css: true
           }, {
-            "--14mfytm": margin != null ? margin : undefined,
-            "--yepcm9": margin + 4 != null ? margin + 4 : undefined,
+            "--14mfytm": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin),
+            "--yepcm9": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin + 4),
             "--marginTop": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin - 4)
           }]
         };"

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -1189,11 +1189,11 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject2(".xfx01vb{color:var(--color)}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: color == null ? null : "x19dipnz",
+            color: color == null ? null : "xfx01vb",
             $$css: true
           }, {
             "--color": color != null ? color : undefined
@@ -1218,11 +1218,11 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x17fnjtu{width:var(--width,revert)}", 4000);
+        _inject2(".x1bl4301{width:var(--width)}", 4000);
         export const styles = {
           default: width => [{
             backgroundColor: "xrkmrrc",
-            width: width == null ? null : "x17fnjtu",
+            width: width == null ? null : "x1bl4301",
             $$css: true
           }, {
             "--width": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
@@ -1250,12 +1250,12 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject2(".xfx01vb{color:var(--color)}", 3000);
         _inject2(".x1mqxbix{color:black}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: color == null ? null : "x19dipnz",
+            color: color == null ? null : "xfx01vb",
             $$css: true
           }, {
             "--color": color != null ? color : undefined
@@ -1282,10 +1282,10 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
+        _inject2(".x15mgraa{--background-color:var(----background-color)}", 1);
         export const styles = {
           default: bgColor => [{
-            "--background-color": bgColor == null ? null : "xyv4n8w",
+            "--background-color": bgColor == null ? null : "x15mgraa",
             $$css: true
           }, {
             "----background-color": bgColor != null ? bgColor : undefined
@@ -1311,11 +1311,11 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x1gykpug:hover{background-color:red}", 3130);
-        _inject2(".x11bf1mc:hover{color:var(--1ijzsae,revert)}", 3130);
+        _inject2(".xtyu0qe:hover{color:var(--1ijzsae)}", 3130);
         export const styles = {
           default: color => [{
             ":hover_backgroundColor": "x1gykpug",
-            ":hover_color": color == null ? null : "x11bf1mc",
+            ":hover_color": color == null ? null : "xtyu0qe",
             $$css: true
           }, {
             "--1ijzsae": color != null ? color : undefined
@@ -1342,12 +1342,12 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x19dipnz{color:var(--color,revert)}", 3000);
+        _inject2(".xfx01vb{color:var(--color)}", 3000);
         _inject2(".x1mqxbix{color:black}", 3000);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: color == null ? null : "x19dipnz",
+            color: color == null ? null : "xfx01vb",
             $$css: true
           }, {
             "--color": color != null ? color : undefined
@@ -1374,10 +1374,10 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xyv4n8w{--background-color:var(----background-color,revert)}", 1);
+        _inject2(".x15mgraa{--background-color:var(----background-color)}", 1);
         export const styles = {
           default: bgColor => [{
-            "--background-color": bgColor == null ? null : "xyv4n8w",
+            "--background-color": bgColor == null ? null : "x15mgraa",
             $$css: true
           }, {
             "----background-color": bgColor != null ? bgColor : undefined
@@ -1407,13 +1407,13 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x9lz66z{color:var(--4xs81a,revert)}", 3000);
+        _inject2(".x1n25116{color:var(--4xs81a)}", 3000);
         _inject2("@media (min-width: 1000px){.xtljkjt.xtljkjt:hover{color:green}}", 3330);
         _inject2(".x17z2mba:hover{color:blue}", 3130);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: (color == null ? "" : "x9lz66z ") + "xtljkjt " + "x17z2mba",
+            color: (color == null ? "" : "x1n25116 ") + "xtljkjt " + "x17z2mba",
             $$css: true
           }, {
             "--4xs81a": color != null ? color : undefined
@@ -1443,13 +1443,13 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x9lz66z{color:var(--4xs81a,revert)}", 3000);
+        _inject2(".x1n25116{color:var(--4xs81a)}", 3000);
         _inject2("@media (min-width: 1000px){.xtljkjt.xtljkjt:hover{color:green}}", 3330);
-        _inject2(".x1pgt9tt:hover{color:var(--w5m4kq,revert)}", 3130);
+        _inject2(".x1d4gdy3:hover{color:var(--w5m4kq)}", 3130);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
-            color: (color == null ? "" : "x9lz66z ") + "xtljkjt " + ('color-mix(' + color + ', blue)' == null ? "" : "x1pgt9tt"),
+            color: (color == null ? "" : "x1n25116 ") + "xtljkjt " + ('color-mix(' + color + ', blue)' == null ? "" : "x1d4gdy3"),
             $$css: true
           }, {
             "--4xs81a": color != null ? color : undefined,
@@ -1482,20 +1482,20 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".xtquba1{margin-right:var(--14mfytm,revert)}", 3000, ".xtquba1{margin-left:var(--14mfytm,revert)}");
-        _inject2(".x1wvyv5g:hover{margin-right:var(--yepcm9,revert)}", 3130, ".x1wvyv5g:hover{margin-left:var(--yepcm9,revert)}");
-        _inject2(".x1lpz8mm{margin-bottom:var(--14mfytm,revert)}", 4000);
-        _inject2(".x5j2iel:hover{margin-bottom:var(--yepcm9,revert)}", 4130);
-        _inject2(".xop2vte{margin-left:var(--14mfytm,revert)}", 3000, ".xop2vte{margin-right:var(--14mfytm,revert)}");
-        _inject2(".x14hq2z5:hover{margin-left:var(--yepcm9,revert)}", 3130, ".x14hq2z5:hover{margin-right:var(--yepcm9,revert)}");
-        _inject2(".x1v67u4u{margin-top:var(--marginTop,revert)}", 4000);
+        _inject2(".x1ie72y1{margin-right:var(--14mfytm)}", 3000, ".x1ie72y1{margin-left:var(--14mfytm)}");
+        _inject2(".x128459:hover{margin-right:var(--yepcm9)}", 3130, ".x128459:hover{margin-left:var(--yepcm9)}");
+        _inject2(".x1hvr6ea{margin-bottom:var(--14mfytm)}", 4000);
+        _inject2(".x3skgmg:hover{margin-bottom:var(--yepcm9)}", 4130);
+        _inject2(".x1k44ad6{margin-left:var(--14mfytm)}", 3000, ".x1k44ad6{margin-right:var(--14mfytm)}");
+        _inject2(".x10ktymb:hover{margin-left:var(--yepcm9)}", 3130, ".x10ktymb:hover{margin-right:var(--yepcm9)}");
+        _inject2(".x17zef60{margin-top:var(--marginTop)}", 4000);
         export const styles = {
           default: margin => [{
             backgroundColor: "xrkmrrc",
-            marginEnd: (margin == null ? "" : "xtquba1 ") + (margin + 4 == null ? "" : "x1wvyv5g"),
-            marginBottom: (margin == null ? "" : "x1lpz8mm ") + (margin + 4 == null ? "" : "x5j2iel"),
-            marginStart: (margin == null ? "" : "xop2vte ") + (margin + 4 == null ? "" : "x14hq2z5"),
-            marginTop: margin - 4 == null ? null : "x1v67u4u",
+            marginEnd: (margin == null ? "" : "x1ie72y1 ") + (margin + 4 == null ? "" : "x128459"),
+            marginBottom: (margin == null ? "" : "x1hvr6ea ") + (margin + 4 == null ? "" : "x3skgmg"),
+            marginStart: (margin == null ? "" : "x1k44ad6 ") + (margin + 4 == null ? "" : "x10ktymb"),
+            marginTop: margin - 4 == null ? null : "x17zef60",
             $$css: true
           }, {
             "--14mfytm": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin),

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -357,7 +357,10 @@ function legacyExpandShorthands(
       });
     })
     .map(([key, value]) => {
-      const index = parseInt((value as $FlowFixMe as string).slice(1), 10);
+      if (typeof value !== 'string') {
+        return null;
+      }
+      const index = parseInt(value.slice(1), 10);
       const thatDynStyle = dynamicStyles[index];
       return {
         ...thatDynStyle,
@@ -369,7 +372,8 @@ function legacyExpandShorthands(
               ? thatDynStyle.path.replace(thatDynStyle.key + '_', key + '_')
               : thatDynStyle.path.replace('_' + thatDynStyle.key, '_' + key),
       };
-    });
+    })
+    .filter(Boolean);
 
   return expandedKeysToKeyPaths;
 }

--- a/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
@@ -175,7 +175,7 @@ function evaluatePartialObjectRecursively(
             (keyPath.length > 0
               ? utils.hash([...keyPath, key].join('_'))
               : key);
-          obj[key] = `var(${varName}, revert)`;
+          obj[key] = `var(${varName})`;
           const node = valuePath.node;
           if (!t.isExpression(node)) {
             throw new Error('Expected expression as style value');

--- a/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
@@ -169,6 +169,7 @@ function evaluatePartialObjectRecursively(
       } else {
         const result = evaluate(valuePath, traversalState, functions);
         if (!result.confident) {
+          const fullKeyPath = [...keyPath, key];
           const varName =
             '--' +
             (keyPath.length > 0
@@ -181,10 +182,18 @@ function evaluatePartialObjectRecursively(
           }
           const expression: t.Expression = node as $FlowFixMe;
 
+          const propName =
+            fullKeyPath.find(
+              (k) =>
+                !k.startsWith(':') && !k.startsWith('@') && k !== 'default',
+            ) ?? key;
+
           const unit =
-            timeUnits.has(key) || lengthUnits.has(key)
-              ? getNumberSuffix(key)
+            timeUnits.has(propName) || lengthUnits.has(propName)
+              ? getNumberSuffix(propName)
               : '';
+
+          console.log('propName', propName, 'unit', unit);
 
           const inlineStyleExpression =
             unit !== ''

--- a/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/parse-stylex-create-arg.js
@@ -193,8 +193,6 @@ function evaluatePartialObjectRecursively(
               ? getNumberSuffix(propName)
               : '';
 
-          console.log('propName', propName, 'unit', unit);
-
           const inlineStyleExpression =
             unit !== ''
               ? t.callExpression(

--- a/packages/shared/__tests__/flatten-raw-style-objects/legacy-shorthand-expansion-test.js
+++ b/packages/shared/__tests__/flatten-raw-style-objects/legacy-shorthand-expansion-test.js
@@ -51,8 +51,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['rowGap', new PreRule('rowGap', 10, ['gap'])],
-        ['columnGap', new PreRule('columnGap', 10, ['gap'])],
+        ['rowGap', new PreRule('rowGap', 10, ['rowGap'])],
+        ['columnGap', new PreRule('columnGap', 10, ['columnGap'])],
       ]);
     });
 
@@ -67,11 +67,11 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
       ).toEqual([
         [
           'containIntrinsicWidth',
-          new PreRule('containIntrinsicWidth', 10, ['containIntrinsicSize']),
+          new PreRule('containIntrinsicWidth', 10, ['containIntrinsicWidth']),
         ],
         [
           'containIntrinsicHeight',
-          new PreRule('containIntrinsicHeight', 10, ['containIntrinsicSize']),
+          new PreRule('containIntrinsicHeight', 10, ['containIntrinsicHeight']),
         ],
       ]);
     });
@@ -134,8 +134,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['rowGap', new PreRule('rowGap', '10px', ['gap'])],
-        ['columnGap', new PreRule('columnGap', '20px', ['gap'])],
+        ['rowGap', new PreRule('rowGap', '10px', ['rowGap'])],
+        ['columnGap', new PreRule('columnGap', '20px', ['columnGap'])],
       ]);
     });
 
@@ -150,8 +150,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, '10px', ['containIntrinsicSize'])],
-        [h, new PreRule(h, '20px', ['containIntrinsicSize'])],
+        [w, new PreRule(w, '10px', [w])],
+        [h, new PreRule(h, '20px', [h])],
       ]);
       expect(
         flattenRawStyleObject(
@@ -161,8 +161,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, 'auto 10px', ['containIntrinsicSize'])],
-        [h, new PreRule(h, '20px', ['containIntrinsicSize'])],
+        [w, new PreRule(w, 'auto 10px', [w])],
+        [h, new PreRule(h, '20px', [h])],
       ]);
       expect(
         flattenRawStyleObject(
@@ -172,8 +172,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, '10px', ['containIntrinsicSize'])],
-        [h, new PreRule(h, 'auto 20px', ['containIntrinsicSize'])],
+        [w, new PreRule(w, '10px', [w])],
+        [h, new PreRule(h, 'auto 20px', [h])],
       ]);
       expect(
         flattenRawStyleObject(
@@ -183,8 +183,8 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        [w, new PreRule(w, 'auto 10px', ['containIntrinsicSize'])],
-        [h, new PreRule(h, 'auto 20px', ['containIntrinsicSize'])],
+        [w, new PreRule(w, 'auto 10px', [w])],
+        [h, new PreRule(h, 'auto 20px', [h])],
       ]);
     });
 

--- a/packages/shared/__tests__/flatten-raw-style-objects/legacy-shorthand-expansion-test.js
+++ b/packages/shared/__tests__/flatten-raw-style-objects/legacy-shorthand-expansion-test.js
@@ -78,19 +78,19 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
 
     test('should expand simple shorthands', () => {
       expect(flattenRawStyleObject({ margin: 10 }, options)).toEqual([
-        ['marginTop', new PreRule('marginTop', 10, ['margin'])],
-        ['marginEnd', new PreRule('marginEnd', 10, ['margin'])],
-        ['marginBottom', new PreRule('marginBottom', 10, ['margin'])],
-        ['marginStart', new PreRule('marginStart', 10, ['margin'])],
+        ['marginTop', new PreRule('marginTop', 10, ['marginTop'])],
+        ['marginEnd', new PreRule('marginEnd', 10, ['marginEnd'])],
+        ['marginBottom', new PreRule('marginBottom', 10, ['marginBottom'])],
+        ['marginStart', new PreRule('marginStart', 10, ['marginStart'])],
       ]);
 
       expect(
         flattenRawStyleObject({ margin: 10, marginBottom: 20 }, options),
       ).toEqual([
-        ['marginTop', new PreRule('marginTop', 10, ['margin'])],
-        ['marginEnd', new PreRule('marginEnd', 10, ['margin'])],
-        ['marginBottom', new PreRule('marginBottom', 10, ['margin'])],
-        ['marginStart', new PreRule('marginStart', 10, ['margin'])],
+        ['marginTop', new PreRule('marginTop', 10, ['marginTop'])],
+        ['marginEnd', new PreRule('marginEnd', 10, ['marginEnd'])],
+        ['marginBottom', new PreRule('marginBottom', 10, ['marginBottom'])],
+        ['marginStart', new PreRule('marginStart', 10, ['marginStart'])],
         ['marginBottom', new PreRule('marginBottom', 20, ['marginBottom'])],
       ]);
     });
@@ -102,25 +102,25 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           options,
         ),
       ).toEqual([
-        ['marginTop', new PreRule('marginTop', '10px', ['margin'])],
-        ['marginEnd', new PreRule('marginEnd', '20px', ['margin'])],
-        ['marginBottom', new PreRule('marginBottom', '10px', ['margin'])],
-        ['marginStart', new PreRule('marginStart', '20px', ['margin'])],
+        ['marginTop', new PreRule('marginTop', '10px', ['marginTop'])],
+        ['marginEnd', new PreRule('marginEnd', '20px', ['marginEnd'])],
+        ['marginBottom', new PreRule('marginBottom', '10px', ['marginBottom'])],
+        ['marginStart', new PreRule('marginStart', '20px', ['marginStart'])],
         [
           'borderTopColor',
-          new PreRule('borderTopColor', 'red', ['borderColor']),
+          new PreRule('borderTopColor', 'red', ['borderTopColor']),
         ],
         [
           'borderEndColor',
-          new PreRule('borderEndColor', 'red', ['borderColor']),
+          new PreRule('borderEndColor', 'red', ['borderEndColor']),
         ],
         [
           'borderBottomColor',
-          new PreRule('borderBottomColor', 'red', ['borderColor']),
+          new PreRule('borderBottomColor', 'red', ['borderBottomColor']),
         ],
         [
           'borderStartColor',
-          new PreRule('borderStartColor', 'red', ['borderColor']),
+          new PreRule('borderStartColor', 'red', ['borderStartColor']),
         ],
       ]);
     });
@@ -192,13 +192,16 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
       expect(
         flattenRawStyleObject({ margin: ['10vh 20px', '10dvh 20px'] }, options),
       ).toEqual([
-        ['marginTop', new PreRule('marginTop', ['10vh', '10dvh'], ['margin'])],
-        ['marginEnd', new PreRule('marginEnd', '20px', ['margin'])],
+        [
+          'marginTop',
+          new PreRule('marginTop', ['10vh', '10dvh'], ['marginTop']),
+        ],
+        ['marginEnd', new PreRule('marginEnd', '20px', ['marginEnd'])],
         [
           'marginBottom',
-          new PreRule('marginBottom', ['10vh', '10dvh'], ['margin']),
+          new PreRule('marginBottom', ['10vh', '10dvh'], ['marginBottom']),
         ],
-        ['marginStart', new PreRule('marginStart', '20px', ['margin'])],
+        ['marginStart', new PreRule('marginStart', '20px', ['marginStart'])],
       ]);
     });
   });
@@ -297,29 +300,29 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'marginTop',
           PreRuleSet.create([
-            new PreRule('marginTop', 0, ['margin', 'default']),
-            new PreRule('marginTop', 10, ['margin', ':hover']),
+            new PreRule('marginTop', 0, ['marginTop', 'default']),
+            new PreRule('marginTop', 10, ['marginTop', ':hover']),
           ]),
         ],
         [
           'marginEnd',
           PreRuleSet.create([
-            new PreRule('marginEnd', 0, ['margin', 'default']),
-            new PreRule('marginEnd', 10, ['margin', ':hover']),
+            new PreRule('marginEnd', 0, ['marginEnd', 'default']),
+            new PreRule('marginEnd', 10, ['marginEnd', ':hover']),
           ]),
         ],
         [
           'marginBottom',
           PreRuleSet.create([
-            new PreRule('marginBottom', 0, ['margin', 'default']),
-            new PreRule('marginBottom', 10, ['margin', ':hover']),
+            new PreRule('marginBottom', 0, ['marginBottom', 'default']),
+            new PreRule('marginBottom', 10, ['marginBottom', ':hover']),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', 0, ['margin', 'default']),
-            new PreRule('marginStart', 10, ['margin', ':hover']),
+            new PreRule('marginStart', 0, ['marginStart', 'default']),
+            new PreRule('marginStart', 10, ['marginStart', ':hover']),
           ]),
         ],
       ]);
@@ -350,29 +353,29 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'marginTop',
           PreRuleSet.create([
-            new PreRule('marginTop', '1px', ['margin', 'default']),
-            new PreRule('marginTop', '10px', ['margin', ':hover']),
+            new PreRule('marginTop', '1px', ['marginTop', 'default']),
+            new PreRule('marginTop', '10px', ['marginTop', ':hover']),
           ]),
         ],
         [
           'marginEnd',
           PreRuleSet.create([
-            new PreRule('marginEnd', '2px', ['margin', 'default']),
-            new PreRule('marginEnd', '20px', ['margin', ':hover']),
+            new PreRule('marginEnd', '2px', ['marginEnd', 'default']),
+            new PreRule('marginEnd', '20px', ['marginEnd', ':hover']),
           ]),
         ],
         [
           'marginBottom',
           PreRuleSet.create([
-            new PreRule('marginBottom', '3px', ['margin', 'default']),
-            new PreRule('marginBottom', '10px', ['margin', ':hover']),
+            new PreRule('marginBottom', '3px', ['marginBottom', 'default']),
+            new PreRule('marginBottom', '10px', ['marginBottom', ':hover']),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', '4px', ['margin', 'default']),
-            new PreRule('marginStart', '20px', ['margin', ':hover']),
+            new PreRule('marginStart', '4px', ['marginStart', 'default']),
+            new PreRule('marginStart', '20px', ['marginStart', ':hover']),
           ]),
         ],
       ]);
@@ -439,29 +442,37 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
         [
           'marginTop',
           PreRuleSet.create([
-            new PreRule('marginTop', '1px', ['margin', 'default']),
-            new PreRule('marginTop', ['10px', '1dvh'], ['margin', ':hover']),
+            new PreRule('marginTop', '1px', ['marginTop', 'default']),
+            new PreRule('marginTop', ['10px', '1dvh'], ['marginTop', ':hover']),
           ]),
         ],
         [
           'marginEnd',
           PreRuleSet.create([
-            new PreRule('marginEnd', '2px', ['margin', 'default']),
-            new PreRule('marginEnd', ['20px', '2dvw'], ['margin', ':hover']),
+            new PreRule('marginEnd', '2px', ['marginEnd', 'default']),
+            new PreRule('marginEnd', ['20px', '2dvw'], ['marginEnd', ':hover']),
           ]),
         ],
         [
           'marginBottom',
           PreRuleSet.create([
-            new PreRule('marginBottom', '3px', ['margin', 'default']),
-            new PreRule('marginBottom', ['10px', '1dvh'], ['margin', ':hover']),
+            new PreRule('marginBottom', '3px', ['marginBottom', 'default']),
+            new PreRule(
+              'marginBottom',
+              ['10px', '1dvh'],
+              ['marginBottom', ':hover'],
+            ),
           ]),
         ],
         [
           'marginStart',
           PreRuleSet.create([
-            new PreRule('marginStart', '4px', ['margin', 'default']),
-            new PreRule('marginStart', ['20px', '2dvw'], ['margin', ':hover']),
+            new PreRule('marginStart', '4px', ['marginStart', 'default']),
+            new PreRule(
+              'marginStart',
+              ['20px', '2dvw'],
+              ['marginStart', ':hover'],
+            ),
           ]),
         ],
       ]);

--- a/packages/shared/src/preprocess-rules/flatten-raw-style-obj.js
+++ b/packages/shared/src/preprocess-rules/flatten-raw-style-obj.js
@@ -64,7 +64,9 @@ export function _flattenRawStyleObject(
             new PreRule(
               property,
               value,
-              keyPath.includes(key) ? keyPath : [...keyPath, key],
+              keyPath.includes(key)
+                ? keyPath.map((k) => (k === key ? property : k))
+                : [...keyPath, property],
             ),
           ]);
         }
@@ -118,7 +120,9 @@ export function _flattenRawStyleObject(
               new PreRule(
                 property,
                 value,
-                keyPath.includes(_key) ? keyPath : [...keyPath, _key],
+                keyPath.includes(_key)
+                  ? keyPath.map((k) => (k === _key ? property : k))
+                  : [...keyPath, property],
               ),
             ]);
           }

--- a/packages/shared/src/preprocess-rules/index.js
+++ b/packages/shared/src/preprocess-rules/index.js
@@ -29,7 +29,10 @@ export function getExpandedKeys(
 
 export default function flatMapExpandedShorthands(
   objEntry: $ReadOnly<[string, TStyleValue]>,
-  options: StyleXOptions,
+  options: $ReadOnly<{
+    styleResolution: StyleXOptions['styleResolution'],
+    ...
+  }>,
 ): $ReadOnlyArray<[string, TStyleValue]> {
   // eslint-disable-next-line prefer-const
   let [key, value] = objEntry;

--- a/packages/shared/src/transform-value.js
+++ b/packages/shared/src/transform-value.js
@@ -141,7 +141,6 @@ export const lengthUnits: Set<string> = new Set([
   'borderBottomWidth',
   'borderEndEndRadius',
   'borderEndStartRadius',
-  // 'borderImageWidth', // can be a unitless number
   'borderInlineEndWidth',
   'borderEndWidth',
   'borderInlineStartWidth',
@@ -185,8 +184,6 @@ export const lengthUnits: Set<string> = new Set([
   'marginLeft',
   'marginRight',
   'marginTop',
-  'maskBorderOutset',
-  'maskBorderWidth',
   'maxBlockSize',
   'maxHeight',
   'maxInlineSize',


### PR DESCRIPTION
# Fixes for dynamic styles for expanded shorthands (when using "legacy-expand-shorthands")

## Work so far

In the previous two PRs, I made it so that when using a dynamic style, if the dynamic value resolves to `null` or `undefined`, then:
- Neither the inline style setting the CSS variable should be applied
- Nor the className that uses that variable should be applied.

In order words, a dynamic style that resolves to `null` should behave just like a regular style that resolves to `null`.

## What was fixed

Until the previous diff, when using `styleResolution: 'legacy-expand-shorthands'` any dynamic styles set to a shorthand were not correctly handled. This is because the keys in the original style object, the inline styles and the applied styles did not match.

This PR fixes that by re-using the same logic used to expand keys to also expand which keys we know are dynamic.

## Also completed

~~We're not correctly adding `px` units for all properties that only take lengths and not numbers. Specifically, shorthand properties such as `margin` are not handled correctly. This will be fixed next.~~

- [x] Done.

~~Also, once these PRs land, we can change the `var(--prop-name, revert)` to just `var(--prop-name)` as the static values used for dynamic styles.~~

- [x] Done