### PR TITLE
fix: convert esm-resolve paths to absolute paths

### DIFF
--- a/packages/babel-plugin/src/utils/state-manager.js
+++ b/packages/babel-plugin/src/utils/state-manager.js
@@ -682,6 +682,9 @@ const filePathResolver = (
         });
 
         if (resolved) {
+          if (resolved.startsWith('.')) {
+            return path.resolve(path.dirname(sourceFilePath), resolved);
+          }
           return resolved;
         }
       }


### PR DESCRIPTION
Small fix to make `esmResolve` work reliably when resolving themes across packages in a mono-repo.