### PR TITLE
Improve monorepo eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,12 +7,14 @@
  *
  */
 
+const path = require('path');
+
 module.exports = {
   settings: {
     react: {
       pragma: 'React',
-      version: '17.0',
-      flowVersion: '0.214.0', // Flow version
+      version: '18.0',
+      flowVersion: '0.261.2', // Flow version
     },
     'ft-flow': {
       onlyFilesWithFlowAnnotation: true,
@@ -21,7 +23,7 @@ module.exports = {
   // babel parser to support ES6/7 features
   parser: 'hermes-eslint',
   extends: ['plugin:ft-flow/recommended', 'prettier'],
-  plugins: ['ft-flow', 'react', 'header'],
+  plugins: ['ft-flow', 'react', 'headers'],
   env: {
     browser: true,
     es6: true,
@@ -32,7 +34,7 @@ module.exports = {
     'build',
     'coverage',
     'dist',
-    'examples',
+    'flow-typed',
     'lib',
     'node_modules',
     'next-env.d.ts',
@@ -61,19 +63,12 @@ module.exports = {
     Partial: 'readonly',
   },
   rules: {
-    'header/header': [
-      2,
-      'block',
-      [
-        '*',
-        ' * Copyright (c) Meta Platforms, Inc. and affiliates.',
-        ' *',
-        ' * This source code is licensed under the MIT license found in the',
-        ' * LICENSE file in the root directory of this source tree.',
-        ' *',
-        { pattern: '(.*)?', template: ' *' },
-        ' ',
-      ],
+    'headers/header-format': [
+      'error',
+      {
+        source: 'file',
+        path: path.join(__dirname, './tools/eslint/copyright-header.txt'),
+      },
     ],
     camelcase: 0,
     'constructor-super': 2,

--- a/examples/example-cli/source/app/Counter.tsx
+++ b/examples/example-cli/source/app/Counter.tsx
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use client';

--- a/examples/example-esbuild/scripts/build.mjs
+++ b/examples/example-esbuild/scripts/build.mjs
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import path from 'path';

--- a/examples/example-rollup/rollup.config.mjs
+++ b/examples/example-rollup/rollup.config.mjs
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import stylexPlugin from '@stylexjs/rollup-plugin';

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint": "8.57.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-ft-flow": "^3.0.11",
+        "eslint-plugin-headers": "~1.2.1",
         "eslint-plugin-react": "^7.37.1",
         "flow-bin": "^0.261.2",
         "hermes-eslint": "^0.26.0",
@@ -11702,14 +11703,17 @@
         "hermes-eslint": ">=0.15.0"
       }
     },
-    "node_modules/eslint-plugin-header": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
-      "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
+    "node_modules/eslint-plugin-headers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-headers/-/eslint-plugin-headers-1.2.1.tgz",
+      "integrity": "sha512-1L41t3DPrXFP6YLK+sAj0xDMGVHpQwI+uGefDwc1bKP91q65AIZoXzQgI7MjZJxB6sK8/vYhXMD8x0V8xLNxJA==",
       "dev": true,
-      "license": "MIT",
+      "license": "ISC",
+      "engines": {
+        "node": "^16.0.0 || >= 18.0.0"
+      },
       "peerDependencies": {
-        "eslint": ">=7.7.0"
+        "eslint": ">=7"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -25938,7 +25942,6 @@
         "clean-css": "^5.3.2",
         "eslint": "^8.57.1",
         "eslint-config-airbnb": "^19.0.4",
-        "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "eslint-plugin-react": "^7.30.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prettier": "prettier --write \"**/*.js\" \"**/*.ts\"",
     "prettier:report": "prettier --check \"**/*.js\"",
     "lint": "npm run lint:report -- --fix",
-    "lint:report": "eslint packages tools",
+    "lint:report": "eslint . --ext .js,.jsx,.mjs",
     "release": "tools/npm/release.js",
     "test:packages": "npm run test --workspaces --if-present",
     "test": "npm run build && npm run flow && npm run test:packages && npm run prettier:report && npm run lint:report"
@@ -30,6 +30,7 @@
     "eslint": "8.57.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-ft-flow": "^3.0.11",
+    "eslint-plugin-headers": "~1.2.1",
     "eslint-plugin-react": "^7.37.1",
     "flow-bin": "^0.261.2",
     "hermes-eslint": "^0.26.0",

--- a/packages/babel-plugin/__tests__/evaluation/stylex-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-evaluation-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/evaluation/stylex-fn-obj-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-fn-obj-evaluation-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
+++ b/packages/babel-plugin/__tests__/evaluation/stylex-import-evaluation-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-metadata-test.js
+++ b/packages/babel-plugin/__tests__/stylex-metadata-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-call-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-call-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-create-theme-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-theme-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-define-vars-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-import-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-import-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-keyframes-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-keyframes-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-legacy-shorthands-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-legacy-shorthands-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-logical-properties-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-logical-properties-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-logical-values-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-logical-values-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-polyfills-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-polyfills-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-pre-plugin-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-pre-plugin-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-stylex-attrs-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-stylex-attrs-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-value-normalize-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-value-normalize-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/__tests__/stylex-transform-variable-removal-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-variable-removal-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/babel-plugin/rollup.config.mjs
+++ b/packages/babel-plugin/rollup.config.mjs
@@ -3,10 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
-
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';

--- a/packages/benchmarks/size/compare.js
+++ b/packages/benchmarks/size/compare.js
@@ -4,8 +4,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/benchmarks/size/fixture/index.js
+++ b/packages/benchmarks/size/fixture/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/benchmarks/size/fixture/lotsOfStylesDynamic.js
+++ b/packages/benchmarks/size/fixture/lotsOfStylesDynamic.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/benchmarks/size/run.js
+++ b/packages/benchmarks/size/run.js
@@ -4,8 +4,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/__tests__/__mocks__/snapshot/components/button.js
+++ b/packages/cli/__tests__/__mocks__/snapshot/components/button.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/__tests__/__mocks__/snapshot/index.js
+++ b/packages/cli/__tests__/__mocks__/snapshot/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/__tests__/__mocks__/snapshot/pages/home.js
+++ b/packages/cli/__tests__/__mocks__/snapshot/pages/home.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/__tests__/__mocks__/snapshot/stylex_bundle.css
+++ b/packages/cli/__tests__/__mocks__/snapshot/stylex_bundle.css
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
  @keyframes xgnty7z-B{0%{opacity:.25;}100%{opacity:1;}}

--- a/packages/cli/__tests__/__mocks__/snapshot2/components/button.js
+++ b/packages/cli/__tests__/__mocks__/snapshot2/components/button.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/__tests__/__mocks__/snapshot2/index.js
+++ b/packages/cli/__tests__/__mocks__/snapshot2/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/__tests__/__mocks__/snapshot2/pages/home.js
+++ b/packages/cli/__tests__/__mocks__/snapshot2/pages/home.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/__tests__/__mocks__/source/components/button.js
+++ b/packages/cli/__tests__/__mocks__/source/components/button.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/__tests__/__mocks__/source/index.js
+++ b/packages/cli/__tests__/__mocks__/source/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/__tests__/__mocks__/source/pages/home.js
+++ b/packages/cli/__tests__/__mocks__/source/pages/home.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/__tests__/__mocks__/source2/components/button.js
+++ b/packages/cli/__tests__/__mocks__/source2/components/button.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/__tests__/__mocks__/source2/index.js
+++ b/packages/cli/__tests__/__mocks__/source2/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/__tests__/__mocks__/source2/pages/home.js
+++ b/packages/cli/__tests__/__mocks__/source2/pages/home.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/cli/rollup.config.mjs
+++ b/packages/cli/rollup.config.mjs
@@ -3,10 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
-
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';

--- a/packages/cli/src/cache.js
+++ b/packages/cli/src/cache.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 import fs from 'fs/promises';
 import path from 'path';

--- a/packages/docs/.eslintrc.js
+++ b/packages/docs/.eslintrc.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 module.exports = {

--- a/packages/docs/components/AnimatedGradientBox/AnimatedGradientBox.js
+++ b/packages/docs/components/AnimatedGradientBox/AnimatedGradientBox.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import * as React from 'react';

--- a/packages/docs/components/AnimatedGradientBox/tokens.stylex.js
+++ b/packages/docs/components/AnimatedGradientBox/tokens.stylex.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import * as stylex from '@stylexjs/stylex';

--- a/packages/docs/components/CtaButton.js
+++ b/packages/docs/components/CtaButton.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import * as React from 'react';

--- a/packages/docs/components/Dial.js
+++ b/packages/docs/components/Dial.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 import React, { useState, useRef } from 'react';
 import stylex from '@stylexjs/stylex';

--- a/packages/docs/components/LoadingSpinner.js
+++ b/packages/docs/components/LoadingSpinner.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import * as React from 'react';

--- a/packages/docs/components/LogoDownloadModal.js
+++ b/packages/docs/components/LogoDownloadModal.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import React, { useRef, useEffect } from 'react';

--- a/packages/docs/components/ZStack.js
+++ b/packages/docs/components/ZStack.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import React from 'react';

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -33,7 +33,6 @@
     "clean-css": "^5.3.2",
     "eslint": "^8.57.1",
     "eslint-config-airbnb": "^19.0.4",
-    "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.30.1",

--- a/packages/docs/src/pages/index.js
+++ b/packages/docs/src/pages/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import * as React from 'react';

--- a/packages/docs/src/pages/playground.js
+++ b/packages/docs/src/pages/playground.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import * as React from 'react';

--- a/packages/docs/src/theme/Footer/index.js
+++ b/packages/docs/src/theme/Footer/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import React from 'react';

--- a/packages/docs/src/theme/Logo/index.js
+++ b/packages/docs/src/theme/Logo/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import React, { useState } from 'react';

--- a/packages/docs/src/theme/MDXComponents/Details.js
+++ b/packages/docs/src/theme/MDXComponents/Details.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 import * as React from 'react';

--- a/packages/eslint-plugin/__tests__/stylex-enforce-extension-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-enforce-extension-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/eslint-plugin/__tests__/stylex-no-unused-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-no-unused-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';

--- a/packages/postcss-plugin/src/builder.js
+++ b/packages/postcss-plugin/src/builder.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 const path = require('node:path');

--- a/packages/postcss-plugin/src/bundler.js
+++ b/packages/postcss-plugin/src/bundler.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 const babel = require('@babel/core');

--- a/packages/postcss-plugin/src/index.js
+++ b/packages/postcss-plugin/src/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 const postcss = require('postcss');

--- a/packages/rollup-plugin/__tests__/__fixtures__/index.js
+++ b/packages/rollup-plugin/__tests__/__fixtures__/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 // index.js

--- a/packages/rollup-plugin/__tests__/__fixtures__/npmStyles.js
+++ b/packages/rollup-plugin/__tests__/__fixtures__/npmStyles.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 // npmStyles.js

--- a/packages/rollup-plugin/__tests__/__fixtures__/otherStyles.js
+++ b/packages/rollup-plugin/__tests__/__fixtures__/otherStyles.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 // otherStyles.js

--- a/packages/rollup-plugin/__tests__/index-test.js
+++ b/packages/rollup-plugin/__tests__/index-test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';
@@ -138,8 +136,6 @@ describe('rollup-plugin-stylex', () => {
        *
        * This source code is licensed under the MIT license found in the
        * LICENSE file in the root directory of this source tree.
-       *
-       *
        */
 
       var styles$2 = {
@@ -155,8 +151,6 @@ describe('rollup-plugin-stylex', () => {
        *
        * This source code is licensed under the MIT license found in the
        * LICENSE file in the root directory of this source tree.
-       *
-       *
        */
 
       const styles$1 = {
@@ -173,8 +167,6 @@ describe('rollup-plugin-stylex', () => {
        *
        * This source code is licensed under the MIT license found in the
        * LICENSE file in the root directory of this source tree.
-       *
-       *
        */
 
       var styles = {
@@ -229,8 +221,6 @@ describe('rollup-plugin-stylex', () => {
          *
          * This source code is licensed under the MIT license found in the
          * LICENSE file in the root directory of this source tree.
-         *
-         *
          */
 
         var _inject2$2 = _inject;
@@ -240,7 +230,7 @@ describe('rollup-plugin-stylex', () => {
           bar: {
             "display-k1xSpc": "display-x1lliihq",
             "width-kzqmXN": "width-xh8yej3",
-            $$css: "__fixtures__/otherStyles.js:16"
+            $$css: "__fixtures__/otherStyles.js:14"
           }
         };
 
@@ -249,8 +239,6 @@ describe('rollup-plugin-stylex', () => {
          *
          * This source code is licensed under the MIT license found in the
          * LICENSE file in the root directory of this source tree.
-         *
-         *
          */
 
         var _inject2$1 = _inject;
@@ -262,7 +250,7 @@ describe('rollup-plugin-stylex', () => {
             "display-k1xSpc": "display-xt0psk2",
             "height-kZKoxP": "height-x1egiwwb",
             "width-kzqmXN": "width-x3hqpx7",
-            $$css: "__fixtures__/npmStyles.js:17"
+            $$css: "__fixtures__/npmStyles.js:15"
           }
         };
 
@@ -271,8 +259,6 @@ describe('rollup-plugin-stylex', () => {
          *
          * This source code is licensed under the MIT license found in the
          * LICENSE file in the root directory of this source tree.
-         *
-         *
          */
 
         var _inject2 = _inject;
@@ -307,7 +293,7 @@ describe('rollup-plugin-stylex', () => {
             "borderStartStartRadius-krdFHd": "borderStartStartRadius-xu4yf9m",
             "borderTopLeftRadius-kIxVMA": null,
             "borderTopRightRadius-ksF3WI": null,
-            $$css: "__fixtures__/index.js:26"
+            $$css: "__fixtures__/index.js:24"
           }
         };
         function App() {

--- a/packages/scripts/flow-translator/flow-module-utils.js
+++ b/packages/scripts/flow-translator/flow-module-utils.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 const fsPromises = require('fs/promises');

--- a/packages/scripts/flow-translator/generate-types.js
+++ b/packages/scripts/flow-translator/generate-types.js
@@ -4,8 +4,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 const fsPromises = require('fs/promises');

--- a/packages/scripts/flow-translator/rewrite-imports.js
+++ b/packages/scripts/flow-translator/rewrite-imports.js
@@ -4,8 +4,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 const fs = require('fs').promises;

--- a/packages/shared/__tests__/stylex-transform-value.js
+++ b/packages/shared/__tests__/stylex-transform-value.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 import transformValue from '../src/transform-value';
 

--- a/tools/eslint/copyright-header.txt
+++ b/tools/eslint/copyright-header.txt
@@ -1,0 +1,4 @@
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.

--- a/tools/npm/release.js
+++ b/tools/npm/release.js
@@ -4,8 +4,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 
 'use strict';


### PR DESCRIPTION
1. Fix the copyright header lint rule. Extra blank comment lines are now avoided. All pragmas are preserved.
2. Get eslint to process `*.mjs` files.
3. Update the React and Flow versions specified in the config.
4. Lint the example directories.