### PR TITLE
Update API configuration docs

### DIFF
--- a/apps/docs/docs/api/configuration/babel-plugin.mdx
+++ b/apps/docs/docs/api/configuration/babel-plugin.mdx
@@ -10,6 +10,38 @@ sidebar_position: 1
 
 ## Configuration options
 
+### `aliases`
+
+```ts
+aliases: {[key: string]: string | Array<string>} // Default: undefined
+```
+
+`aliases` option allows you to alias project directories to absolute paths, making it easier to import modules.
+
+Example: `'@/components/*': [path.join(__dirname, './src/components/*')]`
+
+---
+
+### `classNamePrefix`
+
+```ts
+classNamePrefix: string // Default: 'x'
+```
+
+Prefix to applied to every generated className.
+
+---
+
+### `debug`
+
+```ts
+debug: boolean // Default: false
+```
+
+When `true`, StyleX will insert debug class names to identify the source of the styles.
+
+---
+
 ### `dev`
 
 ```ts
@@ -18,7 +50,58 @@ dev: boolean // Default: false
 
 When `true`, StyleX will insert debug class names to identify the source of the styles.
 
-<hr />
+---
+
+### `genConditionalClasses`
+
+```ts
+genConditionalClasses: boolean // Default: false
+```
+
+Enable experimental compile-time optimization to pre-compute
+`stylex.props` function calls with conditional styles when all
+possible styles used are defined in the same file and known
+at compile-time.
+
+---
+
+### `importSources`
+
+```ts
+importSources: Array<string> // Default: ['@stylexjs/stylex']
+```
+
+Override the package name where you can import stylex from.
+Used for setting up custom module aliases.
+
+---
+
+### `runtimeInjection`
+
+```ts
+runtimeInjection: boolean // Default: the value of `dev`
+```
+
+Should StyleX generate code to inject styles at runtime?
+This may be useful during development but should be disabled in production.
+
+---
+
+### `styleResolution`
+
+```ts
+styleResolution: // Default: 'application-order'
+  | 'application-order'
+  | 'property-specificity'
+```
+
+Strategy to use for merging styles.
+- **application-order**: The last style applied wins. Consistent with how
+  inline styles work on the web.
+- **property-specificity**: More specific styles will win over less specific
+  styles. Consistent with React Native. (`margin-top` wins over `margin`)
+
+---
 
 ### `test`
 
@@ -32,84 +115,7 @@ source of the styles.
 It will *not* generate any styles or functional classNames.
 This can be useful for snapshot testing.
 
-<hr />
-
-### `runtimeInjection`
-
-```ts
-runtimeInjection: boolean // Default: the value of `dev`
-```
-
-Should StyleX generate code to inject styles at runtime?
-This may be useful during development but should be disabled in production.
-
-<hr />
-
-### `classNamePrefix`
-
-```ts
-classNamePrefix: string // Default: 'x'
-```
-
-Prefix to applied to every generated className.
-
-<hr />
-
-### `useRemForFontSize`
-
-```ts
-useRemForFontSize: boolean // Default: false
-```
-
-Should `px` values for `fontSize` be converted to `rem`?
-It is considered a best practice to use `rem` for font sizes to allow
-users to scale the font size up or down.
-
-<hr />
-
-### `styleResolution`
-
-```ts
-styleResolution: // Default: 'application-order'
-  | 'application-order'
-  | 'property-specificity'
-  // @deprecated
-  | 'legacy-expand-shorthands'
-```
-
-Strategy to use for merging styles.
-- **application-order**: The last style applied wins. Consistent with how
-  inline styles work on the web.
-- **property-specificity**: More specific styles will win over less specific
-  styles. Consistent with React Native. (margin-top wins over margin)
-- *Deprecated* - **legacy-expand-shorthands**: Similar to 'application-order'
-  but incomplete and error-prone. Will be removed in a future release.
-
-<hr />
-
-### `importSources`
-
-```ts
-importSources: Array<string> // Default: ['@stylexjs/stylex']
-```
-
-Override the package name where you can import stylex from.
-Used for setting up custom module aliases.
-
-<hr />
-
-### `genConditionalClasses`
-
-```ts
-genConditionalClasses: boolean // Default: false
-```
-
-Enable experimental compile-time optimization to pre-compute
-`stylex.props` function calls with conditional styles when all
-possible styles used are defined in the same file and known
-at compile-time.
-
-<hr />
+---
 
 ### `treeshakeCompensation`
 
@@ -122,19 +128,7 @@ Some bundlers may remove them as dead code. Causing variables to be undefined.
 Enable this option to prevent that by adding an import with no specifier.
 (e.g. `import './my-vars.stylex.js'`)
 
-<hr />
-
-### `aliases`
-
-```ts
-aliases: {[key: string]: string | Array<string>} // Default: undefined
-```
-
-`aliases` option allows you to alias project directories to absolute paths, making it easier to import modules. 
-
-Example: `'@/components/*': [path.join(__dirname, './src/components/*')]`
-
-<hr />
+---
 
 ### `unstable_moduleResolution`
 
@@ -165,3 +159,15 @@ This is required if you plan to use StyleX's theming APIs.
 
 **NOTE**: While theming APIs are stable, the shape of this configuration option
 may change in the future.
+
+---
+
+### `useRemForFontSize`
+
+```ts
+useRemForFontSize: boolean // Default: false
+```
+
+Should `px` values for `fontSize` be converted to `rem`?
+It is considered a best practice to use `rem` for font sizes to allow
+users to scale the font size up or down.

--- a/apps/docs/docs/api/configuration/dev-runtime.mdx
+++ b/apps/docs/docs/api/configuration/dev-runtime.mdx
@@ -3,53 +3,45 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-sidebar_position: 3
+sidebar_position: 1
 ---
 
 # `@stylexjs/dev-runtime`
 
 ## Configuration options
 
+### `classNamePrefix`
+
 ```ts
-export type DevRuntimeOptions = {
-  // Prefix to applied to every generated className
-  // Default: 'x'
-  classNamePrefix?: string,
-
-  // Should `px` values for `fontSize` be converted to `rem`?
-  // It is a best practice to use `rem` for font sizes to allow
-  // users to scale the font size up or down.
-  //
-  // Default: `true`
-  useRemForFontSize?: boolean,
-  
-  // Strategy to use for merging styles
-  // Default: 'application-order'
-  styleResolution?:
-    // The last style applied wins. Consistent with how inline styles work on the web.
-    | 'application-order' 
-    // More specific styles will win over less specific styles. (margin-top wins over margin)
-    // Consistent with how React Native works.
-    | 'property-specificity'
-    // @deprecated
-    // Similar to 'application-order' but incomplete and error-prone.
-    // Will be removed in a future release.
-    | 'legacy-expand-shorthands',
-
-  // A custom function to handle inserting styles into the DOM.
-  insert?: (
-    // Unique key for the style.
-    // aka the className.
-    key: string,
-    // The CSS rule to insert as string.
-    ltrRule: string,
-    // The priority of the rule.
-    // priorities should be sorted in ascending order.
-    // The priority jumps by 1000 for every `@layer` needed.
-    priority: number,
-    // There may sometimes be a RTL equivalent of the rule.
-    // Usually this will be `void`
-    rtlRule?: ?string,
-  ) => void,
-};
+classNamePrefix: string // Default: 'x'
 ```
+
+Prefix to applied to every generated className.
+
+---
+
+### `styleResolution`
+
+```ts
+styleResolution: // Default: 'application-order'
+  | 'application-order'
+  | 'property-specificity'
+```
+
+Strategy to use for merging styles.
+- **application-order**: The last style applied wins. Consistent with how
+  inline styles work on the web.
+- **property-specificity**: More specific styles will win over less specific
+  styles. Consistent with React Native. (`margin-top` wins over `margin`)
+
+---
+
+### `useRemForFontSize`
+
+```ts
+useRemForFontSize: boolean // Default: false
+```
+
+Should `px` values for `fontSize` be converted to `rem`?
+It is considered a best practice to use `rem` for font sizes to allow
+users to scale the font size up or down.

--- a/apps/docs/docs/api/configuration/postcss-plugin.mdx
+++ b/apps/docs/docs/api/configuration/postcss-plugin.mdx
@@ -1,0 +1,60 @@
+---
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+sidebar_position: 4
+---
+
+# `@stylexjs/postcss-plugin`
+
+## Configuration options
+
+### babelConfig
+
+```js
+babelConfig: object; // Default: {}
+```
+
+Options for Babel configuration. By default, the plugin reads the `babel.config.js` in your project. For custom configurations, set `babelrc: false`
+and specify desired options. Refer to [Babel Config Options](https://babeljs.io/docs/options) for available options.
+
+---
+
+### cwd
+
+```js
+cwd: string; // Default: process.cwd()
+```
+
+Working directory for the plugin; defaults to `process.cwd()`.
+
+---
+
+### exclude
+
+```js
+exclude: string[] // Default: []
+```
+
+Array of paths or glob patterns to exclude from compilation. Paths in `exclude` take precedence over `include`.
+
+---
+
+### include
+
+```js
+include: string[] // Required
+```
+
+Array of paths or glob patterns to compile.
+
+---
+
+### useCSSLayers
+
+```js
+useCSSLayers: boolean; // Default: false
+```
+
+Enabling this option switches Stylex from using `:not(#\#)` to using `@layers` for handling CSS specificity.

--- a/apps/docs/docs/api/index.mdx
+++ b/apps/docs/docs/api/index.mdx
@@ -11,8 +11,9 @@ sidebar_position: 1
 ## Configuration
 
 - [`@stylexjs/babel-plugin`](./configuration/babel-plugin.mdx)
-- [`@stylexjs/eslint-plugin`](./configuration/eslint-plugin.mdx)
 - [`@stylexjs/dev-runtime`](./configuration/dev-runtime.mdx)
+- [`@stylexjs/eslint-plugin`](./configuration/eslint-plugin.mdx)
+- [`@stylexjs/postcss-plugin`](./configuration/postcss-plugin.mdx)
 
 ## JavaScript API
 


### PR DESCRIPTION
## What changed / motivation ?

Adds docs for the postcss-plugin and updates the docs for the babel-plugin to include `debug`. Also remove deprecated features from these docs.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code