### PR TITLE
Typo fix in docs

### DIFF
--- a/apps/docs/docs/learn/06-recipes/01-context-driven-styles.mdx
+++ b/apps/docs/docs/learn/06-recipes/01-context-driven-styles.mdx
@@ -16,8 +16,8 @@ StyleX lets you apply styles conditionally. Any condition can be used to do so, 
 The React Context API (and other similar APIs) can be used to avoid prop-drilling
 and provide conditions that child component can read and apply styles conditionally.
 
-Context can help reduce prop-drilling by sharing state across components. This can often
-an alternative to using descendent selectors where the same results can be achieved
+Context can help reduce prop-drilling by sharing state across components. This can often be
+an alternative to using descendent selectors, as the same results can be achieved
 *without* "styling at a distance".
 
 For example, you can manage the open or closed state of a sidebar using React Context


### PR DESCRIPTION
## What changed / motivation ?
I got hung up reading the docs due to an accidental omission of the word "be." Also, to make the last part of this sentence clearer that it's regarding the advantages of the StyleX way of doing things and not the legacy way, I changed the word "where" to "as" and made it a dependent clause with a comma.

## Linked PR/Issues

N/A

## Additional Context

N/A

## Pre-flight checklist

- [X] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [X] Performed a self-review of my code