### PR TITLE
feat: create media query transformer to ensure last query wins

### DIFF
--- a/packages/style-value-parser/src/at-queries-from-tokens/__tests__/media-query-transform-test.js
+++ b/packages/style-value-parser/src/at-queries-from-tokens/__tests__/media-query-transform-test.js
@@ -1,0 +1,339 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+import { lastMediaQueryWinsTransform } from '../media-query-transform.js';
+
+const stylex = {
+  create: (styles) => styles,
+};
+
+describe('Media Query Transformer', () => {
+  test('basic usage: multiple widths', () => {
+    const originalStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px)': '1 / 4',
+          '@media (max-width: 1024px)': '1 / 3',
+          '@media (max-width: 768px)': '1 / -1',
+        },
+      },
+    };
+
+    const expectedStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px))':
+            '1 / 4',
+          '@media (max-width: 1024px) and (not (max-width: 768px))': '1 / 3',
+          '@media (max-width: 768px)': '1 / -1',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('basic usage: nested query', () => {
+    const originalStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px)': {
+            '@media (max-width: 1024px)': '1 / 3',
+            '@media (max-width: 768px)': '1 / -1',
+          },
+          '@media (max-width: 1024px)': '1 / 3',
+          '@media (max-width: 768px)': '1 / -1',
+        },
+      },
+    };
+
+    const expectedStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px))':
+            {
+              '@media (max-width: 1024px) and (not (max-width: 768px))':
+                '1 / 3',
+              '@media (max-width: 768px)': '1 / -1',
+            },
+          '@media (max-width: 1024px) and (not (max-width: 768px))': '1 / 3',
+          '@media (max-width: 768px)': '1 / -1',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('basic usage: nested query', () => {
+    const originalStyles = {
+      table: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px)': {
+            '@media (max-width: 1024px)': '1 / 3',
+            '@media (max-width: 768px)': '1 / -1',
+          },
+          '@media (max-width: 1024px)': '1 / 3',
+          '@media (max-width: 768px)': '1 / -1',
+        },
+        padding: '10px',
+      },
+    };
+
+    const expectedStyles = {
+      table: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px))':
+            {
+              '@media (max-width: 1024px) and (not (max-width: 768px))':
+                '1 / 3',
+              '@media (max-width: 768px)': '1 / -1',
+            },
+          '@media (max-width: 1024px) and (not (max-width: 768px))': '1 / 3',
+          '@media (max-width: 768px)': '1 / -1',
+        },
+        padding: '10px',
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('basic usage: complex object', () => {
+    const originalStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px)': '1 / 4',
+          '@media (max-width: 1024px)': '1 / 3',
+          '@media (max-width: 768px)': '1 / -1',
+        },
+        grid: {
+          default: '1 / 2',
+          '@media (max-width: 1440px)': '1 / 4',
+        },
+        gridRow: {
+          default: '1 / 2',
+          padding: '10px',
+        },
+      },
+    };
+
+    const expectedStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px))':
+            '1 / 4',
+          '@media (max-width: 1024px) and (not (max-width: 768px))': '1 / 3',
+          '@media (max-width: 768px)': '1 / -1',
+        },
+        grid: {
+          default: '1 / 2',
+          '@media (max-width: 1440px)': '1 / 4',
+        },
+        gridRow: {
+          default: '1 / 2',
+          padding: '10px',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('basic usage: lots and lots of widths', () => {
+    const originalStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px)': '1 / 4',
+          '@media (max-width: 1024px)': '1 / 3',
+          '@media (max-width: 768px)': '1 / -1',
+          '@media (max-width: 458px)': '1 / -1',
+        },
+      },
+    };
+
+    const expectedStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px)) and (not (max-width: 458px))':
+            '1 / 4',
+          '@media (max-width: 1024px) and (not (max-width: 768px)) and (not (max-width: 458px))':
+            '1 / 3',
+          '@media (max-width: 768px) and (not (max-width: 458px))': '1 / -1',
+          '@media (max-width: 458px)': '1 / -1',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('single word condition', () => {
+    const originalStyles = stylex.create({
+      colorMode: {
+        mode: {
+          default: 'normal',
+          '@media (color)': 'colorful',
+          '@media (monochrome)': 'grayscale',
+        },
+      },
+    });
+
+    const expectedStyles = {
+      colorMode: {
+        mode: {
+          default: 'normal',
+          '@media (color) and (not (monochrome))': 'colorful',
+          '@media (monochrome)': 'grayscale',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('handles comma-separated (or) media queries', () => {
+    const originalStyles = stylex.create({
+      container: {
+        width: {
+          default: '100%',
+          '@media screen, (max-width: 800px)': '80%',
+          '@media (max-width: 500px)': '60%',
+        },
+      },
+    });
+
+    const expectedStyles = {
+      container: {
+        width: {
+          default: '100%',
+          '@media screen and (not (max-width: 500px)), (max-width: 800px) and (not (max-width: 500px))':
+            '80%',
+          '@media (max-width: 500px)': '60%',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test.skip('handles and media queries', () => {
+    const originalStyles = stylex.create({
+      container: {
+        width: {
+          default: '100%',
+          '@media (min-width: 900px)': '80%',
+          '@media (min-width: 500px) and (max-width: 899px) and (max-height: 300px)':
+            '50%',
+        },
+      },
+    });
+
+    const expectedStyles = {
+      container: {
+        width: {
+          default: '100%',
+          '@media (min-width: 900px) and (not ((min-width: 500px) and (max-width: 899px) and (max-height: 300px)))':
+            '80%',
+          '@media (min-width: 500px) and (max-width: 899px) and (max-height: 300px)':
+            '50%',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test.skip('combination of keywords and rules', () => {
+    const originalStyles = stylex.create({
+      container: {
+        width: {
+          default: '100%',
+          '@media screen and (min-width: 900px)': '80%',
+          '@media print and (max-width: 500px)': '50%',
+        },
+      },
+    });
+
+    const expectedStyles = {
+      container: {
+        width: {
+          default: '100%',
+          '@media screen and (min-width: 900px) and (not (print and (max-width: 500px)))':
+            '80%',
+          '@media print and (max-width: 500px)': '50%',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('basic usage: does not modify single queries', () => {
+    const originalStyles = {
+      gridColumn: {
+        default: '1 / 2',
+        '@media (max-width: 1440px)': '1 / 4',
+      },
+    };
+
+    const expectedStyles = {
+      gridColumn: {
+        default: '1 / 2',
+        '@media (max-width: 1440px)': '1 / 4',
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('ignores legacy media query syntax', () => {
+    const originalStyles = {
+      root: {
+        width: '100%',
+        '@media (min-width: 600px)': {
+          width: '50%',
+        },
+      },
+    };
+
+    const expectedStyles = {
+      root: {
+        width: '100%',
+        '@media (min-width: 600px)': {
+          width: '50%',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+});

--- a/packages/style-value-parser/src/at-queries-from-tokens/media-query-transform.js
+++ b/packages/style-value-parser/src/at-queries-from-tokens/media-query-transform.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import { MediaQuery } from './media-query.js';
+
+export function lastMediaQueryWinsTransform(styles: Object): Object {
+  return dfsProcessQueries(styles, 0);
+}
+
+function combineMediaQueryWithNegations(
+  current: MediaQuery,
+  negations: MediaQuery[],
+): MediaQuery {
+  if (negations.length === 0) {
+    return current;
+  }
+
+  let combinedAst;
+
+  if (current.queries.type === 'or') {
+    combinedAst = {
+      type: 'or',
+      rules: current.queries.rules.map((rule) => ({
+        type: 'and',
+        rules: [
+          rule,
+          ...negations.map((mq) => ({ type: 'not', rule: mq.queries })),
+        ],
+      })),
+    };
+  } else {
+    combinedAst = {
+      type: 'and',
+      rules: [
+        current.queries,
+        ...negations.map((mq) => ({ type: 'not', rule: mq.queries })),
+      ],
+    };
+  }
+
+  return new MediaQuery(combinedAst);
+}
+
+function dfsProcessQueries(
+  obj: { [key: string]: any },
+  depth: number,
+): {
+  [key: string]: any,
+} {
+  const result: { [key: string]: any } = {};
+
+  Object.entries(obj).forEach(([key, value]) => {
+    if (typeof value === 'object' && value !== null) {
+      result[key] = dfsProcessQueries(value, depth + 1);
+    } else {
+      result[key] = value;
+    }
+  });
+
+  if (
+    depth >= 2 &&
+    Object.keys(result).some((key) => key.startsWith('@media '))
+  ) {
+    const mediaKeys = Object.keys(result).filter((key) =>
+      key.startsWith('@media '),
+    );
+
+    const negations = [];
+    const accumulatedNegations = [];
+
+    for (let i = mediaKeys.length - 1; i > 0; i--) {
+      // Skip last iteration
+      const mediaQuery = MediaQuery.parser.parseToEnd(mediaKeys[i]);
+      negations.push(mediaQuery);
+      accumulatedNegations.push([...negations]); // Clone array before pushing
+    }
+    accumulatedNegations.reverse();
+    accumulatedNegations.push([]);
+
+    for (let i = 0; i < mediaKeys.length; i++) {
+      const currentKey = mediaKeys[i];
+      const currentValue = result[currentKey];
+
+      const baseMediaQuery = MediaQuery.parser.parseToEnd(currentKey);
+      const reversedNegations = [...accumulatedNegations[i]].reverse();
+
+      const combinedQuery = combineMediaQueryWithNegations(
+        baseMediaQuery,
+        reversedNegations,
+      );
+
+      const newMediaKey = combinedQuery.toString();
+
+      delete result[currentKey];
+      result[newMediaKey] = currentValue;
+    }
+  }
+
+  return result;
+}

--- a/packages/style-value-parser/src/at-queries-from-tokens/media-query.js
+++ b/packages/style-value-parser/src/at-queries-from-tokens/media-query.js
@@ -43,7 +43,7 @@ type MediaRulePair = {
   key: string,
   value: MediaRuleValue,
 };
-type MediaNotRule = { type: 'not', rule: MediaRulePair | MediaWordRule };
+type MediaNotRule = { type: 'not', rule: MediaQueryRule };
 type MediaAndRules = { type: 'and', rules: $ReadOnlyArray<MediaQueryRule> };
 type MediaOrRules = { type: 'or', rules: $ReadOnlyArray<MediaQueryRule> };
 


### PR DESCRIPTION
create media query transformer to ensure “last query wins” logic

## Context  
Now that we have a usable media query parser in https://github.com/facebook/stylex/pull/743, we can finally implement last media query wins logic. 

## Implementation
High level approach: traverse through styles, search for media queries, do two passes at each node - one to build up a list of negations for each query, and another to apply the negation. 

1. traverse nested styles with dfs
   - dfs to find all nested media queries
   - extract and flatten all media queries per into list for easier transformation

2. iterate media queries in reverse order
   - loop through the extracted media queries from last to first 

3. accumulate negations
   -backwards, for single pass
-  build up a list of negations from previous queries during reverse iteration
   - apply these negations to prevent earlier media queries from overriding more specific ones defined later

4. construct updated media queries
   - forwards order, because we need to reassign the object keys in the same order we see them to avoid breaking js object keys order
   - for each media query: use `MediaQuery.parser.parseToEnd` to convert query string into object representation
 - append all accumulated negations to queries
   - stringify media query using`MediaQuery.toString()`
   - append current queries to negations

5. return updated styles object with negated media queries


## Testing

Use `json.stringify` to ensure object key order is maintained

Scenarios like:
- basic usage: multiple widths 
- basic usage: complex styles object 
- basic usage: lots and lots of widths 
- nested queries
- handles comma-separated (or) media queries
- handles and media queries 
- keywords
- combination of keywords and > rules

Missing: 
- Nested not cases blocked on parsing issues

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code