### PR TITLE
feat: CLI can use additional Babel plugins

### DIFF
--- a/apps/cli-example/.stylex.json5
+++ b/apps/cli-example/.stylex.json5
@@ -4,7 +4,7 @@
   cssBundleName: 'stylex_bundle.css',
   babelPresets: [
     ['@babel/preset-typescript', { allExtensions: true, isTSX: true }],
-    '@babel/preset-react',
+    // '@babel/preset-react',
   ],
   modules_EXPERIMENTAL: [
     ['@stylexjs/open-props', { ignore: ['src', '__tests__'] }],

--- a/packages/babel-plugin/flow_modules/@babel/types/index.js.flow
+++ b/packages/babel-plugin/flow_modules/@babel/types/index.js.flow
@@ -3,6 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
  * @flow strict
  */
 
@@ -3809,8 +3810,8 @@ declare export var getBindingIdentifiers: {
   ): Dups extends true
     ? Record<string, Array<Identifier>>
     : Dups extends false
-    ? Record<string, Identifier>
-    : Record<string, Array<Identifier>> | Record<string, Identifier>,
+      ? Record<string, Identifier>
+      : Record<string, Array<Identifier>> | Record<string, Identifier>,
 
   +keys: $ReadOnly<{
     DeclareClass: $ReadOnlyArray<string>,

--- a/packages/cli/__tests__/__mocks__/snapshot/components/button.js
+++ b/packages/cli/__tests__/__mocks__/snapshot/components/button.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
-import "../stylex_bundle.css";
 import * as stylex from '@stylexjs/stylex';
 import otherStyles from './otherStyles';
 import npmStyles from './npmStyles';
+import "../stylex_bundle.css";
 const fadeAnimation = "xgnty7z-B";
 const styles = {
   foo: {

--- a/packages/cli/__tests__/__mocks__/snapshot/index.js
+++ b/packages/cli/__tests__/__mocks__/snapshot/index.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
-import "./stylex_bundle.css";
 import * as stylex from '@stylexjs/stylex';
 import otherStyles from './otherStyles';
 import npmStyles from './npmStyles';
+import "./stylex_bundle.css";
 const fadeAnimation = "xgnty7z-B";
 const styles = {
   foo: {

--- a/packages/cli/__tests__/__mocks__/snapshot/pages/home.js
+++ b/packages/cli/__tests__/__mocks__/snapshot/pages/home.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
-import "../stylex_bundle.css";
 import * as stylex from '@stylexjs/stylex';
 import otherStyles from './otherStyles';
 import npmStyles from './npmStyles';
+import "../stylex_bundle.css";
 const fadeAnimation = "xgnty7z-B";
 const styles = {
   foo: {

--- a/packages/cli/__tests__/__mocks__/snapshot2/components/button.js
+++ b/packages/cli/__tests__/__mocks__/snapshot2/components/button.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
-import "../../src/stylex_bundle.css";
 import * as stylex from '@stylexjs/stylex';
 import otherStyles from './otherStyles';
 import npmStyles from './npmStyles';
+import "../../src/stylex_bundle.css";
 const fadeAnimation = "xgnty7z-B";
 const styles = {
   foo: {

--- a/packages/cli/__tests__/__mocks__/snapshot2/index.js
+++ b/packages/cli/__tests__/__mocks__/snapshot2/index.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
-import "../src/stylex_bundle.css";
 import * as stylex from '@stylexjs/stylex';
 import otherStyles from './otherStyles';
 import npmStyles from './npmStyles';
+import "../src/stylex_bundle.css";
 const fadeAnimation = "xgnty7z-B";
 const styles = {
   foo: {

--- a/packages/cli/__tests__/__mocks__/snapshot2/pages/home.js
+++ b/packages/cli/__tests__/__mocks__/snapshot2/pages/home.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
-import "../../src/stylex_bundle.css";
 import * as stylex from '@stylexjs/stylex';
 import otherStyles from './otherStyles';
 import npmStyles from './npmStyles';
+import "../../src/stylex_bundle.css";
 const fadeAnimation = "xgnty7z-B";
 const styles = {
   foo: {

--- a/packages/cli/flow_modules/@babel/types/index.js.flow
+++ b/packages/cli/flow_modules/@babel/types/index.js.flow
@@ -3,6 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
  * @flow strict
  */
 
@@ -3809,8 +3810,8 @@ declare export var getBindingIdentifiers: {
   ): Dups extends true
     ? Record<string, Array<Identifier>>
     : Dups extends false
-    ? Record<string, Identifier>
-    : Record<string, Array<Identifier>> | Record<string, Identifier>,
+      ? Record<string, Identifier>
+      : Record<string, Array<Identifier>> | Record<string, Identifier>,
 
   +keys: $ReadOnly<{
     DeclareClass: $ReadOnlyArray<string>,

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -20,6 +20,8 @@ export type CliConfig = {
   styleXBundleName: string,
   watch: boolean,
   babelPresets: $ReadOnlyArray<any>,
+  babelPluginsPre?: $ReadOnlyArray<any>,
+  babelPluginsPost?: $ReadOnlyArray<any>,
   modules_EXPERIMENTAL: $ReadOnlyArray<ModuleType>,
   useCSSLayers?: boolean,
   styleXConfig?: { +[string]: mixed },

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -68,6 +68,8 @@ const styleXBundleName: string = args.styleXBundleName;
 const modules_EXPERIMENTAL: $ReadOnlyArray<ModuleType> =
   args.modules_EXPERIMENTAL;
 const babelPresets: $ReadOnlyArray<any> = args.babelPresets;
+const babelPluginsPre: $ReadOnlyArray<any> = args.babelPluginsPre;
+const babelPluginsPost: $ReadOnlyArray<any> = args.babelPluginsPost;
 const useCSSLayers: boolean = args.useCSSLayers;
 const styleXConfig: { +[string]: mixed } =
   (config.styleXConfig as $FlowFixMe) ?? {};
@@ -79,6 +81,8 @@ const cliArgsConfig: CliConfig = {
   watch,
   styleXBundleName,
   babelPresets,
+  babelPluginsPre,
+  babelPluginsPost,
   useCSSLayers,
   styleXConfig,
 };
@@ -125,6 +129,8 @@ async function styleXCompile(cliArgsConfig: CliConfig) {
       watch,
       styleXBundleName,
       babelPresets,
+      babelPluginsPre,
+      babelPluginsPost,
       useCSSLayers,
       styleXConfig,
       state: configState,

--- a/packages/cli/src/options.js
+++ b/packages/cli/src/options.js
@@ -44,6 +44,18 @@ const options = {
     type: 'array',
     default: [] as $ReadOnlyArray<string | $ReadOnly<[string, { ... }]>>,
   },
+  babelPluginsPre: {
+    describe:
+      'A list of babel plugins to pass to the babel transform before StyleX is compiled',
+    type: 'array',
+    default: [] as $ReadOnlyArray<string | $ReadOnly<[string, { ... }]>>,
+  },
+  babelPluginsPost: {
+    describe:
+      'A list of babel plugins to pass to the babel transform after StyleX is compiled',
+    type: 'array',
+    default: [] as $ReadOnlyArray<string | $ReadOnly<[string, { ... }]>>,
+  },
   modules_EXPERIMENTAL: {
     alias: 'm',
     describe:

--- a/packages/cli/src/plugins.js
+++ b/packages/cli/src/plugins.js
@@ -33,7 +33,14 @@ export const createImportPlugin = (
     visitor: {
       Program: {
         enter(path: NodePath<t.Program>) {
-          path.node.body.unshift(importDeclaration);
+          const lastImportIndex = path.node.body.findLastIndex((node) =>
+            t.isImportDeclaration(node),
+          );
+          if (lastImportIndex === -1) {
+            path.node.body.unshift(importDeclaration);
+          } else {
+            path.node.body.splice(lastImportIndex + 1, 0, importDeclaration);
+          }
         },
       },
     },

--- a/packages/cli/src/transform.js
+++ b/packages/cli/src/transform.js
@@ -122,6 +122,7 @@ export async function transformFile(
     babelrc: false,
     presets: config.babelPresets,
     plugins: [
+      ...(config.babelPluginsPre ?? []),
       createModuleImportModifierPlugin(outputFilePath, config),
       [
         styleXPlugin,
@@ -135,6 +136,7 @@ export async function transformFile(
         },
       ],
       createImportPlugin(relativeImport),
+      ...(config.babelPluginsPost ?? []),
     ],
   });
   if (result == null) {


### PR DESCRIPTION
# Some CLI improvements

1. Added two new configuration options: `babelPluginsPre` and `babelPluginsPost` that are lists of babel plugins that can be run before or after the StyleX plugin during transformation.
2. Changed the injection of the CSS import to be insert *after* all the other import statements. This is to make it easier to use your CSS file for reset styles.