### PR TITLE
Feat: Using `@dual-bundle/import-meta-resolve` replace `esm-resolve`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4731,6 +4731,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@dual-bundle/import-meta-resolve": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
@@ -13052,11 +13062,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/esm-resolve": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/esm-resolve/-/esm-resolve-1.0.11.tgz",
-      "integrity": "sha512-LxF0wfUQm3ldUDHkkV2MIbvvY0TgzIpJ420jHSV1Dm+IlplBEWiJTKWM61GtxUfvjV6iD4OtTYFGAGM2uuIUWg=="
     },
     "node_modules/espree": {
       "version": "9.6.1",
@@ -26898,9 +26903,9 @@
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/traverse": "^7.25.7",
         "@babel/types": "^7.25.8",
+        "@dual-bundle/import-meta-resolve": "^4.1.0",
         "@stylexjs/shared": "0.9.3",
-        "@stylexjs/stylex": "0.9.3",
-        "esm-resolve": "^1.0.11"
+        "@stylexjs/stylex": "0.9.3"
       }
     },
     "packages/cli": {
@@ -27006,6 +27011,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -27021,6 +27027,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -27036,6 +27043,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -27051,6 +27059,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -27066,6 +27075,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -27081,6 +27091,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -27096,6 +27107,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -27111,6 +27123,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -27126,6 +27139,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -29443,6 +29457,11 @@
           }
         }
       }
+    },
+    "@dual-bundle/import-meta-resolve": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg=="
     },
     "@esbuild/aix-ppc64": {
       "version": "0.24.0",
@@ -31868,9 +31887,9 @@
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/traverse": "^7.25.7",
         "@babel/types": "^7.25.8",
+        "@dual-bundle/import-meta-resolve": "^4.1.0",
         "@stylexjs/shared": "0.9.3",
-        "@stylexjs/stylex": "0.9.3",
-        "esm-resolve": "^1.0.11"
+        "@stylexjs/stylex": "0.9.3"
       }
     },
     "@stylexjs/cli": {
@@ -35983,11 +36002,6 @@
     "eslint-visitor-keys": {
       "version": "2.1.0",
       "dev": true
-    },
-    "esm-resolve": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/esm-resolve/-/esm-resolve-1.0.11.tgz",
-      "integrity": "sha512-LxF0wfUQm3ldUDHkkV2MIbvvY0TgzIpJ420jHSV1Dm+IlplBEWiJTKWM61GtxUfvjV6iD4OtTYFGAGM2uuIUWg=="
     },
     "espree": {
       "version": "9.6.1",
@@ -45919,60 +45933,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
       "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
-    },
-    "@next/swc-darwin-arm64": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.1.tgz",
-      "integrity": "sha512-JyxnGCS4qT67hdOKQ0CkgFTp+PXub5W1wsGvIq98TNbF3YEIN7iDekYhYsZzc8Ov0pWEsghQt+tANdidITCLaw==",
-      "optional": true
-    },
-    "@next/swc-darwin-x64": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.1.tgz",
-      "integrity": "sha512-625Z7bb5AyIzswF9hvfZWa+HTwFZw+Jn3lOBNZB87lUS0iuCYDHqk3ujuHCkiyPtSC0xFBtYDLcrZ11mF/ap3w==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-gnu": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.1.tgz",
-      "integrity": "sha512-iVpn3KG3DprFXzVHM09kvb//4CNNXBQ9NB/pTm8LO+vnnnaObnzFdS5KM+w1okwa32xH0g8EvZIhoB3fI3mS1g==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-musl": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.1.tgz",
-      "integrity": "sha512-mVsGyMxTLWZXyD5sen6kGOTYVOO67lZjLApIj/JsTEEohDDt1im2nkspzfV5MvhfS7diDw6Rp/xvAQaWZTv1Ww==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-gnu": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.1.tgz",
-      "integrity": "sha512-wMqf90uDWN001NqCM/auRl3+qVVeKfjJdT9XW+RMIOf+rhUzadmYJu++tp2y+hUbb6GTRhT+VjQzcgg/QTD9NQ==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-musl": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.1.tgz",
-      "integrity": "sha512-ol1X1e24w4j4QwdeNjfX0f+Nza25n+ymY0T2frTyalVczUmzkVD7QGgPTZMHfR1aLrO69hBs0G3QBYaj22J5GQ==",
-      "optional": true
-    },
-    "@next/swc-win32-arm64-msvc": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.1.tgz",
-      "integrity": "sha512-WEmTEeWs6yRUEnUlahTgvZteh5RJc4sEjCQIodJlZZ5/VJwVP8p2L7l6VhzQhT4h7KvLx/Ed4UViBdne6zpIsw==",
-      "optional": true
-    },
-    "@next/swc-win32-ia32-msvc": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.1.tgz",
-      "integrity": "sha512-oFpHphN4ygAgZUKjzga7SoH2VGbEJXZa/KL8bHCAwCjDWle6R1SpiGOdUdA8EJ9YsG1TYWpzY6FTbUA+iAJeww==",
-      "optional": true
-    },
-    "@next/swc-win32-x64-msvc": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.1.tgz",
-      "integrity": "sha512-FFp3nOJ/5qSpeWT0BZQ+YE1pSMk4IMpkME/1DwKBwhg4mJLB9L+6EXuJi4JEwaJdl5iN+UUlmUD3IsR1kx5fAg==",
-      "optional": true
     }
   }
 }

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -19,7 +19,7 @@
     "@babel/core": "^7.25.8",
     "@babel/traverse": "^7.25.7",
     "@babel/types": "^7.25.8",
-    "esm-resolve": "^1.0.11"
+    "@dual-bundle/import-meta-resolve": "^4.1.0"
   },
   "jest": {
     "verbose": true,

--- a/packages/babel-plugin/rollup.config.mjs
+++ b/packages/babel-plugin/rollup.config.mjs
@@ -7,7 +7,6 @@
  *
  */
 
-import alias from '@rollup/plugin-alias';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
@@ -42,19 +41,13 @@ const config = {
   },
   external: process.env['HASTE']
     ? external
-    : [...external, 'esm-resolve', '@stylexjs/shared', '@stylexjs/stylex'],
-  plugins: [
-    alias({
-      entries: [
-        {
-          find: 'esm-resolve',
-          replacement: path.resolve(
-            rootDir,
-            'node_modules/esm-resolve/bundle.js',
-          ),
-        },
+    : [
+        ...external,
+        '@dual-bundle/import-meta-resolve',
+        '@stylexjs/shared',
+        '@stylexjs/stylex',
       ],
-    }),
+  plugins: [
     babel({ babelHelpers: 'bundled', extensions, include: ['./src/**/*'] }),
     nodeResolve({
       preferBuiltins: false,


### PR DESCRIPTION
## What changed / motivation ?

In the past we used `esm-resolve` to resolve es-based projects. But we need write two sets of code for `cjs` and `esm`. In `cjs` we using `require.resolve` and in other we using `esm-resolve` to create a resolve to do this. And in community [`@dual-bundle/import-meta-resolve`](https://www.npmjs.com/package/@dual-bundle/import-meta-resolve) allows us to avoid writing 2 sets of code.

## Linked PR/Issues

Fixes # (issue)

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code