### PR TITLE
Feat:  Allow `stylex.create` nested within TS namespaces

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -36,6 +36,26 @@ function transform(source, opts = {}) {
   }).code;
 }
 
+function transformTypescript(source, opts = {}) {
+  return transformSync(source, {
+    filename: opts.filename,
+    parserOpts: {
+      plugins: ['typescript'],
+    },
+    babelrc: false,
+    plugins: [
+      [
+        stylexPlugin,
+        {
+          runtimeInjection: true,
+          unstable_moduleResolution: { type: 'haste' },
+          ...opts,
+        },
+      ],
+    ],
+  }).code;
+}
+
 describe('@stylexjs/babel-plugin', () => {
   describe('[transform] stylex.create()', () => {
     test('transforms style object', () => {
@@ -1301,6 +1321,36 @@ describe('@stylexjs/babel-plugin', () => {
             $$css: true
           }
         };"
+      `);
+    });
+
+    test('typescript namespace transform', () => {
+      expect(
+        transformTypescript(`
+          import stylex from 'stylex';
+          namespace A {
+            export const styles = stylex.create({
+              default: {
+                color: 'red',
+              }
+            })
+          }
+          stylex.props(A.styles);
+      `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        namespace A {
+          export const styles = {
+            default: {
+              color: "x1e2nbdu",
+              $$css: true
+            }
+          };
+        }
+        stylex.props(A.styles);"
       `);
     });
   });

--- a/packages/babel-plugin/__tests__/stylex-transform-create-theme-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-theme-test.js
@@ -35,6 +35,18 @@ function transform(source, opts = defaultOpts) {
     plugins: [[stylexPlugin, { ...defaultOpts, ...opts }]],
   }).code;
 }
+
+function transformTypescript(source, opts = {}) {
+  return transformSync(source, {
+    filename: opts.filename || '/stylex/packages/TestTheme.stylex.js',
+    parserOpts: {
+      plugins: ['typescript'],
+    },
+    babelrc: false,
+    plugins: [[stylexPlugin, { ...defaultOpts, ...opts }]],
+  }).code;
+}
+
 let defineVarsOutput = '';
 
 const createTheme = `{
@@ -691,5 +703,32 @@ describe('@stylexjs/babel-plugin stylex.createTheme with literals', () => {
         };"
       `);
     });
+  });
+
+  describe('[transform] typescript namespace', () => {
+    expect(
+      transformTypescript(`
+        import stylex from 'stylex';
+        namespace A  {
+          export const buttonTheme = stylex.defineVars(${createTheme});
+          export const buttonThemePositive = stylex.createTheme(buttonTheme, ${createThemeWithDifferentOrder});
+        }  
+    `),
+    ).toMatchInlineSnapshot(`
+      "import stylex from 'stylex';
+      namespace A {
+        export const buttonTheme = {
+          bgColor: "var(--xgck17p)",
+          bgColorDisabled: "var(--xpegid5)",
+          cornerRadius: "var(--xrqfjmn)",
+          fgColor: "var(--x4y59db)",
+          __themeName__: "x568ih9"
+        };
+        export const buttonThemePositive = {
+          $$css: true,
+          x568ih9: "xtrlmmh x568ih9"
+        };
+      }"
+    `);
   });
 });

--- a/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
@@ -36,6 +36,17 @@ function transform(source, opts = defaultOpts) {
   });
 }
 
+function transformTypescript(source, opts = {}) {
+  return transformSync(source, {
+    filename: opts.filename || '/stylex/packages/TestTheme.stylex.js',
+    parserOpts: {
+      plugins: ['typescript'],
+    },
+    babelrc: false,
+    plugins: [[stylexPlugin, { ...defaultOpts, ...opts }]],
+  }).code;
+}
+
 describe('@stylexjs/babel-plugin', () => {
   describe('[transform] stylex.defineVars()', () => {
     test('transforms variables object', () => {
@@ -769,6 +780,35 @@ describe('@stylexjs/babel-plugin', () => {
           fgColor: "var(--xv9uic)",
           __themeName__: "xmpye33"
         };"
+      `);
+    });
+
+    test('transform typescript namespace', () => {
+      expect(
+        transformTypescript(
+          `
+         import stylex from 'stylex';
+         namespace A {
+           export const buttonTheme = stylex.defineVars({
+             bgColor: {
+               default: 'grey'
+             }
+           })
+         }
+      `,
+          { dev: true, ...defaultOpts },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(":root, .x568ih9{--xgck17p:grey;}", 0);
+        namespace A {
+          export const buttonTheme = {
+            bgColor: "var(--xgck17p)",
+            __themeName__: "x568ih9"
+          };
+        }"
       `);
     });
   });

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -343,7 +343,8 @@ function validateStyleXCreate(path: NodePath<t.CallExpression>) {
   const nearestStatement = findNearestStatementAncestor(path);
   if (
     !pathUtils.isProgram(nearestStatement.parentPath) &&
-    !pathUtils.isExportNamedDeclaration(nearestStatement.parentPath)
+    !pathUtils.isExportNamedDeclaration(nearestStatement.parentPath) &&
+    !pathUtils.isTSModuleBlock(nearestStatement.parentPath)
   ) {
     throw path.buildCodeFrameError(messages.ONLY_TOP_LEVEL, SyntaxError);
   }


### PR DESCRIPTION
## What changed / motivation ?

Now current work is WIP, but i need to clarify some situations.

## Linked PR/Issues

#829 

## Additional Context

> Q: Should we add a `manipulateOptions` for babel plugin to infer the coming file is typescript or others?
> Q: Should the `export expression` check of Theme's API be cancelled? If embedded in typescript namespace.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code