### PR TITLE
fix: ensure unique classNames for pseudo classes & elems

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -781,11 +781,11 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2(".x16oeupf::before{color:red}", 8000);
-          _inject2(".xeb2lg0:hover::before{color:blue}", 8130);
+          _inject2(".xzzpreb:hover::before{color:blue}", 8130);
           export const styles = {
             foo: {
               "::before_color": "x16oeupf",
-              ":hover_::before_color": "xeb2lg0",
+              ":hover_::before_color": "xzzpreb",
               $$css: true
             }
           };"
@@ -818,13 +818,13 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2(".x16oeupf::before{color:red}", 8000);
-          _inject2(".xeb2lg0:hover::before{color:blue}", 8130);
-          _inject2(".x18ezmze:hover::before:hover{color:green}", 8260);
-          _inject2(".xnj3kot:hover::before:active{color:purple}", 8300);
+          _inject2(".xzzpreb:hover::before{color:blue}", 8130);
+          _inject2(".x1gobd9t:hover::before:hover{color:green}", 8260);
+          _inject2(".xs8jp5:hover::before:active{color:purple}", 8300);
           export const styles = {
             foo: {
               "::before_color": "x16oeupf",
-              ":hover_::before_color": "xeb2lg0 x18ezmze xnj3kot",
+              ":hover_::before_color": "xzzpreb x1gobd9t xs8jp5",
               $$css: true
             }
           };"

--- a/packages/shared/__tests__/stylex-create-test.js
+++ b/packages/shared/__tests__/stylex-create-test.js
@@ -639,11 +639,16 @@ describe('stylex-create-test', () => {
         {
           "default": {
             "$$css": true,
-            "::before_color": "xvg9oe5",
-            ":hover_::before_color": "xewn9if x1gobd9t x1lvqgcc",
+            "::before_color": "x16oeupf",
+            ":hover_::before_color": "xzzpreb x1gobd9t x1lvqgcc",
           },
         },
         {
+          "x16oeupf": {
+            "ltr": ".x16oeupf::before{color:red}",
+            "priority": 8000,
+            "rtl": null,
+          },
           "x1gobd9t": {
             "ltr": ".x1gobd9t:hover::before:hover{color:green}",
             "priority": 8260,
@@ -654,14 +659,18 @@ describe('stylex-create-test', () => {
             "priority": 8300,
             "rtl": null,
           },
-          "xewn9if": {
-            "ltr": ".xewn9if:hover::before{color:red}",
+          "xzzpreb": {
+            "ltr": ".xzzpreb:hover::before{color:blue}",
             "priority": 8130,
             "rtl": null,
           },
         },
         {
           "default": {
+            "x16oeupf": [
+              "::before",
+              "color",
+            ],
             "x1gobd9t": [
               ":hover",
               "::before",
@@ -674,7 +683,7 @@ describe('stylex-create-test', () => {
               ":active",
               "color",
             ],
-            "xewn9if": [
+            "xzzpreb": [
               ":hover",
               "::before",
               "default",
@@ -686,7 +695,7 @@ describe('stylex-create-test', () => {
     `);
   });
 
-  test.skip('transforms nested pseudo-classes within pseudo elements', () => {
+  test('transforms nested pseudo-classes within pseudo elements', () => {
     const [beforeHover] = styleXCreate({
       default: {
         '::before': {
@@ -712,7 +721,7 @@ describe('stylex-create-test', () => {
     const hoverBeforeClass = hoverBefore.default[':hover_::before_color'];
 
     expect(beforeHoverClass).toMatchInlineSnapshot('"xeb2lg0"');
-    expect(hoverBeforeClass).toMatchInlineSnapshot('"xeb2lg0"');
+    expect(hoverBeforeClass).toMatchInlineSnapshot('"xzzpreb"');
 
     expect(beforeHoverClass).not.toEqual(hoverBeforeClass);
   });

--- a/packages/shared/__tests__/stylex-create-test.js
+++ b/packages/shared/__tests__/stylex-create-test.js
@@ -639,51 +639,42 @@ describe('stylex-create-test', () => {
         {
           "default": {
             "$$css": true,
-            "::before_color": "x16oeupf",
-            ":hover_::before_color": "xeb2lg0 x18ezmze x14o3fp0",
+            "::before_color": "xvg9oe5",
+            ":hover_::before_color": "xewn9if x1gobd9t x1lvqgcc",
           },
         },
         {
-          "x14o3fp0": {
-            "ltr": ".x14o3fp0:hover::before:active{color:yellow}",
-            "priority": 8300,
-            "rtl": null,
-          },
-          "x16oeupf": {
-            "ltr": ".x16oeupf::before{color:red}",
-            "priority": 8000,
-            "rtl": null,
-          },
-          "x18ezmze": {
-            "ltr": ".x18ezmze:hover::before:hover{color:green}",
+          "x1gobd9t": {
+            "ltr": ".x1gobd9t:hover::before:hover{color:green}",
             "priority": 8260,
             "rtl": null,
           },
-          "xeb2lg0": {
-            "ltr": ".xeb2lg0:hover::before{color:blue}",
+          "x1lvqgcc": {
+            "ltr": ".x1lvqgcc:hover::before:active{color:yellow}",
+            "priority": 8300,
+            "rtl": null,
+          },
+          "xewn9if": {
+            "ltr": ".xewn9if:hover::before{color:red}",
             "priority": 8130,
             "rtl": null,
           },
         },
         {
           "default": {
-            "x14o3fp0": [
+            "x1gobd9t": [
+              ":hover",
+              "::before",
+              ":hover",
+              "color",
+            ],
+            "x1lvqgcc": [
               ":hover",
               "::before",
               ":active",
               "color",
             ],
-            "x16oeupf": [
-              "::before",
-              "color",
-            ],
-            "x18ezmze": [
-              ":hover",
-              "::before",
-              ":hover",
-              "color",
-            ],
-            "xeb2lg0": [
+            "xewn9if": [
               ":hover",
               "::before",
               "default",

--- a/packages/shared/src/convert-to-className.js
+++ b/packages/shared/src/convert-to-className.js
@@ -50,8 +50,8 @@ export function convertStyleToClassName(
   const atRuleHashString = sortedPseudos.join('');
   const pseudoHashString = sortedAtRules.join('');
 
-  // TODO: remove the `null` fallback.
-  // This will cause all classNames to change so will need to be careful.
+  // NOTE: 'null' is used to keep existing hashes stable.
+  // This should be removed in a future version.
   const modifierHashString = atRuleHashString + pseudoHashString || 'null';
   const valueAsString = Array.isArray(value) ? value.join(', ') : value;
   const stringToHash = dashedKey + valueAsString + modifierHashString;

--- a/packages/shared/src/convert-to-className.js
+++ b/packages/shared/src/convert-to-className.js
@@ -13,8 +13,8 @@ import dashify from './utils/dashify';
 import transformValue from './transform-value';
 import { generateRule } from './generate-css-rule';
 import { defaultOptions } from './utils/default-options';
-import { arraySort } from './utils/object-utils';
 import * as messages from './messages';
+import { sortAtRules, sortPseudos } from './utils/rule-utils';
 
 // This function takes a single style rule and transforms it into a CSS rule.
 // [color: 'red'] => ['color', 'classname-for-color-red', CSSRULE{ltr, rtl, priority}]
@@ -33,7 +33,7 @@ export function convertStyleToClassName(
   const [key, rawValue] = objEntry;
   const dashedKey = dashify(key);
 
-  let value = Array.isArray(rawValue)
+  let value: string | $ReadOnlyArray<string> = Array.isArray(rawValue)
     ? rawValue.map((eachValue) => transformValue(key, eachValue, options))
     : transformValue(key, rawValue, options);
 
@@ -44,17 +44,17 @@ export function convertStyleToClassName(
     value = variableFallbacks(value);
   }
 
-  const sortedPseudos = arraySort(pseudos ?? []);
-  const sortedAtRules = arraySort(atRules ?? []);
+  const sortedPseudos = sortPseudos(pseudos ?? []);
+  const sortedAtRules = sortAtRules(atRules ?? []);
 
   const atRuleHashString = sortedPseudos.join('');
   const pseudoHashString = sortedAtRules.join('');
 
+  // TODO: remove the `null` fallback.
+  // This will cause all classNames to change so will need to be careful.
   const modifierHashString = atRuleHashString + pseudoHashString || 'null';
-
-  const stringToHash = Array.isArray(value)
-    ? dashedKey + value.join(', ') + modifierHashString
-    : dashedKey + value + modifierHashString;
+  const valueAsString = Array.isArray(value) ? value.join(', ') : value;
+  const stringToHash = dashedKey + valueAsString + modifierHashString;
 
   // NOTE: '<>' is used to keep existing hashes stable.
   // This should be removed in a future version.
@@ -69,7 +69,7 @@ export function convertStyleToClassName(
 
 export default function variableFallbacks(
   values: $ReadOnlyArray<string>,
-): Array<string> {
+): $ReadOnlyArray<string> {
   const firstVar = values.findIndex(
     (val) => val.startsWith('var(') && val.endsWith(')'),
   );

--- a/packages/shared/src/convert-to-className.js
+++ b/packages/shared/src/convert-to-className.js
@@ -47,12 +47,12 @@ export function convertStyleToClassName(
   const sortedPseudos = sortPseudos(pseudos ?? []);
   const sortedAtRules = sortAtRules(atRules ?? []);
 
-  const atRuleHashString = sortedPseudos.join('');
-  const pseudoHashString = sortedAtRules.join('');
+  const pseudoHashString = sortedPseudos.join('');
+  const atRuleHashString = sortedAtRules.join('');
 
   // NOTE: 'null' is used to keep existing hashes stable.
   // This should be removed in a future version.
-  const modifierHashString = atRuleHashString + pseudoHashString || 'null';
+  const modifierHashString = pseudoHashString + atRuleHashString || 'null';
   const valueAsString = Array.isArray(value) ? value.join(', ') : value;
   const stringToHash = dashedKey + valueAsString + modifierHashString;
 

--- a/packages/shared/src/utils/rule-utils.js
+++ b/packages/shared/src/utils/rule-utils.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import { arraySort } from './object-utils';
+
+export const sortPseudos = (
+  pseudos: $ReadOnlyArray<string>,
+): $ReadOnlyArray<string> => {
+  if (pseudos.length < 2) {
+    return pseudos;
+  }
+
+  return pseudos
+    .reduce(
+      (acc, pseudo) => {
+        if (pseudo.startsWith('::')) {
+          return [...acc, pseudo];
+        }
+
+        const lastElement = acc[acc.length - 1];
+        const allButLast = acc.slice(0, acc.length - 1);
+        if (Array.isArray(lastElement)) {
+          return [...allButLast, [...lastElement, pseudo]];
+        } else {
+          return [...allButLast, lastElement, [pseudo]].filter(Boolean);
+        }
+      },
+      [] as $ReadOnlyArray<string | $ReadOnlyArray<string>>,
+    )
+    .flatMap((pseudo) => {
+      if (Array.isArray(pseudo)) {
+        return arraySort(pseudo, stringComparator);
+      }
+      return [pseudo];
+    });
+};
+
+export const sortAtRules = (
+  atRules: $ReadOnlyArray<string>,
+): $ReadOnlyArray<string> => arraySort(atRules);
+
+// a comparator function that sorts strings alphabetically
+// but where `default` always comes first
+const stringComparator = (a: string, b: string): number => {
+  if (a === 'default') {
+    return -1;
+  }
+  if (b === 'default') {
+    return 1;
+  }
+  return a.localeCompare(b);
+};


### PR DESCRIPTION
## What changed

We recently fixed an issue with how pseudo selectors are sorted in StyleX to ensure we don't accidentally mix up pseudo classes and pseudo elements incorrectly. 

However, while we fixed the generated rules in the previous PR, the string hashed to generate a unique className was still using the old logic. This would mean that, e.g. if you used both `::before:hover` *and* `:hover::before` selectors in your styles for the exact same property and value, both rules would generate the same className.

(TODO: Create a separate commit to actually demonstrate this edge-case in a test)

This PR updates the logic used when generating the className to match the logic used when generating the CSS rule to fix this issue.

Fixes #749
