### PR TITLE
fix(@stylexjs/babel-plugin): Support .js resolved file extension imports from .ts files

### DIFF
--- a/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
@@ -406,9 +406,16 @@ describe('Evaluation of imported values works based on configuration', () => {
   });
 
   describe('Module resolution commonJS', () => {
+    afterEach(() => {
+      moduleResolve.mockReset();
+    });
+
     test('Recognizes .ts stylex imports when resolving .js relative imports', () => {
-      moduleResolve.mockReturnValue({
-        pathname: '/project/otherFile.stylex.ts',
+      moduleResolve.mockImplementation((value) => {
+        if (!value.endsWith('/otherFile.stylex.ts')) {
+          throw new Error('File not found');
+        }
+        return new URL('file:///project/otherFile.stylex.ts');
       });
 
       const transformation = transform(

--- a/packages/babel-plugin/src/utils/state-manager.js
+++ b/packages/babel-plugin/src/utils/state-manager.js
@@ -657,18 +657,16 @@ function possibleAliasedPaths(
   return result;
 }
 
+// Try importing without adding any extension
+// and then every supported extension
 const getPossibleFilePaths = (filePath: string) => {
   const extension = path.extname(filePath);
-  const filePathWithoutSourceExtension =
-    extension === '' || !EXTENSIONS.includes(extension)
-      ? filePath
-      : filePath.slice(0, -extension.length);
-  // Try importing without adding any extension
-  // and then every supported extension
-  return [
-    filePath,
-    ...EXTENSIONS.map((ext) => filePathWithoutSourceExtension + ext),
-  ];
+  const filePathHasCodeExtension = EXTENSIONS.includes(extension);
+  const filePathNoCodeExtension = filePathHasCodeExtension
+    ? filePath.slice(0, -extension.length)
+    : filePath;
+
+  return [filePath, ...EXTENSIONS.map((ext) => filePathNoCodeExtension + ext)];
 };
 
 // a function that resolves the absolute path of a file when given the
@@ -695,7 +693,7 @@ const filePathResolver = (
       try {
         return moduleResolve(possiblePath, url.pathToFileURL(sourceFilePath))
           .pathname;
-      } catch (error) {
+      } catch {
         continue;
       }
     }


### PR DESCRIPTION
## What changed / motivation ?

In a TypeScript project using `moduleResolution: 'node16' | 'nodenext'`, relative imports must include the file extension because of the Node.js ESM resolver [requires file extensions](https://nodejs.org/docs/latest-v18.x/api/esm.html#mandatory-file-extensions).

Consider the following:

```ts
import * as stylex from '@stylexjs/stylex';
import { vars } from '../vars.stylex.js';
import { theme } from '../theme.stylex.js';

const styles = stylex.create({
  root: {
    backgroundColor: vars.primary,
  },
});
```

The babel plugin currently attempts to verify whether these relative import files actually exist. It does this by trying to resolve the import string relative to the source file. First by checking the import string itself, then checking each of the valid file extensions in turn (`js,ts,tsx,jsx,mjs,cjs`).

The case above is rejected because it will attempt to resolve e.g. `../vars.stylex.js`, `../vars.stylex.js.ts` but not `../vars.stylex.ts`. This results in a `Only static values are allowed inside of a stylex.create() call` compile error.

This change first checks whether the file extension in the relative import string is one of the recognized extensions, and if so, will remove the extension before attempting to resolve the valid extensions.

## Linked PR/Issues

Related to https://github.com/facebook/stylex/issues/769, which has a similar issue but with the ESLint plugin instead. I'm happy to take a look at the ESLint plugin if this change is accepted.

## Additional Context

I've added a test for this, but not sure it matches the existing code style because it makes use of `jest.mock(..)` for `@dual-bundle/import-meta-resolve`. I don't love this, but I could not find any other test examples for `moduleResolution: 'commonJS'`.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code