### PR TITLE
feat: add dynamic styles to benchmarks fixture

### DIFF
--- a/apps/rollup-example/index.js
+++ b/apps/rollup-example/index.js
@@ -11,9 +11,11 @@
 
 import stylex from '@stylexjs/stylex';
 import { lotsOfStyles } from './lotsOfStyles';
+import { lotsOfStylesDynamic } from './lotsOfStylesDynamic.js';
 
 const styles = lotsOfStyles.map((defs) => Object.values(defs));
+const dynamicStyles = lotsOfStylesDynamic.map((defs) => Object.values(defs));
 
 export default function App() {
-  return stylex.props(styles);
+  return stylex.props(styles, dynamicStyles);
 }

--- a/apps/rollup-example/lotsOfStylesDynamic.js
+++ b/apps/rollup-example/lotsOfStylesDynamic.js
@@ -174,8 +174,8 @@ export const lotsOfStylesDynamic = [
     }),
   }),
   stylex.create({
-    dynamicContainer: (marginEnd) => ({
-      marginEnd,
+    dynamicContainer: (marginInlineEnd) => ({
+      marginInlineEnd,
     }),
     dynamicKeyInfo: (
       backgroundColor,
@@ -183,7 +183,7 @@ export const lotsOfStylesDynamic = [
       borderStyle,
       borderColor,
       borderRadius,
-      marginEnd,
+      marginInlineEnd,
       padding,
     ) => ({
       backgroundColor,
@@ -191,7 +191,7 @@ export const lotsOfStylesDynamic = [
       borderStyle,
       borderColor,
       borderRadius,
-      marginEnd,
+      marginInlineEnd,
       padding,
     }),
     dynamicKeyInfoItem: (marginTop) => ({
@@ -214,10 +214,10 @@ export const lotsOfStylesDynamic = [
       color,
       padding,
     }),
-    dynamicContainer: (borderWidth, borderStyle, marginEnd) => ({
+    dynamicContainer: (borderWidth, borderStyle, marginInlineEnd) => ({
       borderWidth,
       borderStyle,
-      marginEnd,
+      marginInlineEnd,
     }),
     dynamicInputWrapper: (marginTop) => ({
       marginTop,
@@ -244,8 +244,8 @@ export const lotsOfStylesDynamic = [
       margin,
       minWidth,
       padding,
-      paddingEnd,
-      paddingStart,
+      paddingInlineEnd,
+      paddingInlineStart,
       textAlign,
     ) => ({
       borderWidth,
@@ -257,8 +257,8 @@ export const lotsOfStylesDynamic = [
       margin,
       minWidth,
       padding,
-      paddingEnd,
-      paddingStart,
+      paddingInlineEnd,
+      paddingInlineStart,
       textAlign,
     }),
   }),
@@ -270,8 +270,8 @@ export const lotsOfStylesDynamic = [
     dynamicListItem: (paddingTop) => ({
       paddingTop,
     }),
-    dynamicPlus: (marginHorizontal) => ({
-      marginHorizontal,
+    dynamicPlus: (marginInline) => ({
+      marginInline,
     }),
   }),
   stylex.create({
@@ -350,7 +350,7 @@ export const lotsOfStylesDynamic = [
       borderRadius,
       boxShadow,
       display,
-      marginVertical,
+      marginBlock,
       minHeight,
       maxWidth,
       width,
@@ -363,7 +363,7 @@ export const lotsOfStylesDynamic = [
       borderRadius,
       boxShadow,
       display,
-      marginVertical,
+      marginBlock,
       minHeight,
       maxWidth,
       width,
@@ -374,17 +374,17 @@ export const lotsOfStylesDynamic = [
     }),
   }),
   stylex.create({
-    dynamicButton: (width, height, marginEnd, borderRadius) => ({
+    dynamicButton: (width, height, marginInlineEnd, borderRadius) => ({
       width,
       height,
-      marginEnd,
+      marginInlineEnd,
       borderRadius,
     }),
-    dynamicBody: (width, height, borderRadius, marginVertical) => ({
+    dynamicBody: (width, height, borderRadius, marginBlock) => ({
       width,
       height,
       borderRadius,
-      marginVertical,
+      marginBlock,
     }),
     dynamicMeta: (width, height, borderRadius) => ({
       width,
@@ -416,12 +416,12 @@ export const lotsOfStylesDynamic = [
       padding,
       width,
     }),
-    dynamicPlaceholder: (marginStart, marginTop) => ({
-      marginStart,
+    dynamicPlaceholder: (marginInlineStart, marginTop) => ({
+      marginInlineStart,
       marginTop,
     }),
-    dynamicPlaceholderWithBugNub: (marginStart, marginTop) => ({
-      marginStart,
+    dynamicPlaceholderWithBugNub: (marginInlineStart, marginTop) => ({
+      marginInlineStart,
       marginTop,
     }),
     dynamicTitle: (maxWidth) => ({
@@ -528,27 +528,27 @@ export const lotsOfStylesDynamic = [
   stylex.create({
     dynamicMetricCardContent: (
       borderTopStyle,
-      borderStartStyle,
-      borderEndStyle,
+      borderInlineStartStyle,
+      borderInlineEndStyle,
       borderBottomStyle,
       borderTopWidth,
-      borderStartWidth,
-      borderEndWidth,
+      borderInlineStartWidth,
+      borderInlineEndWidth,
       borderBottomWidth,
       boxSizing,
       display,
       flexGrow,
       flexShrink,
       marginTop,
-      marginEnd,
+      marginInlineEnd,
       marginBottom,
-      marginStart,
+      marginInlineStart,
       minHeight,
       minWidth,
       paddingTop,
-      paddingEnd,
+      paddingInlineEnd,
       paddingBottom,
-      paddingStart,
+      paddingInlineStart,
       position,
       zIndex,
       flexDirection,
@@ -557,27 +557,27 @@ export const lotsOfStylesDynamic = [
       height,
     ) => ({
       borderTopStyle,
-      borderStartStyle,
-      borderEndStyle,
+      borderInlineStartStyle,
+      borderInlineEndStyle,
       borderBottomStyle,
       borderTopWidth,
-      borderStartWidth,
-      borderEndWidth,
+      borderInlineStartWidth,
+      borderInlineEndWidth,
       borderBottomWidth,
       boxSizing,
       display,
       flexGrow,
       flexShrink,
       marginTop,
-      marginEnd,
+      marginInlineEnd,
       marginBottom,
-      marginStart,
+      marginInlineStart,
       minHeight,
       minWidth,
       paddingTop,
-      paddingEnd,
+      paddingInlineEnd,
       paddingBottom,
-      paddingStart,
+      paddingInlineStart,
       position,
       zIndex,
       flexDirection,
@@ -585,11 +585,11 @@ export const lotsOfStylesDynamic = [
       alignItems,
       height,
     }),
-    dynamicReactionRoot: (display, alignItems, paddingStart, marginEnd) => ({
+    dynamicReactionRoot: (display, alignItems, paddingInlineStart, marginInlineEnd) => ({
       display,
       alignItems,
-      paddingStart,
-      marginEnd,
+      paddingInlineStart,
+      marginInlineEnd,
     }),
     dynamicReactionContainer: (
       width,
@@ -598,7 +598,7 @@ export const lotsOfStylesDynamic = [
       borderRadius,
       borderStyle,
       borderWidth,
-      marginStart,
+      marginInlineStart,
       position,
     ) => ({
       width,
@@ -607,11 +607,11 @@ export const lotsOfStylesDynamic = [
       borderRadius,
       borderStyle,
       borderWidth,
-      marginStart,
+      marginInlineStart,
       position,
     }),
     dynamicIconContainer: (
-      marginEnd,
+      marginInlineEnd,
       width,
       height,
       alignItems,
@@ -623,7 +623,7 @@ export const lotsOfStylesDynamic = [
       padding,
       position,
     ) => ({
-      marginEnd,
+      marginInlineEnd,
       width,
       height,
       alignItems,
@@ -682,17 +682,17 @@ export const lotsOfStylesDynamic = [
       minWidth,
       maxWidth,
     }),
-    dynamicContentScroll: (overflowY, paddingHorizontal, height) => ({
+    dynamicContentScroll: (overflowY, paddingInline, height) => ({
       overflowY,
-      paddingHorizontal,
+      paddingInline,
       height,
     }),
-    dynamicMsteams: (marginStart) => ({ marginStart }),
+    dynamicMsteams: (marginInlineStart) => ({ marginInlineStart }),
   }),
   stylex.create({
     dynamicGlimmer: (height) => ({ height }),
-    dynamicIcon: (marginEnd, position, top) => ({
-      marginEnd,
+    dynamicIcon: (marginInlineEnd, position, top) => ({
+      marginInlineEnd,
       position,
       top,
     }),
@@ -722,7 +722,7 @@ export const lotsOfStylesDynamic = [
   stylex.create({
     padding: {
       paddingBottom: 'var(--p-space-4)',
-      paddingHorizontal: 'var(--p-space-4)',
+      paddingInline: 'var(--p-space-4)',
       paddingTop: 'var(--p-space-2)',
     },
     dynamicPadding: (padding) => ({
@@ -731,10 +731,10 @@ export const lotsOfStylesDynamic = [
   }),
   stylex.create({
     vert16: {
-      paddingVertical: 16,
+      paddingBlock: 16,
     },
-    dynamicVert: (paddingVertical) => ({
-      paddingVertical,
+    dynamicVert: (paddingBlock) => ({
+      paddingBlock,
     }),
   }),
   stylex.create({

--- a/apps/rollup-example/lotsOfStylesDynamic.js
+++ b/apps/rollup-example/lotsOfStylesDynamic.js
@@ -12,7 +12,7 @@
 import * as stylex from '@stylexjs/stylex';
 
 export const lotsOfStylesDynamic = [
-   stylex.create({
+  stylex.create({
     // Dynamic styles
     dynamicHeight: (height) => ({
       height,

--- a/apps/rollup-example/lotsOfStylesDynamic.js
+++ b/apps/rollup-example/lotsOfStylesDynamic.js
@@ -585,7 +585,12 @@ export const lotsOfStylesDynamic = [
       alignItems,
       height,
     }),
-    dynamicReactionRoot: (display, alignItems, paddingInlineStart, marginInlineEnd) => ({
+    dynamicReactionRoot: (
+      display,
+      alignItems,
+      paddingInlineStart,
+      marginInlineEnd,
+    ) => ({
       display,
       alignItems,
       paddingInlineStart,

--- a/apps/rollup-example/lotsOfStylesDynamic.js
+++ b/apps/rollup-example/lotsOfStylesDynamic.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+'use strict';
+
+import * as stylex from '@stylexjs/stylex';
+
+export const lotsOfStylesDynamic = [
+   stylex.create({
+    // Dynamic styles
+    dynamicHeight: (height) => ({
+      height,
+    }),
+    dynamicPadding: (paddingTop, paddingBottom) => ({
+      paddingTop,
+      paddingBottom,
+    }),
+    dynamicTextColor: (textColor) => ({
+      color: textColor,
+    }),
+  }),
+  stylex.create({
+    // Mixed dynamic and regular styles
+    dynamicHeightWithStatic: (height) => ({
+      height,
+      backgroundColor: 'var(--background-color)',
+    }),
+    dynamicPaddingWithStatic: (paddingTop, paddingBottom) => ({
+      paddingTop,
+      paddingBottom,
+      margin: '8px',
+    }),
+    dynamicTextColorWithStatic: (textColor) => ({
+      color: textColor,
+      fontSize: '16px',
+    }),
+  }),
+];

--- a/apps/rollup-example/lotsOfStylesDynamic.js
+++ b/apps/rollup-example/lotsOfStylesDynamic.js
@@ -13,7 +13,6 @@ import * as stylex from '@stylexjs/stylex';
 
 export const lotsOfStylesDynamic = [
   stylex.create({
-    // Dynamic styles
     dynamicHeight: (height) => ({
       height,
     }),
@@ -26,7 +25,6 @@ export const lotsOfStylesDynamic = [
     }),
   }),
   stylex.create({
-    // Mixed dynamic and regular styles
     dynamicHeightWithStatic: (height) => ({
       height,
       backgroundColor: 'var(--background-color)',
@@ -39,6 +37,690 @@ export const lotsOfStylesDynamic = [
     dynamicTextColorWithStatic: (textColor) => ({
       color: textColor,
       fontSize: '16px',
+    }),
+  }),
+  stylex.create({
+    dynamicHeight: (height) => ({ height }),
+    dynamicPadding: (paddingTop, paddingBottom) => ({
+      paddingTop,
+      paddingBottom,
+    }),
+    dynamicTextColor: (textColor) => ({ color: textColor }),
+    dynamicFontSize: (fontSize) => ({ fontSize }),
+    dynamicFontWeight: (fontWeight) => ({ fontWeight }),
+    dynamicLineHeight: (lineHeight) => ({ lineHeight }),
+    dynamicLetterSpacing: (letterSpacing) => ({ letterSpacing }),
+    dynamicTextTransform: (textTransform) => ({ textTransform }),
+    dynamicTextDecoration: (textDecoration) => ({ textDecoration }),
+  }),
+  stylex.create({
+    dynamicFontSizeWithStatic: (fontSize) => ({
+      fontSize,
+      fontFamily: 'Arial, sans-serif',
+    }),
+    dynamicFontWeightWithStatic: (fontWeight) => ({
+      fontWeight,
+      fontStyle: 'normal',
+    }),
+    dynamicLineHeightWithStatic: (lineHeight) => ({
+      lineHeight,
+      textAlign: 'left',
+    }),
+    dynamicLetterSpacingWithStatic: (letterSpacing) => ({
+      letterSpacing,
+      wordWrap: 'break-word',
+    }),
+    dynamicTextTransformWithStatic: (textTransform) => ({
+      textTransform,
+      textShadow: 'none',
+    }),
+    dynamicTextDecorationWithStatic: (textDecoration) => ({
+      textDecoration,
+      boxSizing: 'border-box',
+    }),
+  }),
+  stylex.create({
+    dynamicWidth: (width) => ({ width }),
+    dynamicMinWidth: (minWidth) => ({ minWidth }),
+    dynamicMaxWidth: (maxWidth) => ({ maxWidth }),
+    dynamicHeight2: (height) => ({ height }),
+    dynamicMinHeight: (minHeight) => ({ minHeight }),
+    dynamicMaxHeight: (maxHeight) => ({ maxHeight }),
+    dynamicBorderRadius: (borderRadius) => ({ borderRadius }),
+    dynamicBoxShadow: (boxShadow) => ({ boxShadow }),
+    dynamicBackgroundImage: (backgroundImage) => ({ backgroundImage }),
+    dynamicBackgroundSize: (backgroundSize) => ({ backgroundSize }),
+    dynamicBackgroundPosition: (backgroundPosition) => ({ backgroundPosition }),
+    dynamicBackgroundRepeat: (backgroundRepeat) => ({ backgroundRepeat }),
+  }),
+  stylex.create({
+    dynamicOpacity: (opacity) => ({ opacity }),
+    dynamicVisibility: (visibility) => ({ visibility }),
+    dynamicDisplay: (display) => ({ display }),
+    dynamicPosition: (position) => ({ position }),
+    dynamicTop: (top) => ({ top }),
+    dynamicRight: (right) => ({ right }),
+    dynamicBottom: (bottom) => ({ bottom }),
+    dynamicLeft: (left) => ({ left }),
+    dynamicZIndex: (zIndex) => ({ zIndex }),
+    dynamicOverflow: (overflow) => ({ overflow }),
+    dynamicOverflowX: (overflowX) => ({ overflowX }),
+    dynamicOverflowY: (overflowY) => ({ overflowY }),
+  }),
+  stylex.create({
+    dynamicCursor: (cursor) => ({ cursor }),
+    dynamicOutline: (outline) => ({ outline }),
+    dynamicOutlineWidth: (outlineWidth) => ({ outlineWidth }),
+    dynamicOutlineStyle: (outlineStyle) => ({ outlineStyle }),
+    dynamicOutlineColor: (outlineColor) => ({ outlineColor }),
+    dynamicListStyle: (listStyle) => ({ listStyle }),
+    dynamicListStyleType: (listStyleType) => ({ listStyleType }),
+    dynamicListStylePosition: (listStylePosition) => ({ listStylePosition }),
+    dynamicListStyleImage: (listStyleImage) => ({ listStyleImage }),
+  }),
+  stylex.create({
+    dynamicInput: (caretColor) => ({
+      'caret-color': caretColor,
+    }),
+    dynamicDisplayInherit: (display) => ({
+      display,
+    }),
+    dynamicInherit: (alignContent, alignItems, flexDirection, flexGrow, flexShrink, height, justifyContent, maxHeight, maxWidth, minHeight, minWidth, position, width) => ({
+      alignContent,
+      alignItems,
+      flexDirection,
+      flexGrow,
+      flexShrink,
+      height,
+      justifyContent,
+      maxHeight,
+      maxWidth,
+      minHeight,
+      minWidth,
+      position,
+      width,
+    }),
+  }),
+  stylex.create({
+    dynamicRailContent: (fontSize, margin) => ({
+      fontSize,
+      margin,
+    }),
+    dynamicRailItem: (marginBottom) => ({
+      marginBottom,
+    }),
+    dynamicRoot: (flexGrow, listStyleType, margin) => ({
+      flexGrow,
+      listStyleType,
+      margin,
+    }),
+    dynamicWidgetSet: (display, marginTop) => ({
+      display,
+      marginTop,
+    }),
+  }),
+  stylex.create({
+    dynamicContainer: (marginEnd) => ({
+      marginEnd,
+    }),
+    dynamicKeyInfo: (backgroundColor, borderWidth, borderStyle, borderColor, borderRadius, marginEnd, padding) => ({
+      backgroundColor,
+      borderWidth,
+      borderStyle,
+      borderColor,
+      borderRadius,
+      marginEnd,
+      padding,
+    }),
+    dynamicKeyInfoItem: (marginTop) => ({
+      marginTop,
+    }),
+  }),
+  stylex.create({
+    dynamicBlueBackground: (backgroundColor, color, padding) => ({
+      backgroundColor,
+      color,
+      padding,
+    }),
+    dynamicRedBackground: (backgroundColor, color, padding) => ({
+      backgroundColor,
+      color,
+      padding,
+    }),
+    dynamicWhiteBackground: (backgroundColor, color, padding) => ({
+      backgroundColor,
+      color,
+      padding,
+    }),
+    dynamicContainer: (borderWidth, borderStyle, marginEnd) => ({
+      borderWidth,
+      borderStyle,
+      marginEnd,
+    }),
+    dynamicInputWrapper: (marginTop) => ({
+      marginTop,
+    }),
+  }),
+  stylex.create({
+    dynamicGreenBackground: (backgroundColor, color, padding) => ({
+      backgroundColor,
+      color,
+      padding,
+    }),
+    dynamicSection: (marginBottom) => ({
+      marginBottom,
+    }),
+  }),
+  stylex.create({
+    dynamicKeyInfo: (borderWidth, borderStyle, borderColor, borderRadius, display, lineHeight, margin, minWidth, padding, paddingEnd, paddingStart, textAlign) => ({
+      borderWidth,
+      borderStyle,
+      borderColor,
+      borderRadius,
+      display,
+      lineHeight,
+      margin,
+      minWidth,
+      padding,
+      paddingEnd,
+      paddingStart,
+      textAlign,
+    }),
+  }),
+  stylex.create({
+    dynamicList: (paddingBottom, paddingTop) => ({
+      paddingBottom,
+      paddingTop,
+    }),
+    dynamicListItem: (paddingTop) => ({
+      paddingTop,
+    }),
+    dynamicPlus: (marginHorizontal) => ({
+      marginHorizontal,
+    }),
+  }),
+  stylex.create({
+    dynamicWrapperFocusable: (outline) => ({
+      ':focus': {
+        outline,
+      },
+    }),
+  }),
+  stylex.create({
+    dynamicHeader: (display, flexGrow, flexShrink, flexBasis) => ({
+      display,
+      flexGrow,
+      flexShrink,
+      flexBasis,
+    }),
+  }),
+  stylex.create({
+    dynamicDialog: (backgroundColor, height, width) => ({
+      backgroundColor,
+      height,
+      width,
+    }),
+  }),
+  stylex.create({
+    dynamicRoot: (backgroundColor, height, width, overflowY) => ({
+      backgroundColor,
+      height,
+      width,
+      overflowY,
+    }),
+  }),
+  stylex.create({
+    dynamicContainer: (backgroundColor, display, flexDirection, height, width) => ({
+      backgroundColor,
+      display,
+      flexDirection,
+      height,
+      width,
+    }),
+    dynamicColumnLayout: (display, flexGrow, flexShrink, minHeight) => ({
+      display,
+      flexGrow,
+      flexShrink,
+      minHeight,
+    }),
+    dynamicBodyContainer: (width, flexGrow, display, justifyContent) => ({
+      width,
+      flexGrow,
+      display,
+      justifyContent,
+    }),
+    dynamicCardWrapper: (display, flexDirection, flexShrink, flexGrow, minWidth, margin) => ({
+      display,
+      flexDirection,
+      flexShrink,
+      flexGrow,
+      minWidth,
+      margin,
+    }),
+    dynamicRoot: (backgroundColor, borderRadius, boxShadow, display, marginVertical, minHeight, maxWidth, width, flexGrow, alignSelf, flexDirection, overflow) => ({
+      backgroundColor,
+      borderRadius,
+      boxShadow,
+      display,
+      marginVertical,
+      minHeight,
+      maxWidth,
+      width,
+      flexGrow,
+      alignSelf,
+      flexDirection,
+      overflow,
+    }),
+  }),
+  stylex.create({
+    dynamicButton: (width, height, marginEnd, borderRadius) => ({
+      width,
+      height,
+      marginEnd,
+      borderRadius,
+    }),
+    dynamicBody: (width, height, borderRadius, marginVertical) => ({
+      width,
+      height,
+      borderRadius,
+      marginVertical,
+    }),
+    dynamicMeta: (width, height, borderRadius) => ({
+      width,
+      height,
+      borderRadius,
+    }),
+  }),
+  stylex.create({
+    dynamicHeader: (display, flexGrow, flexShrink, flexBasis) => ({
+      display,
+      flexGrow,
+      flexShrink,
+      flexBasis,
+    }),
+    dynamicHeaderContainer: (backgroundColor, borderBottomWidth, borderBottomStyle, borderBottomColor, textAlign, padding, width) => ({
+      backgroundColor,
+      borderBottomWidth,
+      borderBottomStyle,
+      borderBottomColor,
+      textAlign,
+      padding,
+      width,
+    }),
+    dynamicPlaceholder: (marginStart, marginTop) => ({
+      marginStart,
+      marginTop,
+    }),
+    dynamicPlaceholderWithBugNub: (marginStart, marginTop) => ({
+      marginStart,
+      marginTop,
+    }),
+    dynamicTitle: (maxWidth) => ({
+      maxWidth,
+    }),
+  }),
+  stylex.create({
+    dynamicShareFeedbackSticky: (position, end, bottom, zIndex) => ({
+      position,
+      end,
+      bottom,
+      zIndex,
+    }),
+    dynamicRoot: (height) => ({
+      height,
+    }),
+    dynamicScrollable: (overflowY, padding, height) => ({
+      overflowY,
+      padding,
+      height,
+    }),
+    dynamicContent: (display, flexDirection, width, margin) => ({
+      display,
+      flexDirection,
+      width,
+      margin,
+    }),
+    dynamicEditor: (boxSizing, backgroundColor, borderRadius, boxShadow, display, marginTop, marginBottom, maxWidth, width, minHeight, flexGrow, alignSelf, flexDirection, padding) => ({
+      boxSizing,
+      backgroundColor,
+      borderRadius,
+      boxShadow,
+      display,
+      marginTop,
+      marginBottom,
+      maxWidth,
+      width,
+      minHeight,
+      flexGrow,
+      alignSelf,
+      flexDirection,
+      padding,
+    }),
+    dynamicHeader: (mediaPrintDisplay) => ({
+      '@media print': {
+        display: mediaPrintDisplay,
+      },
+    }),
+    dynamicEditorContainer: (display, justifyContent, height) => ({
+      display,
+      justifyContent,
+      height,
+    }),
+    dynamicEditorInnerContainer: (width, zIndex) => ({
+      width,
+      zIndex,
+    }),
+    dynamicSidebarContainer: (width, flexShrink, paddingTop, backgroundColor, overflowY, height) => ({
+      width,
+      flexShrink,
+      paddingTop,
+      backgroundColor,
+      overflowY,
+      height,
+    }),
+    dynamicInnerContainer: (marginTop, height) => ({
+      marginTop,
+      height,
+    }),
+    dynamicNoteContainer: (display, flexDirection, height) => ({
+      display,
+      flexDirection,
+      height,
+    }),
+  }),
+  stylex.create({
+    dynamicPhotoStyle: (paddingTop, height) => ({
+      paddingTop,
+      height,
+    }),
+  }),
+  stylex.create({
+    dynamicMetricCardContent: (
+      borderTopStyle,
+      borderStartStyle,
+      borderEndStyle,
+      borderBottomStyle,
+      borderTopWidth,
+      borderStartWidth,
+      borderEndWidth,
+      borderBottomWidth,
+      boxSizing,
+      display,
+      flexGrow,
+      flexShrink,
+      marginTop,
+      marginEnd,
+      marginBottom,
+      marginStart,
+      minHeight,
+      minWidth,
+      paddingTop,
+      paddingEnd,
+      paddingBottom,
+      paddingStart,
+      position,
+      zIndex,
+      flexDirection,
+      justifyContent,
+      alignItems,
+      height
+    ) => ({
+      borderTopStyle,
+      borderStartStyle,
+      borderEndStyle,
+      borderBottomStyle,
+      borderTopWidth,
+      borderStartWidth,
+      borderEndWidth,
+      borderBottomWidth,
+      boxSizing,
+      display,
+      flexGrow,
+      flexShrink,
+      marginTop,
+      marginEnd,
+      marginBottom,
+      marginStart,
+      minHeight,
+      minWidth,
+      paddingTop,
+      paddingEnd,
+      paddingBottom,
+      paddingStart,
+      position,
+      zIndex,
+      flexDirection,
+      justifyContent,
+      alignItems,
+      height,
+    }),
+    dynamicReactionRoot: (display, alignItems, paddingStart, marginEnd) => ({
+      display,
+      alignItems,
+      paddingStart,
+      marginEnd,
+    }),
+    dynamicReactionContainer: (
+      width,
+      height,
+      borderColor,
+      borderRadius,
+      borderStyle,
+      borderWidth,
+      marginStart,
+      position
+    ) => ({
+      width,
+      height,
+      borderColor,
+      borderRadius,
+      borderStyle,
+      borderWidth,
+      marginStart,
+      position,
+    }),
+    dynamicIconContainer: (
+      marginEnd,
+      width,
+      height,
+      alignItems,
+      borderRadius,
+      borderWidth,
+      boxSizing,
+      display,
+      justifyContent,
+      padding,
+      position
+    ) => ({
+      marginEnd,
+      width,
+      height,
+      alignItems,
+      borderRadius,
+      borderWidth,
+      boxSizing,
+      display,
+      justifyContent,
+      padding,
+      position,
+    }),
+    dynamicIconColorViewers: (backgroundColor) => ({ backgroundColor }),
+    dynamicIconColorComments: (backgroundColor) => ({ backgroundColor }),
+    dynamicIconColorQuestions: (backgroundColor) => ({ backgroundColor }),
+    dynamicIconColorLikeReaction: (backgroundColor) => ({ backgroundColor }),
+  }),
+  stylex.create({
+    dynamicContainer: (backgroundColor, height) => ({
+      backgroundColor,
+      height,
+    }),
+  }),
+  stylex.create({
+    dynamicRoot: (backgroundColor, width, height, maxHeight) => ({
+      backgroundColor,
+      width,
+      height,
+      maxHeight,
+    }),
+  }),
+  stylex.create({
+    dynamicContainer: (
+      backgroundColor,
+      display,
+      height,
+      margin,
+      width
+    ) => ({
+      backgroundColor,
+      display,
+      height,
+      margin,
+      width,
+    }),
+    dynamicBackgroundTeams: (backgroundColor) => ({ backgroundColor }),
+  }),
+  stylex.create({
+    dynamicTitle: (width, borderRadius, height) => ({
+      width,
+      borderRadius,
+      height,
+    }),
+    dynamicSubtitle: (width, borderRadius, height) => ({
+      width,
+      borderRadius,
+      height,
+    }),
+  }),
+  stylex.create({
+    dynamicDefaultResponsiveWidth: (width, minWidth, maxWidth) => ({
+      width,
+      minWidth,
+      maxWidth,
+    }),
+    dynamicContentScroll: (overflowY, paddingHorizontal, height) => ({
+      overflowY,
+      paddingHorizontal,
+      height,
+    }),
+    dynamicMsteams: (marginStart) => ({ marginStart }),
+  }),
+  stylex.create({
+    dynamicGlimmer: (height) => ({ height }),
+    dynamicIcon: (marginEnd, position, top) => ({
+      marginEnd,
+      position,
+      top,
+    }),
+    dynamicOuterCard: (
+      backgroundColor,
+      height,
+      borderRadius
+    ) => ({
+      backgroundColor,
+      height,
+      borderRadius,
+    }),
+    dynamicBackgroundTeams: (backgroundColor) => ({ backgroundColor }),
+  }),
+  stylex.create({
+    dynamicBody: (marginTop) => ({ marginTop }),
+  }),
+  stylex.create({
+    dynamicVideoOptionsCard: (
+      padding,
+      marginBottom,
+      borderRadius,
+      boxShadow
+    ) => ({
+      padding,
+      marginBottom,
+      borderRadius,
+      boxShadow,
+    }),
+  }),
+  stylex.create({
+    padding: {
+      paddingBottom: 'var(--p-space-4)',
+      paddingHorizontal: 'var(--p-space-4)',
+      paddingTop: 'var(--p-space-2)',
+    },
+    dynamicPadding: (padding) => ({
+      padding,
+    }),
+  }),
+  stylex.create({
+    vert16: {
+      paddingVertical: 16,
+    },
+    dynamicVert: (paddingVertical) => ({
+      paddingVertical,
+    }),
+  }),
+  stylex.create({
+    item: {
+      listStyleType: 'disc',
+    },
+    dynamicItem: (listStyleType) => ({
+      listStyleType,
+    }),
+  }),
+  stylex.create({
+    container: {
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100%',
+      justifyContent: 'space-between',
+      padding: '0px 16px',
+    },
+    dynamicContainer: (
+      display,
+      flexDirection,
+      height,
+      justifyContent,
+      padding
+    ) => ({
+      display,
+      flexDirection,
+      height,
+      justifyContent,
+      padding,
+    }),
+  }),
+  stylex.create({
+    root: {
+      backgroundColor: 'var(--surface-background)',
+      borderRadius: 8,
+      boxShadow: '0 2px 12px var(--shadow-2)',
+      boxSizing: 'border-box',
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100%',
+      justifyContent: 'space-between',
+      padding: '16px',
+      width: '100%',
+    },
+    dynamicRoot: (
+      backgroundColor,
+      borderRadius,
+      boxShadow,
+      boxSizing,
+      display,
+      flexDirection,
+      height,
+      justifyContent,
+      padding,
+      width
+    ) => ({
+      backgroundColor,
+      borderRadius,
+      boxShadow,
+      boxSizing,
+      display,
+      flexDirection,
+      height,
+      justifyContent,
+      padding,
+      width,
     }),
   }),
 ];

--- a/apps/rollup-example/lotsOfStylesDynamic.js
+++ b/apps/rollup-example/lotsOfStylesDynamic.js
@@ -125,7 +125,21 @@ export const lotsOfStylesDynamic = [
     dynamicDisplayInherit: (display) => ({
       display,
     }),
-    dynamicInherit: (alignContent, alignItems, flexDirection, flexGrow, flexShrink, height, justifyContent, maxHeight, maxWidth, minHeight, minWidth, position, width) => ({
+    dynamicInherit: (
+      alignContent,
+      alignItems,
+      flexDirection,
+      flexGrow,
+      flexShrink,
+      height,
+      justifyContent,
+      maxHeight,
+      maxWidth,
+      minHeight,
+      minWidth,
+      position,
+      width,
+    ) => ({
       alignContent,
       alignItems,
       flexDirection,
@@ -163,7 +177,15 @@ export const lotsOfStylesDynamic = [
     dynamicContainer: (marginEnd) => ({
       marginEnd,
     }),
-    dynamicKeyInfo: (backgroundColor, borderWidth, borderStyle, borderColor, borderRadius, marginEnd, padding) => ({
+    dynamicKeyInfo: (
+      backgroundColor,
+      borderWidth,
+      borderStyle,
+      borderColor,
+      borderRadius,
+      marginEnd,
+      padding,
+    ) => ({
       backgroundColor,
       borderWidth,
       borderStyle,
@@ -212,7 +234,20 @@ export const lotsOfStylesDynamic = [
     }),
   }),
   stylex.create({
-    dynamicKeyInfo: (borderWidth, borderStyle, borderColor, borderRadius, display, lineHeight, margin, minWidth, padding, paddingEnd, paddingStart, textAlign) => ({
+    dynamicKeyInfo: (
+      borderWidth,
+      borderStyle,
+      borderColor,
+      borderRadius,
+      display,
+      lineHeight,
+      margin,
+      minWidth,
+      padding,
+      paddingEnd,
+      paddingStart,
+      textAlign,
+    ) => ({
       borderWidth,
       borderStyle,
       borderColor,
@@ -270,7 +305,13 @@ export const lotsOfStylesDynamic = [
     }),
   }),
   stylex.create({
-    dynamicContainer: (backgroundColor, display, flexDirection, height, width) => ({
+    dynamicContainer: (
+      backgroundColor,
+      display,
+      flexDirection,
+      height,
+      width,
+    ) => ({
       backgroundColor,
       display,
       flexDirection,
@@ -289,7 +330,14 @@ export const lotsOfStylesDynamic = [
       display,
       justifyContent,
     }),
-    dynamicCardWrapper: (display, flexDirection, flexShrink, flexGrow, minWidth, margin) => ({
+    dynamicCardWrapper: (
+      display,
+      flexDirection,
+      flexShrink,
+      flexGrow,
+      minWidth,
+      margin,
+    ) => ({
       display,
       flexDirection,
       flexShrink,
@@ -297,7 +345,20 @@ export const lotsOfStylesDynamic = [
       minWidth,
       margin,
     }),
-    dynamicRoot: (backgroundColor, borderRadius, boxShadow, display, marginVertical, minHeight, maxWidth, width, flexGrow, alignSelf, flexDirection, overflow) => ({
+    dynamicRoot: (
+      backgroundColor,
+      borderRadius,
+      boxShadow,
+      display,
+      marginVertical,
+      minHeight,
+      maxWidth,
+      width,
+      flexGrow,
+      alignSelf,
+      flexDirection,
+      overflow,
+    ) => ({
       backgroundColor,
       borderRadius,
       boxShadow,
@@ -338,7 +399,15 @@ export const lotsOfStylesDynamic = [
       flexShrink,
       flexBasis,
     }),
-    dynamicHeaderContainer: (backgroundColor, borderBottomWidth, borderBottomStyle, borderBottomColor, textAlign, padding, width) => ({
+    dynamicHeaderContainer: (
+      backgroundColor,
+      borderBottomWidth,
+      borderBottomStyle,
+      borderBottomColor,
+      textAlign,
+      padding,
+      width,
+    ) => ({
       backgroundColor,
       borderBottomWidth,
       borderBottomStyle,
@@ -380,7 +449,22 @@ export const lotsOfStylesDynamic = [
       width,
       margin,
     }),
-    dynamicEditor: (boxSizing, backgroundColor, borderRadius, boxShadow, display, marginTop, marginBottom, maxWidth, width, minHeight, flexGrow, alignSelf, flexDirection, padding) => ({
+    dynamicEditor: (
+      boxSizing,
+      backgroundColor,
+      borderRadius,
+      boxShadow,
+      display,
+      marginTop,
+      marginBottom,
+      maxWidth,
+      width,
+      minHeight,
+      flexGrow,
+      alignSelf,
+      flexDirection,
+      padding,
+    ) => ({
       boxSizing,
       backgroundColor,
       borderRadius,
@@ -410,7 +494,14 @@ export const lotsOfStylesDynamic = [
       width,
       zIndex,
     }),
-    dynamicSidebarContainer: (width, flexShrink, paddingTop, backgroundColor, overflowY, height) => ({
+    dynamicSidebarContainer: (
+      width,
+      flexShrink,
+      paddingTop,
+      backgroundColor,
+      overflowY,
+      height,
+    ) => ({
       width,
       flexShrink,
       paddingTop,
@@ -463,7 +554,7 @@ export const lotsOfStylesDynamic = [
       flexDirection,
       justifyContent,
       alignItems,
-      height
+      height,
     ) => ({
       borderTopStyle,
       borderStartStyle,
@@ -508,7 +599,7 @@ export const lotsOfStylesDynamic = [
       borderStyle,
       borderWidth,
       marginStart,
-      position
+      position,
     ) => ({
       width,
       height,
@@ -530,7 +621,7 @@ export const lotsOfStylesDynamic = [
       display,
       justifyContent,
       padding,
-      position
+      position,
     ) => ({
       marginEnd,
       width,
@@ -564,13 +655,7 @@ export const lotsOfStylesDynamic = [
     }),
   }),
   stylex.create({
-    dynamicContainer: (
-      backgroundColor,
-      display,
-      height,
-      margin,
-      width
-    ) => ({
+    dynamicContainer: (backgroundColor, display, height, margin, width) => ({
       backgroundColor,
       display,
       height,
@@ -611,11 +696,7 @@ export const lotsOfStylesDynamic = [
       position,
       top,
     }),
-    dynamicOuterCard: (
-      backgroundColor,
-      height,
-      borderRadius
-    ) => ({
+    dynamicOuterCard: (backgroundColor, height, borderRadius) => ({
       backgroundColor,
       height,
       borderRadius,
@@ -630,7 +711,7 @@ export const lotsOfStylesDynamic = [
       padding,
       marginBottom,
       borderRadius,
-      boxShadow
+      boxShadow,
     ) => ({
       padding,
       marginBottom,
@@ -677,7 +758,7 @@ export const lotsOfStylesDynamic = [
       flexDirection,
       height,
       justifyContent,
-      padding
+      padding,
     ) => ({
       display,
       flexDirection,
@@ -709,7 +790,7 @@ export const lotsOfStylesDynamic = [
       height,
       justifyContent,
       padding,
-      width
+      width,
     ) => ({
       backgroundColor,
       borderRadius,

--- a/typos.toml
+++ b/typos.toml
@@ -2,6 +2,7 @@
 extend-exclude = [
   "*.snap",
   "apps/rollup-example/lotsOfStyles.js", 
+  "apps/rollup-example/lotsOfStylesDynamic.js", 
   "flow-typed/*",
 ]
 


### PR DESCRIPTION
## What changed / motivation ?

This PR added a feature as requested by task #799 , adding dynamic styles to benchmark  fixture, which can then be used by [benchmark workflow](https://github.com/facebook/stylex/blob/main/.github/workflows/performance.yml) on each PR to check performance. This new addition can also help us quantify any performance improvement made to compile dynamic styles, in addition to existing support for static style(e.g. [feat: dynamic styles set inherits to false #794](https://github.com/facebook/stylex/pull/794)).

## Linked PR/Issues

Fixes #799 

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

We do:
- adding additional style examples to fixture
- run `npm run build -w rollup-example` to update `bundle.js`
- we observe generated `bundle.js` to contain the new dynamic styles and observe a size increase when running `./packages/scripts/size.js` script
**[BEFORE]**
<img width="575" alt="image" src="https://github.com/user-attachments/assets/a79662e7-2fa4-4f0e-bfb1-ecf74136654e" />  

**[AFTER]**
<img width="585" alt="image" src="https://github.com/user-attachments/assets/4ed14a4e-beb2-4c35-9979-261cab312b30" />

 


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code