### PR TITLE
feat: add border autofixes to valid styles

### DIFF
--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -687,6 +687,60 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       `,
     },
     {
+      code: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            borderStartWidth: '2px',
+            borderEndWidth: '3px',
+            borderStartStyle: 'solid',
+            borderEndStyle: 'dashed',
+            borderStartColor: 'red',
+            borderEndColor: 'blue',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'The key "borderStartWidth" is not a standard CSS property. Did you mean "borderInlineStartWidth"?',
+        },
+        {
+          message:
+            'The key "borderEndWidth" is not a standard CSS property. Did you mean "borderInlineEndWidth"?',
+        },
+        {
+          message:
+            'The key "borderStartStyle" is not a standard CSS property. Did you mean "borderInlineStartStyle"?',
+        },
+        {
+          message:
+            'The key "borderEndStyle" is not a standard CSS property. Did you mean "borderInlineEndStyle"?',
+        },
+        {
+          message:
+            'The key "borderStartColor" is not a standard CSS property. Did you mean "borderInlineStartColor"?',
+        },
+        {
+          message:
+            'The key "borderEndColor" is not a standard CSS property. Did you mean "borderInlineEndColor"?',
+        },
+      ],
+      output: `
+        import stylex from 'stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            borderInlineStartWidth: '2px',
+            borderInlineEndWidth: '3px',
+            borderInlineStartStyle: 'solid',
+            borderInlineEndStyle: 'dashed',
+            borderInlineStartColor: 'red',
+            borderInlineEndColor: 'blue',
+          },
+        });
+      `,
+    },
+    {
       code: "import stylex from 'stylex'; stylex.create({default: {textAlign: 'lfet'}});",
       errors: [
         {

--- a/packages/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/eslint-plugin/src/stylex-valid-styles.js
@@ -1604,6 +1604,12 @@ const validStyleMapping: $ReadOnly<{ [key: string]: ?string }> = {
   paddingEnd: 'paddingInlineEnd',
   paddingHorizontal: 'paddingInline',
   paddingVertical: 'paddingBlock',
+  borderStartWidth: 'borderInlineStartWidth',
+  borderEndWidth: 'borderInlineEndWidth',
+  borderStartStyle: 'borderInlineStartStyle',
+  borderEndStyle: 'borderInlineEndStyle',
+  borderStartColor: 'borderInlineStartColor',
+  borderEndColor: 'borderInlineEndColor',
 };
 
 const SVGProperties = {


### PR DESCRIPTION
## Context

Some asks and confusion popping up like in [D69623973](https://www.internalfb.com/diff/D69623973). Let's add in border autofixes for the following properties:

- borderStartWidth -> borderInlineStartWidth
- borderEndWidth -> borderInlineEndWidth
- borderStartStyle -> borderInlineStartStyle
- borderEndStyle -> borderInlineEndStyle
- borderStartColor -> borderInlineStartColor
- borderEndColor -> borderInlineEndColor

Follow up to https://github.com/facebook/stylex/pull/805


## Testing
Added tests 

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code