### PR TITLE
fix: Use POSIX paths when inserting import statements

### DIFF
--- a/packages/cli/src/files.js
+++ b/packages/cli/src/files.js
@@ -72,7 +72,7 @@ export function isJSFile(filePath: string): boolean {
 
 // e.g. ./pages/home/index.js -> ../../stylex_bundle.css
 export function getRelativePath(from: string, to: string): string {
-  const relativePath = path.relative(path.parse(from).dir, to);
+  const relativePath = path.posix.relative(path.parse(from).dir, to);
   return formatRelativePath(relativePath);
 }
 


### PR DESCRIPTION
Fixes a Windows-specific bug where the CLI injects import statements with backslashes.

Fixes #774