### PR TITLE
feat: decouple debug class names and data-* attributes

### DIFF
--- a/packages/babel-plugin/src/utils/state-manager.js
+++ b/packages/babel-plugin/src/utils/state-manager.js
@@ -70,6 +70,7 @@ const CheckModuleResolution: Check<ModuleResolution> = z.unionOf3(
 export type StyleXOptions = $ReadOnly<{
   ...RuntimeOptions,
   aliases?: ?$ReadOnly<{ [string]: string | $ReadOnlyArray<string> }>,
+  enableDebugClassNames?: boolean,
   genConditionalClasses: boolean,
   importSources: $ReadOnlyArray<
     string | $ReadOnly<{ from: string, as: string }>,
@@ -162,6 +163,14 @@ export default class StateManager {
       false,
       'options.debug',
     );
+
+    const enableDebugClassNames: StyleXStateOptions['enableDebugClassNames'] =
+      z.logAndDefault(
+        z.boolean(),
+        options.enableDebugClassNames ?? true,
+        true,
+        'options.enableDebugClassNames',
+      );
 
     const test: StyleXStateOptions['test'] = z.logAndDefault(
       z.boolean(),
@@ -282,6 +291,7 @@ export default class StateManager {
       debug,
       definedStylexCSSVariables: {},
       dev,
+      enableDebugClassNames,
       genConditionalClasses,
       importSources,
       rewriteAliases:

--- a/packages/shared/src/common-types.js
+++ b/packages/shared/src/common-types.js
@@ -38,6 +38,7 @@ export type FlatCompiledStyles = $ReadOnly<{
 export type StyleXOptions = $ReadOnly<{
   classNamePrefix: string,
   debug: ?boolean,
+  enableDebugClassNames?: ?boolean,
   definedStylexCSSVariables?: { [key: string]: mixed },
   dev: boolean,
   styleResolution:

--- a/packages/shared/src/convert-to-className.js
+++ b/packages/shared/src/convert-to-className.js
@@ -29,7 +29,11 @@ export function convertStyleToClassName(
   atRules: $ReadOnlyArray<string>,
   options: StyleXOptions = defaultOptions,
 ): StyleRule {
-  const { classNamePrefix = 'x', debug = false } = options;
+  const {
+    classNamePrefix = 'x',
+    debug = false,
+    enableDebugClassNames = true,
+  } = options;
   const [key, rawValue] = objEntry;
   const dashedKey = key.startsWith('--') ? key : dashify(key);
 
@@ -58,9 +62,10 @@ export function convertStyleToClassName(
 
   // NOTE: '<>' is used to keep existing hashes stable.
   // This should be removed in a future version.
-  const className = debug
-    ? `${key}-${classNamePrefix}${createHash('<>' + stringToHash)}`
-    : classNamePrefix + createHash('<>' + stringToHash);
+  const className =
+    debug && enableDebugClassNames
+      ? `${key}-${classNamePrefix}${createHash('<>' + stringToHash)}`
+      : classNamePrefix + createHash('<>' + stringToHash);
 
   const cssRules = generateRule(className, dashedKey, value, pseudos, atRules);
 

--- a/packages/shared/src/utils/default-options.js
+++ b/packages/shared/src/utils/default-options.js
@@ -12,6 +12,7 @@ import type { StyleXOptions } from '../common-types';
 export const defaultOptions: StyleXOptions = {
   dev: false,
   debug: false,
+  enableDebugClassNames: true,
   useRemForFontSize: true,
   test: false,
   classNamePrefix: 'x',


### PR DESCRIPTION
## Context

As discussed, let's decouple debug class names and `data-stylex-src` attributes by creating a new config option `debugClassNamePrefix` to create more optionality on using `data-stylex-src` without debug classnames

The only thing worth considering is we now have chaining that looks like this: debugClassNamePrefix falls back to debug, which falls back to dev, which feels a bit opaque and potentially confusing.

## Testing
Tests pass?

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code