### PR TITLE
Replace $Diff in StyleXTypes

### DIFF
--- a/packages/stylex/src/StyleXTypes.js
+++ b/packages/stylex/src/StyleXTypes.js
@@ -55,9 +55,9 @@ export type StyleXSingleStyle = false | ?NestedCSSPropTypes;
 export type XStyle<+T = NestedCSSPropTypes> = StyleXArray<
   false | ?$ReadOnly<{ ...T, $$css: true }>,
 >;
-export type XStyleWithout<+T: { +[string]: mixed }> = XStyle<
-  $ReadOnly<$Diff<NestedCSSPropTypes, $Exact<T>>>,
->;
+
+export type XStyleWithout<+T: { +[_K in keyof NestedCSSPropTypes]?: mixed }> =
+  XStyle<$ReadOnly<Omit<NestedCSSPropTypes, $Keys<T>>>>;
 
 export type Keyframes = $ReadOnly<{ [name: string]: CSSProperties, ... }>;
 


### PR DESCRIPTION
The Flow team is looking into killing `$Diff` now that Omit exists for a long time. This PR replaces the final `$Diff` in `StyleXTypes` with `Omit`. This was previously replaced from `$Rest` in #976 because some internal code is relying on weird behavior of `$Diff`, but they have been taken care of now so we can move away from it.

Close #994