### PR TITLE
feat: improve media query parser implementation

### DIFF
--- a/packages/style-value-parser/src/at-queries-from-tokens/__tests__/media-query-test.js
+++ b/packages/style-value-parser/src/at-queries-from-tokens/__tests__/media-query-test.js
@@ -1873,6 +1873,30 @@ describe('Test CSS Type: @media queries', () => {
     expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
+  // nested not queries are broken
+  test.skip('@media not (not (not (min-width: 400px)))', () => {
+    const query = '@media not (not (not (min-width: 400px)))';
+    const mediaQuery = MediaQuery.parser.parseToEnd(query);
+    expect(mediaQuery).toMatchInlineSnapshot(`
+      MediaQuery {
+        "queries": {
+          "rule": {
+            "key": "min-width",
+            "type": "pair",
+            "value": {
+              "signCharacter": undefined,
+              "type": "integer",
+              "unit": "px",
+              "value": 400,
+            },
+          },
+          "type": "not",
+        },
+      }
+    `);
+    expect(mediaQuery.toString()).toEqual('@media (min-width: 400px)');
+  });
+
   // not queries with multiple clauses are broken
   test.skip('@media not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px))', () => {
     const query =
@@ -1917,5 +1941,114 @@ describe('Test CSS Type: @media queries', () => {
       }
     `);
     expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
+  });
+  test('flattens nested and rules', () => {
+    const query =
+      '@media (min-width: 400px) and ((max-width: 700px) and (orientation: landscape))';
+    const mediaQuery = MediaQuery.parser.parseToEnd(query);
+    expect(mediaQuery).toMatchInlineSnapshot(`
+      MediaQuery {
+        "queries": {
+          "rules": [
+            {
+              "key": "min-width",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "px",
+                "value": 400,
+              },
+            },
+            {
+              "key": "max-width",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "px",
+                "value": 700,
+              },
+            },
+            {
+              "key": "orientation",
+              "type": "pair",
+              "value": "landscape",
+            },
+          ],
+          "type": "and",
+        },
+      }
+    `);
+    expect(mediaQuery.toString()).toEqual(
+      '@media (min-width: 400px) and (max-width: 700px) and (orientation: landscape)',
+    );
+  });
+
+  test.skip('flattens complex nested and rules', () => {
+    const query =
+      '@media ((min-width: 400px) and (print)) and ((max-width: 700px) and (orientation: landscape))';
+    const mediaQuery = MediaQuery.parser.parseToEnd(query);
+    expect(mediaQuery).toMatchInlineSnapshot(`
+      MediaQuery {
+        "queries": {
+          "rules": [
+            {
+              "key": "min-width",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "px",
+                "value": 400,
+              },
+            },
+            {
+              "key": "max-width",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "px",
+                "value": 700,
+              },
+            },
+            {
+              "key": "orientation",
+              "type": "pair",
+              "value": "landscape",
+            },
+          ],
+          "type": "and",
+        },
+      }
+    `);
+    expect(mediaQuery.toString()).toEqual(
+      '@media (min-width: 400px) and (max-width: 700px) and (orientation: landscape)',
+    );
+  });
+
+  // blocked by double not fix above
+  test.skip('removes duplicate nots', () => {
+    const query = '@media not (not (min-width: 400px))';
+    const mediaQuery = MediaQuery.parser.parseToEnd(query);
+    expect(mediaQuery).toMatchInlineSnapshot(`
+      MediaQuery {
+        "queries": {
+          "rule": {
+            "key": "min-width",
+            "type": "pair",
+            "value": {
+              "signCharacter": undefined,
+              "type": "integer",
+              "unit": "px",
+              "value": 400,
+            },
+          },
+          "type": "not",
+        },
+      }
+    `);
+    expect(mediaQuery.toString()).toEqual('@media (min-width: 400px)');
   });
 });

--- a/packages/style-value-parser/src/at-queries-from-tokens/__tests__/media-query-test.js
+++ b/packages/style-value-parser/src/at-queries-from-tokens/__tests__/media-query-test.js
@@ -12,8 +12,8 @@ import { MediaQuery } from '../media-query.js';
 
 describe('Test CSS Type: @media queries', () => {
   test('@media screen', () => {
-    expect(MediaQuery.parser.parseToEnd('@media screen'))
-      .toMatchInlineSnapshot(`
+    const query = '@media screen';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "screen",
@@ -22,10 +22,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media print', () => {
-    expect(MediaQuery.parser.parseToEnd('@media print')).toMatchInlineSnapshot(`
+    const query = '@media print';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "print",
@@ -34,11 +36,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (width: 100px)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (width: 100px)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (width: 100px)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "width",
@@ -52,11 +55,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (max-width: 50em)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (max-width: 50em)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (max-width: 50em)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "max-width",
@@ -70,11 +74,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (orientation: landscape)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (orientation: landscape)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (orientation: landscape)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "orientation",
@@ -83,23 +88,35 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
-  test('@media not (monochrome)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media not (monochrome)'))
-      .toMatchInlineSnapshot(`
+  test('@media not all and (monochrome)', () => {
+    const query = '@media not all and (monochrome)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
-          "keyValue": "monochrome",
-          "type": "word-rule",
+          "rules": [
+            {
+              "key": "all",
+              "not": true,
+              "type": "media-keyword",
+            },
+            {
+              "keyValue": "monochrome",
+              "type": "word-rule",
+            },
+          ],
+          "type": "and",
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media screen and (min-width: 400px)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media screen and (min-width: 400px)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media screen and (min-width: 400px)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -123,14 +140,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-height: 600px) and (orientation: landscape)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-height: 600px) and (orientation: landscape)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query = '@media (min-height: 600px) and (orientation: landscape)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -154,14 +169,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media screen and (device-aspect-ratio: 16/9)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media screen and (device-aspect-ratio: 16/9)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query = '@media screen and (device-aspect-ratio: 16/9)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -184,11 +197,14 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(
+      '@media screen and (device-aspect-ratio: 16 / 9)',
+    );
   });
 
   test('@media (device-height: 500px)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (device-height: 500px)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (device-height: 500px)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "device-height",
@@ -202,11 +218,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (color)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (color)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (color)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "keyValue": "color",
@@ -214,11 +231,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (color-index)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (color-index)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (color-index)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "keyValue": "color-index",
@@ -226,11 +244,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (monochrome)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (monochrome)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (monochrome)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "keyValue": "monochrome",
@@ -238,12 +257,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
-  // According to MDN, it should be `(grid: 1)` or `(grid: 0)`
   test('@media (grid)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (grid)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (grid)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "keyValue": "grid",
@@ -251,11 +270,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (update: fast)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (update: fast)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (update: fast)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "update",
@@ -264,11 +284,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (overflow-block: scroll)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (overflow-block: scroll)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (overflow-block: scroll)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "overflow-block",
@@ -277,11 +298,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (display-mode: fullscreen)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (display-mode: fullscreen)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (display-mode: fullscreen)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "display-mode",
@@ -290,9 +312,11 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (scripting: enabled)', () => {
+    const query = '@media (scripting: enabled)';
     expect(MediaQuery.parser.parseToEnd('@media (scripting: enabled)'))
       .toMatchInlineSnapshot(`
       MediaQuery {
@@ -303,9 +327,11 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (hover: hover)', () => {
+    const query = '@media (hover: hover)';
     expect(MediaQuery.parser.parseToEnd('@media (hover: hover)'))
       .toMatchInlineSnapshot(`
       MediaQuery {
@@ -316,9 +342,11 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (any-hover: none)', () => {
+    const query = '@media (any-hover: none)';
     expect(MediaQuery.parser.parseToEnd('@media (any-hover: none)'))
       .toMatchInlineSnapshot(`
       MediaQuery {
@@ -329,9 +357,11 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (pointer: coarse)', () => {
+    const query = '@media (pointer: coarse)';
     expect(MediaQuery.parser.parseToEnd('@media (pointer: coarse)'))
       .toMatchInlineSnapshot(`
       MediaQuery {
@@ -342,9 +372,11 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (any-pointer: fine)', () => {
+    const query = '@media (any-pointer: fine)';
     expect(MediaQuery.parser.parseToEnd('@media (any-pointer: fine)'))
       .toMatchInlineSnapshot(`
       MediaQuery {
@@ -355,9 +387,11 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (light-level: dim)', () => {
+    const query = '@media (light-level: dim)';
     expect(MediaQuery.parser.parseToEnd('@media (light-level: dim)'))
       .toMatchInlineSnapshot(`
       MediaQuery {
@@ -368,9 +402,11 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (inverted-colors: inverted)', () => {
+    const query = '@media (inverted-colors: inverted)';
     expect(MediaQuery.parser.parseToEnd('@media (inverted-colors: inverted)'))
       .toMatchInlineSnapshot(`
       MediaQuery {
@@ -381,9 +417,11 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (prefers-reduced-motion: reduce)', () => {
+    const query = '@media (prefers-reduced-motion: reduce)';
     expect(
       MediaQuery.parser.parseToEnd('@media (prefers-reduced-motion: reduce)'),
     ).toMatchInlineSnapshot(`
@@ -395,9 +433,11 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (prefers-contrast: more)', () => {
+    const query = '@media (prefers-contrast: more)';
     expect(MediaQuery.parser.parseToEnd('@media (prefers-contrast: more)'))
       .toMatchInlineSnapshot(`
       MediaQuery {
@@ -408,9 +448,11 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (forced-colors: active)', () => {
+    const query = '@media (forced-colors: active)';
     expect(MediaQuery.parser.parseToEnd('@media (forced-colors: active)'))
       .toMatchInlineSnapshot(`
       MediaQuery {
@@ -421,9 +463,11 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (prefers-reduced-transparency: reduce)', () => {
+    const query = '@media (prefers-reduced-transparency: reduce)';
     expect(
       MediaQuery.parser.parseToEnd(
         '@media (prefers-reduced-transparency: reduce)',
@@ -437,9 +481,11 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (orientation: portrait), (orientation: landscape)', () => {
+    const query = '@media (orientation: portrait), (orientation: landscape)';
     expect(
       MediaQuery.parser.parseToEnd(
         '@media (orientation: portrait), (orientation: landscape)',
@@ -463,14 +509,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 500px) or (max-width: 600px)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 500px) or (max-width: 600px)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query = '@media (min-width: 500px) or (max-width: 600px)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -499,11 +543,14 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(
+      '@media (min-width: 500px), (max-width: 600px)',
+    );
   });
 
   test('(width > 400px)', () => {
-    expect(mediaInequalityRuleParser.parseToEnd('(width > 400px)'))
-      .toMatchInlineSnapshot(`
+    const query = '(width > 400px)';
+    expect(mediaInequalityRuleParser.parseToEnd(query)).toMatchInlineSnapshot(`
       {
         "key": "min-width",
         "type": "pair",
@@ -517,8 +564,9 @@ describe('Test CSS Type: @media queries', () => {
     `);
   });
   test('(width >= 400px)', () => {
-    expect(mediaInequalityRuleParser.parseToEnd('(width >= 400px)'))
-      .toMatchInlineSnapshot(`
+    const query = '(width >= 400px)';
+
+    expect(mediaInequalityRuleParser.parseToEnd(query)).toMatchInlineSnapshot(`
       {
         "key": "min-width",
         "type": "pair",
@@ -533,11 +581,8 @@ describe('Test CSS Type: @media queries', () => {
   });
 
   test('@media (width >= 400px) and (width <= 700px)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (width >= 400px) and (width <= 700px)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query = '@media (width >= 400px) and (width <= 700px)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -566,11 +611,14 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(
+      '@media (min-width: 400px) and (max-width: 700px)',
+    );
   });
 
   test('@media (768px <= width <= 1280px)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (768px <= width <= 1280px)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (768px <= width <= 1280px)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -599,14 +647,14 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(
+      '@media (min-width: 768px) and (max-width: 1280px)',
+    );
   });
 
   test('@media (height > 500px) and (aspect-ratio: 16/9)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (height > 500px) and (aspect-ratio: 16/9)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query = '@media (height > 500px) and (aspect-ratio: 16/9)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -634,14 +682,15 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(
+      '@media (min-height: 500.01px) and (aspect-ratio: 16 / 9)',
+    );
   });
 
   test('@media (color) and (min-width: 400px), screen and (max-width: 700px)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (color) and (min-width: 400px), screen and (max-width: 700px)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (color) and (min-width: 400px), screen and (max-width: 700px)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -689,11 +738,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media not all and (monochrome)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media not all and (monochrome)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media not all and (monochrome)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -711,14 +761,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-aspect-ratio: 3/2) and (max-aspect-ratio: 16/9)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-aspect-ratio: 3/2) and (max-aspect-ratio: 16/9)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (min-aspect-ratio: 3 / 2) and (max-aspect-ratio: 16 / 9)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -745,14 +794,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-resolution: 300dpi) and (max-resolution: 600dpi)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-resolution: 300dpi) and (max-resolution: 600dpi)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (min-resolution: 300dpi) and (max-resolution: 600dpi)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -781,11 +829,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (scripting: none)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (scripting: none)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (scripting: none)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "scripting",
@@ -794,11 +843,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (update: slow)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (update: slow)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (update: slow)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "update",
@@ -807,11 +857,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (overflow-inline: none)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (overflow-inline: none)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (overflow-inline: none)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "overflow-inline",
@@ -820,11 +871,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (display-mode: minimal-ui)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (display-mode: minimal-ui)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (display-mode: minimal-ui)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "display-mode",
@@ -833,11 +885,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (hover: none)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (hover: none)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (hover: none)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "hover",
@@ -846,11 +899,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (any-hover: hover)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (any-hover: hover)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (any-hover: hover)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "any-hover",
@@ -859,11 +913,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (pointer: none)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (pointer: none)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (pointer: none)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "pointer",
@@ -872,11 +927,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (any-pointer: none)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (any-pointer: none)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (any-pointer: none)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "any-pointer",
@@ -885,11 +941,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (light-level: washed)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (light-level: washed)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (light-level: washed)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "light-level",
@@ -898,11 +955,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (inverted-colors: none)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (inverted-colors: none)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (inverted-colors: none)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "inverted-colors",
@@ -911,14 +969,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (prefers-reduced-motion: no-preference)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (prefers-reduced-motion: no-preference)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query = '@media (prefers-reduced-motion: no-preference)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "prefers-reduced-motion",
@@ -927,12 +983,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (prefers-contrast: no-preference)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd('@media (prefers-contrast: no-preference)'),
-    ).toMatchInlineSnapshot(`
+    const query = '@media (prefers-contrast: no-preference)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "prefers-contrast",
@@ -941,11 +997,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (forced-colors: none)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (forced-colors: none)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (forced-colors: none)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "forced-colors",
@@ -954,14 +1011,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (prefers-reduced-transparency: no-preference)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (prefers-reduced-transparency: no-preference)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query = '@media (prefers-reduced-transparency: no-preference)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "prefers-reduced-transparency",
@@ -970,6 +1025,7 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test.skip('@media (width: calc(100% - 20px))', () => {
@@ -991,8 +1047,8 @@ describe('Test CSS Type: @media queries', () => {
   });
 
   test('@media (aspect-ratio: 16 / 9)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (aspect-ratio: 16 / 9)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (aspect-ratio: 16 / 9)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "aspect-ratio",
@@ -1005,11 +1061,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (device-aspect-ratio: 16 / 9)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (device-aspect-ratio: 16 / 9)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (device-aspect-ratio: 16 / 9)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "device-aspect-ratio",
@@ -1022,11 +1079,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-resolution: 150dpi)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (min-resolution: 150dpi)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (min-resolution: 150dpi)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "min-resolution",
@@ -1040,29 +1098,33 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (max-resolution: 600dppx)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (max-resolution: 600dppx)'))
-      .toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "max-resolution",
-          "type": "pair",
-          "value": {
-            "signCharacter": undefined,
-            "type": "integer",
-            "unit": "dppx",
-            "value": 600,
+    const query = '@media (max-resolution: 600dppx)';
+
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "max-resolution",
+            "type": "pair",
+            "value": {
+              "signCharacter": undefined,
+              "type": "integer",
+              "unit": "dppx",
+              "value": 600,
+            },
           },
-        },
-      }
+        }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (color-gamut: srgb)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (color-gamut: srgb)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (color-gamut: srgb)';
+
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "color-gamut",
@@ -1071,11 +1133,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (display-mode: standalone)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (display-mode: standalone)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (display-mode: standalone)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "display-mode",
@@ -1084,14 +1147,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (orientation: landscape) and (pointer: fine)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (orientation: landscape) and (pointer: fine)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query = '@media (orientation: landscape) and (pointer: fine)';
+
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1110,11 +1172,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (prefers-color-scheme: dark)', () => {
-    expect(MediaQuery.parser.parseToEnd('@media (prefers-color-scheme: dark)'))
-      .toMatchInlineSnapshot(`
+    const query = '@media (prefers-color-scheme: dark)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "key": "prefers-color-scheme",
@@ -1123,14 +1186,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (prefers-reduced-motion: reduce) and (update: slow)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (prefers-reduced-motion: reduce) and (update: slow)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query = '@media (prefers-reduced-motion: reduce) and (update: slow)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1149,12 +1210,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (width: 500px), (height: 400px)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd('@media (width: 500px), (height: 400px)'),
-    ).toMatchInlineSnapshot(`
+    const query = '@media (width: 500px), (height: 400px)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1183,14 +1244,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media not all and (monochrome) and (min-width: 600px)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media not all and (monochrome) and (min-width: 600px)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query = '@media not all and (monochrome) and (min-width: 600px)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1218,14 +1277,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 768px) and (max-width: 991px)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 768px) and (max-width: 991px)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query = '@media (min-width: 768px) and (max-width: 991px)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1254,14 +1311,12 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 1200px) and (orientation: landscape)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 1200px) and (orientation: landscape)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query = '@media (min-width: 1200px) and (orientation: landscape)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1285,14 +1340,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 992px) and (max-width: 1199px) and (pointer: fine)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 992px) and (max-width: 1199px) and (pointer: fine)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (min-width: 992px) and (max-width: 1199px) and (pointer: fine)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1326,14 +1380,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 576px) and (max-width: 767px) and (hover: none)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 576px) and (max-width: 767px) and (hover: none)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (min-width: 576px) and (max-width: 767px) and (hover: none)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1367,14 +1420,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 576px), (orientation: portrait) and (max-width: 767px)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 576px), (orientation: portrait) and (max-width: 767px)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (min-width: 576px), (orientation: portrait) and (max-width: 767px)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1413,14 +1465,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 768px) and (max-width: 991px), (orientation: landscape)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 768px) and (max-width: 991px), (orientation: landscape)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (min-width: 768px) and (max-width: 991px), (orientation: landscape)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1459,14 +1510,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1515,14 +1565,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1571,14 +1620,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 576px), (orientation: portrait) and (max-width: 767px), (prefers-color-scheme: dark)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 576px), (orientation: portrait) and (max-width: 767px), (prefers-color-scheme: dark)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (min-width: 576px), (orientation: portrait) and (max-width: 767px), (prefers-color-scheme: dark)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1622,14 +1670,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 768px) and (max-width: 991px), (orientation: landscape) and (update: fast), (prefers-reduced-motion: reduce)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 768px) and (max-width: 991px), (orientation: landscape) and (update: fast), (prefers-reduced-motion: reduce)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (min-width: 768px) and (max-width: 991px), (orientation: landscape) and (update: fast), (prefers-reduced-motion: reduce)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1683,14 +1730,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover), (any-pointer: coarse) and (any-hover: none)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover), (any-pointer: coarse) and (any-hover: none)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover), (any-pointer: coarse) and (any-hover: none)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1754,14 +1800,13 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse), (prefers-reduced-transparency: reduce) and (forced-colors: active)', () => {
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse), (prefers-reduced-transparency: reduce) and (forced-colors: active)',
-      ),
-    ).toMatchInlineSnapshot(`
+    const query =
+      '@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse), (prefers-reduced-transparency: reduce) and (forced-colors: active)';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
           "rules": [
@@ -1825,5 +1870,52 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
+  });
+
+  // not queries with multiple clauses are broken
+  test.skip('@media not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px))', () => {
+    const query =
+      '@media not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px))';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
+      MediaQuery {
+        "queries": {
+          "rules": [
+            {
+              "key": "min-width",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "px",
+                "value": 500,
+              },
+            },
+            {
+              "key": "max-width",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "px",
+                "value": 600,
+              },
+            },
+            {
+              "key": "max-width",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "px",
+                "value": 400,
+              },
+            },
+          ],
+          "type": "and",
+        },
+      }
+    `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 });

--- a/packages/style-value-parser/src/properties/__tests__/border-radius.test.js
+++ b/packages/style-value-parser/src/properties/__tests__/border-radius.test.js
@@ -198,7 +198,7 @@ describe('Test CSS property shorthand: `border-radius`', () => {
     );
   });
 
-  // Assymentric border-radius
+  // Asymmetric border-radius
   test('Valid: border-radius: <length-percentage> / <length-percentage>', () => {
     expect(BorderRadiusShorthand.parse.parseToEnd('10px / 20px')).toEqual(
       new BorderRadiusShorthand(


### PR DESCRIPTION
## What changed / motivation ?

Addes a new `normalize` function in the parser to flatten nested ands and remove unnecessary negations (negations % 2) 

To flatten ands:
  - When the function encounters an `and` rule, it loops over each of its child rules
  - If a child rule is also an `and` rule, its own child rules are merged (or "spread") into the parent `and` rule
  - Results in one `and` rule containing all the conditions on the same level

Remove nested nots:
  - When a `not` rule is encountered, the function recursively normalizes its inner rule and counts consecutive `not` wrappers.  
    - If the count is **even**, the negations cancel out, and the inner rule is returned as if no `not` was applied
    - If the count is **odd**, the result is a single `not` wrapping the innermost rule
  - This cancellation avoids unnecessary nesting and keeps the final query concise

Also fixes:
- Previous `toString` implementation errors
- Tests for `toString` fx in media query parsing. We want to ensure that if we parse a media query and convert it back to a string that we should get the same output.
- Added tests for flattening ands

Note: There's a small number of media query edge cases that are failing with the current parser implementation that we will have to investigate. Double negations cannot be fully tested until then

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code