### PR TITLE
Replace $Rest in stylex

### DIFF
--- a/packages/stylex/src/StyleXTypes.js
+++ b/packages/stylex/src/StyleXTypes.js
@@ -56,7 +56,7 @@ export type XStyle<+T = NestedCSSPropTypes> = StyleXArray<
   false | ?$ReadOnly<{ ...T, $$css: true }>,
 >;
 export type XStyleWithout<+T: { +[string]: mixed }> = XStyle<
-  $ReadOnly<$Rest<NestedCSSPropTypes, $Exact<T>>>,
+  $ReadOnly<$Diff<NestedCSSPropTypes, $Exact<T>>>,
 >;
 
 export type Keyframes = $ReadOnly<{ [name: string]: CSSProperties, ... }>;
@@ -117,7 +117,7 @@ export type StaticStyles<+CSS: { +[string]: mixed } = CSSPropertiesWithExtras> =
   StyleXArray<false | ?GenStylePropType<$ReadOnly<CSS>>>;
 
 export type StaticStylesWithout<+CSS: { +[string]: mixed }> = StaticStyles<
-  $Rest<CSSPropertiesWithExtras, $ReadOnly<CSS>>,
+  Omit<CSSPropertiesWithExtras, $Keys<CSS>>,
 >;
 
 export type StyleXStyles<+CSS: { +[string]: mixed } = CSSPropertiesWithExtras> =
@@ -128,7 +128,7 @@ export type StyleXStyles<+CSS: { +[string]: mixed } = CSSPropertiesWithExtras> =
   >;
 
 export type StyleXStylesWithout<+CSS: { +[string]: mixed }> = StyleXStyles<
-  $Rest<CSSPropertiesWithExtras, $ReadOnly<CSS>>,
+  Omit<CSSPropertiesWithExtras, $Keys<CSS>>,
 >;
 
 export type VarGroup<+Tokens: { +[string]: mixed }, +_ID: string = string> = {


### PR DESCRIPTION

## What changed / motivation ?

The Flow team is looking into killing $Rest now that Omit exists for a long time. This PR replaces these in stylex.


## Linked PR/Issues

Fixes # (issue)

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code