### PR TITLE
docs: small but potentially confusing typo

### DIFF
--- a/apps/docs/docs/learn/05-theming/03-creating-themes.mdx
+++ b/apps/docs/docs/learn/05-theming/03-creating-themes.mdx
@@ -47,7 +47,7 @@ for that element and all its descendants.
 
 ```tsx title="components/MyComponent.js"
 import * as stylex from '@stylexjs/stylex';
-import {colors, spacing} from '../tokens.styles';
+import {colors, spacing} from '../tokens.stylex';
 import {dracula} from '../themes';
 
 const styles = stylex.create({


### PR DESCRIPTION
## What changed / motivation ?

I hate to write a single character PR for a typo, but this one is potentially confusing.

Typo is regarding the special `.stylex` file name extension so is potentially confusing.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code