### PR TITLE
chore: extract eslint get souce code to util

### DIFF
--- a/packages/eslint-plugin/src/stylex-no-unused.js
+++ b/packages/eslint-plugin/src/stylex-no-unused.js
@@ -9,8 +9,6 @@
 
 'use strict';
 
-import getSourceCode from './utils/getSourceCode';
-/*:: import { Rule } from 'eslint'; */
 import type {
   CallExpression,
   Expression,
@@ -25,6 +23,8 @@ import type {
   ExportNamedDeclaration,
   ReturnStatement,
 } from 'estree';
+import getSourceCode from './utils/getSourceCode';
+/*:: import { Rule } from 'eslint'; */
 
 type PropertyValue =
   | Property

--- a/packages/eslint-plugin/src/stylex-no-unused.js
+++ b/packages/eslint-plugin/src/stylex-no-unused.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+import getSourceCode from './utils/getSourceCode';
 /*:: import { Rule } from 'eslint'; */
 import type {
   CallExpression,
@@ -244,12 +245,7 @@ const stylexNoUnused = {
       },
 
       'Program:exit'() {
-        // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
-        const sourceCode =
-          context.sourceCode ||
-          (typeof context.getSourceCode === 'function'
-            ? context.getSourceCode()
-            : null);
+        const sourceCode = getSourceCode(context);
 
         stylexProperties.forEach((namespaces, varName) => {
           namespaces.forEach((node, namespaceName) => {

--- a/packages/eslint-plugin/src/stylex-sort-keys.js
+++ b/packages/eslint-plugin/src/stylex-sort-keys.js
@@ -9,7 +9,6 @@
 
 'use strict';
 
-import getSourceCode from './utils/getSourceCode';
 import type { Token } from 'eslint/eslint-ast';
 import type { RuleFixer, SourceCode } from 'eslint/eslint-rule';
 import type {
@@ -21,6 +20,7 @@ import type {
   ObjectExpression,
   Comment,
 } from 'estree';
+import getSourceCode from './utils/getSourceCode';
 import getPropertyName from './utils/getPropertyName';
 import getPropertyPriorityAndType from './utils/getPropertyPriorityAndType';
 /*:: import { Rule } from 'eslint'; */

--- a/packages/eslint-plugin/src/stylex-sort-keys.js
+++ b/packages/eslint-plugin/src/stylex-sort-keys.js
@@ -227,12 +227,6 @@ const stylexSortKeys = {
 
         const sourceCode = getSourceCode(context);
 
-        if (!sourceCode) {
-          throw new Error(
-            'ESLint context does not provide source code access. Please update ESLint to v>=8.40.0. See: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/',
-          );
-        }
-
         const tokens =
           stack?.prevNode &&
           sourceCode.getTokensBetween(stack.prevNode, node, {

--- a/packages/eslint-plugin/src/stylex-sort-keys.js
+++ b/packages/eslint-plugin/src/stylex-sort-keys.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+import getSourceCode from './utils/getSourceCode';
 import type { Token } from 'eslint/eslint-ast';
 import type { RuleFixer, SourceCode } from 'eslint/eslint-rule';
 import type {
@@ -224,12 +225,7 @@ const stylexSortKeys = {
         const currName = getPropertyName(node);
         let isBlankLineBetweenNodes = stack?.prevBlankLine;
 
-        // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
-        const sourceCode =
-          context.sourceCode ||
-          (typeof context.getSourceCode === 'function'
-            ? context.getSourceCode()
-            : null);
+        const sourceCode = getSourceCode(context);
 
         if (!sourceCode) {
           throw new Error(

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -30,6 +30,8 @@ import { CANNOT_FIX } from './utils/splitShorthands.js';
 
 /*:: import { Rule } from 'eslint'; */
 
+import getSourceCode from './utils/getSourceCode';
+
 const legacyNameMapping: $ReadOnly<{ [key: string]: ?string }> = {
   marginStart: 'marginInlineStart',
   marginEnd: 'marginInlineEnd',
@@ -179,12 +181,7 @@ const stylexValidShorthands = {
         },
         fix: !isUnfixableError
           ? (fixer) => {
-              // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
-              const sourceCode =
-                context.sourceCode ||
-                (typeof context.getSourceCode === 'function'
-                  ? context.getSourceCode()
-                  : null);
+              const sourceCode = getSourceCode(context);
 
               if (!sourceCode) {
                 throw new Error(

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -183,12 +183,6 @@ const stylexValidShorthands = {
           ? (fixer) => {
               const sourceCode = getSourceCode(context);
 
-              if (!sourceCode) {
-                throw new Error(
-                  'ESLint context does not provide source code access. Please update ESLint to v>=8.40.0. See: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/',
-                );
-              }
-
               const startNodeIndentation = getNodeIndentation(
                 sourceCode,
                 property,

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -15,22 +15,16 @@ import type {
   ObjectExpression,
   Comment,
 } from 'estree';
-
 import type { SourceCode } from 'eslint/eslint-rule';
-
 import type { Token } from 'eslint/eslint-ast';
-
 import {
   createBlockInlineTransformer,
   createSpecificTransformer,
   createDirectionalTransformer,
 } from './utils/splitShorthands.js';
-
 import { CANNOT_FIX } from './utils/splitShorthands.js';
-
-/*:: import { Rule } from 'eslint'; */
-
 import getSourceCode from './utils/getSourceCode';
+/*:: import { Rule } from 'eslint'; */
 
 const legacyNameMapping: $ReadOnly<{ [key: string]: ?string }> = {
   marginStart: 'marginInlineStart',

--- a/packages/eslint-plugin/src/utils/getSourceCode.js
+++ b/packages/eslint-plugin/src/utils/getSourceCode.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+/*:: import { Rule } from 'eslint'; */
+import type { SourceCode } from 'eslint/eslint-rule';
+
+// Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
+export default function getSourceCode(
+  context: Rule.RuleContext,
+): SourceCode | null {
+  return (
+    context.sourceCode ||
+    (typeof context.getSourceCode === 'function'
+      ? context.getSourceCode()
+      : null)
+  );
+}

--- a/packages/eslint-plugin/src/utils/getSourceCode.js
+++ b/packages/eslint-plugin/src/utils/getSourceCode.js
@@ -13,13 +13,16 @@
 import type { SourceCode } from 'eslint/eslint-rule';
 
 // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
-export default function getSourceCode(
-  context: Rule.RuleContext,
-): SourceCode | null {
-  return (
+export default function getSourceCode(context: Rule.RuleContext): SourceCode {
+  const sourceCode =
     context.sourceCode ||
     (typeof context.getSourceCode === 'function'
       ? context.getSourceCode()
-      : null)
-  );
+      : null);
+  if (!sourceCode) {
+    throw new Error(
+      'ESLint context does not provide source code access. Please update ESLint to v>=8.40.0. See: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/',
+    );
+  }
+  return sourceCode;
 }

--- a/packages/eslint-plugin/src/utils/getSourceCode.js
+++ b/packages/eslint-plugin/src/utils/getSourceCode.js
@@ -9,8 +9,8 @@
 
 'use strict';
 
-/*:: import { Rule } from 'eslint'; */
 import type { SourceCode } from 'eslint/eslint-rule';
+/*:: import { Rule } from 'eslint'; */
 
 // Fallback to legacy `getSourceCode()` for compatibility with older ESLint versions
 export default function getSourceCode(context: Rule.RuleContext): SourceCode {


### PR DESCRIPTION
## What changed / motivation ?

As per reviewer comment left by @mellyeliu on PR [`feat: add no-unused eslint rule to find unused styles`](https://github.com/facebook/stylex/pull/767#discussion_r1833640097), multiple eslint rule definition files are using identical conditional logic to get source code from Rule context such that we are backwards comparable with older eslint versions. This PR extract this logic into a separate util function so that it can be reused.
 
## Linked PR/Issues

Fixes #767 

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

- `npx jest *` running all test files inside `estlint-plugin` folder, all tests still passing

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code