### PR TITLE
feat: add postcss-plugin

### DIFF
--- a/apps/nextjs-example/app/layout.tsx
+++ b/apps/nextjs-example/app/layout.tsx
@@ -8,6 +8,7 @@
  */
 
 import './globals.css';
+import './stylex.css';
 import { globalTokens as $ } from '@/app/globalTokens.stylex';
 import * as stylex from '@stylexjs/stylex';
 

--- a/apps/nextjs-example/app/stylex.css
+++ b/apps/nextjs-example/app/stylex.css
@@ -12,6 +12,4 @@
  * It is automatically replaced with generated CSS during builds.
  */
 
-@layer stylex {
-  @stylex;
-}
+@stylex;

--- a/apps/nextjs-example/app/stylex.css
+++ b/apps/nextjs-example/app/stylex.css
@@ -7,8 +7,11 @@
  *
  */
 
-/** @type {import('next').NextConfig} */
+/**
+ * The @stylex directive is used by the @stylexjs/postcss-plugin.
+ * It is automatically replaced with generated CSS during builds.
+ */
 
-module.exports = {
-  transpilePackages: ['@stylexjs/open-props'],
-};
+@layer stylex {
+  @stylex;
+}

--- a/apps/nextjs-example/babel.config.js
+++ b/apps/nextjs-example/babel.config.js
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
 const path = require('path');
 module.exports = {
   presets: ['next/babel'],
@@ -8,6 +16,7 @@ module.exports = {
       // https://stylexjs.com/docs/api/configuration/babel-plugin/
       {
         dev: process.env.NODE_ENV === 'development',
+        runtimeInjection: false,
         genConditionalClasses: true,
         treeshakeCompensation: true,
         aliases: {

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -4,8 +4,6 @@
   "private": true,
   "scripts": {
     "clean": "rimraf .next",
-    "predev": "npm run clean",
-    "prebuild": "npm run clean",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
@@ -20,9 +18,8 @@
     "next": "14.0.1"
   },
   "devDependencies": {
-    "@stylexjs/babel-plugin": "^0.7.5",
     "@stylexjs/eslint-plugin": "^0.7.5",
-    "@stylexjs/nextjs-plugin": "^0.7.5",
+    "@stylexjs/postcss-plugin": "^0.9.3",
     "@types/node": "^22.7.6",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",

--- a/apps/nextjs-example/postcss.config.js
+++ b/apps/nextjs-example/postcss.config.js
@@ -7,14 +7,48 @@
  *
  */
 
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = __dirname;
+const monorepoRoot = path.join(projectRoot, '../../');
+
+function getPackageIncludePaths(packageName, nodeModulePaths) {
+  let packagePath = null;
+
+  for (const nodeModulePath of nodeModulePaths) {
+    const packageJsonPath = path.resolve(
+      nodeModulePath,
+      packageName,
+      'package.json',
+    );
+    if (fs.existsSync(packageJsonPath)) {
+      packagePath = path.dirname(packageJsonPath);
+      break;
+    }
+  }
+  if (!packagePath) {
+    throw new Error(`Could not find package ${packageName}`);
+  }
+
+  return [
+    path.join(packagePath, '**/*.{js,mjs}'),
+    '!' + path.join(packagePath, 'node_modules/**/*.{js,mjs}'),
+  ];
+}
+
+const openPropsIncludePaths = getPackageIncludePaths('@stylexjs/open-props', [
+  path.join(projectRoot, 'node_modules'),
+  path.join(monorepoRoot, 'node_modules'),
+]);
+
 module.exports = {
   plugins: {
     '@stylexjs/postcss-plugin': {
       include: [
         'app/**/*.{js,jsx,ts,tsx}',
         'components/**/*.{js,jsx,ts,tsx}',
-        // TODO: Figure out a better way to write this
-        './node_modules/@stylexjs/open-props/lib/**/*.{js,mjs}',
+        ...openPropsIncludePaths,
       ],
       useCSSLayers: true,
     },

--- a/apps/nextjs-example/postcss.config.js
+++ b/apps/nextjs-example/postcss.config.js
@@ -14,7 +14,7 @@ module.exports = {
         'app/**/*.{js,jsx,ts,tsx}',
         'components/**/*.{js,jsx,ts,tsx}',
         // TODO: Figure out a better way to write this
-        './node_modules/@stylexjs/open-props/lib/**/*.{js,jsx,ts,tsx}',
+        './node_modules/@stylexjs/open-props/lib/**/*.{js,mjs}',
       ],
       useCSSLayers: true,
     },

--- a/apps/nextjs-example/postcss.config.js
+++ b/apps/nextjs-example/postcss.config.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+module.exports = {
+  plugins: {
+    '@stylexjs/postcss-plugin': {
+      include: [
+        'app/**/*.{js,jsx,ts,tsx}',
+        'components/**/*.{js,jsx,ts,tsx}',
+        // TODO: Figure out a better way to write this
+        './node_modules/@stylexjs/open-props/lib/**/*.{js,jsx,ts,tsx}',
+      ],
+      useCSSLayers: true,
+    },
+    autoprefixer: {},
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -997,9 +997,8 @@
         "react-dom": "^18"
       },
       "devDependencies": {
-        "@stylexjs/babel-plugin": "^0.7.5",
         "@stylexjs/eslint-plugin": "^0.7.5",
-        "@stylexjs/nextjs-plugin": "^0.7.5",
+        "@stylexjs/postcss-plugin": "^0.9.3",
         "@types/node": "^22.7.6",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
@@ -1165,20 +1164,6 @@
       "integrity": "sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==",
       "dev": true
     },
-    "apps/nextjs-example/node_modules/@stylexjs/babel-plugin": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@stylexjs/babel-plugin/-/babel-plugin-0.7.5.tgz",
-      "integrity": "sha512-KirLQIaOVHpuSZT37qV19Pw8x4te5x6hZ90+2VsrJ4NzwyYFpovlMNsTeT+eE9mcdp84VksIi7QnrNpMvqBJMQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.23.6",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/traverse": "^7.23.6",
-        "@babel/types": "^7.23.6",
-        "@stylexjs/shared": "0.7.5",
-        "@stylexjs/stylex": "0.7.5"
-      }
-    },
     "apps/nextjs-example/node_modules/@stylexjs/eslint-plugin": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@stylexjs/eslint-plugin/-/eslint-plugin-0.7.5.tgz",
@@ -1188,37 +1173,12 @@
         "micromatch": "^4.0.5"
       }
     },
-    "apps/nextjs-example/node_modules/@stylexjs/nextjs-plugin": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@stylexjs/nextjs-plugin/-/nextjs-plugin-0.7.5.tgz",
-      "integrity": "sha512-58HQQj/yZyPD1gEiNwU3wL2HPVXkIZiqgLJiQ8AWJqlCYzY77sh1UbDWRaLBuwZA2jDIOdv1yr8w+0asZTLrNw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.23.9",
-        "@babel/plugin-syntax-flow": "^7.22.5",
-        "@babel/plugin-syntax-jsx": "^7.22.5",
-        "@babel/plugin-syntax-typescript": "^7.22.5",
-        "@stylexjs/babel-plugin": "^0.7.5"
-      },
-      "peerDependencies": {
-        "next": ">=14.0.1 || >=15.0.0 || 15.0.0-rc.0"
-      }
-    },
     "apps/nextjs-example/node_modules/@stylexjs/open-props": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@stylexjs/open-props/-/open-props-0.7.5.tgz",
       "integrity": "sha512-Hul3At8srA7Uq7hpJ1sd0ZrhsT31/rcx5JA+eTSQuhmo1mMqfMHWTr70jWk6TNtZTbn0yY3hw+nJDYCTkup78A==",
       "dependencies": {
         "@stylexjs/stylex": "0.7.5"
-      }
-    },
-    "apps/nextjs-example/node_modules/@stylexjs/shared": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@stylexjs/shared/-/shared-0.7.5.tgz",
-      "integrity": "sha512-B357xldr9Dh3tP646P0JKNnarxy5ei4mkZh1qQmuhgGewbaVcrD8jiEWH3WjEzRrBKfmJtcTxBC3xp507u7O4A==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.1.0"
       }
     },
     "apps/nextjs-example/node_modules/@stylexjs/stylex": {
@@ -1568,23 +1528,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "apps/nextjs-example/node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "apps/nextjs-example/node_modules/next": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/next/-/next-14.0.1.tgz",
@@ -1760,6 +1703,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5200,6 +5144,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
       "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -5214,6 +5159,7 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
       "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -5225,6 +5171,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
       "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+      "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -5233,6 +5180,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -5254,12 +5202,14 @@
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -5274,6 +5224,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5285,6 +5236,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5296,6 +5248,7 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5319,6 +5272,7 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
       "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
@@ -5331,6 +5285,7 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -5345,6 +5300,7 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@isaacs/cliui": {
@@ -8446,6 +8402,10 @@
       "resolved": "packages/open-props",
       "link": true
     },
+    "node_modules/@stylexjs/postcss-plugin": {
+      "resolved": "packages/postcss-plugin",
+      "link": true
+    },
     "node_modules/@stylexjs/rollup-plugin": {
       "resolved": "packages/rollup-plugin",
       "link": true
@@ -9238,7 +9198,8 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
     },
     "node_modules/@vercel/analytics": {
       "version": "1.1.1",
@@ -9444,19 +9405,9 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/acorn": {
-      "version": "7.4.1",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -9727,45 +9678,6 @@
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.findlastindex": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.2.tgz",
-      "integrity": "sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-shim-unscopables": "^1.0.0",
-        "get-intrinsic": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flat": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
-      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11909,6 +11821,7 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -12154,6 +12067,7 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -12618,6 +12532,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -12847,62 +12762,6 @@
         "eslint": ">=7.7.0"
       }
     },
-    "node_modules/eslint-plugin-import": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.0.tgz",
-      "integrity": "sha512-B8s/n+ZluN7sxj9eUf7/pRFERX0r5bnFA2dCaLHy2ZeaQEAz0k+ZZkFWRFHJAqxfxQDx6KLv9LeIki7cFdwW+Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.findlastindex": "^1.2.2",
-        "array.prototype.flat": "^1.3.1",
-        "array.prototype.flatmap": "^1.3.1",
-        "debug": "^3.2.7",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.7",
-        "eslint-module-utils": "^2.8.0",
-        "has": "^1.0.3",
-        "is-core-module": "^2.12.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.6",
-        "object.groupby": "^1.0.0",
-        "object.values": "^1.1.6",
-        "resolve": "^1.22.3",
-        "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
@@ -13041,6 +12900,7 @@
     },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -13054,10 +12914,12 @@
     },
     "node_modules/eslint/node_modules/argparse": {
       "version": "2.0.1",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -13072,6 +12934,7 @@
     },
     "node_modules/eslint/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -13082,10 +12945,12 @@
     },
     "node_modules/eslint/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13098,6 +12963,7 @@
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -13113,6 +12979,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -13122,6 +12989,7 @@
     },
     "node_modules/eslint/node_modules/find-up": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -13136,6 +13004,7 @@
     },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -13148,6 +13017,7 @@
       "version": "13.20.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
       "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -13160,6 +13030,7 @@
     },
     "node_modules/eslint/node_modules/has-flag": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13167,6 +13038,7 @@
     },
     "node_modules/eslint/node_modules/js-yaml": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -13177,6 +13049,7 @@
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -13190,6 +13063,7 @@
     },
     "node_modules/eslint/node_modules/p-locate": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -13203,6 +13077,7 @@
     },
     "node_modules/eslint/node_modules/supports-color": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -13215,6 +13090,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -13231,6 +13107,7 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -13247,6 +13124,7 @@
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -13258,6 +13136,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -13618,8 +13497,9 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "license": "MIT",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -13637,6 +13517,7 @@
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-url-parser": {
@@ -13738,6 +13619,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -13842,6 +13724,7 @@
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.1.0",
@@ -13855,6 +13738,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -13867,6 +13751,7 @@
     },
     "node_modules/flatted": {
       "version": "3.2.7",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/flow-api-translator": {
@@ -14578,7 +14463,8 @@
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
@@ -19916,6 +19802,7 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -20031,6 +19918,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -20322,6 +20210,7 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.truncate": {
@@ -20812,8 +20701,15 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "license": "MIT",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -20823,6 +20719,7 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -21044,19 +20941,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.groupby": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.0.tgz",
-      "integrity": "sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.21.2",
-        "get-intrinsic": "^1.2.1"
-      }
-    },
     "node_modules/object.values": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
@@ -21147,6 +21031,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
       "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dev": true,
       "dependencies": {
         "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
@@ -21418,9 +21303,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -21542,9 +21427,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
-      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "funding": [
         {
           "type": "opencollective",
@@ -21553,12 +21438,16 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -22141,6 +22030,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -22158,6 +22048,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -22172,6 +22063,7 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.25.0.tgz",
       "integrity": "sha512-B5vzcDyTA/T0R7LGMSkLTp3VtRCEe1NItzsM6L/4gDOBGzDDMMMOwxRxogwL9xL07GPBOJrzlggwFaSQOhLVLw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.0",
@@ -23804,12 +23696,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/search-insights": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.8.2.tgz",
-      "integrity": "sha512-PxA9M5Q2bpBelVvJ3oDZR8nuY00Z6qwOxL53wNpgzV28M/D6u9WUbImDckjLSILBF8F1hn/mgyuUaOPtjow4Qw==",
-      "peer": true
-    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "license": "MIT",
@@ -24247,8 +24133,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25252,6 +25139,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -25382,6 +25270,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -27368,24 +27257,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "packages/nextjs-plugin/node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "packages/nextjs-plugin/node_modules/next": {
       "version": "14.0.4",
       "resolved": "https://registry.npmjs.org/next/-/next-14.0.4.tgz",
@@ -27529,6 +27400,29 @@
         "@stylexjs/scripts": "0.9.3"
       }
     },
+    "packages/postcss-plugin": {
+      "version": "0.9.3",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.8",
+        "@stylexjs/babel-plugin": "0.9.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "postcss": "^8.4.49"
+      }
+    },
+    "packages/postcss-plugin/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "packages/rollup-plugin": {
       "name": "@stylexjs/rollup-plugin",
       "version": "0.9.3",
@@ -27610,7 +27504,8 @@
     "@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA=="
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true
     },
     "@algolia/autocomplete-core": {
       "version": "1.9.3",
@@ -27642,8 +27537,7 @@
     "@algolia/autocomplete-shared": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
-      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
-      "requires": {}
+      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ=="
     },
     "@algolia/cache-browser-local-storage": {
       "version": "4.20.0",
@@ -28133,8 +28027,7 @@
     "@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "requires": {}
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w=="
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -29045,8 +28938,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
       "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -29810,6 +29702,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
       "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
       "requires": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -29817,19 +29710,22 @@
         "eslint-visitor-keys": {
           "version": "3.4.1",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-          "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA=="
+          "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+          "dev": true
         }
       }
     },
     "@eslint-community/regexpp": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
-      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw=="
+      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+      "dev": true
     },
     "@eslint/eslintrc": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -29845,12 +29741,14 @@
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
         },
         "globals": {
           "version": "13.24.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
           "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+          "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -29859,6 +29757,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
           "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
           "requires": {
             "argparse": "^2.0.1"
           }
@@ -29866,14 +29765,16 @@
         "type-fest": {
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
         }
       }
     },
     "@eslint/js": {
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true
     },
     "@hapi/hoek": {
       "version": "9.3.0",
@@ -29892,6 +29793,7 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
       "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
@@ -29899,12 +29801,14 @@
       }
     },
     "@humanwhocodes/module-importer": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "@humanwhocodes/object-schema": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "dev": true
     },
     "@isaacs/cliui": {
       "version": "8.0.2",
@@ -31752,8 +31656,7 @@
     "@mdx-js/react": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
-      "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "requires": {}
+      "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg=="
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -31825,8 +31728,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.1.tgz",
       "integrity": "sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@rollup/plugin-babel": {
       "version": "6.0.4",
@@ -31857,8 +31759,7 @@
           "version": "6.4.2",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
           "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "picomatch": {
           "version": "4.0.2",
@@ -32236,12 +32137,6 @@
           "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
           "dev": true
         },
-        "nanoid": {
-          "version": "3.3.7",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-          "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-          "dev": true
-        },
         "next": {
           "version": "14.0.4",
           "resolved": "https://registry.npmjs.org/next/-/next-14.0.4.tgz",
@@ -32324,6 +32219,27 @@
         "@stylexjs/stylex": "0.9.3"
       }
     },
+    "@stylexjs/postcss-plugin": {
+      "version": "file:packages/postcss-plugin",
+      "requires": {
+        "@babel/core": "^7.25.8",
+        "@stylexjs/babel-plugin": "0.9.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "postcss": "^8.4.49"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "requires": {
+            "is-glob": "^4.0.3"
+          }
+        }
+      }
+    },
     "@stylexjs/rollup-plugin": {
       "version": "file:packages/rollup-plugin",
       "requires": {
@@ -32377,50 +32293,42 @@
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.5.1.tgz",
-      "integrity": "sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==",
-      "requires": {}
+      "integrity": "sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ=="
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.5.0.tgz",
-      "integrity": "sha512-8zYdkym7qNyfXpWvu4yq46k41pyNM9SOstoWhKlm+IfdCE1DdnRKeMUPsWIEO/DEkaWxJ8T9esNdG3QwQ93jBA==",
-      "requires": {}
+      "integrity": "sha512-8zYdkym7qNyfXpWvu4yq46k41pyNM9SOstoWhKlm+IfdCE1DdnRKeMUPsWIEO/DEkaWxJ8T9esNdG3QwQ93jBA=="
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.5.0.tgz",
-      "integrity": "sha512-NFdxMq3xA42Kb1UbzCVxplUc0iqSyM9X8kopImvFnB+uSDdzIHOdbs1op8ofAvVRtbg4oZiyRl3fTYeKcOe9Iw==",
-      "requires": {}
+      "integrity": "sha512-NFdxMq3xA42Kb1UbzCVxplUc0iqSyM9X8kopImvFnB+uSDdzIHOdbs1op8ofAvVRtbg4oZiyRl3fTYeKcOe9Iw=="
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.5.1.tgz",
-      "integrity": "sha512-8DPaVVE3fd5JKuIC29dqyMB54sA6mfgki2H2+swh+zNJoynC8pMPzOkidqHOSc6Wj032fhl8Z0TVn1GiPpAiJg==",
-      "requires": {}
+      "integrity": "sha512-8DPaVVE3fd5JKuIC29dqyMB54sA6mfgki2H2+swh+zNJoynC8pMPzOkidqHOSc6Wj032fhl8Z0TVn1GiPpAiJg=="
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.5.1.tgz",
-      "integrity": "sha512-FwOEi0Il72iAzlkaHrlemVurgSQRDFbk0OC8dSvD5fSBPHltNh7JtLsxmZUhjYBZo2PpcU/RJvvi6Q0l7O7ogw==",
-      "requires": {}
+      "integrity": "sha512-FwOEi0Il72iAzlkaHrlemVurgSQRDFbk0OC8dSvD5fSBPHltNh7JtLsxmZUhjYBZo2PpcU/RJvvi6Q0l7O7ogw=="
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.5.1.tgz",
-      "integrity": "sha512-gWGsiwjb4tw+ITOJ86ndY/DZZ6cuXMNE/SjcDRg+HLuCmwpcjOktwRF9WgAiycTqJD/QXqL2f8IzE2Rzh7aVXA==",
-      "requires": {}
+      "integrity": "sha512-gWGsiwjb4tw+ITOJ86ndY/DZZ6cuXMNE/SjcDRg+HLuCmwpcjOktwRF9WgAiycTqJD/QXqL2f8IzE2Rzh7aVXA=="
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.5.1.tgz",
-      "integrity": "sha512-2jT3nTayyYP7kI6aGutkyfJ7UMGtuguD72OjeGLwVNyfPRBD8zQthlvL+fAbAKk5n9ZNcvFkp/b1lZ7VsYqVJg==",
-      "requires": {}
+      "integrity": "sha512-2jT3nTayyYP7kI6aGutkyfJ7UMGtuguD72OjeGLwVNyfPRBD8zQthlvL+fAbAKk5n9ZNcvFkp/b1lZ7VsYqVJg=="
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.5.1.tgz",
-      "integrity": "sha512-a1p6LF5Jt33O3rZoVRBqdxL350oge54iZWHNI6LJB5tQ7EelvD/Mb1mfBiZNAan0dt4i3VArkFRjA4iObuNykQ==",
-      "requires": {}
+      "integrity": "sha512-a1p6LF5Jt33O3rZoVRBqdxL350oge54iZWHNI6LJB5tQ7EelvD/Mb1mfBiZNAan0dt4i3VArkFRjA4iObuNykQ=="
     },
     "@svgr/babel-preset": {
       "version": "6.5.1",
@@ -32932,7 +32840,8 @@
     "@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
     },
     "@vercel/analytics": {
       "version": "1.1.1",
@@ -33077,22 +32986,19 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
       "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
       "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/serve": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
       "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -33111,13 +33017,9 @@
         "negotiator": "0.6.3"
       }
     },
-    "acorn": {
-      "version": "7.4.1",
-      "peer": true
-    },
     "acorn-jsx": {
       "version": "5.3.2",
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0"
@@ -33166,8 +33068,7 @@
       }
     },
     "ajv-keywords": {
-      "version": "3.5.2",
-      "requires": {}
+      "version": "3.5.2"
     },
     "algoliasearch": {
       "version": "4.20.0",
@@ -33302,33 +33203,6 @@
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "es-shim-unscopables": "^1.0.2"
-      }
-    },
-    "array.prototype.findlastindex": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.2.tgz",
-      "integrity": "sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-shim-unscopables": "^1.0.0",
-        "get-intrinsic": "^1.1.3"
-      }
-    },
-    "array.prototype.flat": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
-      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-shim-unscopables": "^1.0.0"
       }
     },
     "array.prototype.flatmap": {
@@ -34477,8 +34351,7 @@
     "css-declaration-sorter": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
-      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
-      "requires": {}
+      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w=="
     },
     "css-functions-list": {
       "version": "3.1.0",
@@ -34676,8 +34549,7 @@
     "cssnano-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "requires": {}
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
     },
     "csso": {
       "version": "4.2.0",
@@ -34771,8 +34643,7 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
       "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -34780,7 +34651,8 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "dev": true
     },
     "deepmerge": {
       "version": "4.2.2"
@@ -35185,6 +35057,7 @@
     },
     "doctrine": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -35847,6 +35720,7 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -35890,15 +35764,18 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "argparse": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "dev": true
         },
         "chalk": {
           "version": "4.1.2",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -35906,20 +35783,24 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "dev": true
         },
         "escape-string-regexp": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         },
         "eslint-scope": {
           "version": "7.2.2",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
           "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+          "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
             "estraverse": "^5.2.0"
@@ -35928,10 +35809,12 @@
         "eslint-visitor-keys": {
           "version": "3.4.3",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+          "dev": true
         },
         "find-up": {
           "version": "5.0.0",
+          "dev": true,
           "requires": {
             "locate-path": "^6.0.0",
             "path-exists": "^4.0.0"
@@ -35939,6 +35822,7 @@
         },
         "glob-parent": {
           "version": "6.0.2",
+          "dev": true,
           "requires": {
             "is-glob": "^4.0.3"
           }
@@ -35947,33 +35831,39 @@
           "version": "13.20.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
           "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+          "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
         },
         "has-flag": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         },
         "js-yaml": {
           "version": "4.1.0",
+          "dev": true,
           "requires": {
             "argparse": "^2.0.1"
           }
         },
         "locate-path": {
           "version": "6.0.0",
+          "dev": true,
           "requires": {
             "p-locate": "^5.0.0"
           }
         },
         "p-locate": {
           "version": "5.0.0",
+          "dev": true,
           "requires": {
             "p-limit": "^3.0.2"
           }
         },
         "supports-color": {
           "version": "7.2.0",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -35981,7 +35871,8 @@
         "type-fest": {
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
         }
       }
     },
@@ -36012,8 +35903,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.9",
@@ -36107,57 +35997,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
       "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
-      "dev": true,
-      "requires": {}
-    },
-    "eslint-plugin-import": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.0.tgz",
-      "integrity": "sha512-B8s/n+ZluN7sxj9eUf7/pRFERX0r5bnFA2dCaLHy2ZeaQEAz0k+ZZkFWRFHJAqxfxQDx6KLv9LeIki7cFdwW+Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "array-includes": "^3.1.6",
-        "array.prototype.findlastindex": "^1.2.2",
-        "array.prototype.flat": "^1.3.1",
-        "array.prototype.flatmap": "^1.3.1",
-        "debug": "^3.2.7",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.7",
-        "eslint-module-utils": "^2.8.0",
-        "has": "^1.0.3",
-        "is-core-module": "^2.12.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.6",
-        "object.groupby": "^1.0.0",
-        "object.values": "^1.1.6",
-        "resolve": "^1.22.3",
-        "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        }
-      }
+      "dev": true
     },
     "eslint-plugin-jsx-a11y": {
       "version": "6.7.1",
@@ -36241,8 +36081,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -36269,6 +36108,7 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
       "requires": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -36278,12 +36118,14 @@
         "acorn": {
           "version": "8.11.2",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-          "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w=="
+          "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+          "dev": true
         },
         "eslint-visitor-keys": {
           "version": "3.4.3",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+          "dev": true
         }
       }
     },
@@ -36544,7 +36386,9 @@
       "version": "3.1.3"
     },
     "fast-glob": {
-      "version": "3.2.12",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -36557,7 +36401,8 @@
       "version": "2.1.0"
     },
     "fast-levenshtein": {
-      "version": "2.0.6"
+      "version": "2.0.6",
+      "dev": true
     },
     "fast-url-parser": {
       "version": "1.1.3",
@@ -36645,6 +36490,7 @@
     },
     "file-entry-cache": {
       "version": "6.0.1",
+      "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
       }
@@ -36708,6 +36554,7 @@
     },
     "flat-cache": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -36717,6 +36564,7 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -36724,7 +36572,8 @@
       }
     },
     "flatted": {
-      "version": "3.2.7"
+      "version": "3.2.7",
+      "dev": true
     },
     "flow-api-translator": {
       "version": "0.25.0",
@@ -37193,7 +37042,8 @@
     "graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
     },
     "gray-matter": {
       "version": "4.0.3",
@@ -37646,8 +37496,7 @@
       }
     },
     "icss-utils": {
-      "version": "5.1.0",
-      "requires": {}
+      "version": "5.1.0"
     },
     "ignore": {
       "version": "5.2.0"
@@ -39747,8 +39596,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "30.0.0-alpha.6",
@@ -40928,7 +40776,8 @@
       "version": "0.4.1"
     },
     "json-stable-stringify-without-jsonify": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "json5": {
       "version": "2.2.3",
@@ -41012,6 +40861,7 @@
     },
     "levn": {
       "version": "0.4.1",
+      "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -41140,7 +40990,8 @@
       "version": "4.1.2"
     },
     "lodash.merge": {
-      "version": "4.6.2"
+      "version": "4.6.2",
+      "dev": true
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -41470,10 +41321,13 @@
       }
     },
     "nanoid": {
-      "version": "3.3.4"
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "natural-compare": {
-      "version": "1.4.0"
+      "version": "1.4.0",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.3"
@@ -41484,10 +41338,9 @@
     "next-example": {
       "version": "file:apps/nextjs-example",
       "requires": {
-        "@stylexjs/babel-plugin": "^0.7.5",
         "@stylexjs/eslint-plugin": "^0.7.5",
-        "@stylexjs/nextjs-plugin": "^0.7.5",
         "@stylexjs/open-props": "^0.7.5",
+        "@stylexjs/postcss-plugin": "^0.9.3",
         "@stylexjs/stylex": "^0.7.5",
         "@types/node": "^22.7.6",
         "@types/react": "^18.3.11",
@@ -41577,20 +41430,6 @@
           "integrity": "sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==",
           "dev": true
         },
-        "@stylexjs/babel-plugin": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/@stylexjs/babel-plugin/-/babel-plugin-0.7.5.tgz",
-          "integrity": "sha512-KirLQIaOVHpuSZT37qV19Pw8x4te5x6hZ90+2VsrJ4NzwyYFpovlMNsTeT+eE9mcdp84VksIi7QnrNpMvqBJMQ==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.23.6",
-            "@babel/helper-module-imports": "^7.22.15",
-            "@babel/traverse": "^7.23.6",
-            "@babel/types": "^7.23.6",
-            "@stylexjs/shared": "0.7.5",
-            "@stylexjs/stylex": "0.7.5"
-          }
-        },
         "@stylexjs/eslint-plugin": {
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/@stylexjs/eslint-plugin/-/eslint-plugin-0.7.5.tgz",
@@ -41600,34 +41439,12 @@
             "micromatch": "^4.0.5"
           }
         },
-        "@stylexjs/nextjs-plugin": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/@stylexjs/nextjs-plugin/-/nextjs-plugin-0.7.5.tgz",
-          "integrity": "sha512-58HQQj/yZyPD1gEiNwU3wL2HPVXkIZiqgLJiQ8AWJqlCYzY77sh1UbDWRaLBuwZA2jDIOdv1yr8w+0asZTLrNw==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.23.9",
-            "@babel/plugin-syntax-flow": "^7.22.5",
-            "@babel/plugin-syntax-jsx": "^7.22.5",
-            "@babel/plugin-syntax-typescript": "^7.22.5",
-            "@stylexjs/babel-plugin": "^0.7.5"
-          }
-        },
         "@stylexjs/open-props": {
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/@stylexjs/open-props/-/open-props-0.7.5.tgz",
           "integrity": "sha512-Hul3At8srA7Uq7hpJ1sd0ZrhsT31/rcx5JA+eTSQuhmo1mMqfMHWTr70jWk6TNtZTbn0yY3hw+nJDYCTkup78A==",
           "requires": {
             "@stylexjs/stylex": "0.7.5"
-          }
-        },
-        "@stylexjs/shared": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/@stylexjs/shared/-/shared-0.7.5.tgz",
-          "integrity": "sha512-B357xldr9Dh3tP646P0JKNnarxy5ei4mkZh1qQmuhgGewbaVcrD8jiEWH3WjEzRrBKfmJtcTxBC3xp507u7O4A==",
-          "dev": true,
-          "requires": {
-            "postcss-value-parser": "^4.1.0"
           }
         },
         "@stylexjs/stylex": {
@@ -41863,11 +41680,6 @@
             "hasown": "^2.0.0"
           }
         },
-        "nanoid": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
-        },
         "next": {
           "version": "14.0.1",
           "resolved": "https://registry.npmjs.org/next/-/next-14.0.1.tgz",
@@ -42083,19 +41895,6 @@
         "es-object-atoms": "^1.0.0"
       }
     },
-    "object.groupby": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.0.tgz",
-      "integrity": "sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.21.2",
-        "get-intrinsic": "^1.2.1"
-      }
-    },
     "object.values": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
@@ -42158,6 +41957,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
       "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dev": true,
       "requires": {
         "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
@@ -42345,9 +42145,9 @@
       "version": "4.0.0"
     },
     "picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
       "version": "2.3.1"
@@ -42427,13 +42227,13 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
-      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "requires": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       }
     },
     "postcss-calc": {
@@ -42468,26 +42268,22 @@
     "postcss-discard-comments": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
-      "requires": {}
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ=="
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "requires": {}
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "requires": {}
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "requires": {}
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
     },
     "postcss-discard-unused": {
       "version": "5.1.0",
@@ -42589,8 +42385,7 @@
       }
     },
     "postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "requires": {}
+      "version": "3.0.0"
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -42615,8 +42410,7 @@
     "postcss-normalize-charset": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "requires": {}
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -42728,8 +42522,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-selector-parser": {
       "version": "6.0.10",
@@ -42769,11 +42562,11 @@
     "postcss-zindex": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-5.1.0.tgz",
-      "integrity": "sha512-fgFMf0OtVSBR1va1JNHYgMxYk73yhn/qb4uQDq1DLGYolz8gHCyr/sesEuGUaYs58E3ZJRcpoGuPVoB7Meiq9A==",
-      "requires": {}
+      "integrity": "sha512-fgFMf0OtVSBR1va1JNHYgMxYk73yhn/qb4uQDq1DLGYolz8gHCyr/sesEuGUaYs58E3ZJRcpoGuPVoB7Meiq9A=="
     },
     "prelude-ls": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "dev": true
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -42783,12 +42576,14 @@
     "prettier": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew=="
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true
     },
     "prettier-plugin-hermes-parser": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.25.0.tgz",
       "integrity": "sha512-B5vzcDyTA/T0R7LGMSkLTp3VtRCEe1NItzsM6L/4gDOBGzDDMMMOwxRxogwL9xL07GPBOJrzlggwFaSQOhLVLw==",
+      "dev": true,
       "requires": {
         "hermes-estree": "0.25.0",
         "hermes-parser": "0.25.0",
@@ -42829,8 +42624,7 @@
     "prism-react-renderer": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
-      "requires": {}
+      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg=="
     },
     "prismjs": {
       "version": "1.29.0"
@@ -43966,12 +43760,6 @@
         "ajv-keywords": "^3.5.2"
       }
     },
-    "search-insights": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.8.2.tgz",
-      "integrity": "sha512-PxA9M5Q2bpBelVvJ3oDZR8nuY00Z6qwOxL53wNpgzV28M/D6u9WUbImDckjLSILBF8F1hn/mgyuUaOPtjow4Qw==",
-      "peer": true
-    },
     "section-matter": {
       "version": "1.0.0",
       "requires": {
@@ -44297,7 +44085,9 @@
       "version": "0.6.1"
     },
     "source-map-js": {
-      "version": "1.0.2"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
     "source-map-support": {
       "version": "0.5.13",
@@ -45027,8 +44817,7 @@
     "ts-api-utils": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
-      "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
-      "requires": {}
+      "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg=="
     },
     "tsconfig-paths": {
       "version": "3.14.2",
@@ -45066,6 +44855,7 @@
     },
     "type-check": {
       "version": "0.4.0",
+      "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1"
       }
@@ -45154,7 +44944,8 @@
     "typescript": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw=="
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "1.0.36",
@@ -45469,14 +45260,12 @@
     "use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
-      "requires": {}
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ=="
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "requires": {}
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
     },
     "use-latest": {
       "version": "1.2.1",
@@ -45487,8 +45276,7 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0",
-      "requires": {}
+      "version": "1.2.0"
     },
     "util-deprecate": {
       "version": "1.0.2"
@@ -45672,8 +45460,7 @@
         "acorn-import-assertions": {
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-          "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-          "requires": {}
+          "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA=="
         },
         "schema-utils": {
           "version": "3.3.0",
@@ -45759,8 +45546,7 @@
         "ws": {
           "version": "7.5.9",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-          "requires": {}
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
         }
       }
     },
@@ -45937,8 +45723,7 @@
         "ws": {
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-          "requires": {}
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg=="
         }
       }
     },

--- a/packages/postcss-plugin/README.md
+++ b/packages/postcss-plugin/README.md
@@ -1,0 +1,135 @@
+# @stylexjs/postcss-plugin
+
+## Documentation Website
+
+[https://stylexjs.com](https://stylexjs.com)
+
+## Installation
+
+Install the package by using:
+
+```bash
+npm install --save-dev @stylexjs/postcss-plugin autoprefixer
+```
+
+or with yarn:
+
+```
+yarn add --dev @stylexjs/postcss-plugin autoprefixer
+```
+
+Add the following to your `postcss.config.js`
+
+```javascript
+// postcss.config.js
+module.exports = {
+  plugins: {
+    '@stylexjs/postcss-plugin': {
+      include: ['src/**/*.{js,jsx,ts,tsx}'],
+    },
+    autoprefixer: {},
+  },
+};
+```
+
+Add the following to your `babel.config.js`
+
+```javascript
+import styleXPlugin from '@stylexjs/babel-plugin';
+
+const config = {
+  plugins: [
+    [
+      styleXPlugin,
+      {
+        // Required for this plugin
+        runtimeInjection: false,
+        dev: true,
+        // Set this to true for snapshot testing
+        // default: false
+        test: false,
+        // Required for CSS variable support
+        unstable_moduleResolution: {
+          // type: 'commonJS' | 'haste'
+          // default: 'commonJS'
+          type: 'commonJS',
+          // The absolute path to the root directory of your project
+          rootDir: __dirname,
+        },
+      },
+    ],
+  ],
+};
+
+export default config;
+```
+
+Add the following to `src/stylex.css`
+
+```css
+/**
+ * The @stylex directive is used by the @stylexjs/postcss-plugin.
+ * It is automatically replaced with generated CSS during builds.
+ */
+@stylex;
+```
+
+Then, import this file from your application entrypoint:
+
+```javascript
+// src/index.js
+import './stylex.css';
+```
+
+## Plugin Options
+
+### include
+
+```js
+include: string[] // Required
+```
+
+Array of paths or glob patterns to compile.
+
+---
+
+### exclude
+
+```js
+exclude: string[] // Default: []
+```
+
+Array of paths or glob patterns to exclude from compilation. Paths in exclude
+take precedence over include.
+
+---
+
+### cwd
+
+```js
+cwd: string; // Default: process.cwd()
+```
+
+Array of paths or glob patterns to exclude from compilation. Paths in exclude
+take precedence over include.
+
+---
+
+---
+
+### babelConfig
+
+```js
+babelConfig: object; // Default: {}
+```
+
+## Options for Babel configuration. By default, the plugin reads from babel.config.js in your project. For custom configurations, set babelrc: false and specify desired options. Refer to [Babel Config Options](https://babeljs.io/docs/options) for available options.
+
+### useCSSLayers
+
+```js
+useCSSLayers: boolean; // Default: false
+```
+
+Enabling this option switches Stylex from using `:not(#\#)` to using `@layers`
+for handling CSS specificity.

--- a/packages/postcss-plugin/README.md
+++ b/packages/postcss-plugin/README.md
@@ -110,10 +110,7 @@ take precedence over include.
 cwd: string; // Default: process.cwd()
 ```
 
-Array of paths or glob patterns to exclude from compilation. Paths in exclude
-take precedence over include.
-
----
+Working directory for the plugin; defaults to process.cwd().
 
 ---
 
@@ -123,7 +120,12 @@ take precedence over include.
 babelConfig: object; // Default: {}
 ```
 
-## Options for Babel configuration. By default, the plugin reads from babel.config.js in your project. For custom configurations, set babelrc: false and specify desired options. Refer to [Babel Config Options](https://babeljs.io/docs/options) for available options.
+Options for Babel configuration. By default, the plugin reads from
+babel.config.js in your project. For custom configurations, set babelrc: false
+and specify desired options. Refer to
+[Babel Config Options](https://babeljs.io/docs/options) for available options.
+
+---
 
 ### useCSSLayers
 

--- a/packages/postcss-plugin/package.json
+++ b/packages/postcss-plugin/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@stylexjs/postcss-plugin",
+  "version": "0.9.3",
+  "description": "PostCSS plugin for StyleX",
+  "main": "src/index.js",
+  "repository": "https://www.github.com/facebook/stylex",
+  "license": "MIT",
+  "dependencies": {
+    "@babel/core": "^7.25.8",
+    "@stylexjs/babel-plugin": "0.9.3",
+    "postcss": "^8.4.49",
+    "fast-glob": "^3.3.2",
+    "glob-parent": "^6.0.2",
+    "is-glob": "^4.0.3"
+  }
+}

--- a/packages/postcss-plugin/src/builder.js
+++ b/packages/postcss-plugin/src/builder.js
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+const path = require('node:path');
+const fs = require('node:fs');
+const { normalize, resolve } = require('path');
+const { globSync } = require('fast-glob');
+const isGlob = require('is-glob');
+const globParent = require('glob-parent');
+const createBundler = require('./bundler');
+
+// Parses a glob pattern and extracts its base directory and pattern.
+// Returns an object with `base` and `glob` properties.
+function parseGlob(pattern) {
+  // License: MIT
+  // Based on:
+  // https://github.com/chakra-ui/panda/blob/6ab003795c0b076efe6879a2e6a2a548cb96580e/packages/node/src/parse-glob.ts
+  let glob = pattern;
+  const base = globParent(pattern);
+
+  if (base !== '.') {
+    glob = pattern.substring(base.length);
+    if (glob.charAt(0) === '/') {
+      glob = glob.substring(1);
+    }
+  }
+
+  if (glob.substring(0, 2) === './') {
+    glob = glob.substring(2);
+  }
+  if (glob.charAt(0) === '/') {
+    glob = glob.substring(1);
+  }
+
+  return { base, glob };
+}
+
+// Parses a file path or glob pattern into a PostCSS dependency message.
+function parseDependency(fileOrGlob) {
+  // License: MIT
+  // Based on:
+  // https://github.com/chakra-ui/panda/blob/6ab003795c0b076efe6879a2e6a2a548cb96580e/packages/node/src/parse-dependency.ts
+  if (fileOrGlob.startsWith('!')) {
+    return null;
+  }
+
+  let message = null;
+
+  if (isGlob(fileOrGlob)) {
+    const { base, glob } = parseGlob(fileOrGlob);
+    message = { type: 'dir-dependency', dir: normalize(resolve(base)), glob };
+  } else {
+    message = { type: 'dependency', file: normalize(resolve(fileOrGlob)) };
+  }
+
+  return message;
+}
+
+// Creates a builder for transforming files and bundling StyleX CSS.
+function createBuilder() {
+  let config = null;
+
+  const bundler = createBundler();
+
+  const fileModifiedMap = new Map();
+
+  // Configures the builder with the provided options.
+  function configure(options) {
+    config = options;
+  }
+
+  /// Retrieves the current configuration.
+  function getConfig() {
+    if (config == null) {
+      throw new Error('Builder not configured');
+    }
+    return config;
+  }
+
+  // Finds the `@stylex;` at-rule in the provided PostCSS root.
+  function findStyleXAtRule(root) {
+    let styleXAtRule = null;
+    root.walkAtRules((atRule) => {
+      if (atRule.name === 'stylex' && !atRule.params) {
+        styleXAtRule = atRule;
+      }
+    });
+    return styleXAtRule;
+  }
+
+  // Retrieves all files that match the include and exclude patterns.
+  function getFiles() {
+    const { cwd, include, exclude } = getConfig();
+    return globSync(include, {
+      onlyFiles: true,
+      ignore: exclude,
+      cwd,
+    });
+  }
+
+  // Transforms the included files, bundles the CSS, and returns the result.
+  async function build({ shouldSkipTransformError }) {
+    const { cwd, babelConfig, useCSSLayers, isDev } = getConfig();
+
+    const files = getFiles();
+    const filesToTransform = [];
+
+    // Remove deleted files since the last build
+    for (const file of fileModifiedMap.keys()) {
+      if (!files.includes(file)) {
+        fileModifiedMap.delete(file);
+        bundler.remove(file);
+      }
+    }
+
+    for (const file of files) {
+      const filePath = path.resolve(cwd, file);
+      const mtimeMs = fs.existsSync(filePath)
+        ? fs.statSync(filePath).mtimeMs
+        : -Infinity;
+
+      // Skip files that have not been modified since the last build
+      // On first run, all files will be transformed
+      const shouldSkip =
+        fileModifiedMap.has(file) && mtimeMs === fileModifiedMap.get(file);
+
+      if (shouldSkip) {
+        continue;
+      }
+
+      fileModifiedMap.set(file, mtimeMs);
+      filesToTransform.push(file);
+    }
+
+    await Promise.all(
+      filesToTransform.map((file) => {
+        const filePath = path.resolve(cwd, file);
+        const contents = fs.readFileSync(filePath, 'utf-8');
+        if (!bundler.shouldTransform(contents)) {
+          return;
+        }
+        return bundler.transform(file, contents, babelConfig, {
+          isDev,
+          shouldSkipTransformError,
+        });
+      }),
+    );
+
+    const css = bundler.bundle({ useCSSLayers });
+    return css;
+  }
+
+  // Retrieves the dependencies that PostCSS should watch.
+  function getDependencies() {
+    const { include } = getConfig();
+    const dependencies = [];
+
+    for (const fileOrGlob of include) {
+      const dependency = parseDependency(fileOrGlob);
+      if (dependency != null) {
+        dependencies.push(dependency);
+      }
+    }
+
+    return dependencies;
+  }
+
+  return {
+    findStyleXAtRule,
+    configure,
+    build,
+    getDependencies,
+  };
+}
+
+module.exports = createBuilder;

--- a/packages/postcss-plugin/src/bundler.js
+++ b/packages/postcss-plugin/src/bundler.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+const babel = require('@babel/core');
+const stylexBabelPlugin = require('@stylexjs/babel-plugin');
+
+// Creates a stateful bundler for processing StyleX rules using Babel.
+module.exports = function createBundler() {
+  const styleXRulesMap = new Map();
+
+  // Determines if the source code should be transformed based on the presence of StyleX imports.
+  function shouldTransform(sourceCode) {
+    return sourceCode.includes('stylex');
+  }
+
+  // Transforms the source code using Babel, extracting StyleX rules and storing them.
+  async function transform(id, sourceCode, babelConfig, options) {
+    const { isDev, shouldSkipTransformError } = options;
+    const { code, map, metadata } = await babel
+      .transformAsync(sourceCode, {
+        filename: id,
+        caller: {
+          name: '@stylexjs/postcss-plugin',
+          isDev,
+        },
+        ...babelConfig,
+      })
+      .catch((error) => {
+        if (shouldSkipTransformError) {
+          console.warn(
+            `[@stylexjs/postcss-plugin] Failed to transform "${id}": ${error.message}`,
+          );
+
+          return { code: sourceCode, map: null, metadata: {} };
+        }
+        throw error;
+      });
+
+    const stylex = metadata.stylex;
+    if (stylex != null && stylex.length > 0) {
+      styleXRulesMap.set(id, stylex);
+    }
+
+    return { code, map, metadata };
+  }
+
+  // Removes the stored StyleX rules for the specified file.
+  function remove(id) {
+    styleXRulesMap.delete(id);
+  }
+
+  //  Bundles all collected StyleX rules into a single CSS string.
+  function bundle({ useCSSLayers }) {
+    const rules = Array.from(styleXRulesMap.values()).flat();
+
+    const css = stylexBabelPlugin.processStylexRules(rules, useCSSLayers);
+
+    return css;
+  }
+
+  return {
+    shouldTransform,
+    transform,
+    remove,
+    bundle,
+  };
+};

--- a/packages/postcss-plugin/src/index.js
+++ b/packages/postcss-plugin/src/index.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+const postcss = require('postcss');
+const createBuilder = require('./builder');
+
+const PLUGIN_NAME = '@stylexjs/postcss-plugin';
+
+const builder = createBuilder();
+
+const isDev = process.env.NODE_ENV === 'development';
+
+const plugin = ({
+  cwd = process.cwd(),
+  // By default reuses the Babel configuration from the project root.
+  // Use `babelrc: false` to disable this behavior.
+  babelConfig = {},
+  include,
+  exclude,
+  useCSSLayers = false,
+}) => {
+  exclude = [
+    // Exclude type declaration files by default because it never contains any CSS rules.
+    '**/*.d.ts',
+    '**/*.flow',
+    ...(exclude ?? []),
+  ];
+
+  // Whether to skip the error when transforming StyleX rules.
+  // Useful in watch mode where Fast Refresh can recover from errors.
+  // Initial transform will still throw errors in watch mode to surface issues early.
+  let shouldSkipTransformError = false;
+
+  return {
+    postcssPlugin: PLUGIN_NAME,
+    plugins: [
+      // Processes the PostCSS root node to find and transform StyleX at-rules.
+      async function (root, result) {
+        const fileName = result.opts.from;
+
+        // Configure the builder with the provided options
+        await builder.configure({
+          include,
+          exclude,
+          cwd,
+          babelConfig,
+          useCSSLayers,
+          isDev,
+        });
+
+        // Find the "@stylex" at-rule
+        const styleXAtRule = builder.findStyleXAtRule(root);
+        if (styleXAtRule == null) {
+          return;
+        }
+
+        // Get dependencies to be watched for changes
+        const dependencies = builder.getDependencies();
+
+        // Add each dependency to the PostCSS result messages.
+        // This watches the entire "./src" directory for "./src/**/*.{ts,tsx}"
+        // to handle new files and deletions reliably in watch mode.
+        for (const dependency of dependencies) {
+          result.messages.push({
+            plugin: PLUGIN_NAME,
+            parent: fileName,
+            ...dependency,
+          });
+        }
+
+        // Build and parse the CSS from collected StyleX rules
+        const css = await builder.build({
+          shouldSkipTransformError,
+        });
+        const parsed = await postcss.parse(css, {
+          from: fileName,
+        });
+
+        // Replace the "@stylex" rule with the generated CSS
+        styleXAtRule.replaceWith(parsed);
+
+        result.root = root;
+
+        if (!shouldSkipTransformError) {
+          // Build was successful, subsequent builds are for watch mode
+          shouldSkipTransformError = true;
+        }
+      },
+    ],
+  };
+};
+
+plugin.postcss = true;
+
+module.exports = plugin;


### PR DESCRIPTION
## What changed / motivation ?

- Adds a PostCSS Plugin named `@stylexjs/postcss-plugin` as described in the linked issue.
- Updates nextjs-example to use` @stylexjs/postcss-plugin`

## Linked PR/Issues

Fixes https://github.com/facebook/stylex/issues/779

## Additional Context

The implementation is mostly based on [postcss-react-strict-dom](https://github.com/javascripter/postcss-react-strict-dom) that I wrote but have decided to convert it to JavaScript instead of TypeScript to make it suitable for this repository.

The plugin is rather simple so I didn't add Flow types for now (same as the current nextjs-plugin).

I've described the overview of this plugin approach [here](https://github.com/facebook/react-strict-dom/issues/236#issuecomment-2474722120).

This PR:
<img width="1623" alt="Screenshot 2024-11-24 at 16 14 35" src="https://github.com/user-attachments/assets/e8f9ff29-c221-43f7-8245-ed4354722f52">
Original:
<img width="1623" alt="Screenshot 2024-11-24 at 16 14 58" src="https://github.com/user-attachments/assets/800d5769-6ca9-4337-93c4-e553b8ebe3db">


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code