### PR TITLE
[babel-plugin] Refactor stylex-transform-create-test.js

### DIFF
--- a/packages/babel-plugin/__tests__/stylex-transform-create-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-create-test.js
@@ -14,7 +14,7 @@ const flowPlugin = require('@babel/plugin-syntax-flow');
 const stylexPlugin = require('../src/index');
 
 function transform(source, opts = {}) {
-  return transformSync(source, {
+  const { code, metadata } = transformSync(source, {
     filename: opts.filename,
     parserOpts: {
       flow: 'all',
@@ -26,823 +26,663 @@ function transform(source, opts = {}) {
         stylexPlugin,
         {
           runtimeInjection: true,
-          unstable_moduleResolution: { type: 'haste' },
+          unstable_moduleResolution: { type: 'commonJS' },
           ...opts,
         },
       ],
     ],
-  }).code;
+  });
+
+  return { code, metadata };
 }
 
 describe('@stylexjs/babel-plugin', () => {
   describe('[transform] stylex.create()', () => {
-    test('supports debug data (haste)', () => {
-      expect(
-        transform(
-          `
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            foo: {
-              color: 'red'
-            },
-            'bar-baz': {
-              display: 'block'
-            },
-            1: {
-              fontSize: '1em'
-            }
-          });
-        `,
-          {
-            debug: true,
-            filename: '/html/js/components/Foo.react.js',
-            unstable_moduleResolution: { type: 'haste' },
-          },
-        ),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".fontSize-xrv4cvt{font-size:1em}", 3000);
-        _inject2(".color-x1e2nbdu{color:red}", 3000);
-        _inject2(".display-x1lliihq{display:block}", 3000);
-        export const styles = {
-          "1": {
-            "fontSize-kGuDYH": "fontSize-xrv4cvt",
-            $$css: "Foo.react.js:10"
-          },
-          foo: {
-            "color-kMwMTN": "color-x1e2nbdu",
-            $$css: "Foo.react.js:4"
-          },
-          "bar-baz": {
-            "display-k1xSpc": "display-x1lliihq",
-            $$css: "Foo.react.js:7"
-          }
-        };"
-      `);
-
-      expect(
-        transform(
-          `
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            foo: {
-              color: 'red'
-            },
-            'bar-baz': {
-              display: 'block'
-            },
-            1: {
-              fontSize: '1em'
-            }
-          });
-        `,
-          {
-            debug: true,
-            filename:
-              '/js/node_modules/npm-package/dist/components/Foo.react.js',
-            unstable_moduleResolution: { type: 'haste' },
-          },
-        ),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".fontSize-xrv4cvt{font-size:1em}", 3000);
-        _inject2(".color-x1e2nbdu{color:red}", 3000);
-        _inject2(".display-x1lliihq{display:block}", 3000);
-        export const styles = {
-          "1": {
-            "fontSize-kGuDYH": "fontSize-xrv4cvt",
-            $$css: "npm-package:components/Foo.react.js:10"
-          },
-          foo: {
-            "color-kMwMTN": "color-x1e2nbdu",
-            $$css: "npm-package:components/Foo.react.js:4"
-          },
-          "bar-baz": {
-            "display-k1xSpc": "display-x1lliihq",
-            $$css: "npm-package:components/Foo.react.js:7"
-          }
-        };"
-      `);
-    });
-
-    test('supports debug data (commonJS)', () => {
-      expect(
-        transform(
-          `
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            foo: {
-              color: 'red'
-            },
-            'bar-baz': {
-              display: 'block'
-            },
-            1: {
-              fontSize: '1em'
-            }
-          });
-        `,
-          {
-            debug: true,
-            filename: '/html/js/components/Foo.react.js',
-            unstable_moduleResolution: { type: 'commonJS' },
-          },
-        ),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".fontSize-xrv4cvt{font-size:1em}", 3000);
-        _inject2(".color-x1e2nbdu{color:red}", 3000);
-        _inject2(".display-x1lliihq{display:block}", 3000);
-        export const styles = {
-          "1": {
-            "fontSize-kGuDYH": "fontSize-xrv4cvt",
-            $$css: "components/Foo.react.js:10"
-          },
-          foo: {
-            "color-kMwMTN": "color-x1e2nbdu",
-            $$css: "components/Foo.react.js:4"
-          },
-          "bar-baz": {
-            "display-k1xSpc": "display-x1lliihq",
-            $$css: "components/Foo.react.js:7"
-          }
-        };"
-      `);
-
-      expect(
-        transform(
-          `
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            foo: {
-              color: 'red'
-            },
-            'bar-baz': {
-              display: 'block'
-            },
-            1: {
-              fontSize: '1em'
-            }
-          });
-        `,
-          {
-            debug: true,
-            filename:
-              '/js/node_modules/npm-package/dist/components/Foo.react.js',
-            unstable_moduleResolution: { type: 'commonJS' },
-          },
-        ),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".fontSize-xrv4cvt{font-size:1em}", 3000);
-        _inject2(".color-x1e2nbdu{color:red}", 3000);
-        _inject2(".display-x1lliihq{display:block}", 3000);
-        export const styles = {
-          "1": {
-            "fontSize-kGuDYH": "fontSize-xrv4cvt",
-            $$css: "npm-package:components/Foo.react.js:10"
-          },
-          foo: {
-            "color-kMwMTN": "color-x1e2nbdu",
-            $$css: "npm-package:components/Foo.react.js:4"
-          },
-          "bar-baz": {
-            "display-k1xSpc": "display-x1lliihq",
-            $$css: "npm-package:components/Foo.react.js:7"
-          }
-        };"
-      `);
-    });
-
-    test('stress test various key types and style variants (haste)', () => {
-      expect(
-        transform(
-          `
-            import stylex from 'stylex';
-
-            export const styles = stylex.create({
-              foo: {
-                color: 'red',
-                ':hover': {
-                  color: 'blue',
-                },
-                '@media (min-width: 768px)': {
-                  color: 'green',
-                },
-              },
-              'bar-baz': {
-                display: 'block',
-                padding: '10px',
-              },
-              1: {
-                fontSize: '14px',
-              },
-            });
-          `,
-          {
-            debug: true,
-            filename: '/src/components/Foo.react.js',
-            unstable_moduleResolution: { type: 'haste' },
-          },
-        ),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".fontSize-xif65rj{font-size:14px}", 3000);
-        _inject2(".color-x1e2nbdu{color:red}", 3000);
-        _inject2(".color-x17z2mba:hover{color:blue}", 3130);
-        _inject2("@media (min-width: 768px){.color-x1eatcr5.color-x1eatcr5{color:green}}", 3200);
-        _inject2(".display-x1lliihq{display:block}", 3000);
-        _inject2(".padding-x7z7khe{padding:10px}", 1000);
-        export const styles = {
-          "1": {
-            "fontSize-kGuDYH": "fontSize-xif65rj",
-            $$css: "Foo.react.js:18"
-          },
-          foo: {
-            "color-kMwMTN": "color-x1e2nbdu",
-            ":hover_color-kDPRdz": "color-x17z2mba",
-            "@media (min-width: 768px)_color-kvvVxc": "color-x1eatcr5",
-            $$css: "Foo.react.js:5"
-          },
-          "bar-baz": {
-            "display-k1xSpc": "display-x1lliihq",
-            "padding-kmVPX3": "padding-x7z7khe",
-            "paddingInline-kg3NbH": null,
-            "paddingStart-kuDDbn": null,
-            "paddingLeft-kE3dHu": null,
-            "paddingEnd-kP0aTx": null,
-            "paddingRight-kpe85a": null,
-            "paddingBlock-k8WAf4": null,
-            "paddingTop-kLKAdn": null,
-            "paddingBottom-kGO01o": null,
-            $$css: "Foo.react.js:14"
-          }
-        };"
-      `);
-    });
-
-    test('stress test various key types and style variants (commonJS)', () => {
-      expect(
-        transform(
-          `
-            import stylex from 'stylex';
-
-            export const styles = stylex.create({
-              foo: {
-                color: 'red',
-                ':hover': {
-                  color: 'blue',
-                },
-                '@media (min-width: 768px)': {
-                  color: 'green',
-                },
-              },
-              'bar-baz': {
-                display: 'block',
-                padding: '10px',
-              },
-              1: {
-                fontSize: '14px',
-              },
-            });
-          `,
-          {
-            debug: true,
-            filename: '/src/components/Foo.react.js',
-            unstable_moduleResolution: { type: 'commonJS' },
-          },
-        ),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".fontSize-xif65rj{font-size:14px}", 3000);
-        _inject2(".color-x1e2nbdu{color:red}", 3000);
-        _inject2(".color-x17z2mba:hover{color:blue}", 3130);
-        _inject2("@media (min-width: 768px){.color-x1eatcr5.color-x1eatcr5{color:green}}", 3200);
-        _inject2(".display-x1lliihq{display:block}", 3000);
-        _inject2(".padding-x7z7khe{padding:10px}", 1000);
-        export const styles = {
-          "1": {
-            "fontSize-kGuDYH": "fontSize-xif65rj",
-            $$css: "components/Foo.react.js:18"
-          },
-          foo: {
-            "color-kMwMTN": "color-x1e2nbdu",
-            ":hover_color-kDPRdz": "color-x17z2mba",
-            "@media (min-width: 768px)_color-kvvVxc": "color-x1eatcr5",
-            $$css: "components/Foo.react.js:5"
-          },
-          "bar-baz": {
-            "display-k1xSpc": "display-x1lliihq",
-            "padding-kmVPX3": "padding-x7z7khe",
-            "paddingInline-kg3NbH": null,
-            "paddingStart-kuDDbn": null,
-            "paddingLeft-kE3dHu": null,
-            "paddingEnd-kP0aTx": null,
-            "paddingRight-kpe85a": null,
-            "paddingBlock-k8WAf4": null,
-            "paddingTop-kLKAdn": null,
-            "paddingBottom-kGO01o": null,
-            $$css: "components/Foo.react.js:14"
-          }
-        };"
-      `);
-    });
-
-    test('transforms style object', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
+    describe('static styles', () => {
+      test('unused style object', () => {
+        const { code } = transform(`
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
-            default: {
+            root: {
               backgroundColor: 'red',
               color: 'blue',
             }
           });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".xju2f9n{color:blue}", 3000);"
-      `);
-    });
+        `);
 
-    test('transforms style object with import *', () => {
-      expect(
-        transform(`
-           import * as foo from 'stylex';
-           const styles = foo.create({
-             default: {
-               backgroundColor: 'red',
-               color: 'blue',
-             }
-           });
-         `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import * as foo from 'stylex';
-        _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".xju2f9n{color:blue}", 3000);"
-      `);
-    });
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);"
+        `);
+      });
 
-    test('transforms style object with named imports', () => {
-      expect(
-        transform(`
-           import {create} from 'stylex';
-           const styles = create({
-             default: {
-               backgroundColor: 'red',
-               color: 'blue',
-             }
-           });
-         `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import { create } from 'stylex';
-        _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".xju2f9n{color:blue}", 3000);"
-      `);
-    });
+      test('style object', () => {
+        const { code } = transform(`
+          import * as stylex from '@stylexjs/stylex';
+          export const styles = stylex.create({
+            root: {
+              backgroundColor: 'red',
+              color: 'blue',
+            }
+          });
+        `);
 
-    test('transforms style object with custom property', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({
-            default: {
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2(".xju2f9n{color:blue}", 3000);
+          export const styles = {
+            root: {
+              kWkggS: "xrkmrrc",
+              kMwMTN: "xju2f9n",
+              $$css: true
+            }
+          };"
+        `);
+      });
+
+      test('style object (multiple)', () => {
+        // Check multiple objects and different key types
+        const { code } = transform(`
+          import * as stylex from '@stylexjs/stylex';
+          export const styles = stylex.create({
+            root: {
+              backgroundColor: 'red',
+            },
+            other: {
+              color: 'blue',
+            },
+            'bar-baz': {
+              color: 'green',
+            },
+            1: {
+              color: 'blue',
+            },
+            [2]: {
+              color: 'purple',
+            },
+          });
+        `);
+
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(".xju2f9n{color:blue}", 3000);
+          _inject2(".x125ip1n{color:purple}", 3000);
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2(".x1prwzq3{color:green}", 3000);
+          export const styles = {
+            "1": {
+              kMwMTN: "xju2f9n",
+              $$css: true
+            },
+            "2": {
+              kMwMTN: "x125ip1n",
+              $$css: true
+            },
+            root: {
+              kWkggS: "xrkmrrc",
+              $$css: true
+            },
+            other: {
+              kMwMTN: "xju2f9n",
+              $$css: true
+            },
+            "bar-baz": {
+              kMwMTN: "x1prwzq3",
+              $$css: true
+            }
+          };"
+        `);
+      });
+
+      test('style object with custom properties', () => {
+        const { code } = transform(`
+          import * as stylex from '@stylexjs/stylex';
+          export const styles = stylex.create({
+            root: {
               '--background-color': 'red',
+              '--otherColor': 'green',
             }
           });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xgau0yw{--background-color:red}", 1);"
-      `);
-    });
+        `);
 
-    test('transforms style object with custom property as value', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({
-            default: {
-              '--final-color': 'var(--background-color)',
+        // Must not modify casing of custom properties
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(".xgau0yw{--background-color:red}", 1);
+          _inject2(".x1p9b6ba{--otherColor:green}", 1);
+          export const styles = {
+            root: {
+              "--background-color": "xgau0yw",
+              "--otherColor": "x1p9b6ba",
+              $$css: true
             }
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x13tgbkp{--final-color:var(--background-color)}", 1);"
-      `);
-    });
+          };"
+        `);
+      });
 
-    test('transforms multiple namespaces', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({
-            default: {
-              backgroundColor: 'red',
+      test('style object with shortform properties', () => {
+        const { code } = transform(`
+          import * as stylex from '@stylexjs/stylex';
+          const borderRadius = 2;
+          export const styles = stylex.create({
+            error: {
+              borderColor: 'red blue',
+              borderStyle: 'dashed solid',
+              borderWidth: '0 0 2px 0',
+              margin: 'calc((100% - 50px) * 0.5) 20px 0',
+              padding: 'calc((100% - 50px) * 0.5) var(--rightpadding, 20px)',
             },
-            default2: {
-              color: 'blue',
-            },
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".xju2f9n{color:blue}", 3000);"
-      `);
-    });
-
-    test('does not transform attr() value', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({
-            default: {
-              content: 'attr(some-attribute)',
+            short: {
+              borderBottomWidth: '5px',
+              borderBottomStyle: 'solid',
+              borderBottomColor: 'red',
+              borderColor: 'var(--divider)',
+              borderRadius: borderRadius * 2,
+              borderStyle: 'solid',
+              borderWidth: 1,
+              marginTop: 'calc((100% - 50px) * 0.5)',
+              marginRight: 20,
+              marginBottom: 0,
+              paddingTop: 0,
             },
           });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xd71okc{content:attr(some-attribute)}", 3000);"
-      `);
-    });
+        `);
 
-    test('does not add unit when setting variable value', () => {
-      expect(
-        transform(
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          const borderRadius = 2;
+          _inject2(".xs4buau{border-color:red blue}", 2000);
+          _inject2(".xn06r42{border-style:dashed solid}", 2000);
+          _inject2(".xn43iik{border-width:0 0 2px 0}", 2000);
+          _inject2(".xe4njm9{margin:calc((100% - 50px) * .5) 20px 0}", 1000);
+          _inject2(".x1lmef92{padding:calc((100% - 50px) * .5) var(--rightpadding,20px)}", 1000);
+          _inject2(".x1lh7sze{border-color:var(--divider)}", 2000);
+          _inject2(".x12oqio5{border-radius:4px}", 2000);
+          _inject2(".x1y0btm7{border-style:solid}", 2000);
+          _inject2(".xmkeg23{border-width:1px}", 2000);
+          _inject2(".xxsse2n{margin-top:calc((100% - 50px) * .5)}", 4000);
+          _inject2(".x1wh8b8d{margin-right:20px}", 4000);
+          _inject2(".xat24cr{margin-bottom:0}", 4000);
+          _inject2(".xexx8yu{padding-top:0}", 4000);
+          export const styles = {
+            error: {
+              kVAM5u: "xs4buau",
+              kzOINU: null,
+              kGJrpR: null,
+              kaZRDh: null,
+              kBCPoo: null,
+              k26BEO: null,
+              k5QoK5: null,
+              kLZC3w: null,
+              kL6WhQ: null,
+              ksu8eU: "xn06r42",
+              kJRH4f: null,
+              kVhnKS: null,
+              k4WBpm: null,
+              k8ry5P: null,
+              kSWEuD: null,
+              kDUl1X: null,
+              kPef9Z: null,
+              kfdmCh: null,
+              kMzoRj: "xn43iik",
+              kjGldf: null,
+              k2ei4v: null,
+              kZ1KPB: null,
+              ke9TFa: null,
+              kWqL5O: null,
+              kLoX6v: null,
+              kEafiO: null,
+              kt9PQ7: null,
+              kogj98: "xe4njm9",
+              kUOVxO: null,
+              keTefX: null,
+              koQZXg: null,
+              k71WvV: null,
+              km5ZXQ: null,
+              kqGvvJ: null,
+              keoZOQ: null,
+              k1K539: null,
+              kmVPX3: "x1lmef92",
+              kg3NbH: null,
+              kuDDbn: null,
+              kE3dHu: null,
+              kP0aTx: null,
+              kpe85a: null,
+              k8WAf4: null,
+              kLKAdn: null,
+              kGO01o: null,
+              $$css: true
+            },
+            short: {
+              kVAM5u: "x1lh7sze",
+              kzOINU: null,
+              kGJrpR: null,
+              kaZRDh: null,
+              kBCPoo: null,
+              k26BEO: null,
+              k5QoK5: null,
+              kLZC3w: null,
+              kL6WhQ: null,
+              kaIpWk: "x12oqio5",
+              krdFHd: null,
+              kfmiAY: null,
+              kVL7Gh: null,
+              kT0f0o: null,
+              kIxVMA: null,
+              ksF3WI: null,
+              kqGeR4: null,
+              kYm2EN: null,
+              ksu8eU: "x1y0btm7",
+              kJRH4f: null,
+              kVhnKS: null,
+              k4WBpm: null,
+              k8ry5P: null,
+              kSWEuD: null,
+              kDUl1X: null,
+              kPef9Z: null,
+              kfdmCh: null,
+              kMzoRj: "xmkeg23",
+              kjGldf: null,
+              k2ei4v: null,
+              kZ1KPB: null,
+              ke9TFa: null,
+              kWqL5O: null,
+              kLoX6v: null,
+              kEafiO: null,
+              kt9PQ7: null,
+              keoZOQ: "xxsse2n",
+              km5ZXQ: "x1wh8b8d",
+              keTefX: null,
+              k71WvV: null,
+              k1K539: "xat24cr",
+              kLKAdn: "xexx8yu",
+              $$css: true
+            }
+          };"
+        `);
+      });
+
+      test('style object with shortform properties (styleResolution: "property-specificity")', () => {
+        const options = {
+          runtimeInjection: false,
+          styleResolution: 'property-specificity',
+        };
+
+        const { code } = transform(
           `
           import * as stylex from '@stylexjs/stylex';
-          import {vars} from 'myTheme.stylex.js';
-
-          const styles = stylex.create({
-            default: {
-              [vars.foo]: 500,
+          const borderRadius = 2;
+          export const styles = stylex.create({
+            error: {
+              borderColor: 'red blue',
+              borderStyle: 'dashed solid',
+              borderWidth: '0 0 2px 0',
+              margin: 'calc((100% - 50px) * 0.5) 20px 0',
+              padding: 'calc((100% - 50px) * 0.5) var(--rightpadding, 20px)',
+            },
+            short: {
+              borderBottomWidth: '5px',
+              borderBottomStyle: 'solid',
+              borderBottomColor: 'red',
+              borderColor: 'var(--divider)',
+              borderRadius: borderRadius * 2,
+              borderStyle: 'solid',
+              borderWidth: 1,
+              marginTop: 'calc((100% - 50px) * 0.5)',
+              marginRight: 20,
+              marginBottom: 0,
+              paddingTop: 0,
             },
           });
         `,
-          {
-            filename: 'MyComponent.js',
-          },
-        ),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import * as stylex from '@stylexjs/stylex';
-        import { vars } from 'myTheme.stylex.js';
-        _inject2(".x4b9xku{--x1w7bng0:500}", 1);"
-      `);
-    });
+          options,
+        );
 
-    test('handles camelCased transition properties', () => {
-      const camelCased = transform(`
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          default: {
-            transitionProperty: 'marginTop',
-          },
-        });
-      `);
-      const kebabCased = transform(`
-        import stylex from 'stylex';
-        const styles = stylex.create({
-          default: {
-            transitionProperty: 'margin-top',
-          },
-        });
-      `);
+        expect(code).toMatchInlineSnapshot(`
+          "import * as stylex from '@stylexjs/stylex';
+          const borderRadius = 2;
+          export const styles = {
+            error: {
+              kVAM5u: "xs4buau",
+              ksu8eU: "xn06r42",
+              kMzoRj: "xn43iik",
+              kogj98: "xe4njm9",
+              kmVPX3: "x1lmef92",
+              $$css: true
+            },
+            short: {
+              kt9PQ7: "xa309fb",
+              kfdmCh: "x1q0q8m5",
+              kL6WhQ: "xud65wk",
+              kVAM5u: "x1lh7sze",
+              kaIpWk: "x12oqio5",
+              ksu8eU: "x1y0btm7",
+              kMzoRj: "xmkeg23",
+              keoZOQ: "xxsse2n",
+              km5ZXQ: "x1wh8b8d",
+              k1K539: "xat24cr",
+              kLKAdn: "xexx8yu",
+              $$css: true
+            }
+          };"
+        `);
+      });
 
-      expect(camelCased).toEqual(kebabCased);
-
-      expect(camelCased).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x1cfch2b{transition-property:margin-top}", 3000);"
-      `);
-    });
-
-    test('leaves transition properties of custom properties alone', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({
-            default: {
-              transitionProperty: '--foo',
+      test('style object requiring vendor prefixes', () => {
+        // TODO: add more vendor-prefixed properties and values
+        const { code } = transform(`
+          import * as stylex from '@stylexjs/stylex';
+          export const styles = stylex.create({
+            root: {
+              userSelect: 'none',
             },
           });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x17389it{transition-property:--foo}", 3000);"
-      `);
-    });
+        `);
 
-    test('transforms nested pseudo-class to CSS', () => {
-      expect(
-        transform(`
-           import stylex from 'stylex';
-           const styles = stylex.create({
-             default: {
-               ':hover': {
-                 backgroundColor: 'red',
-                 color: 'blue',
-               },
-             },
-           });
-         `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x1gykpug:hover{background-color:red}", 3130);
-        _inject2(".x17z2mba:hover{color:blue}", 3130);"
-      `);
-    });
-
-    test('transforms nested pseudo-class within properties to CSS', () => {
-      expect(
-        transform(`
-           import stylex from 'stylex';
-           const styles = stylex.create({
-             default: {
-               backgroundColor: {
-                 ':hover': 'red',
-               },
-               color: {
-                 ':hover': 'blue',
-               }
-             },
-           });
-         `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x1gykpug:hover{background-color:red}", 3130);
-        _inject2(".x17z2mba:hover{color:blue}", 3130);"
-      `);
-    });
-
-    test('transforms array values as fallbacks', () => {
-      expect(
-        transform(`
-           import stylex from 'stylex';
-           const styles = stylex.create({
-             default: {
-               position: ['sticky', 'fixed']
-             },
-           });
-         `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x1ruww2u{position:sticky;position:fixed}", 3000);"
-      `);
-    });
-
-    test('transforms array values as fallbacks within media query', () => {
-      expect(
-        transform(`
-           import stylex from 'stylex';
-           const styles = stylex.create({
-             default: {
-               position: {
-                 default: 'fixed',
-                 '@media (min-width: 768px)': ['sticky', 'fixed'],
-               }
-             },
-           });
-         `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xixxii4{position:fixed}", 3000);
-        _inject2("@media (min-width: 768px){.x1vazst0.x1vazst0{position:sticky;position:fixed}}", 3200);"
-      `);
-    });
-
-    // TODO: add more vendor-prefixed properties and values
-    test('transforms properties requiring vendor prefixes', () => {
-      expect(
-        transform(`
-           import stylex from 'stylex';
-           const styles = stylex.create({
-             default: {
-               userSelect: 'none',
-             },
-           });
-         `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x87ps6o{user-select:none}", 3000);"
-      `);
-    });
-
-    // Legacy, short?
-    test('transforms valid shorthands', () => {
-      expect(
-        transform(`
-           import stylex from 'stylex';
-           const styles = stylex.create({
-             default: {
-               overflow: 'hidden',
-               borderStyle: 'dashed',
-               borderWidth: 1
-             }
-           });
-         `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xb3r6kr{overflow:hidden}", 2000);
-        _inject2(".xbsl7fq{border-style:dashed}", 2000);
-        _inject2(".xmkeg23{border-width:1px}", 2000);"
-      `);
-    });
-
-    test('Uses stylex.firstThatWorks correctly', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            foo: {
-              position: stylex.firstThatWorks('sticky', 'fixed'),
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(".x87ps6o{user-select:none}", 3000);
+          export const styles = {
+            root: {
+              kfSwDN: "x87ps6o",
+              $$css: true
             }
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x15oojuh{position:fixed;position:sticky}", 3000);
-        export const styles = {
-          foo: {
-            kVAEAm: "x15oojuh",
-            $$css: true
-          }
-        };"
-      `);
-    });
-
-    test('transforms complex property values containing custom properties variables', () => {
-      expect(
-        transform(`
-           import stylex from 'stylex';
-           const styles = stylex.create({
-             default: {
-               boxShadow: '0px 2px 4px var(--shadow-1)',
-             }
-           });
-         `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xxnfx33{box-shadow:0 2px 4px var(--shadow-1)}", 3000);"
-      `);
-    });
-
-    describe('pseudo-classes', () => {
-      // TODO: this should either fail or guarantee an insertion order relative to valid pseudo-classes
-      test('transforms invalid pseudo-class', () => {
-        expect(
-          transform(`
-            import stylex from 'stylex';
-            const styles = stylex.create({
-              default: {
-                ':invalpwdijad': {
-                  backgroundColor: 'red',
-                  color: 'blue',
-                },
-              },
-            });
-         `),
-        ).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import stylex from 'stylex';
-          _inject2(".x19iys6w:invalpwdijad{background-color:red}", 3040);
-          _inject2(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
+          };"
         `);
       });
 
-      test('transforms valid pseudo-classes in order', () => {
-        expect(
-          transform(`
-            import stylex from 'stylex';
-            const styles = stylex.create({
-              default: {
-                ':hover': {
-                  color: 'blue',
+      describe('simple values', () => {
+        test('set custom property', () => {
+          const options = {
+            filename: 'MyComponent.js',
+            unstable_moduleResolution: { type: 'haste' },
+          };
+
+          const { code } = transform(
+            `
+            import * as stylex from '@stylexjs/stylex';
+            import {vars} from 'vars.stylex.js';
+
+            export const styles = stylex.create({
+              root: {
+                [vars.foo]: 500,
+              },
+            });
+          `,
+            options,
+          );
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            import { vars } from 'vars.stylex.js';
+            _inject2(".x1pojaxg{--x1mxfvjx:500}", 1);
+            export const styles = {
+              root: {
+                "--x1mxfvjx": "x1pojaxg",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('set "transitionProperty"', () => {
+          const camelCased = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                transitionProperty: 'marginTop',
+              },
+            });
+          `);
+
+          expect(camelCased.code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x1cfch2b{transition-property:margin-top}", 3000);
+            export const styles = {
+              root: {
+                k1ekBW: "x1cfch2b",
+                $$css: true
+              }
+            };"
+          `);
+
+          const kebabCased = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                transitionProperty: 'margin-top',
+              },
+            });
+          `);
+
+          expect(kebabCased.code).toEqual(camelCased.code);
+
+          const customProperty = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                transitionProperty: '--foo',
+              },
+            });
+          `);
+
+          expect(customProperty.code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x17389it{transition-property:--foo}", 3000);
+            export const styles = {
+              root: {
+                k1ekBW: "x17389it",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('use "attr()" function', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                content: 'attr(some-attribute)',
+              },
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".xd71okc{content:attr(some-attribute)}", 3000);
+            export const styles = {
+              root: {
+                kah6P1: "xd71okc",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('use array (fallbacks)', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                position: ['sticky', 'fixed']
+              },
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x1ruww2u{position:sticky;position:fixed}", 3000);
+            export const styles = {
+              root: {
+                kVAEAm: "x1ruww2u",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('use "stylex.firstThatWorks"', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                position: stylex.firstThatWorks('sticky', 'fixed'),
+              }
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x15oojuh{position:fixed;position:sticky}", 3000);
+            export const styles = {
+              root: {
+                kVAEAm: "x15oojuh",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('use CSS variable', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                backgroundColor: 'var(--background-color)',
+              }
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".xn9heto{background-color:var(--background-color)}", 3000);
+            export const styles = {
+              root: {
+                kWkggS: "xn9heto",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('use string containing CSS variables', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                boxShadow: '0px 2px 4px var(--shadow-1)',
+              }
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".xxnfx33{box-shadow:0 2px 4px var(--shadow-1)}", 3000);
+            export const styles = {
+              root: {
+                kGVxlE: "xxnfx33",
+                $$css: true
+              }
+            };"
+          `);
+        });
+      });
+
+      describe('object values: pseudo-classes', () => {
+        test('invalid pseudo-class', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                color: {
+                  ':invalidpseudo': 'blue'
                 },
-                ':active': {
-                  color: 'red',
+              },
+            });
+          `);
+
+          // TODO: this should either fail or guarantee an insertion order relative to valid pseudo-classes
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x1qo2jjy:invalidpseudo{color:blue}", 3040);
+            export const styles = {
+              root: {
+                kMwMTN: "x1qo2jjy",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('valid pseudo-class', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                backgroundColor: {
+                  ':hover': 'red',
                 },
-                ':focus': {
-                  color: 'yellow',
-                },
-                ':nth-child(2n)': {
-                  color: 'purple'
+                color: {
+                  ':hover': 'blue',
                 }
               },
             });
-         `),
-        ).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import stylex from 'stylex';
-          _inject2(".x17z2mba:hover{color:blue}", 3130);
-          _inject2(".x96fq8s:active{color:red}", 3170);
-          _inject2(".x1wvtd7d:focus{color:yellow}", 3150);
-          _inject2(".x126ychx:nth-child(2n){color:purple}", 3060);"
-        `);
-      });
+          `);
 
-      test('transforms pseudo-class with array value as fallbacks', () => {
-        expect(
-          transform(`
-            import stylex from 'stylex';
-            const styles = stylex.create({
-              default: {
-                ':hover': {
-                  position: ['sticky', 'fixed'],
-                }
-              },
-            });
-         `),
-        ).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import stylex from 'stylex';
-          _inject2(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
-        `);
-      });
-    });
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x1gykpug:hover{background-color:red}", 3130);
+            _inject2(".x17z2mba:hover{color:blue}", 3130);
+            export const styles = {
+              root: {
+                kWkggS: "x1gykpug",
+                kMwMTN: "x17z2mba",
+                $$css: true
+              }
+            };"
+          `);
+        });
 
-    describe('pseudo-classes within properties', () => {
-      // TODO: this should either fail or guarantee an insertion order relative to valid pseudo-classes
-      test('transforms invalid pseudo-class', () => {
-        expect(
-          transform(`
-            import stylex from 'stylex';
-            const styles = stylex.create({
-              default: {
-                backgroundColor: {':invalpwdijad': 'red'},
-                color: {':invalpwdijad': 'blue'},
-              },
-            });
-         `),
-        ).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import stylex from 'stylex';
-          _inject2(".x19iys6w:invalpwdijad{background-color:red}", 3040);
-          _inject2(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
-        `);
-      });
-
-      test('transforms valid pseudo-classes in order', () => {
-        expect(
-          transform(`
-            import stylex from 'stylex';
-            const styles = stylex.create({
-              default: {
+        test('pseudo-class generated order', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
                 color: {
                   ':hover': 'blue',
                   ':active':'red',
@@ -851,109 +691,139 @@ describe('@stylexjs/babel-plugin', () => {
                 },
               },
             });
-         `),
-        ).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import stylex from 'stylex';
-          _inject2(".x17z2mba:hover{color:blue}", 3130);
-          _inject2(".x96fq8s:active{color:red}", 3170);
-          _inject2(".x1wvtd7d:focus{color:yellow}", 3150);
-          _inject2(".x126ychx:nth-child(2n){color:purple}", 3060);"
-        `);
-      });
+          `);
 
-      test('transforms pseudo-class with array value as fallbacks', () => {
-        expect(
-          transform(`
-            import stylex from 'stylex';
-            const styles = stylex.create({
-              default: {
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x17z2mba:hover{color:blue}", 3130);
+            _inject2(".x96fq8s:active{color:red}", 3170);
+            _inject2(".x1wvtd7d:focus{color:yellow}", 3150);
+            _inject2(".x126ychx:nth-child(2n){color:purple}", 3060);
+            export const styles = {
+              root: {
+                kMwMTN: "x17z2mba x96fq8s x1wvtd7d x126ychx",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('pseudo-class with array fallbacks', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
                 position: {
                   ':hover': ['sticky', 'fixed'],
                 }
               },
             });
-          `),
-        ).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import stylex from 'stylex';
-          _inject2(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
-        `);
-      });
-    });
+          `);
 
-    // TODO: more unsupported pseudo-classes
-    describe('pseudo-elements', () => {
-      test('transforms ::before and ::after', () => {
-        expect(
-          transform(`
-             import stylex from 'stylex';
-             const styles = stylex.create({
-               foo: {
-                 '::before': {
-                   color: 'red'
-                 },
-                 '::after': {
-                   color: 'blue'
-                 },
-               },
-             });
-           `),
-        ).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import stylex from 'stylex';
-          _inject2(".x16oeupf::before{color:red}", 8000);
-          _inject2(".xdaarc3::after{color:blue}", 8000);"
-        `);
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);
+            export const styles = {
+              root: {
+                kVAEAm: "x1nxcus0",
+                $$css: true
+              }
+            };"
+          `);
+        });
       });
 
-      test('transforms ::placeholder', () => {
-        expect(
-          transform(`
-            import stylex from 'stylex';
-            const styles = stylex.create({
+      describe('object values: pseudo-elements', () => {
+        test('"::before" and "::after"', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              foo: {
+                '::before': {
+                  color: 'red'
+                },
+                '::after': {
+                  color: 'blue'
+                },
+              },
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x16oeupf::before{color:red}", 8000);
+            _inject2(".xdaarc3::after{color:blue}", 8000);
+            export const styles = {
+              foo: {
+                kxBb7d: "x16oeupf",
+                kB1Fuz: "xdaarc3",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('"::placeholder"', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
               foo: {
                 '::placeholder': {
                   color: 'gray',
                 },
               },
             });
-          `),
-        ).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import stylex from 'stylex';
-          _inject2(".x6yu8oj::placeholder{color:gray}", 8000);"
-        `);
-      });
+          `);
 
-      test('transforms ::thumb', () => {
-        expect(
-          transform(`
-            import stylex from 'stylex';
-            const styles = stylex.create({
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x6yu8oj::placeholder{color:gray}", 8000);
+            export const styles = {
+              foo: {
+                k8Qsv1: "x6yu8oj",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('"::thumb"', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
               foo: {
                 '::thumb': {
                   width: 16,
                 },
               },
             });
-          `),
-        ).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import stylex from 'stylex';
-          _inject2(".x1en94km::-webkit-slider-thumb, .x1en94km::-moz-range-thumb, .x1en94km::-ms-thumb{width:16px}", 9000);"
-        `);
-      });
+          `);
 
-      test('transforms pseudo class within a pseudo element', () => {
-        expect(
-          transform(`
-            import stylex from 'stylex';
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x1en94km::-webkit-slider-thumb, .x1en94km::-moz-range-thumb, .x1en94km::-ms-thumb{width:16px}", 9000);
+            export const styles = {
+              foo: {
+                k8pbKx: "x1en94km",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('"::before" containing pseudo-classes', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
             export const styles = stylex.create({
               foo: {
                 '::before': {
@@ -964,20 +834,928 @@ describe('@stylexjs/babel-plugin', () => {
                 },
               },
             });
-          `),
-        ).toMatchInlineSnapshot(`
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x16oeupf::before{color:red}", 8000);
+            _inject2(".xeb2lg0::before:hover{color:blue}", 8130);
+            export const styles = {
+              foo: {
+                kxBb7d: "x16oeupf xeb2lg0",
+                $$css: true
+              }
+            };"
+          `);
+        });
+      });
+
+      describe('object values: queries', () => {
+        test('media queries', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                backgroundColor: {
+                  default: 'red',
+                  '@media (min-width: 1000px)': 'blue',
+                  '@media (min-width: 2000px)': 'purple',
+                }
+              },
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".xrkmrrc{background-color:red}", 3000);
+            _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+            _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
+            export const styles = {
+              root: {
+                kWkggS: "xrkmrrc xc445zv x1ssfqz5",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('supports queries', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                backgroundColor: {
+                  default:'red',
+                  '@supports (hover: hover)': 'blue',
+                  '@supports not (hover: hover)': 'purple',
+                }
+              },
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".xrkmrrc{background-color:red}", 3000);
+            _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
+            _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);
+            export const styles = {
+              root: {
+                kWkggS: "xrkmrrc x6m3b6q x6um648",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('media query with pseudo-classes', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                fontSize: {
+                  default: '1rem',
+                  '@media (min-width: 800px)': {
+                    default: '2rem',
+                    ':hover': '2.2rem'
+                  }
+                }
+              },
+            });
+          `);
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x1jchvi3{font-size:1rem}", 3000);
+            _inject2("@media (min-width: 800px){.x1w3nbkt.x1w3nbkt{font-size:2rem}}", 3200);
+            _inject2("@media (min-width: 800px){.xicay7j.xicay7j:hover{font-size:2.2rem}}", 3330);
+            export const styles = {
+              root: {
+                kGuDYH: "x1jchvi3 x1w3nbkt xicay7j",
+                $$css: true
+              }
+            };"
+          `);
+        });
+
+        test('media query with array fallbacks', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              default: {
+                position: {
+                  default: 'fixed',
+                  '@media (min-width: 768px)': ['sticky', 'fixed'],
+                }
+              },
+            });
+          `);
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".xixxii4{position:fixed}", 3000);
+            _inject2("@media (min-width: 768px){.x1vazst0.x1vazst0{position:sticky;position:fixed}}", 3200);
+            export const styles = {
+              default: {
+                kVAEAm: "xixxii4 x1vazst0",
+                $$css: true
+              }
+            };"
+          `);
+        });
+      });
+    });
+
+    describe('dynamic styles', () => {
+      test('style function', () => {
+        const { code } = transform(`
+          import * as stylex from '@stylexjs/stylex';
+          export const styles = stylex.create({
+            root: (color) => ({
+              backgroundColor: 'red',
+              color,
+            })
+          });
+        `);
+
+        expect(code).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
-          import stylex from 'stylex';
-          _inject2(".x16oeupf::before{color:red}", 8000);
-          _inject2(".xeb2lg0::before:hover{color:blue}", 8130);
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2(".xfx01vb{color:var(--color)}", 3000);
+          _inject2("@property --color { syntax: \\"*\\"; inherits: false;}", 0);
           export const styles = {
-            foo: {
-              kxBb7d: "x16oeupf xeb2lg0",
+            root: color => [{
+              kWkggS: "xrkmrrc",
+              kMwMTN: "xfx01vb",
+              $$css: true
+            }, {
+              "--color": color != null ? color : undefined
+            }]
+          };"
+        `);
+      });
+
+      test('style function and object', () => {
+        const { code } = transform(`
+          import * as stylex from '@stylexjs/stylex';
+          export const styles = stylex.create({
+            one: (color) => ({
+              color: color,
+            }),
+            two: {
+              color: 'black',
+            },
+          });
+        `);
+
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(".xfx01vb{color:var(--color)}", 3000);
+          _inject2(".x1mqxbix{color:black}", 3000);
+          _inject2("@property --color { syntax: \\"*\\"; inherits: false;}", 0);
+          export const styles = {
+            one: color => [{
+              kMwMTN: "xfx01vb",
+              $$css: true
+            }, {
+              "--color": color != null ? color : undefined
+            }],
+            two: {
+              kMwMTN: "x1mqxbix",
               $$css: true
             }
           };"
         `);
+      });
+
+      test('style function with custom properties', () => {
+        const { code } = transform(`
+          import * as stylex from '@stylexjs/stylex';
+          export const styles = stylex.create({
+            root: (bgColor, otherColor) => ({
+              '--background-color': bgColor,
+              '--otherColor': otherColor,
+            }),
+          });
+        `);
+
+        // NOTE: the generated variable name is a little weird, but valid.
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(".x15mgraa{--background-color:var(----background-color)}", 1);
+          _inject2(".x1qph05k{--otherColor:var(----otherColor)}", 1);
+          _inject2("@property ----background-color { syntax: \\"*\\"; inherits: false;}", 0);
+          _inject2("@property ----otherColor { syntax: \\"*\\"; inherits: false;}", 0);
+          export const styles = {
+            root: (bgColor, otherColor) => [{
+              "--background-color": bgColor == null ? null : "x15mgraa",
+              "--otherColor": otherColor == null ? null : "x1qph05k",
+              $$css: true
+            }, {
+              "----background-color": bgColor != null ? bgColor : undefined,
+              "----otherColor": otherColor != null ? otherColor : undefined
+            }]
+          };"
+        `);
+      });
+
+      describe('simple values', () => {
+        test('set number unit', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: (width) => ({
+                width,
+              })
+            });
+          `);
+
+          // Check that dynamic number values get units where appropriate
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x1bl4301{width:var(--width)}", 4000);
+            _inject2("@property --width { syntax: \\"*\\"; inherits: false;}", 0);
+            export const styles = {
+              root: width => [{
+                kzqmXN: "x1bl4301",
+                $$css: true
+              }, {
+                "--width": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
+              }]
+            };"
+          `);
+        });
+
+        test('set custom property', () => {
+          const options = {
+            filename: 'MyComponent.js',
+            unstable_moduleResolution: { type: 'haste' },
+          };
+
+          const { code } = transform(
+            `
+            import * as stylex from '@stylexjs/stylex';
+            import {vars} from 'vars.stylex.js';
+
+            export const styles = stylex.create({
+              root: (width) => ({
+                [vars.width]: width
+              })
+            });
+          `,
+            options,
+          );
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            import { vars } from 'vars.stylex.js';
+            _inject2(".x14vhreu{--x1anmu0j:var(----x1anmu0j)}", 1);
+            _inject2("@property ----x1anmu0j { syntax: \\"*\\"; inherits: false;}", 0);
+            export const styles = {
+              root: width => [{
+                "--x1anmu0j": width == null ? null : "x14vhreu",
+                $$css: true
+              }, {
+                "----x1anmu0j": width != null ? width : undefined
+              }]
+            };"
+          `);
+        });
+      });
+
+      describe('object values: pseudo-classes', () => {
+        test('valid pseudo-class', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: (color) => ({
+                backgroundColor: {
+                  ':hover': color,
+                },
+                color: {
+                  ':hover': color,
+                }
+              }),
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x1ttfofm:hover{background-color:var(--1e2mv7m)}", 3130);
+            _inject2(".x74ai9j:hover{color:var(--1113oo7)}", 3130);
+            _inject2("@property --1e2mv7m { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --1113oo7 { syntax: \\"*\\"; inherits: false;}", 0);
+            export const styles = {
+              root: color => [{
+                kWkggS: "x1ttfofm",
+                kMwMTN: "x74ai9j",
+                $$css: true
+              }, {
+                "--1e2mv7m": color != null ? color : undefined,
+                "--1113oo7": color != null ? color : undefined
+              }]
+            };"
+          `);
+        });
+
+        test('pseudo-class generated order', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: (hover, active, focus) => ({
+                color: {
+                  ':hover': hover,
+                  ':active': active,
+                  ':focus': focys,
+                  ':nth-child(2n)': 'purple',
+                },
+              }),
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x74ai9j:hover{color:var(--1113oo7)}", 3130);
+            _inject2(".x19c4yy1:active{color:var(--hxnnmm)}", 3170);
+            _inject2(".x10peeyq:focus{color:var(--8tbbve)}", 3150);
+            _inject2(".x126ychx:nth-child(2n){color:purple}", 3060);
+            _inject2("@property --1113oo7 { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --hxnnmm { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --8tbbve { syntax: \\"*\\"; inherits: false;}", 0);
+            export const styles = {
+              root: (hover, active, focus) => [{
+                kMwMTN: "x74ai9j x19c4yy1 x10peeyq x126ychx",
+                $$css: true
+              }, {
+                "--1113oo7": hover != null ? hover : undefined,
+                "--hxnnmm": active != null ? active : undefined,
+                "--8tbbve": focys != null ? focys : undefined
+              }]
+            };"
+          `);
+        });
+      });
+
+      describe('object values: pseudo-elements', () => {
+        test('"::before" and "::after"', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              foo: (a, b) => ({
+                '::before': {
+                  color: a
+                },
+                '::after': {
+                  color: b
+                },
+              }),
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x6r7ojb::before{color:var(--1g451k2)}", 8000);
+            _inject2(".x5ga601::after{color:var(--19erzii)}", 8000);
+            _inject2("@property --1g451k2 { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --19erzii { syntax: \\"*\\"; inherits: false;}", 0);
+            export const styles = {
+              foo: (a, b) => [{
+                kxBb7d: "x6r7ojb",
+                kB1Fuz: "x5ga601",
+                $$css: true
+              }, {
+                "--1g451k2": a != null ? a : undefined,
+                "--19erzii": b != null ? b : undefined
+              }]
+            };"
+          `);
+        });
+
+        test('"::placeholder"', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              foo: (color) => ({
+                '::placeholder': {
+                  color,
+                },
+              }),
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".xwdnmik::placeholder{color:var(--163tekb)}", 8000);
+            _inject2("@property --163tekb { syntax: \\"*\\"; inherits: false;}", 0);
+            export const styles = {
+              foo: color => [{
+                k8Qsv1: "xwdnmik",
+                $$css: true
+              }, {
+                "--163tekb": color != null ? color : undefined
+              }]
+            };"
+          `);
+        });
+
+        test('"::thumb"', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              foo: (width) => ({
+                '::thumb': {
+                  width,
+                },
+              }),
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x3j4sww::-webkit-slider-thumb, .x3j4sww::-moz-range-thumb, .x3j4sww::-ms-thumb{width:var(--msahdu)}", 9000);
+            _inject2("@property --msahdu { syntax: \\"*\\"; inherits: false;}", 0);
+            export const styles = {
+              foo: width => [{
+                k8pbKx: "x3j4sww",
+                $$css: true
+              }, {
+                "--msahdu": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
+              }]
+            };"
+          `);
+        });
+
+        test('"::before" containing pseudo-classes', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              foo: (color) => ({
+                '::before': {
+                  color: {
+                    default: 'red',
+                    ':hover': color,
+                  }
+                },
+              }),
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x16oeupf::before{color:red}", 8000);
+            _inject2(".x10u3axo::before:hover{color:var(--6bge3v)}", 8130);
+            _inject2("@property --6bge3v { syntax: \\"*\\"; inherits: false;}", 0);
+            export const styles = {
+              foo: color => [{
+                kxBb7d: "x16oeupf x10u3axo",
+                $$css: true
+              }, {
+                "--6bge3v": color != null ? color : undefined
+              }]
+            };"
+          `);
+        });
+      });
+
+      describe('object values: queries', () => {
+        test('media queries', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: (a, b, c) => ({
+                width: {
+                  default: 'color-mix(' + color + ', blue)',
+                  '@media (min-width: 1000px)': b,
+                  '@media (min-width: 2000px)': c,
+                }
+              }),
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x1svif2g{width:var(--1xmrurk)}", 4000);
+            _inject2("@media (min-width: 1000px){.x1a6pj3q.x1a6pj3q{width:var(--wm47pl)}}", 4200);
+            _inject2("@media (min-width: 2000px){.xf0apgt.xf0apgt{width:var(--1obb2yn)}}", 4200);
+            _inject2("@property --1xmrurk { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --wm47pl { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --1obb2yn { syntax: \\"*\\"; inherits: false;}", 0);
+            export const styles = {
+              root: (a, b, c) => [{
+                kzqmXN: "x1svif2g x1a6pj3q xf0apgt",
+                $$css: true
+              }, {
+                "--1xmrurk": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)('color-mix(' + color + ', blue)'),
+                "--wm47pl": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(b),
+                "--1obb2yn": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(c)
+              }]
+            };"
+          `);
+        });
+
+        test('supports queries', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: (a, b, c) => ({
+                color: {
+                  default: a,
+                  '@supports (hover: hover)': b,
+                  '@supports not (hover: hover)': c,
+                }
+              }),
+            });
+          `);
+
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x1n25116{color:var(--4xs81a)}", 3000);
+            _inject2("@supports (hover: hover){.x1oeo35w.x1oeo35w{color:var(--b262sw)}}", 3030);
+            _inject2("@supports not (hover: hover){.x10db8fb.x10db8fb{color:var(--wu2acw)}}", 3030);
+            _inject2("@property --4xs81a { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --b262sw { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --wu2acw { syntax: \\"*\\"; inherits: false;}", 0);
+            export const styles = {
+              root: (a, b, c) => [{
+                kMwMTN: "x1n25116 x1oeo35w x10db8fb",
+                $$css: true
+              }, {
+                "--4xs81a": a != null ? a : undefined,
+                "--b262sw": b != null ? b : undefined,
+                "--wu2acw": c != null ? c : undefined
+              }]
+            };"
+          `);
+        });
+
+        test('media query with pseudo-classes', () => {
+          const { code } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: (a, b, c) => ({
+                fontSize: {
+                  default: a,
+                  '@media (min-width: 800px)': {
+                    default: b,
+                    ':hover': c
+                  }
+                }
+              }),
+            });
+          `);
+          expect(code).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import * as stylex from '@stylexjs/stylex';
+            _inject2(".x1cfcgx7{font-size:var(--19zvkyr)}", 3000);
+            _inject2("@media (min-width: 800px){.x956mei.x956mei{font-size:var(--1xajcet)}}", 3200);
+            _inject2("@media (min-width: 800px){.xarp7f8.xarp7f8:hover{font-size:var(--ke45ok)}}", 3330);
+            _inject2("@property --19zvkyr { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --1xajcet { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --ke45ok { syntax: \\"*\\"; inherits: false;}", 0);
+            export const styles = {
+              root: (a, b, c) => [{
+                kGuDYH: "x1cfcgx7 x956mei xarp7f8",
+                $$css: true
+              }, {
+                "--19zvkyr": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(a),
+                "--1xajcet": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(b),
+                "--ke45ok": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(c)
+              }]
+            };"
+          `);
+        });
+      });
+    });
+
+    describe('options `debug:true`', () => {
+      test('adds debug data', () => {
+        const options = {
+          debug: true,
+          filename: '/html/js/components/Foo.react.js',
+        };
+
+        const { code } = transform(
+          `
+            import * as stylex from '@stylexjs/stylex';
+          export const styles = stylex.create({
+            foo: {
+              color: 'red'
+            },
+            'bar-baz': {
+              display: 'block'
+            },
+            1: {
+              fontSize: '1em'
+            }
+          });
+        `,
+          options,
+        );
+
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(".fontSize-xrv4cvt{font-size:1em}", 3000);
+          _inject2(".color-x1e2nbdu{color:red}", 3000);
+          _inject2(".display-x1lliihq{display:block}", 3000);
+          export const styles = {
+            "1": {
+              "fontSize-kGuDYH": "fontSize-xrv4cvt",
+              $$css: "components/Foo.react.js:10"
+            },
+            foo: {
+              "color-kMwMTN": "color-x1e2nbdu",
+              $$css: "components/Foo.react.js:4"
+            },
+            "bar-baz": {
+              "display-k1xSpc": "display-x1lliihq",
+              $$css: "components/Foo.react.js:7"
+            }
+          };"
+        `);
+      });
+
+      test('adds debug data for npm packages', () => {
+        const options = {
+          debug: true,
+          filename: '/js/node_modules/npm-package/dist/components/Foo.react.js',
+        };
+
+        const { code } = transform(
+          `
+          import * as stylex from '@stylexjs/stylex';
+          export const styles = stylex.create({
+            foo: {
+              color: 'red'
+            },
+            'bar-baz': {
+              display: 'block'
+            },
+            1: {
+              fontSize: '1em'
+            }
+          });
+        `,
+          options,
+        );
+
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(".fontSize-xrv4cvt{font-size:1em}", 3000);
+          _inject2(".color-x1e2nbdu{color:red}", 3000);
+          _inject2(".display-x1lliihq{display:block}", 3000);
+          export const styles = {
+            "1": {
+              "fontSize-kGuDYH": "fontSize-xrv4cvt",
+              $$css: "npm-package:components/Foo.react.js:10"
+            },
+            foo: {
+              "color-kMwMTN": "color-x1e2nbdu",
+              $$css: "npm-package:components/Foo.react.js:4"
+            },
+            "bar-baz": {
+              "display-k1xSpc": "display-x1lliihq",
+              $$css: "npm-package:components/Foo.react.js:7"
+            }
+          };"
+        `);
+      });
+
+      test('adds debug data (haste)', () => {
+        const options = {
+          debug: true,
+          filename: '/html/js/components/Foo.react.js',
+          unstable_moduleResolution: { type: 'haste' },
+        };
+
+        const { code } = transform(
+          `
+          import * as stylex from '@stylexjs/stylex';
+          export const styles = stylex.create({
+            foo: {
+              color: 'red'
+            },
+            'bar-baz': {
+              display: 'block'
+            },
+            1: {
+              fontSize: '1em'
+            }
+          });
+        `,
+          options,
+        );
+
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(".fontSize-xrv4cvt{font-size:1em}", 3000);
+          _inject2(".color-x1e2nbdu{color:red}", 3000);
+          _inject2(".display-x1lliihq{display:block}", 3000);
+          export const styles = {
+            "1": {
+              "fontSize-kGuDYH": "fontSize-xrv4cvt",
+              $$css: "Foo.react.js:10"
+            },
+            foo: {
+              "color-kMwMTN": "color-x1e2nbdu",
+              $$css: "Foo.react.js:4"
+            },
+            "bar-baz": {
+              "display-k1xSpc": "display-x1lliihq",
+              $$css: "Foo.react.js:7"
+            }
+          };"
+        `);
+      });
+
+      test('adds debug data for npm packages (haste)', () => {
+        const options = {
+          debug: true,
+          filename: '/node_modules/npm-package/dist/components/Foo.react.js',
+          unstable_moduleResolution: { type: 'haste' },
+        };
+
+        const { code } = transform(
+          `
+          import * as stylex from '@stylexjs/stylex';
+          export const styles = stylex.create({
+            foo: {
+              color: 'red'
+            },
+            'bar-baz': {
+              display: 'block'
+            },
+            1: {
+              fontSize: '1em'
+            }
+          });
+        `,
+          options,
+        );
+
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(".fontSize-xrv4cvt{font-size:1em}", 3000);
+          _inject2(".color-x1e2nbdu{color:red}", 3000);
+          _inject2(".display-x1lliihq{display:block}", 3000);
+          export const styles = {
+            "1": {
+              "fontSize-kGuDYH": "fontSize-xrv4cvt",
+              $$css: "npm-package:components/Foo.react.js:10"
+            },
+            foo: {
+              "color-kMwMTN": "color-x1e2nbdu",
+              $$css: "npm-package:components/Foo.react.js:4"
+            },
+            "bar-baz": {
+              "display-k1xSpc": "display-x1lliihq",
+              $$css: "npm-package:components/Foo.react.js:7"
+            }
+          };"
+        `);
+      });
+    });
+
+    // LEGACY (TODO: Remove)
+    describe('legacy / deprecated', () => {
+      test('transforms nested pseudo-class to CSS', () => {
+        expect(
+          transform(`
+            import stylex from 'stylex';
+            const styles = stylex.create({
+              default: {
+                ':hover': {
+                  backgroundColor: 'red',
+                  color: 'blue',
+                },
+              },
+            });
+          `).code,
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import stylex from 'stylex';
+          _inject2(".x1gykpug:hover{background-color:red}", 3130);
+          _inject2(".x17z2mba:hover{color:blue}", 3130);"
+        `);
+      });
+
+      describe('pseudo-classes', () => {
+        // TODO: this should either fail or guarantee an insertion order relative to valid pseudo-classes
+        test('transforms invalid pseudo-class', () => {
+          expect(
+            transform(`
+              import stylex from 'stylex';
+              const styles = stylex.create({
+                default: {
+                  ':invalpwdijad': {
+                    backgroundColor: 'red',
+                    color: 'blue',
+                  },
+                },
+              });
+            `).code,
+          ).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import stylex from 'stylex';
+            _inject2(".x19iys6w:invalpwdijad{background-color:red}", 3040);
+            _inject2(".x5z3o4w:invalpwdijad{color:blue}", 3040);"
+          `);
+        });
+
+        test('transforms valid pseudo-classes in order', () => {
+          expect(
+            transform(`
+              import stylex from 'stylex';
+              const styles = stylex.create({
+                default: {
+                  ':hover': {
+                    color: 'blue',
+                  },
+                  ':active': {
+                    color: 'red',
+                  },
+                  ':focus': {
+                    color: 'yellow',
+                  },
+                  ':nth-child(2n)': {
+                    color: 'purple'
+                  }
+                },
+              });
+            `).code,
+          ).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import stylex from 'stylex';
+            _inject2(".x17z2mba:hover{color:blue}", 3130);
+            _inject2(".x96fq8s:active{color:red}", 3170);
+            _inject2(".x1wvtd7d:focus{color:yellow}", 3150);
+            _inject2(".x126ychx:nth-child(2n){color:purple}", 3060);"
+          `);
+        });
+
+        test('transforms pseudo-class with array value as fallbacks', () => {
+          expect(
+            transform(`
+              import stylex from 'stylex';
+              const styles = stylex.create({
+                default: {
+                  ':hover': {
+                    position: ['sticky', 'fixed'],
+                  }
+                },
+              });
+            `).code,
+          ).toMatchInlineSnapshot(`
+            "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+            var _inject2 = _inject;
+            import stylex from 'stylex';
+            _inject2(".x1nxcus0:hover{position:sticky;position:fixed}", 3130);"
+          `);
+        });
       });
 
       test('transforms legacy pseudo class within a pseudo element', () => {
@@ -994,7 +1772,7 @@ describe('@stylexjs/babel-plugin', () => {
                 },
               },
             });
-          `),
+          `).code,
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
@@ -1027,7 +1805,7 @@ describe('@stylexjs/babel-plugin', () => {
                 },
               },
             });
-          `),
+          `).code,
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
@@ -1064,7 +1842,7 @@ describe('@stylexjs/babel-plugin', () => {
                 },
               },
             });
-          `),
+          `).code,
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
@@ -1082,9 +1860,7 @@ describe('@stylexjs/babel-plugin', () => {
           };"
         `);
       });
-    });
 
-    describe('queries', () => {
       test('transforms media queries', () => {
         expect(
           transform(`
@@ -1100,7 +1876,7 @@ describe('@stylexjs/babel-plugin', () => {
                 },
               },
             });
-          `),
+          `).code,
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
@@ -1126,7 +1902,7 @@ describe('@stylexjs/babel-plugin', () => {
                 },
               },
             });
-          `),
+          `).code,
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
@@ -1136,819 +1912,56 @@ describe('@stylexjs/babel-plugin', () => {
           _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);"
         `);
       });
-    });
 
-    describe('queries within properties', () => {
-      test('transforms media queries', () => {
+      test('transforms dynamic shorthands in legacy-expand-shorthands mode', () => {
         expect(
-          transform(`
+          transform(
+            `
             import stylex from 'stylex';
-            const styles = stylex.create({
-              default: {
-                backgroundColor: {
-                  default: 'red',
-                  '@media (min-width: 1000px)': 'blue',
-                  '@media (min-width: 2000px)': 'purple',
-                }
-              },
-            });
-          `),
-        ).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import stylex from 'stylex';
-          _inject2(".xrkmrrc{background-color:red}", 3000);
-          _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
-          _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);"
-        `);
-      });
-
-      test('transforms supports queries', () => {
-        expect(
-          transform(`
-            import stylex from 'stylex';
-            const styles = stylex.create({
-              default: {
-                backgroundColor: {
-                  default:'red',
-                  '@supports (hover: hover)': 'blue',
-                  '@supports not (hover: hover)': 'purple',
-                }
-              },
-            });
-          `),
-        ).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import stylex from 'stylex';
-          _inject2(".xrkmrrc{background-color:red}", 3000);
-          _inject2("@supports (hover: hover){.x6m3b6q.x6m3b6q{background-color:blue}}", 3030);
-          _inject2("@supports not (hover: hover){.x6um648.x6um648{background-color:purple}}", 3030);"
-        `);
-      });
-    });
-
-    test('auto-expands shorthands', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const borderRadius = 2;
-          const styles = stylex.create({
-            default: {
-              margin: 'calc((100% - 50px) * 0.5) 20px 0',
-            },
-            error: {
-              borderColor: 'red blue',
-              borderStyle: 'dashed',
-              borderWidth: '0 0 2px 0',
-            },
-            root: {
-              borderWidth: 1,
-              borderStyle: 'solid',
-              borderColor: 'var(--divider)',
-              borderRadius: borderRadius * 2,
-              borderBottomWidth: '5px',
-              borderBottomStyle: 'solid',
-              borderBottomColor: 'red',
-            },
-            short: {
-              padding: 'calc((100% - 50px) * 0.5) var(--rightpadding, 20px)',
-              paddingTop: 0,
-            },
-            valid: {
-              borderColor: 'green',
-              borderStyle: 'solid',
-              borderWidth: 1,
-            }
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        const borderRadius = 2;
-        _inject2(".xe4njm9{margin:calc((100% - 50px) * .5) 20px 0}", 1000);
-        _inject2(".xs4buau{border-color:red blue}", 2000);
-        _inject2(".xbsl7fq{border-style:dashed}", 2000);
-        _inject2(".xn43iik{border-width:0 0 2px 0}", 2000);
-        _inject2(".xmkeg23{border-width:1px}", 2000);
-        _inject2(".x1y0btm7{border-style:solid}", 2000);
-        _inject2(".x1lh7sze{border-color:var(--divider)}", 2000);
-        _inject2(".x12oqio5{border-radius:4px}", 2000);
-        _inject2(".xa309fb{border-bottom-width:5px}", 4000);
-        _inject2(".x1q0q8m5{border-bottom-style:solid}", 4000);
-        _inject2(".xud65wk{border-bottom-color:red}", 4000);
-        _inject2(".x1lmef92{padding:calc((100% - 50px) * .5) var(--rightpadding,20px)}", 1000);
-        _inject2(".xexx8yu{padding-top:0}", 4000);
-        _inject2(".x1bg2uv5{border-color:green}", 2000);"
-      `);
-    });
-
-    test('Last property wins, even if shorthand', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const borderRadius = 2;
-          const styles = stylex.create({
-            default: {
-              marginTop: 5,
-              marginEnd: 10,
-              marginBottom: 15,
-              marginStart: 20,
-            },
-            override: {
-              marginBottom: 100,
-              margin: 0,
-            }
-          });
-          stylex(styles.default, styles.override);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        const borderRadius = 2;
-        _inject2(".x1ok221b{margin-top:5px}", 4000);
-        _inject2(".x1sa5p1d{margin-inline-end:10px}", 3000);
-        _inject2(".x1fqp7bg{margin-bottom:15px}", 4000);
-        _inject2(".xqsn43r{margin-inline-start:20px}", 3000);
-        _inject2(".x1ghz6dp{margin:0}", 1000);
-        "x1ghz6dp";"
-      `);
-    });
-
-    test('Adds null for constituent properties of shorthands', () => {
-      expect(
-        transform(
-          `
-            import stylex from 'stylex';
-            const borderRadius = 2;
             export const styles = stylex.create({
-              default: {
-                margin: 'calc((100% - 50px) * 0.5) 20px 0',
-              },
-              error: {
-                borderColor: 'red blue',
-                borderStyle: 'dashed',
-                borderWidth: '0 0 2px 0',
-              },
-              root: {
-                borderWidth: 1,
-                borderStyle: 'solid',
-                borderColor: 'var(--divider)',
-                borderRadius: borderRadius * 2,
-                borderBottomWidth: '5px',
-                borderBottomStyle: 'solid',
-                borderBottomColor: 'red',
-              },
-              short: {
-                padding: 'calc((100% - 50px) * 0.5) var(--rightpadding, 20px)',
-                paddingTop: 0,
-              },
-              shortReversed: {
-                paddingTop: 0,
-                padding: 'calc((100% - 50px) * 0.5) var(--rightpadding, 20px)',
-              },
-              valid: {
-                borderColor: 'green',
-                borderStyle: 'solid',
-                borderWidth: 1,
-              }
-            });
-         `,
-          { runtimeInjection: false },
-        ),
-      ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        const borderRadius = 2;
-        export const styles = {
-          default: {
-            kogj98: "xe4njm9",
-            kUOVxO: null,
-            keTefX: null,
-            koQZXg: null,
-            k71WvV: null,
-            km5ZXQ: null,
-            kqGvvJ: null,
-            keoZOQ: null,
-            k1K539: null,
-            $$css: true
-          },
-          error: {
-            kVAM5u: "xs4buau",
-            kzOINU: null,
-            kGJrpR: null,
-            kaZRDh: null,
-            kBCPoo: null,
-            k26BEO: null,
-            k5QoK5: null,
-            kLZC3w: null,
-            kL6WhQ: null,
-            ksu8eU: "xbsl7fq",
-            kJRH4f: null,
-            kVhnKS: null,
-            k4WBpm: null,
-            k8ry5P: null,
-            kSWEuD: null,
-            kDUl1X: null,
-            kPef9Z: null,
-            kfdmCh: null,
-            kMzoRj: "xn43iik",
-            kjGldf: null,
-            k2ei4v: null,
-            kZ1KPB: null,
-            ke9TFa: null,
-            kWqL5O: null,
-            kLoX6v: null,
-            kEafiO: null,
-            kt9PQ7: null,
-            $$css: true
-          },
-          root: {
-            kMzoRj: "xmkeg23",
-            kjGldf: null,
-            k2ei4v: null,
-            kZ1KPB: null,
-            ke9TFa: null,
-            kWqL5O: null,
-            kLoX6v: null,
-            kEafiO: null,
-            ksu8eU: "x1y0btm7",
-            kJRH4f: null,
-            kVhnKS: null,
-            k4WBpm: null,
-            k8ry5P: null,
-            kSWEuD: null,
-            kDUl1X: null,
-            kPef9Z: null,
-            kVAM5u: "x1lh7sze",
-            kzOINU: null,
-            kGJrpR: null,
-            kaZRDh: null,
-            kBCPoo: null,
-            k26BEO: null,
-            k5QoK5: null,
-            kLZC3w: null,
-            kaIpWk: "x12oqio5",
-            krdFHd: null,
-            kfmiAY: null,
-            kVL7Gh: null,
-            kT0f0o: null,
-            kIxVMA: null,
-            ksF3WI: null,
-            kqGeR4: null,
-            kYm2EN: null,
-            kt9PQ7: "xa309fb",
-            kfdmCh: "x1q0q8m5",
-            kL6WhQ: "xud65wk",
-            $$css: true
-          },
-          short: {
-            kmVPX3: "x1lmef92",
-            kg3NbH: null,
-            kuDDbn: null,
-            kE3dHu: null,
-            kP0aTx: null,
-            kpe85a: null,
-            k8WAf4: null,
-            kGO01o: null,
-            kLKAdn: "xexx8yu",
-            $$css: true
-          },
-          shortReversed: {
-            kmVPX3: "x1lmef92",
-            kg3NbH: null,
-            kuDDbn: null,
-            kE3dHu: null,
-            kP0aTx: null,
-            kpe85a: null,
-            k8WAf4: null,
-            kLKAdn: null,
-            kGO01o: null,
-            $$css: true
-          },
-          valid: {
-            kVAM5u: "x1bg2uv5",
-            kzOINU: null,
-            kGJrpR: null,
-            kaZRDh: null,
-            kBCPoo: null,
-            k26BEO: null,
-            k5QoK5: null,
-            kLZC3w: null,
-            kL6WhQ: null,
-            ksu8eU: "x1y0btm7",
-            kJRH4f: null,
-            kVhnKS: null,
-            k4WBpm: null,
-            k8ry5P: null,
-            kSWEuD: null,
-            kDUl1X: null,
-            kPef9Z: null,
-            kfdmCh: null,
-            kMzoRj: "xmkeg23",
-            kjGldf: null,
-            k2ei4v: null,
-            kZ1KPB: null,
-            ke9TFa: null,
-            kWqL5O: null,
-            kLoX6v: null,
-            kEafiO: null,
-            kt9PQ7: null,
-            $$css: true
-          }
-        };"
-      `);
-    });
-
-    test('Can leave shorthands as is when configured.', () => {
-      expect(
-        transform(
-          `
-          import stylex from 'stylex';
-          const borderRadius = 2;
-          export const styles = stylex.create({
-            default: {
-              marginTop: 'calc((100% - 50px) * 0.5)',
-              marginRight: 20,
-              marginBottom: 0,
-            },
-            error: {
-              borderVerticalColor: 'red',
-              borderHorizontalColor: 'blue',
-              borderStyle: 'dashed',
-              borderBottomWidth: 2,
-            },
-            root: {
-              borderWidth: 1,
-              borderStyle: 'solid',
-              borderColor: 'var(--divider)',
-              borderRadius: borderRadius * 2,
-              borderBottomWidth: 5,
-              borderBottomStyle: 'solid',
-              borderBottomColor: 'red',
-            },
-            short: {
-              paddingVertical: 'calc((100% - 50px) * 0.5)',
-              paddingHorizontal: 'var(--rightpadding, 20px)',
-              paddingTop: 0,
-            },
-            shortReversed: {
-              paddingTop: 0,
-              paddingVertical: 'calc((100% - 50px) * 0.5)',
-              paddingHorizontal: 'var(--rightpadding, 20px)',
-            },
-            valid: {
-              borderColor: 'green',
-              borderStyle: 'solid',
-              borderWidth: 1,
-            }
-          });
-         `,
-          { runtimeInjection: false, styleResolution: 'property-specificity' },
-        ),
-      ).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
-        const borderRadius = 2;
-        export const styles = {
-          default: {
-            keoZOQ: "xxsse2n",
-            km5ZXQ: "x1wh8b8d",
-            k1K539: "xat24cr",
-            $$css: true
-          },
-          error: {
-            k5QoK5: "xzu6wam",
-            kzOINU: "xgomli1",
-            ksu8eU: "xbsl7fq",
-            kt9PQ7: "xlxy82",
-            $$css: true
-          },
-          root: {
-            kMzoRj: "xmkeg23",
-            ksu8eU: "x1y0btm7",
-            kVAM5u: "x1lh7sze",
-            kaIpWk: "x12oqio5",
-            kt9PQ7: "xa309fb",
-            kfdmCh: "x1q0q8m5",
-            kL6WhQ: "xud65wk",
-            $$css: true
-          },
-          short: {
-            k8WAf4: "x190pm2f",
-            kg3NbH: "x1n86tx6",
-            kLKAdn: "xexx8yu",
-            $$css: true
-          },
-          shortReversed: {
-            kLKAdn: "xexx8yu",
-            k8WAf4: "x190pm2f",
-            kg3NbH: "x1n86tx6",
-            $$css: true
-          },
-          valid: {
-            kVAM5u: "x1bg2uv5",
-            ksu8eU: "x1y0btm7",
-            kMzoRj: "xmkeg23",
-            $$css: true
-          }
-        };"
-      `);
-    });
-  });
-
-  describe('[transform] stylex.create() with functions', () => {
-    test('transforms style object with function', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            default: (color) => ({
-              backgroundColor: 'red',
-              color,
-            })
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".xfx01vb{color:var(--color)}", 3000);
-        _inject2("@property --color { syntax: \\"*\\"; inherits: false;}", 0);
-        export const styles = {
-          default: color => [{
-            kWkggS: "xrkmrrc",
-            kMwMTN: "xfx01vb",
-            $$css: true
-          }, {
-            "--color": color != null ? color : undefined
-          }]
-        };"
-      `);
-    });
-
-    test('adds units for numbers in style object with function', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            default: (width) => ({
-              backgroundColor: 'red',
-              width,
-            })
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x1bl4301{width:var(--width)}", 4000);
-        _inject2("@property --width { syntax: \\"*\\"; inherits: false;}", 0);
-        export const styles = {
-          default: width => [{
-            kWkggS: "xrkmrrc",
-            kzqmXN: "x1bl4301",
-            $$css: true
-          }, {
-            "--width": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
-          }]
-        };"
-      `);
-    });
-
-    test('transforms mix of objects and functions', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            default: (color) => ({
-              backgroundColor: 'red',
-              color: color,
-            }),
-            mono: {
-              color: 'black',
-            },
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".xfx01vb{color:var(--color)}", 3000);
-        _inject2(".x1mqxbix{color:black}", 3000);
-        _inject2("@property --color { syntax: \\"*\\"; inherits: false;}", 0);
-        export const styles = {
-          default: color => [{
-            kWkggS: "xrkmrrc",
-            kMwMTN: "xfx01vb",
-            $$css: true
-          }, {
-            "--color": color != null ? color : undefined
-          }],
-          mono: {
-            kMwMTN: "x1mqxbix",
-            $$css: true
-          }
-        };"
-      `);
-    });
-    test('transforms styles that set CSS vars', () => {
-      // NOTE: the generated variable name is a little weird, but valid.
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            default: (bgColor) => ({
-              '--background-color': bgColor,
-            }),
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x15mgraa{--background-color:var(----background-color)}", 1);
-        _inject2("@property ----background-color { syntax: \\"*\\"; inherits: false;}", 0);
-        export const styles = {
-          default: bgColor => [{
-            "--background-color": bgColor == null ? null : "x15mgraa",
-            $$css: true
-          }, {
-            "----background-color": bgColor != null ? bgColor : undefined
-          }]
-        };"
-      `);
-    });
-    test('transforms functions with nested dynamic values', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            default: (color) => ({
-              ':hover': {
+              default: (margin) => ({
                 backgroundColor: 'red',
-                color,
-              },
-            }),
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x1gykpug:hover{background-color:red}", 3130);
-        _inject2(".xtyu0qe:hover{color:var(--1ijzsae)}", 3130);
-        _inject2("@property --1ijzsae { syntax: \\"*\\"; inherits: false;}", 0);
-        export const styles = {
-          default: color => [{
-            kGzVvX: "x1gykpug",
-            kDPRdz: "xtyu0qe",
-            $$css: true
-          }, {
-            "--1ijzsae": color != null ? color : undefined
-          }]
-        };"
-      `);
-    });
-    test('transforms mix of objects and functions', () => {
-      expect(
-        transform(`
+                margin: {
+                  default: margin,
+                  ':hover': margin + 4,
+                },
+                marginTop: margin - 4,
+              })
+            });
+          `,
+            { styleResolution: 'legacy-expand-shorthands' },
+          ).code,
+        ).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
           import stylex from 'stylex';
-          export const styles = stylex.create({
-            default: (color) => ({
-              backgroundColor: 'red',
-              color: color,
-            }),
-            mono: {
-              color: 'black',
-            },
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".xfx01vb{color:var(--color)}", 3000);
-        _inject2(".x1mqxbix{color:black}", 3000);
-        _inject2("@property --color { syntax: \\"*\\"; inherits: false;}", 0);
-        export const styles = {
-          default: color => [{
-            kWkggS: "xrkmrrc",
-            kMwMTN: "xfx01vb",
-            $$css: true
-          }, {
-            "--color": color != null ? color : undefined
-          }],
-          mono: {
-            kMwMTN: "x1mqxbix",
-            $$css: true
-          }
-        };"
-      `);
-    });
-    test('transforms styles that set CSS vars', () => {
-      // NOTE: the generated variable name is a little weird, but valid.
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            default: (bgColor) => ({
-              '--background-color': bgColor,
-            }),
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x15mgraa{--background-color:var(----background-color)}", 1);
-        _inject2("@property ----background-color { syntax: \\"*\\"; inherits: false;}", 0);
-        export const styles = {
-          default: bgColor => [{
-            "--background-color": bgColor == null ? null : "x15mgraa",
-            $$css: true
-          }, {
-            "----background-color": bgColor != null ? bgColor : undefined
-          }]
-        };"
-      `);
-    });
-    test('transforms functions with dynamic values within conditional values', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            default: (color) => ({
-              backgroundColor: 'red',
-              color: {
-                default: color,
-                ':hover': {
-                  '@media (min-width: 1000px)': 'green',
-                  default: 'blue',
-                }
-              },
-            }),
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x1n25116{color:var(--4xs81a)}", 3000);
-        _inject2("@media (min-width: 1000px){.xtljkjt.xtljkjt:hover{color:green}}", 3330);
-        _inject2(".x17z2mba:hover{color:blue}", 3130);
-        _inject2("@property --4xs81a { syntax: \\"*\\"; inherits: false;}", 0);
-        export const styles = {
-          default: color => [{
-            kWkggS: "xrkmrrc",
-            kMwMTN: "x1n25116 xtljkjt x17z2mba",
-            $$css: true
-          }, {
-            "--4xs81a": color != null ? color : undefined
-          }]
-        };"
-      `);
-    });
-    test('transforms functions with multiple dynamic values within conditional values', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            default: (color) => ({
-              backgroundColor: 'red',
-              color: {
-                default: color,
-                ':hover': {
-                  '@media (min-width: 1000px)': 'green',
-                  default: 'color-mix(' + color + ', blue)',
-                }
-              },
-            }),
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x1n25116{color:var(--4xs81a)}", 3000);
-        _inject2("@media (min-width: 1000px){.xtljkjt.xtljkjt:hover{color:green}}", 3330);
-        _inject2(".x1d4gdy3:hover{color:var(--w5m4kq)}", 3130);
-        _inject2("@property --4xs81a { syntax: \\"*\\"; inherits: false;}", 0);
-        _inject2("@property --w5m4kq { syntax: \\"*\\"; inherits: false;}", 0);
-        export const styles = {
-          default: color => [{
-            kWkggS: "xrkmrrc",
-            kMwMTN: "x1n25116 xtljkjt x1d4gdy3",
-            $$css: true
-          }, {
-            "--4xs81a": color != null ? color : undefined,
-            "--w5m4kq": 'color-mix(' + color + ', blue)' != null ? 'color-mix(' + color + ', blue)' : undefined
-          }]
-        };"
-      `);
-    });
-
-    test('transforms shorthands in legacy-expand-shorthands mode', () => {
-      expect(
-        transform(
-          `
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            default: (margin) => ({
-              backgroundColor: 'red',
-              margin: {
-                default: margin,
-                ':hover': margin + 4,
-              },
-              marginTop: margin - 4,
-            })
-          });
-        `,
-          { styleResolution: 'legacy-expand-shorthands' },
-        ),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2(".x1ie72y1{margin-right:var(--14mfytm)}", 3000, ".x1ie72y1{margin-left:var(--14mfytm)}");
-        _inject2(".x128459:hover{margin-right:var(--yepcm9)}", 3130, ".x128459:hover{margin-left:var(--yepcm9)}");
-        _inject2(".x1hvr6ea{margin-bottom:var(--14mfytm)}", 4000);
-        _inject2(".x3skgmg:hover{margin-bottom:var(--yepcm9)}", 4130);
-        _inject2(".x1k44ad6{margin-left:var(--14mfytm)}", 3000, ".x1k44ad6{margin-right:var(--14mfytm)}");
-        _inject2(".x10ktymb:hover{margin-left:var(--yepcm9)}", 3130, ".x10ktymb:hover{margin-right:var(--yepcm9)}");
-        _inject2(".x17zef60{margin-top:var(--marginTop)}", 4000);
-        _inject2("@property --14mfytm { syntax: \\"*\\"; inherits: false;}", 0);
-        _inject2("@property --yepcm9 { syntax: \\"*\\"; inherits: false;}", 0);
-        _inject2("@property --marginTop { syntax: \\"*\\"; inherits: false;}", 0);
-        export const styles = {
-          default: margin => [{
-            kWkggS: "xrkmrrc",
-            kETOaJ: "x1ie72y1 x128459",
-            k1K539: "x1hvr6ea x3skgmg",
-            kXtLW5: "x1k44ad6 x10ktymb",
-            keoZOQ: "x17zef60",
-            $$css: true
-          }, {
-            "--14mfytm": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin),
-            "--yepcm9": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin + 4),
-            "--marginTop": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin - 4)
-          }]
-        };"
-      `);
-    });
-  });
-
-  describe('[transform] setting vars with stylex.create()', () => {
-    test('preserves kebab-case in CSS variable names', () => {
-      // NOTE: the generated variable name is a little weird, but valid.
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            default: {
-              '--background-color': 'red',
-            },
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xgau0yw{--background-color:red}", 1);
-        export const styles = {
-          default: {
-            "--background-color": "xgau0yw",
-            $$css: true
-          }
-        };"
-      `);
-    });
-
-    test('preserves camelCase in CSS variable names', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({
-            default: {
-              '--myCustomVar': 'red',
-              '--anotherCamelVar': '10px',
-            },
-          });
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x1ujxqga{--myCustomVar:red}", 1);
-        _inject2(".x1g24lt9{--anotherCamelVar:10px}", 1);"
-      `);
+          _inject2(".xrkmrrc{background-color:red}", 3000);
+          _inject2(".x1ie72y1{margin-right:var(--14mfytm)}", 3000, ".x1ie72y1{margin-left:var(--14mfytm)}");
+          _inject2(".x128459:hover{margin-right:var(--yepcm9)}", 3130, ".x128459:hover{margin-left:var(--yepcm9)}");
+          _inject2(".x1hvr6ea{margin-bottom:var(--14mfytm)}", 4000);
+          _inject2(".x3skgmg:hover{margin-bottom:var(--yepcm9)}", 4130);
+          _inject2(".x1k44ad6{margin-left:var(--14mfytm)}", 3000, ".x1k44ad6{margin-right:var(--14mfytm)}");
+          _inject2(".x10ktymb:hover{margin-left:var(--yepcm9)}", 3130, ".x10ktymb:hover{margin-right:var(--yepcm9)}");
+          _inject2(".x17zef60{margin-top:var(--marginTop)}", 4000);
+          _inject2("@property --14mfytm { syntax: \\"*\\"; inherits: false;}", 0);
+          _inject2("@property --yepcm9 { syntax: \\"*\\"; inherits: false;}", 0);
+          _inject2("@property --marginTop { syntax: \\"*\\"; inherits: false;}", 0);
+          export const styles = {
+            default: margin => [{
+              kWkggS: "xrkmrrc",
+              kETOaJ: "x1ie72y1 x128459",
+              k1K539: "x1hvr6ea x3skgmg",
+              kXtLW5: "x1k44ad6 x10ktymb",
+              keoZOQ: "x17zef60",
+              $$css: true
+            }, {
+              "--14mfytm": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin),
+              "--yepcm9": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin + 4),
+              "--marginTop": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin - 4)
+            }]
+          };"
+        `);
+      });
     });
   });
 });

--- a/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
+++ b/packages/babel-plugin/__tests__/stylex-transform-stylex-props-test.js
@@ -313,6 +313,64 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
+    test('Last property wins, even if shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const borderRadius = 2;
+          export const styles = stylex.create({
+            default: {
+              marginTop: 5,
+              marginEnd: 10,
+              marginBottom: 15,
+              marginStart: 20,
+            },
+            override: {
+              marginBottom: 100,
+              margin: 0,
+            }
+          });
+          const result = stylex.props(styles.default, styles.override);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        const borderRadius = 2;
+        _inject2(".x1ok221b{margin-top:5px}", 4000);
+        _inject2(".x1sa5p1d{margin-inline-end:10px}", 3000);
+        _inject2(".x1fqp7bg{margin-bottom:15px}", 4000);
+        _inject2(".xqsn43r{margin-inline-start:20px}", 3000);
+        _inject2(".x1ghz6dp{margin:0}", 1000);
+        export const styles = {
+          default: {
+            keoZOQ: "x1ok221b",
+            k71WvV: "x1sa5p1d",
+            k1K539: "x1fqp7bg",
+            keTefX: "xqsn43r",
+            koQZXg: null,
+            km5ZXQ: null,
+            $$css: true
+          },
+          override: {
+            kogj98: "x1ghz6dp",
+            kUOVxO: null,
+            keTefX: null,
+            koQZXg: null,
+            k71WvV: null,
+            km5ZXQ: null,
+            kqGvvJ: null,
+            keoZOQ: null,
+            k1K539: null,
+            $$css: true
+          }
+        };
+        const result = {
+          className: "x1ghz6dp"
+        };"
+      `);
+    });
+
     test('stylex call using styles with pseudo selectors', () => {
       expect(
         transform(`


### PR DESCRIPTION
Improve test coverage and make navigating the suite easier.

* Rename tests and organize into groups.
  * Consolidate redundant tests.
  * Move a 'props' tests to props test file.
  * Move tests for legacy API to bottom of file. 
  * Return `code` and `metadata` from `transform`; future iteration will remove use of `runtimeInjection` option from tests.
* Use OSS default imports and options.
  * Imports are updated to be `import * as stylex from '@stylexjs/stylex'` (except legacy tests).
  * Tests run using cjs modules by default.
* Add missing tests for dynamic styles.
  * Tests for use with pseudo-class, pseudo-element, and queries.


<img width="616" alt="image" src="https://github.com/user-attachments/assets/9911f9e1-ed9f-46a7-8ece-e3c804a902a4" />

<img width="649" alt="image" src="https://github.com/user-attachments/assets/c56736e4-5b97-4329-b828-293637642eb8" />




