### PR TITLE
Fix style compilation for string and number keys

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -45,7 +45,13 @@ describe('@stylexjs/babel-plugin', () => {
           import stylex from 'stylex';
           export const styles = stylex.create({
             foo: {
-              position: stylex.firstThatWorks('sticky', 'fixed'),
+              color: 'red'
+            },
+            'bar-baz': {
+              display: 'block'
+            },
+            1: {
+              fontSize: '1em'
             }
           });
         `,
@@ -59,11 +65,21 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".position-x15oojuh{position:fixed;position:sticky}", 3000);
+        _inject2(".fontSize-xrv4cvt{font-size:1em}", 3000);
+        _inject2(".color-x1e2nbdu{color:red}", 3000);
+        _inject2(".display-x1lliihq{display:block}", 3000);
         export const styles = {
+          "1": {
+            fontSize: "fontSize-xrv4cvt",
+            $$css: "Foo.react.js:10"
+          },
           foo: {
-            position: "position-x15oojuh",
+            color: "color-x1e2nbdu",
             $$css: "Foo.react.js:4"
+          },
+          "bar-baz": {
+            display: "display-x1lliihq",
+            $$css: "Foo.react.js:7"
           }
         };"
       `);
@@ -74,7 +90,13 @@ describe('@stylexjs/babel-plugin', () => {
           import stylex from 'stylex';
           export const styles = stylex.create({
             foo: {
-              position: stylex.firstThatWorks('sticky', 'fixed'),
+              color: 'red'
+            },
+            'bar-baz': {
+              display: 'block'
+            },
+            1: {
+              fontSize: '1em'
             }
           });
         `,
@@ -89,24 +111,40 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".position-x15oojuh{position:fixed;position:sticky}", 3000);
+        _inject2(".fontSize-xrv4cvt{font-size:1em}", 3000);
+        _inject2(".color-x1e2nbdu{color:red}", 3000);
+        _inject2(".display-x1lliihq{display:block}", 3000);
         export const styles = {
+          "1": {
+            fontSize: "fontSize-xrv4cvt",
+            $$css: "npm-package:components/Foo.react.js:10"
+          },
           foo: {
-            position: "position-x15oojuh",
+            color: "color-x1e2nbdu",
             $$css: "npm-package:components/Foo.react.js:4"
+          },
+          "bar-baz": {
+            display: "display-x1lliihq",
+            $$css: "npm-package:components/Foo.react.js:7"
           }
         };"
       `);
     });
 
-    test('supports debug data (haste)', () => {
+    test('supports debug data (commonJS)', () => {
       expect(
         transform(
           `
           import stylex from 'stylex';
           export const styles = stylex.create({
             foo: {
-              position: stylex.firstThatWorks('sticky', 'fixed'),
+              color: 'red'
+            },
+            'bar-baz': {
+              display: 'block'
+            },
+            1: {
+              fontSize: '1em'
             }
           });
         `,
@@ -120,11 +158,21 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".position-x15oojuh{position:fixed;position:sticky}", 3000);
+        _inject2(".fontSize-xrv4cvt{font-size:1em}", 3000);
+        _inject2(".color-x1e2nbdu{color:red}", 3000);
+        _inject2(".display-x1lliihq{display:block}", 3000);
         export const styles = {
+          "1": {
+            fontSize: "fontSize-xrv4cvt",
+            $$css: "components/Foo.react.js:10"
+          },
           foo: {
-            position: "position-x15oojuh",
+            color: "color-x1e2nbdu",
             $$css: "components/Foo.react.js:4"
+          },
+          "bar-baz": {
+            display: "display-x1lliihq",
+            $$css: "components/Foo.react.js:7"
           }
         };"
       `);
@@ -135,7 +183,13 @@ describe('@stylexjs/babel-plugin', () => {
           import stylex from 'stylex';
           export const styles = stylex.create({
             foo: {
-              position: stylex.firstThatWorks('sticky', 'fixed'),
+              color: 'red'
+            },
+            'bar-baz': {
+              display: 'block'
+            },
+            1: {
+              fontSize: '1em'
             }
           });
         `,
@@ -150,11 +204,21 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".position-x15oojuh{position:fixed;position:sticky}", 3000);
+        _inject2(".fontSize-xrv4cvt{font-size:1em}", 3000);
+        _inject2(".color-x1e2nbdu{color:red}", 3000);
+        _inject2(".display-x1lliihq{display:block}", 3000);
         export const styles = {
+          "1": {
+            fontSize: "fontSize-xrv4cvt",
+            $$css: "npm-package:components/Foo.react.js:10"
+          },
           foo: {
-            position: "position-x15oojuh",
+            color: "color-x1e2nbdu",
             $$css: "npm-package:components/Foo.react.js:4"
+          },
+          "bar-baz": {
+            display: "display-x1lliihq",
+            $$css: "npm-package:components/Foo.react.js:7"
           }
         };"
       `);


### PR DESCRIPTION
## What changed / motivation ?

Styles with string or number keys have different types in the Babel AST. This patch correctly generates sourcemap data for those key types. And it ensures that the compiled style is always preserved even if sourcemap data isn't generated.

Fix #919
Close #920

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code