### PR TITLE
fix(babel-plugin): import resolve should respect windows system

### DIFF
--- a/packages/babel-plugin/src/utils/state-manager.js
+++ b/packages/babel-plugin/src/utils/state-manager.js
@@ -680,8 +680,9 @@ const filePathResolver = (
     // Try to resolve relative paths as is
     if (importPathStr.startsWith('.')) {
       try {
-        return moduleResolve(importPathStr, url.pathToFileURL(sourceFilePath))
-          .pathname;
+        return url.fileURLToPath(
+          moduleResolve(importPathStr, url.pathToFileURL(sourceFilePath)),
+        );
       } catch {
         continue;
       }
@@ -691,8 +692,9 @@ const filePathResolver = (
     const allAliases = possibleAliasedPaths(importPathStr, aliases);
     for (const possiblePath of allAliases) {
       try {
-        return moduleResolve(possiblePath, url.pathToFileURL(sourceFilePath))
-          .pathname;
+        return url.fileURLToPath(
+          moduleResolve(possiblePath, url.pathToFileURL(sourceFilePath)),
+        );
       } catch {
         continue;
       }


### PR DESCRIPTION
## What changed / motivation ?

Before i replaced esm resolve but i ignored windows user :( . This pull request is a fix for windows.

## Linked PR/Issues

Fixes #848 

## Additional Context

According [url spec](https://url.spec.whatwg.org/#url-class). pathname is start with slash. It's not right for windows, and using `url.pathToFileURL` can return the true path


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code