### PR TITLE
feat: add new eslint rule for flagging legacy media query/pseudo class syntax

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -42,12 +42,13 @@ opening your ESLint configuration file and adding the plugin and rules.
 ### @stylexjs/valid-styles
 
 StyleX requires styles that are statically analyzable. This rule will detect
-invalid styles that StyleX cannot handle and provides basic type checking for style values.
+invalid styles that StyleX cannot handle and provides basic type checking for
+style values.
 
 #### Disallowed CSS properties and suggested fixes
 
-Listed are common CSS properties that are **not allowed** in StyleX, along
-with their **suggested replacements**.
+Listed are common CSS properties that are **not allowed** in StyleX, along with
+their **suggested replacements**.
 
 ### @stylexjs/sort-keys
 
@@ -132,3 +133,33 @@ using `stylex.defineVars()`.
 
 This rule flags unused styles created with `stylex.create(...)`. If a style key
 is defined but never used, the rule auto-strips them from the create call.
+
+### `stylex-no-legacy-media-queries`
+
+This rule flags usages of the original media query/pseudo class syntax that
+wraps multiple property values within a single @-rule or pseudo class like this:
+
+```js
+const styles = stylex.create({
+  root: {
+    width: '100%',
+    '@media (min-width: 600px)': {
+      width: '50%',
+    },
+  },
+});
+```
+
+This syntax is deprecated and should be replaced with the new syntax specified
+[here](https://stylexjs.com/docs/learn/styling-ui/defining-styles/#media-queries-and-other--rules)
+
+```js
+const styles = stylex.create({
+  root: {
+    width: {
+      default: '100%',
+      '@media (min-width: 600px)': '50%',
+    },
+  },
+});
+```

--- a/packages/eslint-plugin/__tests__/stylex-no-legacy-media-queries-test.js
+++ b/packages/eslint-plugin/__tests__/stylex-no-legacy-media-queries-test.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const { RuleTester: ESLintTester } = require('eslint');
+const rule = require('../src/stylex-no-legacy-media-queries');
+
+const eslintTester = new ESLintTester({
+  parser: require.resolve('hermes-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+eslintTester.run('stylex-no-legacy-media-queries', rule.default, {
+  valid: [
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          '::placeholder': {
+            color: '#999',
+          },
+          width: {
+            default: '100%',
+            '@media (min-width: 600px)': {
+              default: '50%',
+              '@media screen': '40%'
+            },
+          }
+        },
+        ':dummy': {
+          color: '#999',
+        }
+      });
+    `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      import stylex from 'stylex';
+      const styles = stylex.create({
+        main: {
+          width: '100%',
+          '@media (min-width: 600px)': {
+            width: '50%',
+          }
+        }
+      });
+      `,
+      errors: [
+        {
+          message:
+            'This media query syntax is deprecated. Use the new syntax specified here: https://stylexjs.com/docs/learn/styling-ui/defining-styles/#media-queries-and-other--rules',
+        },
+      ],
+    },
+    {
+      code: `
+      import {create} from '@stylexjs/stylex';
+      const styles = create({
+        main: {
+          width: '100%',
+          ':hover': {
+            width: '50%',
+          }
+        }
+      });
+      `,
+      errors: [
+        {
+          message:
+            'This pseudo class syntax is deprecated. Use the new syntax specified here: https://stylexjs.com/docs/learn/styling-ui/defining-styles/#pseudo-classes',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -11,17 +11,20 @@ import validStyles from './stylex-valid-styles';
 import sortKeys from './stylex-sort-keys';
 import validShorthands from './stylex-valid-shorthands';
 import noUnused from './stylex-no-unused';
+import noLegacyMediaQueries from './stylex-no-legacy-media-queries';
 
 const rules: {
   'valid-styles': typeof validStyles,
   'sort-keys': typeof sortKeys,
   'valid-shorthands': typeof validShorthands,
   'no-unused': typeof noUnused,
+  'no-legacy-media-queries': typeof noLegacyMediaQueries,
 } = {
   'valid-styles': validStyles,
   'sort-keys': sortKeys,
   'valid-shorthands': validShorthands,
   'no-unused': noUnused,
+  'no-legacy-media-queries': noLegacyMediaQueries,
 };
 
 export { rules };

--- a/packages/eslint-plugin/src/stylex-no-legacy-media-queries.js
+++ b/packages/eslint-plugin/src/stylex-no-legacy-media-queries.js
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+import type { Node, ImportDeclaration, CallExpression } from 'estree';
+/*:: import { Rule } from 'eslint'; */
+
+type Schema = {
+  validImports: Array<string>,
+  minKeys: number,
+  allowLineSeparatedGroups: boolean,
+};
+
+const stylexNoLegacyMediaQueries = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow legacy media query/pseudo class syntax',
+      recommended: true,
+      url: 'https://github.com/facebook/stylex/tree/main/packages/eslint-plugin',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validImports: {
+            type: 'array',
+            items: { type: 'string' },
+            default: ['stylex', '@stylexjs/stylex'],
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context: Rule.RuleContext): { ... } {
+    const {
+      validImports: importsToLookFor = ['stylex', '@stylexjs/stylex'],
+    }: Schema = context.options[0] || {};
+
+    const styleXDefaultImports = new Set<string>();
+    const styleXCreateImports = new Set<string>();
+
+    function isStylexCreateCallee(node: Node) {
+      return (
+        (node.type === 'MemberExpression' &&
+          node.object.type === 'Identifier' &&
+          styleXDefaultImports.has(node.object.name) &&
+          node.property.type === 'Identifier' &&
+          node.property.name === 'create') ||
+        (node.type === 'Identifier' && styleXCreateImports.has(node.name))
+      );
+    }
+
+    function isStylexCreateDeclaration(node: Node) {
+      return (
+        node &&
+        node.type === 'CallExpression' &&
+        isStylexCreateCallee(node.callee) &&
+        node.arguments.length === 1
+      );
+    }
+
+    return {
+      ImportDeclaration(node: ImportDeclaration): void {
+        if (
+          node.source.type !== 'Literal' ||
+          typeof node.source.value !== 'string'
+        ) {
+          return;
+        }
+
+        if (!importsToLookFor.includes(node.source.value)) {
+          return;
+        }
+
+        node.specifiers.forEach((specifier) => {
+          if (
+            specifier.type === 'ImportDefaultSpecifier' ||
+            specifier.type === 'ImportNamespaceSpecifier'
+          ) {
+            styleXDefaultImports.add(specifier.local.name);
+          }
+
+          if (
+            specifier.type === 'ImportSpecifier' &&
+            specifier.imported.name === 'create'
+          ) {
+            styleXCreateImports.add(specifier.local.name);
+          }
+        });
+      },
+
+      CallExpression(node: CallExpression): void {
+        const firstArg = node.arguments[0];
+        if (
+          isStylexCreateDeclaration(node) &&
+          firstArg.type === 'ObjectExpression'
+        ) {
+          // Loop through the named styles
+          firstArg.properties.forEach((property) => {
+            // we only care about properties with object values
+            if (
+              property.type !== 'Property' ||
+              property.value.type !== 'ObjectExpression'
+            ) {
+              return;
+            }
+
+            // Loop through the properties of the named style
+            property.value.properties.forEach((property) => {
+              // again, we only care about properties with object values
+              if (
+                property.type !== 'Property' ||
+                property.value.type !== 'ObjectExpression'
+              ) {
+                return;
+              }
+
+              // Verify that the property is not a media query
+              if (
+                property.key.type === 'Literal' &&
+                typeof property.key.value === 'string' &&
+                property.key.value.startsWith('@')
+              ) {
+                context.report({
+                  node: property,
+                  message:
+                    'This media query syntax is deprecated. Use the new syntax specified here: https://stylexjs.com/docs/learn/styling-ui/defining-styles/#media-queries-and-other--rules',
+                });
+              }
+
+              // Verify the property is not a pseudo selector (but pseudo elements are ok)
+              if (property.key.type === 'Literal') {
+                const literalValue = property.key.value;
+                if (
+                  typeof literalValue === 'string' &&
+                  literalValue.startsWith(':') &&
+                  !literalValue.startsWith('::')
+                )
+                  context.report({
+                    node: property,
+                    message:
+                      'This pseudo class syntax is deprecated. Use the new syntax specified here: https://stylexjs.com/docs/learn/styling-ui/defining-styles/#pseudo-classes',
+                  });
+              }
+            });
+          });
+        }
+      },
+    };
+  },
+};
+
+export default stylexNoLegacyMediaQueries as typeof stylexNoLegacyMediaQueries;


### PR DESCRIPTION

# Summary:

This diff adds a new eslint rule for flagging usage of stylex's legacy media query/pseudo class syntax that looks like this:

```js
const styles = stylex.create({
  root: {
    width: '100%',
   '@media (min-width: 600px)': {
      width: '50%',
    }
  }
});
```

The lint messages direct developers to instead use this syntax:

```js
const styles = stylex.create({
  root: {
    width: {
      default: '100%',
      '@media (min-width: 600px)': '50%'
    }
  }
});
```

The new lint rule is notably not auto-fixable in this diff but that is something I'm going to be working on next.

# Test Plan:

I introduced new eslint "RuleTester" tests that are passing.
