### PR TITLE
style-value-parser/feat: add parser support for more types of media queries

### DIFF
--- a/packages/style-value-parser/src/at-queries/__tests__/media-query-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/media-query-test.js
@@ -1035,17 +1035,32 @@ describe('Test CSS Type: @media queries', () => {
     expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
-
-  test.skip('@media (min-width: calc(300px + 5em))', () => {
-    expect(
-      MediaQuery.parser.parseToEnd('@media (min-width: calc(300px + 5em))'),
-    ).toMatchInlineSnapshot();
+  test('@media (min-width: calc(300px + 5em))', () => {
+    const query = '@media (min-width: calc(300px + 5em))';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
+      MediaQuery {
+        "queries": {
+          "key": "min-width",
+          "type": "pair",
+          "value": "calc(300px + 5em)",
+        },
+      }
+    `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
-  test.skip('@media (max-height: calc(100vh - 50px))', () => {
-    expect(
-      MediaQuery.parser.parseToEnd('@media (max-height: calc(100vh - 50px))'),
-    ).toMatchInlineSnapshot();
+  test('@media (max-height: calc(100vh - 50px))', () => {
+    const query = '@media (max-height: calc(100vh - 50px))';
+    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
+      MediaQuery {
+        "queries": {
+          "key": "max-height",
+          "type": "pair",
+          "value": "calc(100vh - 50px)",
+        },
+      }
+    `);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
   test('@media (aspect-ratio: 16 / 9)', () => {

--- a/packages/style-value-parser/src/at-queries/__tests__/media-query-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/media-query-test.js
@@ -1891,8 +1891,7 @@ describe('Test CSS Type: @media queries', () => {
     expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
-  // nested not queries are broken
-  test.skip('@media not (not (not (min-width: 400px)))', () => {
+  test('@media not (not (not (min-width: 400px)))', () => {
     const query = '@media not (not (not (min-width: 400px)))';
     const mediaQuery = MediaQuery.parser.parseToEnd(query);
     expect(mediaQuery).toMatchInlineSnapshot(`
@@ -1912,53 +1911,57 @@ describe('Test CSS Type: @media queries', () => {
         },
       }
     `);
-    expect(mediaQuery.toString()).toEqual('@media (min-width: 400px)');
+    expect(mediaQuery.toString()).toEqual('@media (not (min-width: 400px))');
   });
 
-  // not queries with multiple clauses are broken
-  test.skip('@media not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px))', () => {
+  test('@media not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px))', () => {
     const query =
       '@media not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px))';
     expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
-          "rules": [
-            {
-              "key": "min-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 500,
+          "rule": {
+            "rules": [
+              {
+                "key": "min-width",
+                "type": "pair",
+                "value": {
+                  "signCharacter": undefined,
+                  "type": "integer",
+                  "unit": "px",
+                  "value": 500,
+                },
               },
-            },
-            {
-              "key": "max-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 600,
+              {
+                "key": "max-width",
+                "type": "pair",
+                "value": {
+                  "signCharacter": undefined,
+                  "type": "integer",
+                  "unit": "px",
+                  "value": 600,
+                },
               },
-            },
-            {
-              "key": "max-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 400,
+              {
+                "key": "max-width",
+                "type": "pair",
+                "value": {
+                  "signCharacter": undefined,
+                  "type": "integer",
+                  "unit": "px",
+                  "value": 400,
+                },
               },
-            },
-          ],
-          "type": "and",
+            ],
+            "type": "and",
+          },
+          "type": "not",
         },
       }
     `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
+    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(
+      '@media (not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px)))',
+    );
   });
   test('flattens nested and rules', () => {
     const query =
@@ -2003,9 +2006,9 @@ describe('Test CSS Type: @media queries', () => {
     );
   });
 
-  test.skip('flattens complex nested and rules', () => {
+  test('flattens complex nested and rules', () => {
     const query =
-      '@media ((min-width: 400px) and (print)) and ((max-width: 700px) and (orientation: landscape))';
+      '@media ((min-width: 400px) and ((max-width: 700px) and (orientation: landscape)))';
     const mediaQuery = MediaQuery.parser.parseToEnd(query);
     expect(mediaQuery).toMatchInlineSnapshot(`
       MediaQuery {
@@ -2046,61 +2049,122 @@ describe('Test CSS Type: @media queries', () => {
     );
   });
 
-  // blocked by double not fix above
-  test.skip('removes duplicate nots', () => {
+  test('removes duplicate nots', () => {
     const query = '@media not (not (min-width: 400px))';
     const mediaQuery = MediaQuery.parser.parseToEnd(query);
     expect(mediaQuery).toMatchInlineSnapshot(`
       MediaQuery {
         "queries": {
-          "rule": {
-            "key": "min-width",
-            "type": "pair",
-            "value": {
-              "signCharacter": undefined,
-              "type": "integer",
-              "unit": "px",
-              "value": 400,
-            },
+          "key": "min-width",
+          "type": "pair",
+          "value": {
+            "signCharacter": undefined,
+            "type": "integer",
+            "unit": "px",
+            "value": 400,
           },
-          "type": "not",
         },
       }
     `);
     expect(mediaQuery.toString()).toEqual('@media (min-width: 400px)');
   });
-});
 
-test('@media only screen', () => {
-  const query = '@media only screen';
-  const parsed = MediaQuery.parser.parseToEnd(query);
-  expect(parsed.queries).toMatchInlineSnapshot(`
-    {
-      "key": "screen",
-      "not": false,
-      "only": true,
-      "type": "media-keyword",
-    }
-  `);
-  expect(parsed.toString()).toBe('@media only screen');
-});
+  test('@media only screen', () => {
+    const query = '@media only screen';
+    const parsed = MediaQuery.parser.parseToEnd(query);
+    expect(parsed.queries).toMatchInlineSnapshot(`
+      {
+        "key": "screen",
+        "not": false,
+        "only": true,
+        "type": "media-keyword",
+      }
+    `);
+    expect(parsed.toString()).toBe('@media only screen');
+  });
 
-test('@media only print and (color)', () => {
-  const query = '@media only print and (color)';
-  const parsed = MediaQuery.parser.parseToEnd(query);
-  expect(parsed.toString()).toBe('@media only print and (color)');
-});
+  test('@media only print and (color)', () => {
+    const query = '@media only print and (color)';
+    const parsed = MediaQuery.parser.parseToEnd(query);
+    expect(parsed.toString()).toBe('@media only print and (color)');
+  });
 
-test('@media not screen', () => {
-  const query = '@media not screen';
-  const parsed = MediaQuery.parser.parseToEnd(query);
-  expect(parsed.queries).toMatchInlineSnapshot(`
-    {
-      "key": "screen",
-      "not": true,
-      "only": false,
-      "type": "media-keyword",
-    }
-  `);
-  expect(parsed.toString()).toBe('@media not screen');
+  test('@media not screen', () => {
+    const query = '@media not screen';
+    const parsed = MediaQuery.parser.parseToEnd(query);
+    expect(parsed.queries).toMatchInlineSnapshot(`
+      {
+        "key": "screen",
+        "not": true,
+        "only": false,
+        "type": "media-keyword",
+      }
+    `);
+    expect(parsed.toString()).toBe('@media not screen');
+  });
+
+  test('@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px)) and (not (max-width: 458px))', () => {
+    const query =
+      '@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px)) and (not (max-width: 458px))';
+    const parsed = MediaQuery.parser.parseToEnd(query);
+    expect(parsed.queries).toMatchInlineSnapshot(`
+      {
+        "rules": [
+          {
+            "key": "max-width",
+            "type": "pair",
+            "value": {
+              "signCharacter": undefined,
+              "type": "integer",
+              "unit": "px",
+              "value": 1440,
+            },
+          },
+          {
+            "rule": {
+              "key": "max-width",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "px",
+                "value": 1024,
+              },
+            },
+            "type": "not",
+          },
+          {
+            "rule": {
+              "key": "max-width",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "px",
+                "value": 768,
+              },
+            },
+            "type": "not",
+          },
+          {
+            "rule": {
+              "key": "max-width",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "px",
+                "value": 458,
+              },
+            },
+            "type": "not",
+          },
+        ],
+        "type": "and",
+      }
+    `);
+    expect(parsed.toString()).toBe(
+      '@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px)) and (not (max-width: 458px))',
+    );
+  });
 });

--- a/packages/style-value-parser/src/at-queries/__tests__/media-query-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/media-query-test.js
@@ -18,6 +18,7 @@ describe('Test CSS Type: @media queries', () => {
         "queries": {
           "key": "screen",
           "not": false,
+          "only": false,
           "type": "media-keyword",
         },
       }
@@ -32,6 +33,7 @@ describe('Test CSS Type: @media queries', () => {
         "queries": {
           "key": "print",
           "not": false,
+          "only": false,
           "type": "media-keyword",
         },
       }
@@ -100,6 +102,7 @@ describe('Test CSS Type: @media queries', () => {
             {
               "key": "all",
               "not": true,
+              "only": false,
               "type": "media-keyword",
             },
             {
@@ -123,6 +126,7 @@ describe('Test CSS Type: @media queries', () => {
             {
               "key": "screen",
               "not": false,
+              "only": false,
               "type": "media-keyword",
             },
             {
@@ -181,6 +185,7 @@ describe('Test CSS Type: @media queries', () => {
             {
               "key": "screen",
               "not": false,
+              "only": false,
               "type": "media-keyword",
             },
             {
@@ -718,6 +723,7 @@ describe('Test CSS Type: @media queries', () => {
                 {
                   "key": "screen",
                   "not": false,
+                  "only": false,
                   "type": "media-keyword",
                 },
                 {
@@ -750,6 +756,7 @@ describe('Test CSS Type: @media queries', () => {
             {
               "key": "all",
               "not": true,
+              "only": false,
               "type": "media-keyword",
             },
             {
@@ -1028,11 +1035,6 @@ describe('Test CSS Type: @media queries', () => {
     expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
   });
 
-  test.skip('@media (width: calc(100% - 20px))', () => {
-    expect(
-      MediaQuery.parser.parseToEnd('@media (width: calc(100% - 20px))'),
-    ).toMatchInlineSnapshot();
-  });
 
   test.skip('@media (min-width: calc(300px + 5em))', () => {
     expect(
@@ -1256,6 +1258,7 @@ describe('Test CSS Type: @media queries', () => {
             {
               "key": "all",
               "not": true,
+              "only": false,
               "type": "media-keyword",
             },
             {
@@ -2051,4 +2054,38 @@ describe('Test CSS Type: @media queries', () => {
     `);
     expect(mediaQuery.toString()).toEqual('@media (min-width: 400px)');
   });
+});
+
+test('@media only screen', () => {
+  const query = '@media only screen';
+  const parsed = MediaQuery.parser.parseToEnd(query);
+  expect(parsed.queries).toMatchInlineSnapshot(`
+    {
+      "key": "screen",
+      "not": false,
+      "only": true,
+      "type": "media-keyword",
+    }
+  `);
+  expect(parsed.toString()).toBe('@media only screen');
+});
+
+test('@media only print and (color)', () => {
+  const query = '@media only print and (color)';
+  const parsed = MediaQuery.parser.parseToEnd(query);
+  expect(parsed.toString()).toBe('@media only print and (color)');
+});
+
+test('@media not screen', () => {
+  const query = '@media not screen';
+  const parsed = MediaQuery.parser.parseToEnd(query);
+  expect(parsed.queries).toMatchInlineSnapshot(`
+    {
+      "key": "screen",
+      "not": true,
+      "only": false,
+      "type": "media-keyword",
+    }
+  `);
+  expect(parsed.toString()).toBe('@media not screen');
 });

--- a/packages/style-value-parser/src/at-queries/__tests__/media-query-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/media-query-test.js
@@ -2167,4 +2167,91 @@ describe('Test CSS Type: @media queries', () => {
       '@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px)) and (not (max-width: 458px))',
     );
   });
+
+  test('rejects invalid media queries', () => {
+    const parse = (str: string) => MediaQuery.parser.parseToEnd(str);
+
+    // empty / missing rules
+    expect(() => parse('@media')).toThrow();
+    expect(() => parse('@media ')).toThrow();
+    expect(() => parse('@media ()')).toThrow();
+
+    // incorrect operators or delimiters
+    expect(() => parse('@media (width > )')).toThrow();
+    expect(() => parse('@media ( > 600px)')).toThrow();
+    expect(() => parse('@media (600px > width) or')).toThrow();
+    expect(() => parse('@media (width < )')).toThrow();
+    expect(() => parse('@media (width <=)')).toThrow();
+    expect(() => parse('@media (>= width)')).toThrow();
+    expect(() => parse('@media (width :)')).toThrow();
+    expect(() => parse('@media (: 600px)')).toThrow();
+    expect(() => parse('@media (min-width 600px)')).toThrow();
+
+    // illegal identifiers or token types
+    expect(() => parse('@media (width @ 600px)')).toThrow();
+    expect(() => parse('@media (width: #$%)')).toThrow();
+    expect(() => parse('@media (width: [])')).toThrow();
+
+    // unmatched or misnested parens
+    expect(() => parse('@media (width < 600px')).toThrow();
+    expect(() => parse('@media ((min-width: 600px)')).toThrow();
+    expect(() => parse('@media (min-width: 600px))')).toThrow();
+    expect(() =>
+      parse('@media ((min-width: 600px) and (max-width: 1200px)) and )'),
+    ).toThrow();
+    expect(() =>
+      parse('@media (min-width: 600px and max-width: 1200px)'),
+    ).toThrow();
+
+    // bad logical structure
+    expect(() => parse('@media and (min-width: 600px)')).toThrow();
+    expect(() => parse('@media or (max-width: 1200px)')).toThrow();
+    expect(() => parse('@media not and (print)')).toThrow();
+    expect(() => parse('@media not or (print)')).toThrow();
+    expect(() => parse('@media (min-width: 600px) or')).toThrow();
+    expect(() => parse('@media and')).toThrow();
+    expect(() => parse('@media (color) and')).toThrow();
+    expect(() =>
+      parse('@media (width > 1024px), and (height > 1024px)'),
+    ).toThrow();
+
+    // illegal use of variables in media queries
+    expect(() => parse('@media (min-width: var(--test))')).toThrow();
+    expect(() =>
+      parse('@media (min-width: var(--foo) and (max-width: 700px))'),
+    ).toThrow();
+    expect(() =>
+      parse('@media (min-width: var(foo) and (max-width: 700px))'),
+    ).toThrow();
+
+    // invalid `not` usage
+    expect(() => parse('@media not')).toThrow();
+    expect(() => parse('@media not (min-width: )')).toThrow();
+    expect(() => parse('@media (not)')).toThrow();
+    expect(() => parse('@media ((not (min-width: 600px))')).toThrow();
+
+    // incomplete rules
+    expect(() => parse('@media (width:)')).toThrow();
+    expect(() => parse('@media (min-width:)')).toThrow();
+    expect(() => parse('@media (max-width: )')).toThrow();
+
+    // unknown keyword or media types
+    expect(() => parse('@media 100gecs')).toThrow();
+    expect(() => parse('@media only 100gecs')).toThrow();
+    expect(() => parse('@media not 100gecs')).toThrow();
+
+    // malformed double inequalities
+    expect(() => parse('@media (300px < width <)')).toThrow();
+    expect(() => parse('@media (< width < 700px)')).toThrow();
+    expect(() => parse('@media (300px > > width < 700px)')).toThrow();
+
+    // broken groupings
+    expect(() => parse('@media ((width: 600px) and)')).toThrow();
+    expect(() => parse('@media ((and (width: 600px)))')).toThrow();
+    expect(() => parse('@media (())')).toThrow();
+
+    expect(() => parse('@media (only max-width: 500px)')).toThrow();
+    expect(() => parse('@media screen and (only screen) ')).toThrow();
+    expect(() => parse('@media not (only (screen))')).toThrow();
+  });
 });


### PR DESCRIPTION
Lots of edge cases to fix:
- ~~support `only` keyword~~
- ~~calc parsing broken with certain parentheses~~
     - ~~implement `toString` in `Calc` parser class~~
- ~~duplicate not parsing broken~~
- ~~strange nested parentheses edge cases~~
- ~~refactor some width -> max-width logic~~
- ...to add as I test

Testing:
- so many tests! will refactor in a follow up PR
- added a number of invalid media query assertions
- i'm almost certain i'm missing some edge cases, but I think this covers 95+% of use cases and most of what we'll see practically. will continue to iterate

refs: [mdn media query docs](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) 
[lightning css playground](https://lightningcss.dev/playground/index.html#%7B%22minify%22%3Afalse%2C%22customMedia%22%3Atrue%2C%22cssModules%22%3Afalse%2C%22analyzeDependencies%22%3Afalse%2C%22targets%22%3A%7B%22chrome%22%3A6225920%7D%2C%22include%22%3A0%2C%22exclude%22%3A0%2C%22source%22%3A%22%40custom-media%20--modern%20(color)%2C%20(hover)%3B%5Cn%5Cn%5Cn%40custom-media%20--%20(color)%2C%20(hover)%3B%5Cn%5Cn.foo%20%7B%5Cn%20%20background%3A%20yellow%3B%5Cn%5Cn%20%20-webkit-border-radius%3A%202px%3B%5Cn%20%20-moz-border-radius%3A%202px%3B%5Cn%20%20border-radius%3A%202px%3B%5Cn%5Cn%20%20-webkit-transition%3A%20background%20200ms%3B%5Cn%20%20-moz-transition%3A%20background%20200ms%3B%5Cn%20%20transition%3A%20background%20200ms%3B%5Cn%5Cn%20%20%26.bar%20%7B%5Cn%20%20%20%20color%3A%20green%3B%5Cn%20%20%7D%5Cn%7D%5Cn%5Cn%5Cn%5Cn%40media%20(min-width%3A%20500px)%20or%20(max-width%3A%20600px)%20and%20not%20(max-width%3A%2000px)%5Cn%20%7B%5Cn%20%20.a%20%7B%5Cn%20%20%20%20color%3A%20green%3B%5Cn%20%20%7D%5Cn%7D%5Cn%5Cn%40media%20print%20and%20((max-width%3A%20768px)%20or%20(orientation%3A%20portrait))%20%7B%5Cn%20%20.a%20%7B%5Cn%20%20%20%20color%3A%20green%3B%5Cn%20%20%7D%5Cn%7D%22%2C%22visitorEnabled%22%3Afalse%2C%22visitor%22%3A%22%7B%5Cn%20%20Color(color)%20%7B%5Cn%20%20%20%20if%20(color.type%20%3D%3D%3D%20'rgb')%20%7B%5Cn%20%20%20%20%20%20color.g%20%3D%200%3B%5Cn%20%20%20%20%20%20return%20color%3B%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%22%2C%22unusedSymbols%22%3A%5B%5D%2C%22version%22%3A%22local%22%7D) to double check syntax

