### PR TITLE
fix: add .d.ts for stylex babel plugin to resolve cjs export and typescript mismatch

### DIFF
--- a/packages/babel-plugin/src/index.d.ts
+++ b/packages/babel-plugin/src/index.d.ts
@@ -1,0 +1,47 @@
+// Solves the issue: https://github.com/facebook/stylex/issues/889
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+import type { PluginObj } from '@babel/core';
+import type { StyleXOptions } from './utils/state-manager';
+export type Options = StyleXOptions;
+/**
+ * Entry point for the StyleX babel plugin.
+ */
+declare function styleXTransform(): PluginObj;
+declare function stylexPluginWithOptions(
+  options: Partial<StyleXOptions>,
+): [typeof styleXTransform, Partial<StyleXOptions>];
+/**
+ *
+ * @param rules An array of CSS rules that has been generated and collected from all JS files
+ * in a project
+ * @returns A string that represents the final CSS file.
+ *
+ * This function take an Array of CSS rules, de-duplicates them, sorts them priority and generates
+ * a final CSS file.
+ *
+ * When Stylex is correctly configured, the babel plugin will return an array of CSS rule objects.
+ * You're expected to concatenate all the Rules into a single Array and use this function to convert
+ * that into the final CSS file.
+ *
+ * End-users can choose to not use this function and use their own logic instead.
+ */
+export type Rule = [string, { ltr: string; rtl?: null | string }, number];
+declare function processStylexRules(
+  rules: Array<Rule>,
+  useLayers: boolean,
+): string;
+export type StyleXTransformObj = Readonly<{
+  (): PluginObj;
+  withOptions: typeof stylexPluginWithOptions;
+  processStylexRules: typeof processStylexRules;
+}>;
+declare const $$EXPORT_DEFAULT_DECLARATION$$: StyleXTransformObj;
+export = $$EXPORT_DEFAULT_DECLARATION$$;


### PR DESCRIPTION
## What changed / motivation ?
Added a temporary `.d.ts` file for stylex babel plugin. This overrides the output of 
```ts
export default EXPORT_DEFAULT_DECLARATION
```
to
```ts
export = $$EXPORT_DEFAULT_DECLARATION$$;
```
Although this doesn't looks like a good solution. Need to find a good solution later.

## Linked PR/Issues

Fixes # [(issue)](https://github.com/facebook/stylex/issues/889)

## Additional Context
After change types works fine
<img width="770" alt="Screenshot 2025-03-03 at 10 51 01 AM" src="https://github.com/user-attachments/assets/d1427990-8848-487e-a304-6000de1bf125" />

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code