### PR TITLE
feat: add no-unused eslint rule to find unused styles

### DIFF
--- a/apps/docs/.eslintrc.js
+++ b/apps/docs/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
     // The Eslint rule still needs work, but you can
     // enable it to test things out.
     '@stylexjs/valid-styles': 'error',
-    // '@stylexjs/no-unused' : 'warn',
+    // '@stylexjs/no-unused': 'warn',
     // 'ft-flow/space-after-type-colon': 0,
     // 'ft-flow/no-types-missing-file-annotation': 0,
     // 'ft-flow/generic-spacing': 0,

--- a/apps/docs/.eslintrc.js
+++ b/apps/docs/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     // The Eslint rule still needs work, but you can
     // enable it to test things out.
     '@stylexjs/valid-styles': 'error',
+    // '@stylexjs/no-unused' : 'warn',
     // 'ft-flow/space-after-type-colon': 0,
     // 'ft-flow/no-types-missing-file-annotation': 0,
     // 'ft-flow/generic-spacing': 0,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.25.8",
+    "@stylexjs/eslint-plugin": "0.8.0",
     "@stylexjs/babel-plugin": "0.9.3",
     "clean-css": "^5.3.2",
     "eslint": "^8.57.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.3.0",
         "@rollup/plugin-replace": "^6.0.1",
-         "@stylexjs/eslint-plugin": "^0.8.0",
         "@types/estree": "^1.0.6",
         "@types/jest": "^29.5.13",
         "babel-plugin-syntax-hermes-parser": "^0.25.0",
@@ -117,6 +116,7 @@
       "devDependencies": {
         "@babel/eslint-parser": "^7.25.8",
         "@stylexjs/babel-plugin": "0.9.3",
+        "@stylexjs/eslint-plugin": "0.8.0",
         "clean-css": "^5.3.2",
         "eslint": "^8.57.1",
         "eslint-config-airbnb": "^19.0.4",
@@ -139,6 +139,17 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "apps/docs/node_modules/@stylexjs/eslint-plugin": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@stylexjs/eslint-plugin/-/eslint-plugin-0.8.0.tgz",
+      "integrity": "sha512-1o626c96axO8nWpsY5PYV9CI+12Hr+cD4R4iYGlPRCHqbT0G4lgwBQorrJvb/ChK9Y/u5c7VZq2q2O5/G9C1AA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-shorthand-expand": "^1.2.0",
+        "micromatch": "^4.0.5"
       }
     },
     "apps/docs/node_modules/array.prototype.findlastindex": {
@@ -34941,6 +34952,7 @@
         "@docusaurus/preset-classic": "2.4.1",
         "@mdx-js/react": "^1.6.22",
         "@stylexjs/babel-plugin": "0.9.3",
+        "@stylexjs/eslint-plugin": "0.8.0",
         "@stylexjs/stylex": "0.9.3",
         "@vercel/analytics": "^1.1.1",
         "clean-css": "^5.3.2",
@@ -34966,6 +34978,16 @@
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.14.0"
+          }
+        },
+        "@stylexjs/eslint-plugin": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@stylexjs/eslint-plugin/-/eslint-plugin-0.8.0.tgz",
+          "integrity": "sha512-1o626c96axO8nWpsY5PYV9CI+12Hr+cD4R4iYGlPRCHqbT0G4lgwBQorrJvb/ChK9Y/u5c7VZq2q2O5/G9C1AA==",
+          "dev": true,
+          "requires": {
+            "css-shorthand-expand": "^1.2.0",
+            "micromatch": "^4.0.5"
           }
         },
         "array.prototype.findlastindex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.3.0",
         "@rollup/plugin-replace": "^6.0.1",
+         "@stylexjs/eslint-plugin": "^0.8.0",
         "@types/estree": "^1.0.6",
         "@types/jest": "^29.5.13",
         "babel-plugin-syntax-hermes-parser": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-replace": "^6.0.1",
-    "@stylexjs/eslint-plugin": "^0.8.0",
     "@types/estree": "^1.0.6",
     "@types/jest": "^29.5.13",
     "babel-plugin-syntax-hermes-parser": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-replace": "^6.0.1",
+    "@stylexjs/eslint-plugin": "^0.8.0",
     "@types/estree": "^1.0.6",
     "@types/jest": "^29.5.13",
     "babel-plugin-syntax-hermes-parser": "^0.25.0",

--- a/packages/eslint-plugin/__tests__/stylex-no-unused-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-no-unused-test.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const { RuleTester: ESLintTester } = require('eslint');
+const rule = require('../src/stylex-no-unused');
+
+const eslintTester = new ESLintTester({
+  parser: require.resolve('hermes-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+eslintTester.run('stylex-no-unused', rule.default, {
+  valid: [
+    { // all style used; identifier and literal 
+        code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            borderColor: {
+              default: 'green',
+              ':hover': 'red',
+              '@media (min-width: 1540px)': 1366,
+            },
+            borderRadius: 10,
+            display: 'flex',
+          },
+          dynamic: (color) => ({
+            backgroundColor: color,
+          })
+        });
+        const sizeStyles = stylex.create({
+          [8]: {
+            height: 8,
+            width: 8,
+          },
+          [10]: {
+            height: 10,
+            width: 10,
+          },
+          [12]: {
+            height: 12,
+            width: 12,
+          },
+        });
+        export default function TestComponent() {
+          return(
+            <div {...stylex.props(styles.main, styles.dynamic, sizeStyles[8])}>
+            </div>
+          )
+        }
+      `,
+      },
+    { // styles default export
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          borderColor: {
+            default: 'green',
+            ':hover': 'red',
+            '@media (min-width: 1540px)': 1366,
+          },
+          borderRadius: 10,
+          display: 'flex',
+        },
+        dynamic: (color) => ({
+          backgroundColor: color,
+        })
+      });
+      export default styles;
+    `,
+    },
+    { // styles anonymous default export
+      code: `
+      import stylex from 'stylex';
+      export default stylex.create({
+        maxDimensionsModal: {
+          maxWidth: '90%',
+          maxHeight: '90%',
+        },
+        halfWindowWidth: {
+          width: '50vw',
+        },
+      })
+    `,
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            borderColor: {
+              default: 'green',
+              ':hover': 'red',
+              '@media (min-width: 1540px)': 1366,
+            },
+            borderRadius: 10,
+            display: 'flex',
+          },
+          dynamic: (color) => ({
+            backgroundColor: color,
+          })
+        });
+        export default function TestComponent() {
+          return(
+            <div {...stylex.props(styles.dynamic)}>
+            </div>
+          )
+        }
+      `,
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          dynamic: (color) => ({
+            backgroundColor: color,
+          })
+        });
+        export default function TestComponent() {
+          return(
+            <div {...stylex.props(styles.dynamic)}>
+            </div>
+          )
+        }
+      `,
+      errors: [
+        {
+          message:
+            'Unused style detected: styles.main',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/__tests__/stylex-no-unused-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-no-unused-test.js
@@ -58,7 +58,96 @@ eslintTester.run('stylex-no-unused', rule.default, {
         });
         export default function TestComponent() {
           return(
-            <div {...stylex.props(styles.main, styles.dynamic, sizeStyles[8])}>
+            <div {...stylex.props(styles.main, styles.dynamic('red'), sizeStyles[8])}>
+            </div>
+          )
+        }
+      `,
+    },
+    {
+      // stylex not default export
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            borderColor: {
+              default: 'green',
+              ':hover': 'red',
+              '@media (min-width: 1540px)': 1366,
+            },
+            borderRadius: 10,
+            display: 'flex',
+          },
+          dynamic: (color) => ({
+            backgroundColor: color,
+          })
+        });
+        export const sizeStyles = stylex.create({
+          [8]: {
+            height: 8,
+            width: 8,
+          },
+          [10]: {
+            height: 10,
+            width: 10,
+          },
+          [12]: {
+            height: 12,
+            width: 12,
+          },
+        });
+        export default function TestComponent() {
+          return(
+            <div {...stylex.props(styles.main, styles.dynamic('red'))}>
+            </div>
+          )
+        }
+      `,
+    },
+    {
+      // indirect usage of style
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            display: 'flex',
+          },
+          dynamic: (color) => ({
+            backgroundColor: color,
+          })
+        });
+        const sizeStyles = stylex.create({
+          [8]: {
+            height: 8,
+            width: 8,
+          },
+          [10]: {
+            height: 10,
+            width: 10,
+          },
+          [12]: {
+            height: 12,
+            width: 12,
+          },
+        });
+        const widthStyles = stylex.create({
+            widthModeConstrained: {
+              width: 'auto',
+            },
+            widthModeFlexible: {
+              width: '100%',
+            },
+        })
+        // style used as export
+        function getWidthStyles() {
+          return widthStyles;
+        }
+        export default function TestComponent({ width: number}) {
+          // style used as variable
+          const red = styles.dynamic('red');
+          const display = width > 10 ? sizeStyles[12] :  sizeStyles[8]
+          return(
+            <div {...stylex.props(styles.main, red, display)}>
             </div>
           )
         }
@@ -86,7 +175,22 @@ eslintTester.run('stylex-no-unused', rule.default, {
     `,
     },
     {
-      // styles anonymous default export
+      // styles named default inline export
+      code: `
+      import stylex from 'stylex';
+      export default styles = stylex.create({
+        maxDimensionsModal: {
+          maxWidth: '90%',
+          maxHeight: '90%',
+        },
+        halfWindowWidth: {
+          width: '50vw',
+        },
+      })
+    `,
+    },
+    {
+      // styles anonymous default inline export
       code: `
       import stylex from 'stylex';
       export default stylex.create({
@@ -121,7 +225,7 @@ eslintTester.run('stylex-no-unused', rule.default, {
         });
         export default function TestComponent() {
           return(
-            <div {...stylex.props(styles.dynamic)}>
+            <div {...stylex.props(styles.dynamic('red'))}>
             </div>
           )
         }
@@ -135,11 +239,122 @@ eslintTester.run('stylex-no-unused', rule.default, {
         });
         export default function TestComponent() {
           return(
-            <div {...stylex.props(styles.dynamic)}>
+            <div {...stylex.props(styles.dynamic('red'))}>
             </div>
           )
         }
       `,
+      errors: [
+        {
+          message: 'Unused style detected: styles.main',
+        },
+      ],
+    },
+    {
+      // Import form: import * as stylex from '@stylexjs/stylex';
+      code: `
+        import * as customStylex from '@stylexjs/stylex';
+        const styles = customStylex.create({
+          main: {
+            display: 'flex',
+          },
+          dynamic: (color) => ({
+            backgroundColor: color,
+          })
+        });
+        export default function TestComponent() {
+          return(
+            <div {...stylex.props(styles.dynamic('red'))}>
+            </div>
+          )
+        }`,
+      output: `
+        import * as customStylex from '@stylexjs/stylex';
+        const styles = customStylex.create({
+          dynamic: (color) => ({
+            backgroundColor: color,
+          })
+        });
+        export default function TestComponent() {
+          return(
+            <div {...stylex.props(styles.dynamic('red'))}>
+            </div>
+          )
+        }`,
+      errors: [
+        {
+          message: 'Unused style detected: styles.main',
+        },
+      ],
+    },
+    {
+      // Import form: import {create} from '@stylexjs/stylex';
+      code: `
+        import {create, attrs} from '@stylexjs/stylex';
+        const styles = create({
+          main: {
+            display: 'flex',
+          },
+          dynamic: (color) => ({
+            backgroundColor: color,
+          })
+        });
+        export default function TestComponent() {
+          return(
+            <div {...stylex.props(styles.dynamic('red'))}>
+            </div>
+          )
+        }`,
+      output: `
+        import {create, attrs} from '@stylexjs/stylex';
+        const styles = create({
+          dynamic: (color) => ({
+            backgroundColor: color,
+          })
+        });
+        export default function TestComponent() {
+          return(
+            <div {...stylex.props(styles.dynamic('red'))}>
+            </div>
+          )
+        }`,
+      errors: [
+        {
+          message: 'Unused style detected: styles.main',
+        },
+      ],
+    },
+    {
+      // Import form: import {create as c} from '@stylexjs/stylex';
+      code: `
+        import {create as c} from '@stylexjs/stylex';
+        const styles = c({
+          main: {
+            display: 'flex',
+          },
+          dynamic: (color) => ({
+            backgroundColor: color,
+          })
+        });
+        export default function TestComponent() {
+          return(
+            <div {...stylex.props(styles.dynamic('red'))}>
+            </div>
+          )
+        }`,
+      output: `
+        import {create as c} from '@stylexjs/stylex';
+        const styles = c({
+          dynamic: (color) => ({
+            backgroundColor: color,
+          })
+        });
+        export default function TestComponent() {
+          return(
+            <div {...stylex.props(styles.dynamic('red'))}>
+            </div>
+          )
+        }`,
       errors: [
         {
           message: 'Unused style detected: styles.main',

--- a/packages/eslint-plugin/__tests__/stylex-no-unused-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-no-unused-test.js
@@ -24,8 +24,9 @@ const eslintTester = new ESLintTester({
 
 eslintTester.run('stylex-no-unused', rule.default, {
   valid: [
-    { // all style used; identifier and literal 
-        code: `
+    {
+      // all style used; identifier and literal
+      code: `
         import stylex from 'stylex';
         const styles = stylex.create({
           main: {
@@ -62,8 +63,9 @@ eslintTester.run('stylex-no-unused', rule.default, {
           )
         }
       `,
-      },
-    { // styles default export
+    },
+    {
+      // styles default export
       code: `
       import stylex from 'stylex';
       const styles = stylex.create({
@@ -83,7 +85,8 @@ eslintTester.run('stylex-no-unused', rule.default, {
       export default styles;
     `,
     },
-    { // styles anonymous default export
+    {
+      // styles anonymous default export
       code: `
       import stylex from 'stylex';
       export default stylex.create({
@@ -96,7 +99,7 @@ eslintTester.run('stylex-no-unused', rule.default, {
         },
       })
     `,
-    }
+    },
   ],
   invalid: [
     {
@@ -139,8 +142,7 @@ eslintTester.run('stylex-no-unused', rule.default, {
       `,
       errors: [
         {
-          message:
-            'Unused style detected: styles.main',
+          message: 'Unused style detected: styles.main',
         },
       ],
     },

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -10,15 +10,18 @@
 import validStyles from './stylex-valid-styles';
 import sortKeys from './stylex-sort-keys';
 import validShorthands from './stylex-valid-shorthands';
+import noUnused from './stylex-no-unused';
 
 const rules: {
   'valid-styles': typeof validStyles,
   'sort-keys': typeof sortKeys,
   'valid-shorthands': typeof validShorthands,
+  'no-unused': typeof noUnused,
 } = {
   'valid-styles': validStyles,
   'sort-keys': sortKeys,
   'valid-shorthands': validShorthands,
+  'no-unused': noUnused,
 };
 
 export { rules };

--- a/packages/eslint-plugin/src/stylex-no-unused.js
+++ b/packages/eslint-plugin/src/stylex-no-unused.js
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+/*:: import { Rule } from 'eslint'; */
+import type {
+  CallExpression,
+  Expression,
+  Node,
+  Program,
+  Property,
+  SpreadElement,
+  RestElement,
+  MemberExpression,
+  AssignmentProperty,
+  ExportDefaultDeclaration
+} from 'estree';
+
+type PropertyValue = Property | SpreadElement | AssignmentProperty | RestElement;
+function isStylexCallee(node: Node) {
+  return (
+    node.type === 'MemberExpression' &&
+    node.object.type === 'Identifier' &&
+    node.object.name === 'stylex' &&
+    node.property.type === 'Identifier' &&
+    node.property.name === 'create'
+  );
+}
+
+function isStylexDeclaration(node: Node) {
+  return (
+    node &&
+    node.type === 'CallExpression' &&
+    isStylexCallee(node.callee) &&
+    node.arguments.length === 1 &&
+    node.arguments[0].type === 'ObjectExpression'
+  );
+}
+
+function getPropertiesByName(node: Node | null) {
+  const properties = new Map<any, PropertyValue>();
+  if(node == null) {
+    return properties;
+  }
+  node.properties
+    ?.filter(property => !property.computed && !property.method)
+    .forEach(property => {
+      const {key} = property;
+      if (key?.type === 'Identifier') {
+        properties.set(key.name, property);
+      } else if (key?.type === 'Literal') {
+        properties.set(key.value, property);
+      }
+    });
+  return properties;
+}
+
+const stylexNoUnused = {
+  meta: {
+    fixable: 'code',
+  },
+  create(context: Rule.RuleContext): { ... } {
+    const stylexProperties = new Map<string, Map<any, PropertyValue>>();
+
+    function saveStylexCalls(node: Node) {
+      const id = node.id;
+      const init = node.init;
+      if (id && id.type === 'Identifier' && init && isStylexDeclaration(init)) {
+        stylexProperties.set(
+          id.name,
+          getPropertiesByName((init.arguments && init.arguments?.length > 0) ? init.arguments[0] : null),
+        );
+      }
+    }
+    function checkArguments(namespaces: Map<any, PropertyValue>): (argument: Expression | SpreadElement | null) => void {
+      return function (argument: Expression | SpreadElement | null): void {
+        if (argument) {
+          if (argument.type === 'Literal') {
+            namespaces.delete(argument.value);
+          } else if (argument.type === 'ObjectExpression') {
+            argument.properties.forEach(property => {
+              if (property.key) {
+                namespaces.delete(property.key.name);
+              }
+            });
+          } else if (argument.type === 'ArrayExpression') {
+            argument.elements.forEach(element => {
+              namespaces.delete(element?.value);
+            });
+          } else if (argument.type === 'ConditionalExpression') {
+            const {consequent, alternate} = argument;
+            // check for nested expressions
+            checkArguments(namespaces)(consequent);
+            checkArguments(namespaces)(alternate);
+          } else if (
+            argument.type === 'LogicalExpression' &&
+            argument.operator === '&&'
+          ) {
+            // check for nested expressions but only on the right
+            checkArguments(namespaces)(argument.right);
+          }
+        }
+      };
+    }
+
+
+    return {
+      Program(node: Program) {
+        // stylex.create can only be singular variable declarations at the root
+        // of the file so we can look directly on Program and populate our set.
+        node.body
+          .filter(({type}) => type === 'VariableDeclaration')
+          .map(({declarations}) => (declarations && declarations.length === 1) ? declarations[0]: null)
+          .filter(Boolean)
+          .filter(({init}) => init && isStylexDeclaration(init))
+          .forEach(saveStylexCalls);
+      },
+
+      // detect stylex usage "stylex.__" or "styles[__]"
+      MemberExpression(node: MemberExpression) {
+        if (
+          node.object.type === 'Identifier' &&
+          stylexProperties.has(node.object.name)
+        ) {
+          if (node.computed && node.property.type !== 'Literal') {
+            stylexProperties.delete(node.object.name);
+          } else if (node.property.type === 'Identifier') {
+            stylexProperties.get(node.object.name)?.delete(node.property.name);
+          } else if (node.property.type === 'Literal') {
+            stylexProperties.get(node.object.name)?.delete(node.property.value);
+          }
+        }
+      },
+      // catch function call "functionName(param)"
+      CallExpression(node: CallExpression) {
+        const functionName = node.callee?.name;
+        if (functionName == null || !stylexProperties.has(functionName)) {
+          return;
+        }
+        const namespaces = stylexProperties.get(functionName);
+        if(namespaces == null) {
+          return;
+        }
+        node.arguments?.forEach(checkArguments(namespaces));
+      },
+
+      ExportDefaultDeclaration(node: ExportDefaultDeclaration) {
+        const exportName = node.declaration.name;
+        if (exportName == null || !stylexProperties.has(exportName)) {
+          return;
+        }
+        stylexProperties.delete(exportName);
+      },
+
+      'Program:exit'() {
+        // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
+        const sourceCode = context.sourceCode ||
+        (typeof context.getSourceCode === 'function'
+          ? context.getSourceCode()
+          : null);
+
+        stylexProperties.forEach((namespaces, varName) => {
+          namespaces.forEach((node, namespaceName) => {
+            context.report({
+              node,
+              message: `Unused style detected: ${varName}.${namespaceName}`,
+              fix(fixer) {
+                const commaOffset =
+                  sourceCode.getTokenAfter(node, {
+                    includeComments: false,
+                  })?.value === ',' ? 1 : 0;
+                const left = sourceCode.getTokenBefore(node, {
+                  includeComments: false,
+                });
+                if(node.range == null || left?.range == null) {
+                  return null;
+                }
+                return fixer.removeRange([
+                  left.range[1],
+                  node.range[1] + commaOffset,
+                ]);
+              },
+            });
+          });
+        });
+
+        stylexProperties.clear();
+      },
+    };
+  },
+};
+
+export default stylexNoUnused as typeof stylexNoUnused;


### PR DESCRIPTION
## What changed / motivation ?

Addresses task [ESLint: find unused styles #702](https://github.com/facebook/stylex/issues/702?fbclid=IwZXh0bgNhZW0CMTEAAR2MT8Ix_O_v1dR3d67dGTsuDgK6e_Z7zB0YeIa2Ks6JUMXAi-O8eaep-90_aem_UI7ZN09GF1cJd6VKzo0D_Q).

Identify all styles that 1) not used; 2) not exported. The feature also allow auto fix by removing fields that are unused.

```typescript

import stylex from 'stylex';
// exported, considered all used
const styles = stylex.create({
  main: {
    borderColor: {
      default: 'green',
      ':hover': 'red',
      '@media (min-width: 1540px)': 1366,
    },
    borderRadius: 10,
    display: 'flex',
  },
  dynamic: (color) => ({
    backgroundColor: color,
  })
});
// not exported, not used, will report warning `Unused style detected: stylesUnused.maxDimensionsModal`
const stylesUnused = stylex.create({
    maxDimensionsModal: {
      maxWidth: '90%',
      maxHeight: '90%',
    },
});
export default styles;

```

## Linked PR/Issues

fixes [#702](https://github.com/facebook/stylex/issues/702?fbclid=IwZXh0bgNhZW0CMTEAAR2MT8Ix_O_v1dR3d67dGTsuDgK6e_Z7zB0YeIa2Ks6JUMXAi-O8eaep-90_aem_UI7ZN09GF1cJd6VKzo0D_Q).

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Created sets of tests in [stylex-no-unused-test.js](https://github.com/facebook/stylex/compare/feat/eslint-no-unused?expand=1#diff-4eac7326185bea697fc4ca099d46cb4e429448585a0d5ab35345a93dd6841dbc), all 5 tests passed; also conducted manual testing in `apps/docs/` folder.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code