### PR TITLE
fix: fix readCache to use custom cache path when set

### DIFF
--- a/packages/cli/src/cache.js
+++ b/packages/cli/src/cache.js
@@ -8,7 +8,7 @@
  */
 import fs from 'fs/promises';
 import path from 'path';
-const { utils } = require('@stylexjs/shared');
+import { utils } from '@stylexjs/shared';
 
 const hash = utils.hash;
 
@@ -17,13 +17,13 @@ export function getDefaultCachePath() {
   return path.join('node_modules', '.stylex-cache');
 }
 
-async function getCacheFilePath(cachePath, filePath) {
+export async function getCacheFilePath(cachePath, filePath) {
   const fileName = filePath.replace(/[\\/]/g, '__');
   return path.join(cachePath, `${fileName}.json`);
 }
 
-export async function readCache(filePath) {
-  const cacheFile = await getCacheFilePath(getDefaultCachePath(), filePath);
+export async function readCache(cachePath, filePath) {
+  const cacheFile = await getCacheFilePath(cachePath, filePath);
   try {
     const cacheData = await fs.readFile(cacheFile, 'utf-8');
     return JSON.parse(cacheData);

--- a/packages/cli/src/cache.js
+++ b/packages/cli/src/cache.js
@@ -8,7 +8,9 @@
  */
 import fs from 'fs/promises';
 import path from 'path';
-import crypto from 'crypto';
+const { utils } = require('@stylexjs/shared');
+
+const hash = utils.hash;
 
 // Default cache directory in `node_modules/.stylex-cache`
 export function getDefaultCachePath() {
@@ -94,5 +96,5 @@ export async function computeHash(filePath) {
   }
 
   const content = await fs.readFile(newPath, 'utf-8');
-  return crypto.createHash('md5').update(content).digest('hex');
+  return hash(content);
 }

--- a/packages/cli/src/transform.js
+++ b/packages/cli/src/transform.js
@@ -108,7 +108,7 @@ export async function compileFile(
     oldOutputHash = await computeHash(outputFilePath);
   }
 
-  const cacheData = await readCache(filePath);
+  const cacheData = await readCache(cachePath, filePath);
 
   if (
     cacheData &&


### PR DESCRIPTION
## What changed / motivation ?

Oversight in https://github.com/facebook/stylex/pull/792 where `readCache` is still reading from default cache path

## Testing

Added more comprehensive testing, previously we were just ensuring the correct cache files were written, not checking the read functionality

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code