### PR TITLE
fix: add cache invalidation on config change

### DIFF
--- a/packages/cli/__tests__/compile-stylex-folder-test.js
+++ b/packages/cli/__tests__/compile-stylex-folder-test.js
@@ -295,6 +295,7 @@ describe('cache mechanism works as expected', () => {
       expect(cacheContent).toHaveProperty('inputHash');
       expect(cacheContent).toHaveProperty('outputHash');
       expect(cacheContent).toHaveProperty('collectedCSS');
+      expect(cacheContent).toHaveProperty('configHash');
     }
   });
 
@@ -304,6 +305,28 @@ describe('cache mechanism works as expected', () => {
     // Ensure no additional writes were made due to no file changes
     expect(writeSpy).toHaveBeenCalledTimes(0);
     writeSpy.mockRestore();
+  });
+
+  test('recompiles when config changes', async () => {
+    config.styleXBundleName = 'stylex_bundle_new.css';
+    await compileDirectory(config);
+
+    // Ensure cache is rewritten due to cache invalidation
+    expect(writeSpy).toHaveBeenCalledTimes(3);
+
+    const cacheFiles = await fs.readdir(cachePath);
+    expect(cacheFiles.length).toEqual(3);
+
+    for (const cacheFile of cacheFiles) {
+      const cacheFilePath = path.join(cachePath, cacheFile);
+      const cacheContent = JSON.parse(
+        await fs.readFile(cacheFilePath, 'utf-8'),
+      );
+      expect(cacheContent).toHaveProperty('inputHash');
+      expect(cacheContent).toHaveProperty('outputHash');
+      expect(cacheContent).toHaveProperty('collectedCSS');
+      expect(cacheContent).toHaveProperty('configHash');
+    }
   });
 
   test('recompiles when input changes', async () => {
@@ -386,6 +409,7 @@ describe('CLI works with a custom cache path', () => {
       expect(cacheContent).toHaveProperty('inputHash');
       expect(cacheContent).toHaveProperty('outputHash');
       expect(cacheContent).toHaveProperty('collectedCSS');
+      expect(cacheContent).toHaveProperty('configHash');
     }
   });
 

--- a/packages/cli/src/cache.js
+++ b/packages/cli/src/cache.js
@@ -60,7 +60,23 @@ export async function deleteCache(cachePath, filePath) {
   }
 }
 
-export async function computeHash(filePath) {
+export function computeStyleXConfigHash(config) {
+  // Excluding `input` and `output` paths to hash config settings
+  const configOptions = Object.fromEntries(
+    Object.entries(config).filter(
+      ([key]) => key !== 'input' && key !== 'output',
+    ),
+  );
+
+  const jsonRepresentation = JSON.stringify(
+    configOptions,
+    Object.keys(configOptions).sort(),
+  );
+
+  return hash(jsonRepresentation);
+}
+
+export async function computeFilePathHash(filePath) {
   const absoluteFilePath = path.resolve(filePath);
   const parsedFile = path.parse(absoluteFilePath);
 


### PR DESCRIPTION
## What changed / motivation ?

Let's invalidate the cache whenever StyleX config options change:
- Stringify config (without input/output paths, as accounted for) into key sorted JSON, hash output, add to cache check

## Testing

Added test for config change

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code