### PR TITLE
fix: use ESM imports in CLI

### DIFF
--- a/packages/cli/src/cache.js
+++ b/packages/cli/src/cache.js
@@ -8,7 +8,7 @@
  */
 import fs from 'fs/promises';
 import path from 'path';
-const { utils } = require('@stylexjs/shared');
+import { utils } from '@stylexjs/shared';
 
 const hash = utils.hash;
 


### PR DESCRIPTION
## What changed / motivation ?

Replace `require()` function with ESM.