### PR TITLE
feat: add autofix for logical to inline properties in valid-styles rule

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -584,6 +584,72 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       ],
     },
     {
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            marginStart: '10px',
+            marginEnd: '5px',
+            marginHorizontal: '15px',
+            marginVertical: '15px',
+            paddingStart: '10px',
+            paddingEnd: '5px',
+            paddingHorizontal: '5px',
+            paddingVertical: '15px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'The key "marginStart" is not allowed by stylex. Use "marginInlineStart" instead.',
+        },
+        {
+          message:
+            'The key "marginEnd" is not allowed by stylex. Use "marginInlineEnd" instead.',
+        },
+        {
+          message:
+            'The key "marginHorizontal" is not allowed by stylex. Use "marginInline" instead.',
+        },
+        {
+          message:
+            'The key "marginVertical" is not allowed by stylex. Use "marginBlock" instead.',
+        },
+        {
+          message:
+            'The key "paddingStart" is not allowed by stylex. Use "paddingInlineStart" instead.',
+        },
+        {
+          message:
+            'The key "paddingEnd" is not allowed by stylex. Use "paddingInlineEnd" instead.',
+        },
+        {
+          message:
+            'The key "paddingHorizontal" is not allowed by stylex. Use "paddingInline" instead.',
+        },
+        {
+          message:
+            'The key "paddingVertical" is not allowed by stylex. Use "paddingBlock" instead.',
+        },
+      ],
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            marginInlineStart: '10px',
+            marginInlineEnd: '5px',
+            marginInline: '15px',
+            marginBlock: '15px',
+            paddingInlineStart: '10px',
+            paddingInlineEnd: '5px',
+            paddingInline: '5px',
+            paddingBlock: '15px',
+          },
+        });
+      `,
+    },
+    {
       code: "import stylex from 'stylex'; stylex.create({default: {textAlign: 'lfet'}});",
       errors: [
         {

--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -617,35 +617,35 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       errors: [
         {
           message:
-            'The key "marginStart" is not allowed by stylex. Use "marginInlineStart" instead.',
+            'The key "marginStart" is not a standard CSS property. Did you mean "marginInlineStart"?',
         },
         {
           message:
-            'The key "marginEnd" is not allowed by stylex. Use "marginInlineEnd" instead.',
+            'The key "marginEnd" is not a standard CSS property. Did you mean "marginInlineEnd"?',
         },
         {
           message:
-            'The key "marginHorizontal" is not allowed by stylex. Use "marginInline" instead.',
+            'The key "marginHorizontal" is not a standard CSS property. Did you mean "marginInline"?',
         },
         {
           message:
-            'The key "marginVertical" is not allowed by stylex. Use "marginBlock" instead.',
+            'The key "marginVertical" is not a standard CSS property. Did you mean "marginBlock"?',
         },
         {
           message:
-            'The key "paddingStart" is not allowed by stylex. Use "paddingInlineStart" instead.',
+            'The key "paddingStart" is not a standard CSS property. Did you mean "paddingInlineStart"?',
         },
         {
           message:
-            'The key "paddingEnd" is not allowed by stylex. Use "paddingInlineEnd" instead.',
+            'The key "paddingEnd" is not a standard CSS property. Did you mean "paddingInlineEnd"?',
         },
         {
           message:
-            'The key "paddingHorizontal" is not allowed by stylex. Use "paddingInline" instead.',
+            'The key "paddingHorizontal" is not a standard CSS property. Did you mean "paddingInline"?',
         },
         {
           message:
-            'The key "paddingVertical" is not allowed by stylex. Use "paddingBlock" instead.',
+            'The key "paddingVertical" is not a standard CSS property. Did you mean "paddingBlock"?',
         },
       ],
       output: `

--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -40,6 +40,21 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       });
     `,
     `
+      import stylex from "stylex";
+      const styles = stylex.create({
+        validStyle: {
+          marginInlineStart: "10px",
+          marginInlineEnd: "5px",
+          marginInline: "15px",
+          marginBlock: "20px",
+          paddingInlineStart: "8px",
+          paddingInlineEnd: "12px",
+          paddingInline: "10px",
+          paddingBlock: "16px",
+        },
+      });
+    `,
+    `
       import stylex from 'stylex';
       const start = 'start';
       const grayscale = 'grayscale';

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -2667,7 +2667,7 @@ const stylexValidStyles = {
           ) {
             originalKey = style.key.value;
           }
-          // add autofix here
+
           return context.report({
             node: style.key,
             loc: style.key.loc,

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -1595,6 +1595,17 @@ const SupportedVendorSpecificCSSProperties = {
   ),
 };
 
+const validStyleMapping: $ReadOnly<{ [key: string]: ?string }> = {
+  marginStart: 'marginInlineStart',
+  marginEnd: 'marginInlineEnd',
+  marginHorizontal: 'marginInline',
+  marginVertical: 'marginBlock',
+  paddingStart: 'paddingInlineStart',
+  paddingEnd: 'paddingInlineEnd',
+  paddingHorizontal: 'paddingInline',
+  paddingVertical: 'paddingBlock',
+};
+
 const SVGProperties = {
   colorInterpolation: makeUnionRule('auto', 'sRGB', 'linearRGB'),
   // colorRendering: color,
@@ -2292,6 +2303,7 @@ const stylexValidStyles = {
   meta: {
     type: 'problem',
     hasSuggestions: true,
+    fixable: 'code',
     docs: {
       descriptions: 'Enforce that you create valid stylex styles',
       category: 'Possible Errors',
@@ -2635,10 +2647,41 @@ const stylexValidStyles = {
             const distance = getDistance(key, cssProp, 2);
             return distance <= 2;
           });
+
+          const replacementKey =
+            style.key.type === 'Identifier' && validStyleMapping[style.key.name]
+              ? validStyleMapping[style.key.name]
+              : style.key.type === 'Literal' &&
+                  typeof style.key.value === 'string' &&
+                  validStyleMapping[style.key.value]
+                ? validStyleMapping[style.key.value]
+                : null;
+
+          let originalKey = '';
+
+          if (style.key.type === 'Identifier') {
+            originalKey = style.key.name;
+          } else if (
+            style.key.type === 'Literal' &&
+            typeof style.key.value === 'string'
+          ) {
+            originalKey = style.key.value;
+          }
+          // add autofix here
           return context.report({
             node: style.key,
             loc: style.key.loc,
-            message: 'This is not a key that is allowed by stylex',
+            message:
+              replacementKey &&
+              (style.key.type === 'Identifier' || style.key.type === 'Literal')
+                ? `The key "${originalKey}" is not allowed by stylex. Use "${replacementKey}" instead.`
+                : 'This is not a key that is allowed by stylex',
+            fix: (fixer) => {
+              if (replacementKey) {
+                return fixer.replaceText(style.key, replacementKey);
+              }
+              return null;
+            },
             suggest:
               closestKey != null
                 ? [

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -2674,7 +2674,7 @@ const stylexValidStyles = {
             message:
               replacementKey &&
               (style.key.type === 'Identifier' || style.key.type === 'Literal')
-                ? `The key "${originalKey}" is not allowed by stylex. Use "${replacementKey}" instead.`
+                ? `The key "${originalKey}" is not a standard CSS property. Did you mean "${replacementKey}"?`
                 : 'This is not a key that is allowed by stylex',
             fix: (fixer) => {
               if (replacementKey) {


### PR DESCRIPTION
## Context

As per internal discussions, let's add an autofix into the valid-styles rule. Some of this logic exists in the valid-shorthands rule, but it makes sense to move the erroring here for the repos in which valid-shorthands is not enabled.

I've kept the descriptor in the autofix short and simple to avoid clutter on a lint error that will likely crop up a lot, but can also link to https://fb.workplace.com/groups/stylexfyi/posts/1769833193785624 or something related as context. Open to feedback here!

As a next step, we should work towards splitting up the valid-styles rule into more discrete chunks to increase the granularity of error reporting/messaging (perhaps after the codemodding)

## Tests

Added tests for the following styles: 
- marginStart -> marginInlineStart
- marginEnd -> marginInlineEnd
- marginHorizontal -> marginInline
- marginVertical -> marginBlock
- paddingStart -> paddingInlineStart
- paddingEnd -> paddingInlineEnd
- paddingHorizontal -> paddingInline
- paddingVertical -> paddingBlock

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code