### PR TITLE
fix: Properly parse multi-value shorthand with slash

### DIFF
--- a/packages/shared/__tests__/split-value-test.js
+++ b/packages/shared/__tests__/split-value-test.js
@@ -46,6 +46,11 @@ describe('Ensure CSS values are split correctly', () => {
   });
 
   test('Splits a string of values with slash notation appropriately.', () => {
-    expect(splitValue('1px/2px 3px 4px 5px')).toEqual(['1px/2px', '3px', '4px', '5px']);
+    expect(splitValue('1px/2px 3px 4px 5px')).toEqual([
+      '1px/2px',
+      '3px',
+      '4px',
+      '5px',
+    ]);
   });
 });

--- a/packages/shared/__tests__/split-value-test.js
+++ b/packages/shared/__tests__/split-value-test.js
@@ -45,12 +45,27 @@ describe('Ensure CSS values are split correctly', () => {
     ).toEqual(['calc((100% - 50px) * 0.5)', 'var(--rightpadding,20px)']);
   });
 
-  test('Splits a string of values with slash notation appropriately.', () => {
-    expect(splitValue('1px/2px 3px 4px 5px')).toEqual([
-      '1px/2px',
-      '3px',
-      '4px',
-      '5px',
+  test('Expands a string of values with slash notation appropriately.', () => {
+    expect(splitValue('1px / 2px 3px 4px 5px', 'borderRadius')).toEqual([
+      '1px 2px',
+      '1px 3px',
+      '1px 4px',
+      '1px 5px',
     ]);
+    expect(splitValue('1px 2px / 3px 4px', 'borderRadius')).toEqual([
+      '1px 3px',
+      '2px 4px',
+      '1px 3px',
+      '2px 4px',
+    ]);
+    expect(splitValue('1px 2px / 3px 4px 5px', 'borderRadius')).toEqual([
+      '1px 3px',
+      '2px 4px',
+      '1px 5px',
+      '2px 4px',
+    ]);
+    expect(
+      splitValue('1px 2px 3px 4px / 5px 6px 7px 8px', 'borderRadius'),
+    ).toEqual(['1px 5px', '2px 6px', '3px 7px', '4px 8px']);
   });
 });

--- a/packages/shared/__tests__/split-value-test.js
+++ b/packages/shared/__tests__/split-value-test.js
@@ -44,4 +44,8 @@ describe('Ensure CSS values are split correctly', () => {
       splitValue('calc((100% - 50px) * 0.5) var(--rightpadding, 20px)'),
     ).toEqual(['calc((100% - 50px) * 0.5)', 'var(--rightpadding,20px)']);
   });
+
+  test('Splits a string of values with slash notation appropriately.', () => {
+    expect(splitValue('1px/2px 3px 4px 5px')).toEqual(['1px/2px', '3px', '4px', '5px']);
+  });
 });

--- a/packages/shared/src/preprocess-rules/legacy-expand-shorthands.js
+++ b/packages/shared/src/preprocess-rules/legacy-expand-shorthands.js
@@ -162,7 +162,7 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
   ],
 
   borderRadius: (rawValue: TStyleValue): TReturn => {
-    const [top, right = top, bottom = top, left = right] = splitValue(rawValue);
+    const [top, right = top, bottom = top, left = right] = splitValue(rawValue, 'borderRadius');
 
     return [
       ['borderTopStartRadius', top],

--- a/packages/shared/src/preprocess-rules/legacy-expand-shorthands.js
+++ b/packages/shared/src/preprocess-rules/legacy-expand-shorthands.js
@@ -162,7 +162,10 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
   ],
 
   borderRadius: (rawValue: TStyleValue): TReturn => {
-    const [top, right = top, bottom = top, left = right] = splitValue(rawValue, 'borderRadius');
+    const [top, right = top, bottom = top, left = right] = splitValue(
+      rawValue,
+      'borderRadius',
+    );
 
     return [
       ['borderTopStartRadius', top],

--- a/packages/shared/src/utils/split-css-value.js
+++ b/packages/shared/src/utils/split-css-value.js
@@ -23,47 +23,47 @@ function printNode(node: PostCSSValueASTNode): string {
   }
 }
 
-// Merges slash-separated values within nodes into single nodes.
-function combineNodesWithSlash(nodes: PostCSSValueASTNode[]) {
+// Splits PostCSS value nodes for border-radius into horizontal and vertical groups by slash.
+function splitNodesBySlash(nodes: PostCSSValueASTNode[]): PostCSSValueASTNode[][] {
   const result = [];
+  let current = [];
 
-  for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i];
-
-    if (node.type !== 'div' || node.value !== '/') {
-      result.push(node);
-      continue;
+  for (const node of nodes) {
+    const isSeparator = node.type === 'div' && node.value === '/';
+    if (isSeparator) {
+      if (current.length > 0) {
+        result.push(current);
+        current = [];
+      }
+    } else {
+      current.push(node);
     }
+  }
 
-    if (i === 0 || i === nodes.length - 1) {
-      result.push(node);
-      continue;
-    }
-
-    const prev = result.at(-1);
-    const next = nodes[i + 1];
-
-    if (!prev || !next || prev.type !== 'word' || next.type !== 'word') {
-      result.push(node);
-      continue;
-    }
-
-    result.pop();
-    const combinedNode = {
-      ...prev,
-      value: prev.value + node.value + next.value,
-      sourceEndIndex: next.sourceEndIndex,
-    };
-    result.push(combinedNode);
-    i++;
+  if (current.length > 0) {
+    result.push(current);
   }
 
   return result;
 }
 
+// Expands a border-radius shorthand value to an array of four values.
+function expandBorderRadiusShorthand(group: PostCSSValueASTNode[]) {
+  if (group.length === 2) return [group[0], group[1], group[0], group[1]];
+  if (group.length === 3) return [group[0], group[1], group[2], group[1]];
+  if (group.length === 4) return [group[0], group[1], group[2], group[3]];
+  return Array(4).fill(group[0]);
+}
+
+// Combines two arrays of border-radius values into a single formatted string.
+function combineBorderRadiusValues(verticals: string[], horizontals: string[]) {
+  return verticals.map((value, i) => `${value} ${horizontals[i]}`);
+}
+
 // Using split(' ') Isn't enough because of values like calc.
 export default function splitValue(
   str: TStyleValue,
+  propertyName: string = '',
 ): $ReadOnlyArray<number | string | null> {
   if (str == null || typeof str === 'number') {
     return [str];
@@ -76,11 +76,28 @@ export default function splitValue(
 
   const parsed = parser(str.trim());
 
-  const nodes = combineNodesWithSlash(
-    parsed.nodes.filter((node) => node.type !== 'space'),
-  )
-    .filter((node) => node.type !== 'div')
-    .map(printNode);
+  let nodes: string[] = [];
+  if (propertyName === 'borderRadius') {
+    const groups = splitNodesBySlash(
+      parsed.nodes.filter((node) => node.type !== 'space'),
+    );
+    if (groups.length === 1) {
+      nodes = parsed.nodes.filter((node) => node.type !== 'div').map(printNode);
+    } else {
+      // edge case
+      const vertical = expandBorderRadiusShorthand(
+        groups[0].filter((node) => node.type !== 'div'),
+      ).map(printNode);
+      const horizontal = expandBorderRadiusShorthand(
+        groups[1].filter((node) => node.type !== 'div'),
+      ).map(printNode);
+      nodes = combineBorderRadiusValues(vertical, horizontal);
+    }
+  } else {
+    nodes = parsed.nodes
+      .filter((node) => node.type !== 'space' && node.type !== 'div')
+      .map(printNode);
+  }
 
   if (
     nodes.length > 1 &&

--- a/packages/shared/src/utils/split-css-value.js
+++ b/packages/shared/src/utils/split-css-value.js
@@ -55,7 +55,7 @@ function combineNodesWithSlash(nodes: PostCSSValueASTNode[]) {
         sourceEndIndex: next.sourceEndIndex,
       };
       result.push(combinedNode);
-      i++; // 次の要素をスキップ
+      i++;
   }
 
   return result;

--- a/packages/shared/src/utils/split-css-value.js
+++ b/packages/shared/src/utils/split-css-value.js
@@ -24,7 +24,9 @@ function printNode(node: PostCSSValueASTNode): string {
 }
 
 // Splits PostCSS value nodes for border-radius into horizontal and vertical groups by slash.
-function splitNodesBySlash(nodes: PostCSSValueASTNode[]): PostCSSValueASTNode[][] {
+function splitNodesBySlash(
+  nodes: PostCSSValueASTNode[],
+): PostCSSValueASTNode[][] {
   const result = [];
   let current = [];
 

--- a/packages/shared/src/utils/split-css-value.js
+++ b/packages/shared/src/utils/split-css-value.js
@@ -50,12 +50,12 @@ function combineNodesWithSlash(nodes: PostCSSValueASTNode[]) {
 
     result.pop();
     const combinedNode = {
-        ...prev,
-        value: prev.value + node.value + next.value,
-        sourceEndIndex: next.sourceEndIndex,
-      };
-      result.push(combinedNode);
-      i++;
+      ...prev,
+      value: prev.value + node.value + next.value,
+      sourceEndIndex: next.sourceEndIndex,
+    };
+    result.push(combinedNode);
+    i++;
   }
 
   return result;
@@ -76,7 +76,9 @@ export default function splitValue(
 
   const parsed = parser(str.trim());
 
-  const nodes = combineNodesWithSlash(parsed.nodes.filter((node) => node.type !== 'space'))
+  const nodes = combineNodesWithSlash(
+    parsed.nodes.filter((node) => node.type !== 'space'),
+  )
     .filter((node) => node.type !== 'div')
     .map(printNode);
 


### PR DESCRIPTION
## What changed / motivation ?

Fixed the expansion handling of border-radius shorthand values containing the '/' separator.

## Linked PR/Issues

Fixes #730 

## Additional Context

- Modified the splitValue function to handle nodes containing '/' by merging them with adjacent nodes
- Example: '1px / 2px' is now correctly processed as borderStartStartRadius: '1px / 2px'
- Added test cases in packages/shared/__tests__/split-value-test.js

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code