### PR TITLE
feat: dynamic styles set inherits to false

### DIFF
--- a/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
@@ -369,6 +369,7 @@ describe('Evaluation of imported values works based on configuration', () => {
         import 'otherFile.stylex';
         import { MyTheme } from 'otherFile.stylex';
         _inject2(".__hashed_var__b69i2g{--__hashed_var__1jqb1tb:var(----__hashed_var__1jqb1tb)}", 1);
+        _inject2("@property ----__hashed_var__1jqb1tb { inherits: false }", 0);
         const styles = {
           color: color => [{
             "--__hashed_var__1jqb1tb": color == null ? null : "__hashed_var__b69i2g",
@@ -388,6 +389,14 @@ describe('Evaluation of imported values works based on configuration', () => {
               "rtl": null,
             },
             1,
+          ],
+          [
+            "----__hashed_var__1jqb1tb",
+            {
+              "ltr": "@property ----__hashed_var__1jqb1tb { inherits: false }",
+              "rtl": null,
+            },
+            0,
           ],
         ]
       `);

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -1323,6 +1323,7 @@ describe('@stylexjs/babel-plugin', () => {
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xfx01vb{color:var(--color)}", 3000);
+        _inject2("@property --color { inherits: false }", 0);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
@@ -1352,6 +1353,7 @@ describe('@stylexjs/babel-plugin', () => {
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".x1bl4301{width:var(--width)}", 4000);
+        _inject2("@property --width { inherits: false }", 0);
         export const styles = {
           default: width => [{
             backgroundColor: "xrkmrrc",
@@ -1385,6 +1387,7 @@ describe('@stylexjs/babel-plugin', () => {
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xfx01vb{color:var(--color)}", 3000);
         _inject2(".x1mqxbix{color:black}", 3000);
+        _inject2("@property --color { inherits: false }", 0);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
@@ -1416,6 +1419,7 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x15mgraa{--background-color:var(----background-color)}", 1);
+        _inject2("@property ----background-color { inherits: false }", 0);
         export const styles = {
           default: bgColor => [{
             "--background-color": bgColor == null ? null : "x15mgraa",
@@ -1445,6 +1449,7 @@ describe('@stylexjs/babel-plugin', () => {
         import stylex from 'stylex';
         _inject2(".x1gykpug:hover{background-color:red}", 3130);
         _inject2(".xtyu0qe:hover{color:var(--1ijzsae)}", 3130);
+        _inject2("@property --1ijzsae { inherits: false }", 0);
         export const styles = {
           default: color => [{
             ":hover_backgroundColor": "x1gykpug",
@@ -1477,6 +1482,7 @@ describe('@stylexjs/babel-plugin', () => {
         _inject2(".xrkmrrc{background-color:red}", 3000);
         _inject2(".xfx01vb{color:var(--color)}", 3000);
         _inject2(".x1mqxbix{color:black}", 3000);
+        _inject2("@property --color { inherits: false }", 0);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
@@ -1508,6 +1514,7 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".x15mgraa{--background-color:var(----background-color)}", 1);
+        _inject2("@property ----background-color { inherits: false }", 0);
         export const styles = {
           default: bgColor => [{
             "--background-color": bgColor == null ? null : "x15mgraa",
@@ -1543,6 +1550,7 @@ describe('@stylexjs/babel-plugin', () => {
         _inject2(".x1n25116{color:var(--4xs81a)}", 3000);
         _inject2("@media (min-width: 1000px){.xtljkjt.xtljkjt:hover{color:green}}", 3330);
         _inject2(".x17z2mba:hover{color:blue}", 3130);
+        _inject2("@property --4xs81a { inherits: false }", 0);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
@@ -1579,6 +1587,8 @@ describe('@stylexjs/babel-plugin', () => {
         _inject2(".x1n25116{color:var(--4xs81a)}", 3000);
         _inject2("@media (min-width: 1000px){.xtljkjt.xtljkjt:hover{color:green}}", 3330);
         _inject2(".x1d4gdy3:hover{color:var(--w5m4kq)}", 3130);
+        _inject2("@property --4xs81a { inherits: false }", 0);
+        _inject2("@property --w5m4kq { inherits: false }", 0);
         export const styles = {
           default: color => [{
             backgroundColor: "xrkmrrc",
@@ -1622,6 +1632,9 @@ describe('@stylexjs/babel-plugin', () => {
         _inject2(".x1k44ad6{margin-left:var(--14mfytm)}", 3000, ".x1k44ad6{margin-right:var(--14mfytm)}");
         _inject2(".x10ktymb:hover{margin-left:var(--yepcm9)}", 3130, ".x10ktymb:hover{margin-right:var(--yepcm9)}");
         _inject2(".x17zef60{margin-top:var(--marginTop)}", 4000);
+        _inject2("@property --14mfytm { inherits: false }", 0);
+        _inject2("@property --yepcm9 { inherits: false }", 0);
+        _inject2("@property --marginTop { inherits: false }", 0);
         export const styles = {
           default: margin => [{
             backgroundColor: "xrkmrrc",

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -113,6 +113,19 @@ export default function transformStyleXCreate(
       memberExpressions,
     });
 
+    // add injection that mark variables used for dynamic styles as `inherits: false`
+    const injectedInheritStyles: { [string]: InjectableStyle } = {};
+    if(fns != null){
+      const dynamicFnsNames = Object.values(fns)?.map(entry => Object.keys(entry[1])).flat();
+      dynamicFnsNames.forEach(fnsName => {      
+        injectedInheritStyles[fnsName] = {
+          priority: 0,
+          ltr: `@property ${fnsName} { inherits: false }`,
+          rtl: null,
+        };
+      })
+    }
+
     if (!confident) {
       throw path.buildCodeFrameError(messages.NON_STATIC_VALUE, SyntaxError);
     }
@@ -124,6 +137,7 @@ export default function transformStyleXCreate(
     const injectedStyles = {
       ...injectedKeyframes,
       ...injectedStylesSansKeyframes,
+      ...injectedInheritStyles,
     };
 
     let varName = null;

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -115,15 +115,17 @@ export default function transformStyleXCreate(
 
     // add injection that mark variables used for dynamic styles as `inherits: false`
     const injectedInheritStyles: { [string]: InjectableStyle } = {};
-    if(fns != null){
-      const dynamicFnsNames = Object.values(fns)?.map(entry => Object.keys(entry[1])).flat();
-      dynamicFnsNames.forEach(fnsName => {      
+    if (fns != null) {
+      const dynamicFnsNames = Object.values(fns)
+        ?.map((entry) => Object.keys(entry[1]))
+        .flat();
+      dynamicFnsNames.forEach((fnsName) => {
         injectedInheritStyles[fnsName] = {
           priority: 0,
           ltr: `@property ${fnsName} { inherits: false }`,
           rtl: null,
         };
-      })
+      });
     }
 
     if (!confident) {

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -113,6 +113,11 @@ export default function transformStyleXCreate(
       memberExpressions,
     });
 
+    if (!confident) {
+      throw path.buildCodeFrameError(messages.NON_STATIC_VALUE, SyntaxError);
+    }
+    const plainObject = value;
+
     // add injection that mark variables used for dynamic styles as `inherits: false`
     const injectedInheritStyles: { [string]: InjectableStyle } = {};
     if (fns != null) {
@@ -127,11 +132,7 @@ export default function transformStyleXCreate(
         };
       });
     }
-
-    if (!confident) {
-      throw path.buildCodeFrameError(messages.NON_STATIC_VALUE, SyntaxError);
-    }
-    const plainObject = value;
+    
     // eslint-disable-next-line prefer-const
     let [compiledStyles, injectedStylesSansKeyframes, classPathsPerNamespace] =
       stylexCreate(plainObject, state.options);


### PR DESCRIPTION
## What changed / motivation ?

Addresses task https://github.com/facebook/stylex/issues/734?fbclid=IwZXh0bgNhZW0CMTEAAR2-QvBRO5HXoBYI-LmCO1benFCf76i8rsQqF7eQ9C3elQYx859Zpkr4rRI_aem_hLD_maBEZrcTD5svWp7J3A.

Generate `@property` declarations for all variables that are created for dynamic styles and declare them as not inheriting. Increase stylex variable compiler efficiency by disabling all dynamic styles from cascading down from the node defining the variable.

## Linked PR/Issues

Fixes #734 

## Additional Context
`npx jest stylex-transform-create-test`

Test file [stylex-transform-create-test.js](https://github.com/facebook/stylex/compare/feat/dynamic-styles-inherits-false?expand=1#diff-1ae52714c572f4282c394af92227b4198e93ffdccd6bf7c38129b36f09250280) should have `@property` injection added for all stylex dynamic styles.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code