### PR TITLE
fix: bring back cross-origin config for fixing playground

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What changed / motivation ?

This PR brings back the `vercel.json` file that is sets the hosting configuration to enable cross origin policies which are needed for the playground to work.