### PR TITLE
Revert "fix: Properly parse multi-value shorthand with slash"

### DIFF
--- a/packages/shared/__tests__/split-value-test.js
+++ b/packages/shared/__tests__/split-value-test.js
@@ -44,28 +44,4 @@ describe('Ensure CSS values are split correctly', () => {
       splitValue('calc((100% - 50px) * 0.5) var(--rightpadding, 20px)'),
     ).toEqual(['calc((100% - 50px) * 0.5)', 'var(--rightpadding,20px)']);
   });
-
-  test('Expands a string of values with slash notation appropriately.', () => {
-    expect(splitValue('1px / 2px 3px 4px 5px', 'borderRadius')).toEqual([
-      '1px 2px',
-      '1px 3px',
-      '1px 4px',
-      '1px 5px',
-    ]);
-    expect(splitValue('1px 2px / 3px 4px', 'borderRadius')).toEqual([
-      '1px 3px',
-      '2px 4px',
-      '1px 3px',
-      '2px 4px',
-    ]);
-    expect(splitValue('1px 2px / 3px 4px 5px', 'borderRadius')).toEqual([
-      '1px 3px',
-      '2px 4px',
-      '1px 5px',
-      '2px 4px',
-    ]);
-    expect(
-      splitValue('1px 2px 3px 4px / 5px 6px 7px 8px', 'borderRadius'),
-    ).toEqual(['1px 5px', '2px 6px', '3px 7px', '4px 8px']);
-  });
 });

--- a/packages/shared/src/preprocess-rules/legacy-expand-shorthands.js
+++ b/packages/shared/src/preprocess-rules/legacy-expand-shorthands.js
@@ -162,10 +162,7 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
   ],
 
   borderRadius: (rawValue: TStyleValue): TReturn => {
-    const [top, right = top, bottom = top, left = right] = splitValue(
-      rawValue,
-      'borderRadius',
-    );
+    const [top, right = top, bottom = top, left = right] = splitValue(rawValue);
 
     return [
       ['borderTopStartRadius', top],


### PR DESCRIPTION
facebook/stylex#859 is causing undefined type errors, likely from accessing a property on an undefined variable. Reverting as we investigate cause.