### PR TITLE
chore: revert npm ci 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
-      - run: npm ci
+      - run: npm install
       - run: npm run prettier:report
 
   type-check:
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
-      - run: npm ci
+      - run: npm install
       - run: npm run flow
 
   lint:
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
-      - run: npm ci
+      - run: npm install
       - run: npm run build
       - run: npm run lint:report
 
@@ -46,5 +46,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
-      - run: npm ci
+      - run: npm install
       - run: npm run test


### PR DESCRIPTION
## What changed / motivation ?

Vercel builds seem to be erroring with https://github.com/facebook/stylex/pull/906, let's switch back to debug. `package-lock.js` in main may be in a weird state

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code