### PR TITLE
feat: exported return types of 'stylex.types.*' fns

### DIFF
--- a/packages/stylex/src/VarTypes.js
+++ b/packages/stylex/src/VarTypes.js
@@ -7,12 +7,7 @@
  * @flow strict
  */
 
-export type ValueWithDefault<+T> =
-  | T
-  | $ReadOnly<{
-      default: ValueWithDefault<T>,
-      [string]: ValueWithDefault<T>,
-    }>;
+import type { ValueWithDefault } from './util-types';
 
 export type CSSSyntax =
   | '*'

--- a/packages/stylex/src/stylex.js
+++ b/packages/stylex/src/stylex.js
@@ -21,7 +21,6 @@ import type {
   MapNamespaces,
 } from './StyleXTypes';
 import type {
-  ValueWithDefault,
   Angle,
   Color,
   Url,
@@ -36,22 +35,8 @@ import type {
   TransformFunction,
   TransformList,
 } from './VarTypes';
-export type {
-  ValueWithDefault,
-  Angle,
-  Color,
-  Url,
-  Image,
-  Integer,
-  LengthPercentage,
-  Length,
-  Percentage,
-  Num,
-  Resolution,
-  Time,
-  TransformFunction,
-  TransformList,
-} from './VarTypes';
+import type { ValueWithDefault } from './util-types';
+export * as Types from './VarTypes';
 
 export type {
   VarGroup,

--- a/packages/stylex/src/stylex.js
+++ b/packages/stylex/src/stylex.js
@@ -36,6 +36,22 @@ import type {
   TransformFunction,
   TransformList,
 } from './VarTypes';
+export type {
+  ValueWithDefault,
+  Angle,
+  Color,
+  Url,
+  Image,
+  Integer,
+  LengthPercentage,
+  Length,
+  Percentage,
+  Num,
+  Resolution,
+  Time,
+  TransformFunction,
+  TransformList,
+} from './VarTypes';
 
 export type {
   VarGroup,

--- a/packages/stylex/src/util-types.js
+++ b/packages/stylex/src/util-types.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+export type ValueWithDefault<+T> =
+  | T
+  | $ReadOnly<{
+      default: ValueWithDefault<T>,
+      [string]: ValueWithDefault<T>,
+    }>;

--- a/packages/stylex/type-tests/theming1.js.flow
+++ b/packages/stylex/type-tests/theming1.js.flow
@@ -10,7 +10,8 @@
 /* eslint-disable no-unused-vars */
 
 import * as React from 'react';
-import stylex from '../src/stylex';
+import * as stylex from '../src/stylex';
+import stylexLegacy from '../src/stylex';
 import type { StyleXVar, VarGroup, Theme } from '../src/StyleXTypes';
 
 const DARK = '@media (prefers-color-scheme: dark)';
@@ -52,7 +53,7 @@ const correctTheme = stylex.createTheme(buttonTokens, {
 
 correctTheme as Theme<typeof buttonTokens, string>;
 
-const result: string = stylex(correctTheme);
+const result: string = stylexLegacy(correctTheme);
 const result2: $ReadOnly<{
   className?: string,
   style?: $ReadOnly<{ [string]: string | number }>,
@@ -140,6 +141,14 @@ const typedTokens = stylex.defineVars({
   translucent: stylex.types.number<number>(0.5),
   shortAnimation: stylex.types.time<string | 0>('0.5s'),
 });
+
+const _bgColor: StyleXVar<stylex.Types.Color<string>> = typedTokens.bgColor;
+const _cornerRadius: StyleXVar<stylex.Types.Length<string | number>> =
+  typedTokens.cornerRadius;
+const _translucent: StyleXVar<stylex.Types.Num<number>> =
+  typedTokens.translucent;
+const _shortAnimation: StyleXVar<stylex.Types.Time<string | 0>> =
+  typedTokens.shortAnimation;
 
 const correctlyTypedTheme = stylex.createTheme(typedTokens, {
   bgColor: stylex.types.color('red'),


### PR DESCRIPTION
## What changed / motivation ?

Fixes #857

New types are exported such as `stylex.Color` and `stylex.Length`.

These are the return types of the `stylex.types.*` function. So, for example,

- `stylex.types.color("red")` is of type `stylex.Color<string>`

## Question

Should the types be under `stylex.types` instead?

- `stylex.types.color("red")` would be of type `stylex.types.Color<string>`