### PR TITLE
chore: disallow spreading in stylex.create

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-validation-declarations-test.js
+++ b/packages/babel-plugin/__tests__/stylex-validation-declarations-test.js
@@ -127,3 +127,21 @@ describe.skip('@stylexjs/babel-plugin', () => {
     });
   });
 });
+
+describe('stylex.create validation', () => {
+  test('throws on object spread in stylex.create', () => {
+    expect(() =>
+      transform(
+        `
+        import stylex from 'stylex';
+        const shared = { foo: { color: 'red' } };
+        const styles = stylex.create({
+          ...shared,
+          bar: { color: 'blue' }
+        });
+      `,
+        { filename: '/src/Foo.js' },
+      ),
+    ).toThrow(messages.NO_OBJECT_SPREADS);
+  });
+});

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -351,11 +351,18 @@ function validateStyleXCreate(path: NodePath<t.CallExpression>) {
       SyntaxError,
     );
   }
-  if (path.node.arguments[0].type !== 'ObjectExpression') {
+
+  const arg = path.node.arguments[0];
+  if (arg.type !== 'ObjectExpression') {
     throw path.buildCodeFrameError(
       messages.NON_OBJECT_FOR_STYLEX_CALL,
       SyntaxError,
     );
+  }
+
+  const hasSpread = arg.properties.some((prop) => t.isSpreadElement(prop));
+  if (hasSpread) {
+    throw path.buildCodeFrameError(messages.NO_OBJECT_SPREADS, SyntaxError);
   }
 }
 

--- a/packages/docs/docs/learn/04-styling-ui/01-defining-styles.mdx
+++ b/packages/docs/docs/learn/04-styling-ui/01-defining-styles.mdx
@@ -31,6 +31,7 @@ The following are **not** allowed:
 - Function calls (except StyleX functions)
 - Values imported from other modules (except for CSS Variables created using
   StyleX from a `.stylex.js` file.)
+- Object spreads (e.g., `{...style}`)
 
 ## Creating styles
 

--- a/packages/shared/src/messages.js
+++ b/packages/shared/src/messages.js
@@ -69,3 +69,5 @@ export const ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS =
   'Only named parameters are allowed in Dynamic Style functions. Destructuring, spreading or default values are not allowed.';
 export const NON_CONTIGUOUS_VARS =
   'All variables passed to `stylex.firstThatWorks` must be contiguous.';
+export const NO_OBJECT_SPREADS =
+  'Object spreads are not allowed in stylex.create call.';


### PR DESCRIPTION
## Context

Explicitly disallow spreads within `stylex.create()` calls in the docs for planned js runtime merging optimizations. Update docs to reflect this.

## Testing

Added test with object spread in `stylex.create()` to ensure throw.

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code