### PR TITLE
fix: should respect filename for babel 

### DIFF
--- a/packages/postcss-plugin/src/builder.js
+++ b/packages/postcss-plugin/src/builder.js
@@ -145,7 +145,7 @@ function createBuilder() {
         if (!bundler.shouldTransform(contents)) {
           return;
         }
-        return bundler.transform(file, contents, babelConfig, {
+        return bundler.transform(filePath, contents, babelConfig, {
           isDev,
           shouldSkipTransformError,
         });


### PR DESCRIPTION
## What changed / motivation ?

Now `postcss plugin` don't pass the full path for babel transform. So if we using this plugin in a mono repo we can't get the right path for translate. 

## Linked PR/Issues

Fixes # (issue)

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

![image](https://github.com/user-attachments/assets/51b8bd11-7d9f-499a-9278-47e96447549e)

Note at the first part of the content is the file id get from vite. the second part is get from postcss plugin.

Why cause it?

because i pass the rootDir for plugin. ( I'm not sure if this is as expected) The rootDir is the monorepo root. Based on this, it may be cause erros in a mono repo because the generated class names
will not match.

https://github.com/facebook/stylex/blob/dc49bae074f3906c394a149004b88363bc696a08/packages/babel-plugin/src/utils/state-manager.js#L552

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code