### PR TITLE
fix: fix pseudo elements in dynamic styles

### DIFF
--- a/packages/babel-plugin/__tests__/transform-create-test.js
+++ b/packages/babel-plugin/__tests__/transform-create-test.js
@@ -1185,7 +1185,7 @@ describe('@stylexjs/babel-plugin', () => {
                 color: {
                   ':hover': hover,
                   ':active': active,
-                  ':focus': focys,
+                  ':focus': focus,
                   ':nth-child(2n)': 'purple',
                 },
               }),
@@ -1210,7 +1210,7 @@ describe('@stylexjs/babel-plugin', () => {
               }, {
                 "--1113oo7": hover != null ? hover : undefined,
                 "--hxnnmm": active != null ? active : undefined,
-                "--8tbbve": focys != null ? focys : undefined
+                "--8tbbve": focus != null ? focus : undefined
               }]
             };"
           `);
@@ -1239,8 +1239,8 @@ describe('@stylexjs/babel-plugin', () => {
             import * as stylex from '@stylexjs/stylex';
             _inject2(".x6r7ojb::before{color:var(--1g451k2)}", 8000);
             _inject2(".x5ga601::after{color:var(--19erzii)}", 8000);
-            _inject2("@property --1g451k2 { syntax: \\"*\\"; inherits: false;}", 0);
-            _inject2("@property --19erzii { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --1g451k2 { syntax: \\"*\\";}", 0);
+            _inject2("@property --19erzii { syntax: \\"*\\";}", 0);
             export const styles = {
               foo: (a, b) => [{
                 kxBb7d: "x6r7ojb",
@@ -1271,7 +1271,7 @@ describe('@stylexjs/babel-plugin', () => {
             var _inject2 = _inject;
             import * as stylex from '@stylexjs/stylex';
             _inject2(".xwdnmik::placeholder{color:var(--163tekb)}", 8000);
-            _inject2("@property --163tekb { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --163tekb { syntax: \\"*\\";}", 0);
             export const styles = {
               foo: color => [{
                 k8Qsv1: "xwdnmik",
@@ -1300,7 +1300,7 @@ describe('@stylexjs/babel-plugin', () => {
             var _inject2 = _inject;
             import * as stylex from '@stylexjs/stylex';
             _inject2(".x3j4sww::-webkit-slider-thumb, .x3j4sww::-moz-range-thumb, .x3j4sww::-ms-thumb{width:var(--msahdu)}", 9000);
-            _inject2("@property --msahdu { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --msahdu { syntax: \\"*\\";}", 0);
             export const styles = {
               foo: width => [{
                 k8pbKx: "x3j4sww",
@@ -1333,7 +1333,7 @@ describe('@stylexjs/babel-plugin', () => {
             import * as stylex from '@stylexjs/stylex';
             _inject2(".x16oeupf::before{color:red}", 8000);
             _inject2(".x10u3axo::before:hover{color:var(--6bge3v)}", 8130);
-            _inject2("@property --6bge3v { syntax: \\"*\\"; inherits: false;}", 0);
+            _inject2("@property --6bge3v { syntax: \\"*\\";}", 0);
             export const styles = {
               foo: color => [{
                 kxBb7d: "x16oeupf x10u3axo",

--- a/packages/babel-plugin/src/visitors/stylex-create/index.js
+++ b/packages/babel-plugin/src/visitors/stylex-create/index.js
@@ -124,12 +124,20 @@ export default function transformStyleXCreate(
     const injectedInheritStyles: { [string]: InjectableStyle } = {};
     if (fns != null) {
       const dynamicFnsNames = Object.values(fns)
-        ?.map((entry) => Object.keys(entry[1]))
+        ?.map((entry) =>
+          Object.entries(entry[1]).map(([variableName, obj]) => ({
+            variableName,
+            path: obj.path,
+          })),
+        )
         .flat();
-      dynamicFnsNames.forEach((fnsName) => {
-        injectedInheritStyles[fnsName] = {
+
+      dynamicFnsNames.forEach(({ variableName, path }) => {
+        // Pseudo elements can only access css vars via inheritance
+        const isPseudoElement = path.some((p) => p.startsWith('::'));
+        injectedInheritStyles[variableName] = {
           priority: 0,
-          ltr: `@property ${fnsName} { syntax: "*"; inherits: false;}`,
+          ltr: `@property ${variableName} { syntax: "*";${isPseudoElement ? '' : ' inherits: false;'}}`,
           rtl: null,
         };
       });


### PR DESCRIPTION
## What changed / motivation ?

Pseudo elements not working in dynamic styles because we're setting `inherits: false`, see [978](https://github.com/facebook/stylex/issues/978)

## Linked PR/Issues

Fixes [978](https://github.com/facebook/stylex/issues/978)

## Testing

Ran on tests added in https://github.com/facebook/stylex/pull/977
Before:
<img width="325" alt="image" src="https://github.com/user-attachments/assets/4d7184fe-2229-4fbe-974c-1829d3accbbd" />

After
<img width="310" alt="image" src="https://github.com/user-attachments/assets/2554db52-f583-4143-b2dd-d559d0bbcdf7" />

Value is now set correctly

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code