### PR TITLE
fix(@stylexjs/eslint-plugin): Remove false positive in valid-styles when import contains extension

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -508,7 +508,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     })`,
     // test for stylex create vars tokens
     `
-    import stylex from'stylex';
+    import stylex from 'stylex';
     import {TextTypeTokens as TextType, ColorTokens} from 'DspSharedTextTokens.stylex';
     stylex.create({
       root: {
@@ -521,7 +521,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     `,
     // test using vars as keys
     `
-    import stylex from'stylex';
+    import stylex from 'stylex';
     import { componentVars } from './bug.stylex';
     stylex.create({
       host: {
@@ -536,6 +536,28 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     stylex.create({
       root: (position) => ({
         [tokens.position]: \`\${position}px\`,
+      })
+    })
+    `,
+    // test importing vars from paths including code file extension
+    `
+    import stylex from 'stylex';
+    import { vars } from './vars.stylex';
+    import { varsJs } from './vars.stylex.js';
+    import { varsTs } from './vars.stylex.ts';
+    import { varsTsx } from './vars.stylex.tsx';
+    import { varsJsx } from './vars.stylex.jsx';
+    import { varsMjs } from './vars.stylex.mjs';
+    import { varsCjs } from './vars.stylex.cjs';
+    stylex.create({
+      root: (position) => ({
+        [vars.color]: 'blue',
+        [varsJs.color]: 'blue',
+        [varsTs.color]: 'blue',
+        [varsTsx.color]: 'blue',
+        [varsJsx.color]: 'blue',
+        [varsMjs.color]: 'blue',
+        [varsCjs.color]: 'blue',
       })
     })
     `,

--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -550,7 +550,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     import { varsMjs } from './vars.stylex.mjs';
     import { varsCjs } from './vars.stylex.cjs';
     stylex.create({
-      root: (position) => ({
+      root: {
         [vars.color]: 'blue',
         [varsJs.color]: 'blue',
         [varsTs.color]: 'blue',
@@ -558,7 +558,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
         [varsJsx.color]: 'blue',
         [varsMjs.color]: 'blue',
         [varsCjs.color]: 'blue',
-      })
+      },
     })
     `,
   ],

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -2395,7 +2395,13 @@ const stylexValidStyles = {
       propLimits = {},
     }: Schema = context.options[0] || {};
 
-    const stylexDefineVarsFileExtension = '.stylex';
+    function isValidStylexDefineVarsFileExtension(filename: string) {
+      const stylexExtension = '.stylex';
+      const extensions = ['.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs'];
+      return ['', ...extensions].some((ext) =>
+        filename.endsWith(`${stylexExtension}${ext}`),
+      );
+    }
     const stylexDefineVarsTokenImports = new Set<string>();
     const styleXDefaultImports = new Set<string>();
     const styleXCreateImports = new Set<string>();
@@ -2866,9 +2872,8 @@ const stylexValidStyles = {
         }
         const sourceValue = node.source.value;
         const isStylexImport = importsToLookFor.includes(sourceValue);
-        const isStylexDefineVarsImport = sourceValue.endsWith(
-          stylexDefineVarsFileExtension,
-        );
+        const isStylexDefineVarsImport =
+          isValidStylexDefineVarsFileExtension(sourceValue);
         if (!(isStylexImport || isStylexDefineVarsImport)) {
           return;
         }


### PR DESCRIPTION
## What changed / motivation ?

`@stylexjs/valid-styles` erroneously reports an issue when the file import includes a file extension, e.g.,

```ts
import * as stylex from '@stylexjs/stylex';
import { vars } from './vars.stylex.ts';

const styles = stylex.create({
  root: {
    fontFamily: vars.primaryFont,
  },
});
```

See the linked issue below for more details.

## Linked PR/Issues

Fixes https://github.com/facebook/stylex/issues/769

## Additional Context

I added 1 test

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code