### PR TITLE
feat: replace crypto with murmurhash for cli caching

### DIFF
--- a/packages/cli/src/cache.js
+++ b/packages/cli/src/cache.js
@@ -8,7 +8,9 @@
  */
 import fs from 'fs/promises';
 import path from 'path';
-import crypto from 'crypto';
+const { utils } = require('@stylexjs/shared');
+
+const hash = utils.hash;
 
 // Default cache directory in `node_modules/.stylex-cache`
 export function getDefaultCachePath() {
@@ -94,5 +96,5 @@ export async function computeHash(filePath) {
   }
 
   const content = await fs.readFile(newPath, 'utf-8');
-  return crypto.createHash('md5').update(content).digest('hex');
+  return hash(content);
 }


### PR DESCRIPTION
## What changed / motivation ?

`murmurhash` is in fact faster than `crypto`, and we don't need the added security for caching. let's switch for consistency

## Testing

tests pass, yolo

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code