### PR TITLE
fix: fix valid-shorthands object casting error on css-shorthand-expand null return

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -173,6 +173,22 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          borderRight: '4px solid var(--fds-gray-10)'
+        },
+      })
+    `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "borderRight: 4px solid var(--fds-gray-10)" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
         import stylex from 'stylex';
         const styles = stylex.create({
           main: {

--- a/packages/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/eslint-plugin/src/utils/splitShorthands.js
@@ -175,6 +175,11 @@ export function splitSpecificShorthands(
 
   const longform = cssExpand(property, strippedValue);
 
+  if (!longform) {
+    // If css shorthand expand fails, we won't auto-fix
+    return [[toCamelCase(property), CANNOT_FIX]];
+  }
+
   // If the longform is empty or all values are the same, no need to expand
   // Relevant for properties like `borderColor` or `borderStyle`
   if (


### PR DESCRIPTION
## What changed / motivation ?

Certain complex shorthand values like `'4px solid var(--fds-gray-10)'` seem to trip up the css-shorthand-expand package, which defaults to returning null. Let's handle the cases by prematurely returning and not providing an autofix in such cases.

## Testing
**_Still identifying repros to make the test more robust_**

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code