### PR TITLE
[babel-plugin] Refactor transform-polyfills-test

### DIFF
--- a/packages/babel-plugin/__tests__/legacy/transform-logical-properties-test.js
+++ b/packages/babel-plugin/__tests__/legacy/transform-logical-properties-test.js
@@ -10,7 +10,7 @@
 jest.autoMockOff();
 
 const { transformSync } = require('@babel/core');
-const stylexPlugin = require('../src/index');
+const stylexPlugin = require('../../src/index');
 
 function transform(source, opts = {}) {
   return transformSync(source, {
@@ -324,22 +324,6 @@ describe('@stylexjs/babel-plugin', () => {
 
     /* Position offsets */
 
-    test('"insetBlockStart"', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { insetBlockStart: 0 } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x13vifvy{top:0}", 4000);
-        const classnames = "x13vifvy";"
-      `);
-    });
-
     test('"insetBlock"', () => {
       expect(
         transform(`
@@ -629,170 +613,6 @@ describe('@stylexjs/babel-plugin', () => {
         import stylex from 'stylex';
         _inject2(".x1c1uobl{padding-inline-start:0}", 3000);
         const classnames = "x1c1uobl";"
-      `);
-    });
-
-    /**
-     * Non-standard properties
-     */
-
-    test('[non-standard] "end" (aka "insetInlineEnd")', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { end: 5 } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xceh6e4{inset-inline-end:5px}", 3000);
-        const classnames = "xceh6e4";"
-      `);
-    });
-
-    test('[non-standard] "marginEnd" (aka "marginInlineEnd")', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { marginEnd: 0 } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x14z9mp{margin-inline-end:0}", 3000);
-        const classnames = "x14z9mp";"
-      `);
-    });
-
-    test('[non-standard] "marginHorizontal" (aka "marginInline")', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { marginHorizontal: 0 } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xrxpjvj{margin-inline:0}", 2000);
-        const classnames = "xrxpjvj";"
-      `);
-    });
-
-    test('[non-standard] "marginStart" (aka "marginInlineStart")', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { marginStart: 0 } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x1lziwak{margin-inline-start:0}", 3000);
-        const classnames = "x1lziwak";"
-      `);
-    });
-
-    test('[non-standard] "marginVertical" (aka "marginBlock")', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { marginVertical: 0 } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x10im51j{margin-block:0}", 2000);
-        const classnames = "x10im51j";"
-      `);
-    });
-
-    test('[non-standard] "paddingEnd" (aka "paddingInlineEnd")', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { paddingEnd: 0 } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xyri2b{padding-inline-end:0}", 3000);
-        const classnames = "xyri2b";"
-      `);
-    });
-
-    test('[non-standard] "paddingHorizontal" (aka "paddingInline")', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { paddingHorizontal: 0 } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xnjsko4{padding-inline:0}", 2000);
-        const classnames = "xnjsko4";"
-      `);
-    });
-
-    test('[non-standard] "paddingStart" (aka "paddingInlineStart")', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { paddingStart: 0 } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x1c1uobl{padding-inline-start:0}", 3000);
-        const classnames = "x1c1uobl";"
-      `);
-    });
-
-    test('[non-standard] "paddingVertical" (aka "paddingBlock")', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { paddingVertical: 0 } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xt970qd{padding-block:0}", 2000);
-        const classnames = "xt970qd";"
-      `);
-    });
-
-    test('[non-standard] "start" (aka "insetInlineStart")', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { start: 5 } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x1fb7gu6{inset-inline-start:5px}", 3000);
-        const classnames = "x1fb7gu6";"
       `);
     });
 

--- a/packages/babel-plugin/__tests__/legacy/transform-logical-values-test.js
+++ b/packages/babel-plugin/__tests__/legacy/transform-logical-values-test.js
@@ -10,7 +10,7 @@
 jest.autoMockOff();
 
 const { transformSync } = require('@babel/core');
-const stylexPlugin = require('../src/index');
+const stylexPlugin = require('../../src/index');
 
 function transform(source, opts = {}) {
   return transformSync(source, {
@@ -125,74 +125,6 @@ describe('@stylexjs/babel-plugin', () => {
         import stylex from 'stylex';
         _inject2(".x1yc453h{text-align:start}", 3000);
         const classnames = "x1yc453h";"
-      `);
-    });
-
-    /**
-     * Non-standard values
-     */
-
-    test('[non-standard] value "end" (aka "inlineEnd") for "clear" property', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { clear: 'end' } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xodj72a{clear:right}", 3000, ".xodj72a{clear:left}");
-        const classnames = "xodj72a";"
-      `);
-    });
-
-    test('[non-standard] value "start" (aka "inlineStart") for "clear" property', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { clear: 'start' } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x390i0x{clear:left}", 3000, ".x390i0x{clear:right}");
-        const classnames = "x390i0x";"
-      `);
-    });
-
-    test('[non-standard] value "end" (aka "inlineEnd") for "float" property', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { float: 'end' } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x1guec7k{float:right}", 3000, ".x1guec7k{float:left}");
-        const classnames = "x1guec7k";"
-      `);
-    });
-
-    test('[non-standard] value "start" (aka "inlineStart") for "float" property', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { float: 'start' } });
-          const classnames = stylex(styles.x);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".xrbpyxo{float:left}", 3000, ".xrbpyxo{float:right}");
-        const classnames = "xrbpyxo";"
       `);
     });
 

--- a/packages/babel-plugin/__tests__/transform-polyfills-test.js
+++ b/packages/babel-plugin/__tests__/transform-polyfills-test.js
@@ -13,13 +13,14 @@ const { transformSync } = require('@babel/core');
 const stylexPlugin = require('../src/index');
 
 function transform(source, opts = {}) {
-  return transformSync(source, {
+  const { code, metadata } = transformSync(source, {
     filename: opts.filename,
     parserOpts: {
       flow: 'all',
     },
     plugins: [[stylexPlugin, opts]],
-  }).code;
+  });
+  return { code, metadata };
 }
 
 describe('@stylexjs/babel-plugin', () => {
@@ -27,37 +28,341 @@ describe('@stylexjs/babel-plugin', () => {
    * CSS polyfills
    */
 
-  describe.skip('[transform] stylex polyfills', () => {
-    test('lineClamp', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { lineClamp: 3 } });
-        `),
-      ).toMatchInlineSnapshot();
+  describe('[transform] CSS property polyfills', () => {
+    test.skip('lineClamp', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { lineClamp: 3 } });
+      `);
+
+      expect(metadata).toMatchInlineSnapshot();
     });
 
-    test('pointerEvents', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({
-            a: { pointerEvents: 'auto' },
-            b: { pointerEvents: 'box-none' },
-            c: { pointerEvents: 'box-only' },
-            d: { pointerEvents: 'none' }
-          });
-        `),
-      ).toMatchInlineSnapshot();
+    test.skip('pointerEvents', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({
+          a: { pointerEvents: 'auto' },
+          b: { pointerEvents: 'box-none' },
+          c: { pointerEvents: 'box-only' },
+          d: { pointerEvents: 'none' }
+        });
+      `);
+      expect(metadata).toMatchInlineSnapshot();
     });
 
-    test('scrollbarWidth', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({ x: { scrollbarWidth: 'none' } });
-        `),
-      ).toMatchInlineSnapshot();
+    test.skip('scrollbarWidth', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { scrollbarWidth: 'none' } });
+      `);
+      expect(metadata).toMatchInlineSnapshot();
+    });
+
+    /**
+     * Non-standard properties
+     * These are deprecated and should be removed once Meta has migrated off them.
+     */
+
+    test('[non-standard] "end" (aka "insetInlineEnd")', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { end: 5 } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xceh6e4",
+              {
+                "ltr": ".xceh6e4{inset-inline-end:5px}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "marginEnd" (aka "marginInlineEnd")', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { marginEnd: 0 } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x14z9mp",
+              {
+                "ltr": ".x14z9mp{margin-inline-end:0}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "marginHorizontal" (aka "marginInline")', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { marginHorizontal: 0 } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xrxpjvj",
+              {
+                "ltr": ".xrxpjvj{margin-inline:0}",
+                "rtl": null,
+              },
+              2000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "marginStart" (aka "marginInlineStart")', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { marginStart: 0 } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1lziwak",
+              {
+                "ltr": ".x1lziwak{margin-inline-start:0}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "marginVertical" (aka "marginBlock")', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { marginVertical: 0 } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x10im51j",
+              {
+                "ltr": ".x10im51j{margin-block:0}",
+                "rtl": null,
+              },
+              2000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "paddingEnd" (aka "paddingInlineEnd")', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { paddingEnd: 0 } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xyri2b",
+              {
+                "ltr": ".xyri2b{padding-inline-end:0}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "paddingHorizontal" (aka "paddingInline")', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { paddingHorizontal: 0 } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xnjsko4",
+              {
+                "ltr": ".xnjsko4{padding-inline:0}",
+                "rtl": null,
+              },
+              2000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "paddingStart" (aka "paddingInlineStart")', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { paddingStart: 0 } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1c1uobl",
+              {
+                "ltr": ".x1c1uobl{padding-inline-start:0}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "paddingVertical" (aka "paddingBlock")', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { paddingVertical: 0 } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xt970qd",
+              {
+                "ltr": ".xt970qd{padding-block:0}",
+                "rtl": null,
+              },
+              2000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "start" (aka "insetInlineStart")', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { start: 5 } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1fb7gu6",
+              {
+                "ltr": ".x1fb7gu6{inset-inline-start:5px}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+  });
+
+  describe('[transform] CSS value polyfills', () => {
+    /**
+     * Non-standard values
+     * These are deprecated and should be removed once Meta has migrated off them.
+     */
+
+    test('[non-standard] value "end" (aka "inlineEnd") for "clear" property', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { clear: 'end' } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xodj72a",
+              {
+                "ltr": ".xodj72a{clear:right}",
+                "rtl": ".xodj72a{clear:left}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] value "start" (aka "inlineStart") for "clear" property', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { clear: 'start' } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x390i0x",
+              {
+                "ltr": ".x390i0x{clear:left}",
+                "rtl": ".x390i0x{clear:right}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] value "end" (aka "inlineEnd") for "float" property', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { float: 'end' } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1guec7k",
+              {
+                "ltr": ".x1guec7k{float:right}",
+                "rtl": ".x1guec7k{float:left}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] value "start" (aka "inlineStart") for "float" property', () => {
+      const { metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { float: 'start' } });
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xrbpyxo",
+              {
+                "ltr": ".xrbpyxo{float:left}",
+                "rtl": ".xrbpyxo{float:right}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
     });
   });
 });


### PR DESCRIPTION
Move tests for all CSS polyfills into 'transform-polyfills'. Snapshot the metadata of each transform.

The logical property/value tests are preserved in the `legacy` test directory for now. Almost all these tests are no longer needed, as there is no polyfill transform applied.