### PR TITLE
Add a CHANGELOG file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## 0.12.0 (TBD, 2025)
+
+### New features
+
+* Hash keys in compiled style objects to reduce generated code size.
+
+### Deprecations
+
+* Deprecate `dev-runtime` package.
+* Deprecate `esbuild-plugin` package.
+* Deprecate `nextjs-plugin` package.
+* Deprecate `open-props` package.
+* Deprecate `webpack-plugin` package.
+
+
+## 0.11.1 (Mar 3, 2025)
+
+### Fixes
+
+* Fix `style.create` compilation regression for string and number keys.
+* Fix babel path resolution within monorepos.
+
+
+## 0.11.0 (Feb 27, 2025)


### PR DESCRIPTION
## What changed / motivation ?

This patch adds a CHANGELOG file to the root of the repo (see [this example](https://github.com/facebook/react-strict-dom/blob/main/CHANGELOG.md)) that starts logging changed since 0.11.0. This file will provide a simple way for us to document notable changes between releases that developers should be aware of.