### PR TITLE
fix: Use POSIX paths when inserting import statements correctly this …

### DIFF
--- a/packages/cli/src/files.js
+++ b/packages/cli/src/files.js
@@ -73,7 +73,11 @@ export function isJSFile(filePath: string): boolean {
 // e.g. ./pages/home/index.js -> ../../stylex_bundle.css
 export function getRelativePath(from: string, to: string): string {
   const relativePath = path.posix.relative(path.parse(from).dir, to);
-  return formatRelativePath(relativePath);
+  return formatRelativePath(toPosixPath(relativePath));
+}
+
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join(path.posix.sep);
 }
 
 function formatRelativePath(filePath: string) {


### PR DESCRIPTION
Fixes #774

I was finally able to test this fix on a Windows machine and this finally works as expected.