### PR TITLE
fix: add inline processing for borderWidth, borderColor, borderStyle to valid-shorthands

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -173,6 +173,22 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          borderRight: '4px solid var(--fds-gray-10)'
+        },
+      })
+    `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "borderRight: 4px solid var(--fds-gray-10)" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
         import stylex from 'stylex';
         const styles = stylex.create({
           main: {
@@ -287,15 +303,15 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-          import stylex from 'stylex';
-          const styles = stylex.create({
-            main: {
-              borderWidth: 'calc(100% - 20px) calc(90% - 20px)',
-              borderColor: 'var(--test-color, #ccc) linear-gradient(to right, #ff7e5f, #feb47b)',
-              background: 'no-repeat center/cover, linear-gradient(to right, #ff7e5f, #feb47b)'
-            },
-          })
-        `,
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          borderWidth: 'calc(100% - 20px) calc(90% - 20px)',
+          borderColor: 'var(--test-color, #ccc) linear-gradient(to right, #ff7e5f, #feb47b)',
+          background: 'no-repeat center/cover, linear-gradient(to right, #ff7e5f, #feb47b)'
+        },
+      })
+      `,
       errors: [
         {
           message:
@@ -310,7 +326,26 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
             'Property shorthands using multiple values like "background: no-repeat center/cover, linear-gradient(to right, #ff7e5f, #feb47b)" are not supported in StyleX. Separate into individual properties.',
         },
       ],
+      output: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          borderTopWidth: 'calc(100% - 20px)',
+          borderRightWidth: 'calc(90% - 20px)',
+          borderBottomWidth: 'calc(100% - 20px)',
+          borderLeftWidth: 'calc(90% - 20px)',
+          borderTopColor: 'var(--test-color, #ccc)',
+          borderRightColor: 'linear-gradient(to right, #ff7e5f, #feb47b)',
+          borderBottomColor: 'var(--test-color, #ccc)',
+          borderLeftColor: 'linear-gradient(to right, #ff7e5f, #feb47b)',
+          backgroundImage: 'no-repeat, linear-gradient(to right, #ff7e5f, #feb47b)',
+          backgroundPosition: 'center',
+          backgroundSize: 'cover',
+        },
+      })
+      `,
     },
+
     {
       code: `
           import stylex from 'stylex';

--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -188,6 +188,61 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       ],
     },
     {
+      options: [{ preferInline: true }],
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            borderRadius: '10px 15px 20px 25px',
+          },
+        });
+      `,
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            borderStartStartRadius: '10px',
+            borderStartEndRadius: '15px',
+            borderEndEndRadius: '20px',
+            borderEndStartRadius: '25px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "borderRadius: 10px 15px 20px 25px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            borderRadius: '10px 15px 20px 25px',
+          },
+        });
+      `,
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          main: {
+            borderTopLeftRadius: '10px',
+            borderTopRightRadius: '15px',
+            borderBottomRightRadius: '20px',
+            borderBottomLeftRadius: '25px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "borderRadius: 10px 15px 20px 25px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
       code: `
         import stylex from 'stylex';
         const styles = stylex.create({

--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -326,24 +326,6 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
             'Property shorthands using multiple values like "background: no-repeat center/cover, linear-gradient(to right, #ff7e5f, #feb47b)" are not supported in StyleX. Separate into individual properties.',
         },
       ],
-      output: `
-      import stylex from 'stylex';
-      const styles = stylex.create({
-        main: {
-          borderTopWidth: 'calc(100% - 20px)',
-          borderRightWidth: 'calc(90% - 20px)',
-          borderBottomWidth: 'calc(100% - 20px)',
-          borderLeftWidth: 'calc(90% - 20px)',
-          borderTopColor: 'var(--test-color, #ccc)',
-          borderRightColor: 'linear-gradient(to right, #ff7e5f, #feb47b)',
-          borderBottomColor: 'var(--test-color, #ccc)',
-          borderLeftColor: 'linear-gradient(to right, #ff7e5f, #feb47b)',
-          backgroundImage: 'no-repeat, linear-gradient(to right, #ff7e5f, #feb47b)',
-          backgroundPosition: 'center',
-          backgroundSize: 'cover',
-        },
-      })
-      `,
     },
 
     {
@@ -732,6 +714,97 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
             'Property shorthands using multiple values like "paddingBlock: 10em 1em" are not supported in StyleX. Separate into individual properties.',
         },
       ],
+    },
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          borderWidth: '4px 5px 6px 7px',
+          borderStyle: 'solid dashed dotted double',
+          borderColor: 'var(--fds-gray-10) var(--fds-gray-20) var(--fds-gray-30) var(--fds-gray-40)',
+        },
+      })
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "borderWidth: 4px 5px 6px 7px" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderStyle: solid dashed dotted double" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderColor: var(--fds-gray-10) var(--fds-gray-20) var(--fds-gray-30) var(--fds-gray-40)" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+      output: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          borderTopWidth: '4px',
+          borderRightWidth: '5px',
+          borderBottomWidth: '6px',
+          borderLeftWidth: '7px',
+          borderTopStyle: 'solid',
+          borderRightStyle: 'dashed',
+          borderBottomStyle: 'dotted',
+          borderLeftStyle: 'double',
+          borderTopColor: 'var(--fds-gray-10)',
+          borderRightColor: 'var(--fds-gray-20)',
+          borderBottomColor: 'var(--fds-gray-30)',
+          borderLeftColor: 'var(--fds-gray-40)',
+        },
+      })
+      `
+    },
+    {
+      options: [{ preferInline: true }],
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          borderWidth: '4px 5px 6px 7px',
+          borderStyle: 'solid dashed dotted double',
+          borderColor: 'var(--fds-gray-10) var(--fds-gray-20) var(--fds-gray-30) var(--fds-gray-40)',
+        },
+      })
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "borderWidth: 4px 5px 6px 7px" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderStyle: solid dashed dotted double" are not supported in StyleX. Separate into individual properties.',
+        },
+        {
+          message:
+            'Property shorthands using multiple values like "borderColor: var(--fds-gray-10) var(--fds-gray-20) var(--fds-gray-30) var(--fds-gray-40)" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+      output: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          borderTopWidth: '4px',
+          borderInlineEndWidth: '5px',
+          borderBottomWidth: '6px',
+          borderInlineStartWidth: '7px',
+          borderTopStyle: 'solid',
+          borderInlineEndStyle: 'dashed',
+          borderBottomStyle: 'dotted',
+          borderInlineStartStyle: 'double',
+          borderTopColor: 'var(--fds-gray-10)',
+          borderInlineEndColor: 'var(--fds-gray-20)',
+          borderBottomColor: 'var(--fds-gray-30)',
+          borderInlineStartColor: 'var(--fds-gray-40)',
+        },
+      })
+      `
     },
     {
       code: `

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -42,24 +42,9 @@ const shorthandAliases: $ReadOnly<{
 }> = {
   background: createSpecificTransformer('background'),
   font: createSpecificTransformer('font'),
-  borderColor: createDirectionalTransformer(
-    'border',
-    'Block',
-    'Inline',
-    'Color',
-  ),
-  borderWidth: createDirectionalTransformer(
-    'border',
-    'Block',
-    'Inline',
-    'Width',
-  ),
-  borderStyle: createDirectionalTransformer(
-    'border',
-    'Block',
-    'Inline',
-    'Style',
-  ),
+  borderColor: createSpecificTransformer('border-color'),
+  borderWidth: createSpecificTransformer('border-width'),
+  borderStyle: createSpecificTransformer('border-style'),
   borderTop: createSpecificTransformer('border-top'),
   borderRight: createSpecificTransformer('border-right'),
   borderBottom: createSpecificTransformer('border-bottom'),

--- a/packages/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/eslint-plugin/src/stylex-valid-shorthands.js
@@ -42,9 +42,24 @@ const shorthandAliases: $ReadOnly<{
 }> = {
   background: createSpecificTransformer('background'),
   font: createSpecificTransformer('font'),
-  borderColor: createSpecificTransformer('border-color'),
-  borderWidth: createSpecificTransformer('border-width'),
-  borderStyle: createSpecificTransformer('border-style'),
+  borderColor: createDirectionalTransformer(
+    'border',
+    'Block',
+    'Inline',
+    'Color',
+  ),
+  borderWidth: createDirectionalTransformer(
+    'border',
+    'Block',
+    'Inline',
+    'Width',
+  ),
+  borderStyle: createDirectionalTransformer(
+    'border',
+    'Block',
+    'Inline',
+    'Style',
+  ),
   borderTop: createSpecificTransformer('border-top'),
   borderRight: createSpecificTransformer('border-right'),
   borderBottom: createSpecificTransformer('border-bottom'),

--- a/packages/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/eslint-plugin/src/utils/splitShorthands.js
@@ -203,18 +203,32 @@ export function splitSpecificShorthands(
     'border-style',
   ];
 
+  const borderRadiusMap: { [string]: string } = {
+    'border-top-left-radius': 'borderStartStartRadius',
+    'border-top-right-radius': 'borderStartEndRadius',
+    'border-bottom-left-radius': 'borderEndStartRadius',
+    'border-bottom-right-radius': 'borderEndEndRadius',
+  };
+
   const longformStyle: { [key: string]: number | string } = {};
 
   Object.entries(longform).forEach(([key, val]) => {
     const newKey =
-      directionalProperties.includes(property) &&
-      _preferInline &&
-      /-(left|right)/.test(key)
-        ? key.replace(
-            /-(left|right)/,
-            (_, direction) => `-${directionMap[direction]}`,
-          )
-        : key;
+      property === 'border-radius' && _preferInline
+        ? borderRadiusMap[key] || null
+        : directionalProperties.includes(property) &&
+            _preferInline &&
+            /-(left|right)/.test(key)
+          ? key.replace(
+              /-(left|right)/,
+              (_, direction) => `-${directionMap[direction]}`,
+            )
+          : key;
+
+    if (!newKey) {
+      // If css shorthand expand fails, we won't auto-fix
+      return [[toCamelCase(property), CANNOT_FIX]];
+    }
 
     const correctedVal = addSpacesAfterCommasInParentheses(val);
     longformStyle[toCamelCase(newKey)] = allowImportant

--- a/packages/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/eslint-plugin/src/utils/splitShorthands.js
@@ -37,6 +37,7 @@ export const createDirectionalTransformer = (
   baseProperty: string,
   blockSuffix: string,
   inlineSuffix: string,
+  basePropertySuffix: string = '',
 ): ((
   rawValue: number | string,
   allowImportant?: boolean,
@@ -54,7 +55,7 @@ export const createDirectionalTransformer = (
       return [[`${baseProperty}`, top]];
     }
 
-    if (splitValues.length === 2) {
+    if (splitValues.length === 2 && baseProperty === "margin" || baseProperty === "padding" ) {
       return [
         [`${baseProperty}${blockSuffix}`, top],
         [`${baseProperty}${inlineSuffix}`, right],
@@ -63,16 +64,16 @@ export const createDirectionalTransformer = (
 
     return preferInline
       ? [
-          [`${baseProperty}Top`, top],
-          [`${baseProperty}${inlineSuffix}End`, right],
-          [`${baseProperty}Bottom`, bottom],
-          [`${baseProperty}${inlineSuffix}Start`, left],
+          [`${baseProperty}Top${basePropertySuffix}`, top],
+          [`${baseProperty}${inlineSuffix}End${basePropertySuffix}`, right],
+          [`${baseProperty}Bottom${basePropertySuffix}`, bottom],
+          [`${baseProperty}${inlineSuffix}Start${basePropertySuffix}`, left],
         ]
       : [
-          [`${baseProperty}Top`, top],
-          [`${baseProperty}Right`, right],
-          [`${baseProperty}Bottom`, bottom],
-          [`${baseProperty}Left`, left],
+          [`${baseProperty}Top${basePropertySuffix}`, top],
+          [`${baseProperty}Right${basePropertySuffix}`, right],
+          [`${baseProperty}Bottom${basePropertySuffix}`, bottom],
+          [`${baseProperty}Left${basePropertySuffix}`, left],
         ];
   };
 };
@@ -174,6 +175,11 @@ export function splitSpecificShorthands(
   }
 
   const longform = cssExpand(property, strippedValue);
+
+  if (!longform) {
+    // If css shorthand expand fails, we won't auto-fix
+    return [[toCamelCase(property), CANNOT_FIX]];
+  }
 
   // If the longform is empty or all values are the same, no need to expand
   // Relevant for properties like `borderColor` or `borderStyle`


### PR DESCRIPTION
## Context
When using the `preferInline` config, we were expanding margin/padding to equivalent inline logical properties. However, we overlooked applying the same transform to certain border properties.

The change introduced here extends the inline logical transformation to border properties (specifically borderWidth, borderStyle, and borderColor) by applying the same logic used for margin and padding. We take the output from `css-shorthand-expand` and apply a transform to the physical properties returned.

## Testing

Added test expansions for borderWidth, borderStyle, and borderColor with `preferInline` set to default (false) and true

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code