### PR TITLE
[babel-plugin] Reorganize and move shared tests

### DIFF
--- a/packages/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -38,11 +38,9 @@ describe('@stylexjs/babel-plugin', () => {
             }
           });
         `);
-
         expect(code).toMatchInlineSnapshot(
           '"import * as stylex from \'@stylexjs/stylex\';"',
         );
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -77,7 +75,6 @@ describe('@stylexjs/babel-plugin', () => {
             }
           });
         `);
-
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
@@ -88,7 +85,6 @@ describe('@stylexjs/babel-plugin', () => {
             }
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -135,7 +131,6 @@ describe('@stylexjs/babel-plugin', () => {
             },
           });
         `);
-
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
@@ -161,7 +156,6 @@ describe('@stylexjs/babel-plugin', () => {
             }
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -209,22 +203,23 @@ describe('@stylexjs/babel-plugin', () => {
             root: {
               '--background-color': 'red',
               '--otherColor': 'green',
+              '--foo': 10
             }
           });
         `);
-
         // Must not modify casing of custom properties
+        // Must not add units to unitless values
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
             root: {
               "--background-color": "xgau0yw",
               "--otherColor": "x1p9b6ba",
+              "--foo": "x40g909",
               $$css: true
             }
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -244,11 +239,21 @@ describe('@stylexjs/babel-plugin', () => {
                 },
                 1,
               ],
+              [
+                "x40g909",
+                {
+                  "ltr": ".x40g909{--foo:10}",
+                  "rtl": null,
+                },
+                1,
+              ],
             ],
           }
         `);
       });
 
+      // TODO: eventually these multi-value shortforms should not be allowed
+      // Requires Meta migration to be completed.
       test('style object with shortform properties', () => {
         const { code, metadata } = transform(`
           import * as stylex from '@stylexjs/stylex';
@@ -276,7 +281,6 @@ describe('@stylexjs/babel-plugin', () => {
             },
           });
         `);
-
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           const borderRadius = 2;
@@ -376,7 +380,6 @@ describe('@stylexjs/babel-plugin', () => {
             }
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -494,7 +497,6 @@ describe('@stylexjs/babel-plugin', () => {
           runtimeInjection: false,
           styleResolution: 'property-specificity',
         };
-
         const { code, metadata } = transform(
           `
           import * as stylex from '@stylexjs/stylex';
@@ -524,7 +526,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           options,
         );
-
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           const borderRadius = 2;
@@ -553,7 +554,6 @@ describe('@stylexjs/babel-plugin', () => {
             }
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -700,7 +700,6 @@ describe('@stylexjs/babel-plugin', () => {
             },
           });
         `);
-
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
@@ -710,7 +709,6 @@ describe('@stylexjs/babel-plugin', () => {
             }
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -733,7 +731,6 @@ describe('@stylexjs/babel-plugin', () => {
             filename: 'MyComponent.js',
             unstable_moduleResolution: { type: 'haste' },
           };
-
           const { code, metadata } = transform(
             `
             import * as stylex from '@stylexjs/stylex';
@@ -747,7 +744,6 @@ describe('@stylexjs/babel-plugin', () => {
           `,
             options,
           );
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             import { vars } from 'vars.stylex.js';
@@ -758,7 +754,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -784,7 +779,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(camelCased.code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -794,7 +788,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(camelCased.metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -818,9 +811,7 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(kebabCased.code).toEqual(camelCased.code);
-
           expect(kebabCased.metadata).toEqual(kebabCased.metadata);
 
           const customProperty = transform(`
@@ -831,7 +822,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(customProperty.code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -841,7 +831,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(customProperty.metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -849,6 +838,193 @@ describe('@stylexjs/babel-plugin', () => {
                   "x17389it",
                   {
                     "ltr": ".x17389it{transition-property:--foo}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+              ],
+            }
+          `);
+
+          const multiProperty = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              one: {
+                transitionProperty: 'opacity, insetInlineStart',
+              },
+              two: {
+                transitionProperty: 'opacity, inset-inline-start',
+              },
+            });
+          `);
+          expect(multiProperty.code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              one: {
+                k1ekBW: "xh6nlrc",
+                $$css: true
+              },
+              two: {
+                k1ekBW: "xh6nlrc",
+                $$css: true
+              }
+            };"
+          `);
+          expect(multiProperty.metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "xh6nlrc",
+                  {
+                    "ltr": ".xh6nlrc{transition-property:opacity,inset-inline-start}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+              ],
+            }
+          `);
+        });
+
+        test('set "willChange"', () => {
+          const camelCased = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                willChange: 'insetInlineStart',
+              },
+            });
+          `);
+          expect(camelCased.code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: {
+                k6sLGO: "x1n5prqt",
+                $$css: true
+              }
+            };"
+          `);
+          expect(camelCased.metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x1n5prqt",
+                  {
+                    "ltr": ".x1n5prqt{will-change:inset-inline-start}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+              ],
+            }
+          `);
+
+          const kebabCased = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                willChange: 'inset-inline-start',
+              },
+            });
+          `);
+          expect(kebabCased.code).toEqual(camelCased.code);
+          expect(kebabCased.metadata).toEqual(kebabCased.metadata);
+
+          const customProperty = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                willChange: '--foo',
+              },
+            });
+          `);
+          expect(customProperty.code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: {
+                k6sLGO: "x1lxaxzv",
+                $$css: true
+              }
+            };"
+          `);
+          expect(customProperty.metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x1lxaxzv",
+                  {
+                    "ltr": ".x1lxaxzv{will-change:--foo}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+              ],
+            }
+          `);
+
+          const multiProperty = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              one: {
+                willChange: 'opacity, insetInlineStart',
+              },
+              two: {
+                willChange: 'opacity, inset-inline-start',
+              }
+            });
+          `);
+          expect(multiProperty.code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              one: {
+                k6sLGO: "x30a982",
+                $$css: true
+              },
+              two: {
+                k6sLGO: "x30a982",
+                $$css: true
+              }
+            };"
+          `);
+          expect(multiProperty.metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x30a982",
+                  {
+                    "ltr": ".x30a982{will-change:opacity,inset-inline-start}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+              ],
+            }
+          `);
+
+          const keyword = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                willChange: 'scroll-position'
+              }
+            });
+          `);
+          expect(keyword.code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: {
+                k6sLGO: "x1q5hf6d",
+                $$css: true
+              }
+            };"
+          `);
+          expect(keyword.metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x1q5hf6d",
+                  {
+                    "ltr": ".x1q5hf6d{will-change:scroll-position}",
                     "rtl": null,
                   },
                   3000,
@@ -867,7 +1043,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -877,7 +1052,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -903,7 +1077,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -913,7 +1086,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -921,42 +1093,6 @@ describe('@stylexjs/babel-plugin', () => {
                   "x1ruww2u",
                   {
                     "ltr": ".x1ruww2u{position:sticky;position:fixed}",
-                    "rtl": null,
-                  },
-                  3000,
-                ],
-              ],
-            }
-          `);
-        });
-
-        test('use "stylex.firstThatWorks"', () => {
-          const { code, metadata } = transform(`
-            import * as stylex from '@stylexjs/stylex';
-            export const styles = stylex.create({
-              root: {
-                position: stylex.firstThatWorks('sticky', 'fixed'),
-              }
-            });
-          `);
-
-          expect(code).toMatchInlineSnapshot(`
-            "import * as stylex from '@stylexjs/stylex';
-            export const styles = {
-              root: {
-                kVAEAm: "x15oojuh",
-                $$css: true
-              }
-            };"
-          `);
-
-          expect(metadata).toMatchInlineSnapshot(`
-            {
-              "stylex": [
-                [
-                  "x15oojuh",
-                  {
-                    "ltr": ".x15oojuh{position:fixed;position:sticky}",
                     "rtl": null,
                   },
                   3000,
@@ -975,7 +1111,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -985,7 +1120,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1011,7 +1145,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1021,7 +1154,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1039,6 +1171,161 @@ describe('@stylexjs/babel-plugin', () => {
         });
       });
 
+      describe('function value: stylex.firstThatWorks()', () => {
+        test('args: value, value', () => {
+          // Checks various combinations of fallbacks
+          const { code, metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                position: stylex.firstThatWorks('sticky', 'fixed'),
+              }
+            });
+          `);
+          expect(code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: {
+                kVAEAm: "x15oojuh",
+                $$css: true
+              }
+            };"
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x15oojuh",
+                  {
+                    "ltr": ".x15oojuh{position:fixed;position:sticky}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+              ],
+            }
+          `);
+        });
+
+        // TODO: Fix parser bug
+        test.skip('args: value, var', () => {
+          // Checks various combinations of fallbacks
+          const { code, metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                color: stylex.firstThatWorks('red', 'var(--color)'),
+              }
+            });
+          `);
+          expect(code).toMatchInlineSnapshot();
+          expect(metadata).toMatchInlineSnapshot();
+        });
+
+        test('args: var, value', () => {
+          // Checks various combinations of fallbacks
+          const { code, metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                color: stylex.firstThatWorks('var(--color)', 'red'),
+              }
+            });
+          `);
+          expect(code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: {
+                kMwMTN: "x8nmrrw",
+                $$css: true
+              }
+            };"
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x8nmrrw",
+                  {
+                    "ltr": ".x8nmrrw{color:var(--color,red)}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+              ],
+            }
+          `);
+        });
+
+        test('args: var, var', () => {
+          // Checks various combinations of fallbacks
+          const { code, metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                color: stylex.firstThatWorks('var(--color)', 'var(--otherColor)'),
+              }
+            });
+          `);
+          expect(code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: {
+                kMwMTN: "x1775bb3",
+                $$css: true
+              }
+            };"
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x1775bb3",
+                  {
+                    "ltr": ".x1775bb3{color:var(--color,var(--otherColor))}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+              ],
+            }
+          `);
+        });
+
+        // TODO: Fix parser bug
+        test.skip('args: func, var, value', () => {
+          const { code, metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                color: stylex.firstThatWorks('color-mix(in srgb, currentColor 20%, transparent)', 'var(--color)', 'red'),
+              }
+            });
+          `);
+          expect(code).toMatchInlineSnapshot();
+          expect(metadata).toMatchInlineSnapshot();
+        });
+
+        // TODO: Fix parser bug
+        test.skip('args: func, var, value, value', () => {
+          // Ignore simple fallbacks after the first one
+          const { code, metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                color: stylex.firstThatWorks('color-mix(in srgb, currentColor 20%, transparent)', 'var(--color)', 'red', 'green'),
+              }
+            });
+          `);
+          expect(code).toMatchInlineSnapshot();
+          expect(metadata).toMatchInlineSnapshot();
+        });
+      });
+
+      describe.skip('function value: stylex.types.*()', () => {
+        // TODO: port tests from "stylex-types-test.js" in "shared"
+      });
+
       describe('object values: pseudo-classes', () => {
         test('invalid pseudo-class', () => {
           const { code, metadata } = transform(`
@@ -1051,8 +1338,8 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
-          // TODO: this should either fail or guarantee an insertion order relative to valid pseudo-classes
+          // TODO: this should either fail or guarantee an insertion
+          // order relative to valid pseudo-classes
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1062,7 +1349,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1093,7 +1379,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1104,7 +1389,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1143,7 +1427,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1153,7 +1436,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1210,7 +1492,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           // TODO: Fix duplicate class name - https://github.com/facebook/stylex/issues/1001
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
@@ -1221,7 +1502,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1249,7 +1529,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1259,7 +1538,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1292,7 +1570,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1303,7 +1580,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1339,7 +1615,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1349,7 +1624,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1377,7 +1651,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1387,7 +1660,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1418,7 +1690,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1428,7 +1699,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1468,7 +1738,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1478,7 +1747,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1524,7 +1792,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1534,7 +1801,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1582,7 +1848,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1592,7 +1857,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1637,7 +1901,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1647,7 +1910,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1685,7 +1947,6 @@ describe('@stylexjs/babel-plugin', () => {
             })
           });
         `);
-
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
@@ -1698,7 +1959,6 @@ describe('@stylexjs/babel-plugin', () => {
             }]
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -1743,7 +2003,6 @@ describe('@stylexjs/babel-plugin', () => {
             },
           });
         `);
-
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
@@ -1759,7 +2018,6 @@ describe('@stylexjs/babel-plugin', () => {
             }
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -1802,7 +2060,6 @@ describe('@stylexjs/babel-plugin', () => {
             }),
           });
         `);
-
         // NOTE: the generated variable name is a little weird, but valid.
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
@@ -1817,7 +2074,6 @@ describe('@stylexjs/babel-plugin', () => {
             }]
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -1868,7 +2124,6 @@ describe('@stylexjs/babel-plugin', () => {
               })
             });
           `);
-
           // Check that dynamic number values get units where appropriate
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
@@ -1881,7 +2136,6 @@ describe('@stylexjs/babel-plugin', () => {
               }]
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1911,7 +2165,6 @@ describe('@stylexjs/babel-plugin', () => {
             filename: 'MyComponent.js',
             unstable_moduleResolution: { type: 'haste' },
           };
-
           const { code, metadata } = transform(
             `
             import * as stylex from '@stylexjs/stylex';
@@ -1925,7 +2178,6 @@ describe('@stylexjs/babel-plugin', () => {
           `,
             options,
           );
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             import { vars } from 'vars.stylex.js';
@@ -1938,7 +2190,6 @@ describe('@stylexjs/babel-plugin', () => {
               }]
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -1979,7 +2230,6 @@ describe('@stylexjs/babel-plugin', () => {
               }),
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -1993,7 +2243,6 @@ describe('@stylexjs/babel-plugin', () => {
               }]
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -2048,7 +2297,6 @@ describe('@stylexjs/babel-plugin', () => {
               }),
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -2062,7 +2310,6 @@ describe('@stylexjs/babel-plugin', () => {
               }]
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -2143,7 +2390,6 @@ describe('@stylexjs/babel-plugin', () => {
               }),
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -2157,7 +2403,6 @@ describe('@stylexjs/babel-plugin', () => {
               }]
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -2209,7 +2454,6 @@ describe('@stylexjs/babel-plugin', () => {
               }),
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -2221,7 +2465,6 @@ describe('@stylexjs/babel-plugin', () => {
               }]
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -2257,7 +2500,6 @@ describe('@stylexjs/babel-plugin', () => {
               }),
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -2269,7 +2511,6 @@ describe('@stylexjs/babel-plugin', () => {
               }]
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -2308,7 +2549,6 @@ describe('@stylexjs/babel-plugin', () => {
               }),
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -2320,7 +2560,6 @@ describe('@stylexjs/babel-plugin', () => {
               }]
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -2368,7 +2607,6 @@ describe('@stylexjs/babel-plugin', () => {
               }),
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -2382,7 +2620,6 @@ describe('@stylexjs/babel-plugin', () => {
               }]
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -2452,7 +2689,6 @@ describe('@stylexjs/babel-plugin', () => {
               }),
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -2466,7 +2702,6 @@ describe('@stylexjs/babel-plugin', () => {
               }]
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -2538,7 +2773,6 @@ describe('@stylexjs/babel-plugin', () => {
               }),
             });
           `);
-
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
@@ -2552,7 +2786,6 @@ describe('@stylexjs/babel-plugin', () => {
               }]
             };"
           `);
-
           expect(metadata).toMatchInlineSnapshot(`
             {
               "stylex": [
@@ -2617,7 +2850,6 @@ describe('@stylexjs/babel-plugin', () => {
           debug: true,
           filename: '/html/js/components/Foo.react.js',
         };
-
         const { code, metadata } = transform(
           `
             import * as stylex from '@stylexjs/stylex';
@@ -2635,7 +2867,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           options,
         );
-
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
@@ -2653,7 +2884,6 @@ describe('@stylexjs/babel-plugin', () => {
             }
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -2691,7 +2921,6 @@ describe('@stylexjs/babel-plugin', () => {
           debug: true,
           filename: '/js/node_modules/npm-package/dist/components/Foo.react.js',
         };
-
         const { code, metadata } = transform(
           `
           import * as stylex from '@stylexjs/stylex';
@@ -2709,7 +2938,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           options,
         );
-
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
@@ -2727,7 +2955,6 @@ describe('@stylexjs/babel-plugin', () => {
             }
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -2766,7 +2993,6 @@ describe('@stylexjs/babel-plugin', () => {
           filename: '/html/js/components/Foo.react.js',
           unstable_moduleResolution: { type: 'haste' },
         };
-
         const { code, metadata } = transform(
           `
           import * as stylex from '@stylexjs/stylex';
@@ -2784,7 +3010,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           options,
         );
-
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
@@ -2802,7 +3027,6 @@ describe('@stylexjs/babel-plugin', () => {
             }
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [
@@ -2841,7 +3065,6 @@ describe('@stylexjs/babel-plugin', () => {
           filename: '/node_modules/npm-package/dist/components/Foo.react.js',
           unstable_moduleResolution: { type: 'haste' },
         };
-
         const { code, metadata } = transform(
           `
           import * as stylex from '@stylexjs/stylex';
@@ -2859,7 +3082,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           options,
         );
-
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
@@ -2877,7 +3099,6 @@ describe('@stylexjs/babel-plugin', () => {
             }
           };"
         `);
-
         expect(metadata).toMatchInlineSnapshot(`
           {
             "stylex": [

--- a/packages/babel-plugin/__tests__/transform-stylex-createTheme-test.js
+++ b/packages/babel-plugin/__tests__/transform-stylex-createTheme-test.js
@@ -198,7 +198,7 @@ describe('@stylexjs/babel-plugin', () => {
 
     test('theme object deep in file tree', () => {
       const options = {
-        filename: '/stylex/packages/src/css/NestedTheme.stylex.js',
+        varsFilename: '/stylex/packages/src/css/vars.stylex.js',
       };
       const fixture = createFixture(`
         export const theme = stylex.createTheme(vars, ${themeObject});

--- a/packages/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
+++ b/packages/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
@@ -40,9 +40,34 @@ function transform(source, opts = {}) {
 
 describe('@stylexjs/babel-plugin', () => {
   describe('[transform] stylex.defineConsts()', () => {
-    test('constants object', () => {
+    test('constants are unique', () => {
       const { code, metadata } = transform(`
         import stylex from 'stylex';
+        export const breakpoints = stylex.defineConsts({ padding: '10px' });
+      `);
+
+      const { code: codeDuplicate, metadata: metadataDuplicate } = transform(`
+        import stylex from 'stylex';
+        export const breakpoints = stylex.defineConsts({ padding: '10px' });
+      `);
+
+      // Assert the generated constants are consistent for the same inputs
+      expect(code).toEqual(codeDuplicate);
+      expect(metadata).toEqual(metadataDuplicate);
+
+      const { code: codeOther, metadata: metadataOther } = transform(`
+        import stylex from 'stylex';
+        export const breakpoints = stylex.defineConsts({ margin: '10px' });
+      `);
+
+      // Assert the generated constants are different for different inputs
+      expect(code).not.toEqual(codeOther);
+      expect(metadata).not.toEqual(metadataOther);
+    });
+
+    test('constants object', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
         export const breakpoints = stylex.defineConsts({
           sm: '(min-width: 768px)',
           md: '(min-width: 1024px)',
@@ -51,7 +76,7 @@ describe('@stylexjs/babel-plugin', () => {
       `);
 
       expect(code).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import * as stylex from '@stylexjs/stylex';
         export const breakpoints = {
           sm: "(min-width: 768px)",
           md: "(min-width: 1024px)",
@@ -104,7 +129,7 @@ describe('@stylexjs/babel-plugin', () => {
 
       const { code, metadata } = transform(
         `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         export const breakpoints = stylex.defineConsts({
           sm: '(min-width: 768px)',
           md: '(min-width: 1024px)',
@@ -115,7 +140,7 @@ describe('@stylexjs/babel-plugin', () => {
       );
 
       expect(code).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import * as stylex from '@stylexjs/stylex';
         export const breakpoints = {
           sm: "(min-width: 768px)",
           md: "(min-width: 1024px)",
@@ -163,14 +188,14 @@ describe('@stylexjs/babel-plugin', () => {
 
     test('constant names: special characters', () => {
       const { code, metadata } = transform(`
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         export const sizes = stylex.defineConsts({
           'font-size*large': '18px',
         });
       `);
 
       expect(code).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import * as stylex from '@stylexjs/stylex';
         export const sizes = {
           "font-size*large": "18px",
           __constName__: "TestTheme.stylex.js//sizes",
@@ -196,14 +221,14 @@ describe('@stylexjs/babel-plugin', () => {
 
     test('constant names: number', () => {
       const { code, metadata } = transform(`
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         export const levels = stylex.defineConsts({
           1: 'one'
         });
       `);
 
       expect(code).toMatchInlineSnapshot(`
-        "import stylex from 'stylex';
+        "import * as stylex from '@stylexjs/stylex';
         export const levels = {
           "1": "one",
           __constName__: "TestTheme.stylex.js//levels",

--- a/packages/babel-plugin/__tests__/transform-stylex-defineVars-test.js
+++ b/packages/babel-plugin/__tests__/transform-stylex-defineVars-test.js
@@ -14,7 +14,7 @@ import stylexPlugin from '../src/index';
 
 function transform(source, opts = {}) {
   const { code, metadata } = transformSync(source, {
-    filename: opts.filename || '/stylex/packages/TestTheme.stylex.js',
+    filename: opts.filename || '/stylex/packages/vars.stylex.js',
     parserOpts: {
       flow: 'all',
     },
@@ -56,10 +56,10 @@ describe('@stylexjs/babel-plugin', () => {
       expect(code).toMatchInlineSnapshot(`
         "import * as stylex from '@stylexjs/stylex';
         export const vars = {
-          color: "var(--xjrzwe6)",
-          nextColor: "var(--x1ybzi8d)",
-          otherColor: "var(--x1o4mfbm)",
-          __themeName__: "xm1nzai"
+          color: "var(--xwx8imx)",
+          nextColor: "var(--xk6xtqk)",
+          otherColor: "var(--xaaua2w)",
+          __themeName__: "xop34xu"
         };"
       `);
 
@@ -67,25 +67,25 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
-              "xm1nzai",
+              "xop34xu",
               {
-                "ltr": ":root, .xm1nzai{--xjrzwe6:red;--x1ybzi8d:green;--x1o4mfbm:blue;}",
+                "ltr": ":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}",
                 "rtl": null,
               },
               0,
             ],
             [
-              "xm1nzai-1lveb7",
+              "xop34xu-1lveb7",
               {
-                "ltr": "@media (prefers-color-scheme: dark){:root, .xm1nzai{--x1o4mfbm:lightblue;}}",
+                "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xaaua2w:lightblue;}}",
                 "rtl": null,
               },
               0.1,
             ],
             [
-              "xm1nzai-bdddrq",
+              "xop34xu-bdddrq",
               {
-                "ltr": "@media print{:root, .xm1nzai{--x1o4mfbm:white;}}",
+                "ltr": "@media print{:root, .xop34xu{--xaaua2w:white;}}",
                 "rtl": null,
               },
               0.1,
@@ -121,10 +121,10 @@ describe('@stylexjs/babel-plugin', () => {
       expect(code).toMatchInlineSnapshot(`
         "import * as stylex from '@stylexjs/stylex';
         export const vars = {
-          color: "var(--xjrzwe6)",
-          nextColor: "var(--x1ybzi8d)",
-          otherColor: "var(--x1o4mfbm)",
-          __themeName__: "xm1nzai"
+          color: "var(--xwx8imx)",
+          nextColor: "var(--xk6xtqk)",
+          otherColor: "var(--xaaua2w)",
+          __themeName__: "xop34xu"
         };"
       `);
 
@@ -132,25 +132,25 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
-              "xm1nzai",
+              "xop34xu",
               {
-                "ltr": ":root, .xm1nzai{--xjrzwe6:red;--x1ybzi8d:green;--x1o4mfbm:blue;}",
+                "ltr": ":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}",
                 "rtl": null,
               },
               0,
             ],
             [
-              "xm1nzai-1lveb7",
+              "xop34xu-1lveb7",
               {
-                "ltr": "@media (prefers-color-scheme: dark){:root, .xm1nzai{--x1o4mfbm:lightblue;}}",
+                "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xaaua2w:lightblue;}}",
                 "rtl": null,
               },
               0.1,
             ],
             [
-              "xm1nzai-bdddrq",
+              "xop34xu-bdddrq",
               {
-                "ltr": "@media print{:root, .xm1nzai{--x1o4mfbm:white;}}",
+                "ltr": "@media print{:root, .xop34xu{--xaaua2w:white;}}",
                 "rtl": null,
               },
               0.1,
@@ -162,7 +162,7 @@ describe('@stylexjs/babel-plugin', () => {
 
     test('tokens object deep in file tree', () => {
       const options = {
-        filename: '/stylex/packages/src/css/NestedTheme.stylex.js',
+        filename: '/stylex/packages/src/css/vars.stylex.js',
       };
       const { code, metadata } = transform(
         `
@@ -177,8 +177,8 @@ describe('@stylexjs/babel-plugin', () => {
       expect(code).toMatchInlineSnapshot(`
         "import * as stylex from '@stylexjs/stylex';
         export const vars = {
-          color: "var(--xg2rpke)",
-          __themeName__: "xc81hgp"
+          color: "var(--xt4ziaz)",
+          __themeName__: "x1xohuxq"
         };"
       `);
 
@@ -186,12 +186,66 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
-              "xc81hgp",
+              "x1xohuxq",
               {
-                "ltr": ":root, .xc81hgp{--xg2rpke:red;}",
+                "ltr": ":root, .x1xohuxq{--xt4ziaz:red;}",
                 "rtl": null,
               },
               0,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('tokens object with nested @-rules', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.defineVars({
+          color: {
+            default: 'blue',
+            '@media (prefers-color-scheme: dark)': {
+              default: 'lightblue',
+              '@supports (color: oklab(0 0 0))': 'oklab(0.7 -0.3 -0.4)',
+            }
+          },
+        });
+      `);
+
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        export const vars = {
+          color: "var(--xwx8imx)",
+          __themeName__: "xop34xu"
+        };"
+      `);
+
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xop34xu",
+              {
+                "ltr": ":root, .xop34xu{--xwx8imx:blue;}",
+                "rtl": null,
+              },
+              0,
+            ],
+            [
+              "xop34xu-1lveb7",
+              {
+                "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;}}",
+                "rtl": null,
+              },
+              0.1,
+            ],
+            [
+              "xop34xu-1e6ryz3",
+              {
+                "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:oklab(0.7 -0.3 -0.4);}}}",
+                "rtl": null,
+              },
+              0.2,
             ],
           ],
         }
@@ -215,7 +269,7 @@ describe('@stylexjs/babel-plugin', () => {
         export const vars = {
           "--color": "var(--color)",
           "--otherColor": "var(--otherColor)",
-          __themeName__: "xm1nzai"
+          __themeName__: "xop34xu"
         };"
       `);
 
@@ -223,17 +277,17 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
-              "xm1nzai",
+              "xop34xu",
               {
-                "ltr": ":root, .xm1nzai{--color:red;--otherColor:blue;}",
+                "ltr": ":root, .xop34xu{--color:red;--otherColor:blue;}",
                 "rtl": null,
               },
               0,
             ],
             [
-              "xm1nzai-1tdxo4z",
+              "xop34xu-1tdxo4z",
               {
-                "ltr": ":hover{:root, .xm1nzai{--otherColor:lightblue;}}",
+                "ltr": ":hover{:root, .xop34xu{--otherColor:lightblue;}}",
                 "rtl": null,
               },
               0.1,
@@ -277,7 +331,7 @@ describe('@stylexjs/babel-plugin', () => {
           "--color": "var(--color)",
           "--nextColor": "var(--nextColor)",
           "--otherColor": "var(--otherColor)",
-          __themeName__: "xm1nzai"
+          __themeName__: "xop34xu"
         };"
       `);
 
@@ -285,25 +339,25 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
-              "xm1nzai",
+              "xop34xu",
               {
-                "ltr": ":root, .xm1nzai{--color:red;--nextColor:green;--otherColor:blue;}",
+                "ltr": ":root, .xop34xu{--color:red;--nextColor:green;--otherColor:blue;}",
                 "rtl": null,
               },
               0,
             ],
             [
-              "xm1nzai-1lveb7",
+              "xop34xu-1lveb7",
               {
-                "ltr": "@media (prefers-color-scheme: dark){:root, .xm1nzai{--otherColor:lightblue;}}",
+                "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--otherColor:lightblue;}}",
                 "rtl": null,
               },
               0.1,
             ],
             [
-              "xm1nzai-bdddrq",
+              "xop34xu-bdddrq",
               {
-                "ltr": "@media print{:root, .xm1nzai{--otherColor:white;}}",
+                "ltr": "@media print{:root, .xop34xu{--otherColor:white;}}",
                 "rtl": null,
               },
               0.1,
@@ -326,8 +380,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         const COLOR = 'red';
         export const vars = {
-          color: "var(--xjrzwe6)",
-          __themeName__: "xm1nzai"
+          color: "var(--xwx8imx)",
+          __themeName__: "xop34xu"
         };"
       `);
 
@@ -335,9 +389,9 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
-              "xm1nzai",
+              "xop34xu",
               {
-                "ltr": ":root, .xm1nzai{--xjrzwe6:red;}",
+                "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
               0,
@@ -360,8 +414,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         const NUMBER = 10;
         export const vars = {
-          size: "var(--x7bt6xx)",
-          __themeName__: "xm1nzai"
+          size: "var(--xu6xznv)",
+          __themeName__: "xop34xu"
         };"
       `);
 
@@ -369,9 +423,9 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
-              "xm1nzai",
+              "xop34xu",
               {
-                "ltr": ":root, .xm1nzai{--x7bt6xx:10rem;}",
+                "ltr": ":root, .xop34xu{--xu6xznv:10rem;}",
                 "rtl": null,
               },
               0,
@@ -394,8 +448,8 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         const NUMBER = 10;
         export const vars = {
-          radius: "var(--x1cazb2m)",
-          __themeName__: "xm1nzai"
+          radius: "var(--xbbre8)",
+          __themeName__: "xop34xu"
         };"
       `);
 
@@ -403,9 +457,9 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
-              "xm1nzai",
+              "xop34xu",
               {
-                "ltr": ":root, .xm1nzai{--x1cazb2m:20;}",
+                "ltr": ":root, .xop34xu{--xbbre8:20;}",
                 "rtl": null,
               },
               0,
@@ -430,8 +484,8 @@ describe('@stylexjs/babel-plugin', () => {
       expect(code).toMatchInlineSnapshot(`
         "import * as stylex from '@stylexjs/stylex';
         export const vars = {
-          color: "var(--xjrzwe6)",
-          __themeName__: "xm1nzai"
+          color: "var(--xwx8imx)",
+          __themeName__: "xop34xu"
         };"
       `);
 
@@ -439,33 +493,33 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
-              "xjrzwe6",
+              "xwx8imx",
               {
-                "ltr": "@property --xjrzwe6 { syntax: "<color>"; inherits: true; initial-value: red }",
+                "ltr": "@property --xwx8imx { syntax: "<color>"; inherits: true; initial-value: red }",
                 "rtl": null,
               },
               0,
             ],
             [
-              "xm1nzai",
+              "xop34xu",
               {
-                "ltr": ":root, .xm1nzai{--xjrzwe6:red;}",
+                "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
               0,
             ],
             [
-              "xm1nzai-1lveb7",
+              "xop34xu-1lveb7",
               {
-                "ltr": "@media (prefers-color-scheme: dark){:root, .xm1nzai{--xjrzwe6:white;}}",
+                "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:white;}}",
                 "rtl": null,
               },
               0.1,
             ],
             [
-              "xm1nzai-bdddrq",
+              "xop34xu-bdddrq",
               {
-                "ltr": "@media print{:root, .xm1nzai{--xjrzwe6:black;}}",
+                "ltr": "@media print{:root, .xop34xu{--xwx8imx:black;}}",
                 "rtl": null,
               },
               0.1,
@@ -489,12 +543,12 @@ describe('@stylexjs/babel-plugin', () => {
       expect(code).toMatchInlineSnapshot(`
         "import * as stylex from '@stylexjs/stylex';
         export const vars = {
-          color: "var(--xjrzwe6)",
-          __themeName__: "xm1nzai"
+          color: "var(--xwx8imx)",
+          __themeName__: "xop34xu"
         };
         export const otherVars = {
-          otherColor: "var(--x162zdew)",
-          __themeName__: "xc6dbti"
+          otherColor: "var(--xnjepv0)",
+          __themeName__: "x1pfrffu"
         };"
       `);
 
@@ -502,17 +556,64 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
-              "xm1nzai",
+              "xop34xu",
               {
-                "ltr": ":root, .xm1nzai{--xjrzwe6:red;}",
+                "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
               0,
             ],
             [
-              "xc6dbti",
+              "x1pfrffu",
               {
-                "ltr": ":root, .xc6dbti{--x162zdew:orange;}",
+                "ltr": ":root, .x1pfrffu{--xnjepv0:orange;}",
+                "rtl": null,
+              },
+              0,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('multiple variables objects (dependency)', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.defineVars({
+          color: 'red'
+        });
+        export const otherVars = stylex.defineVars({
+          otherColor: vars.color
+        });
+      `);
+
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        export const vars = {
+          color: "var(--xwx8imx)",
+          __themeName__: "xop34xu"
+        };
+        export const otherVars = {
+          otherColor: "var(--xnjepv0)",
+          __themeName__: "x1pfrffu"
+        };"
+      `);
+
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xop34xu",
+              {
+                "ltr": ":root, .xop34xu{--xwx8imx:red;}",
+                "rtl": null,
+              },
+              0,
+            ],
+            [
+              "x1pfrffu",
+              {
+                "ltr": ":root, .x1pfrffu{--xnjepv0:var(--xwx8imx);}",
                 "rtl": null,
               },
               0,
@@ -523,13 +624,72 @@ describe('@stylexjs/babel-plugin', () => {
     });
 
     describe('options `debug:true`', () => {
-      test('tokens object, including keys with special characters', () => {
+      test('tokens object includes debug data', () => {
         const options = { debug: true };
         const { code, metadata } = transform(
           `
           import * as stylex from '@stylexjs/stylex';
           export const vars = stylex.defineVars({
-            color: 'red',
+            color: {
+              default: 'blue',
+              '@media (prefers-color-scheme: dark)': {
+                default: 'lightblue',
+                '@supports (color: oklab(0 0 0))': 'oklab(0.7 -0.3 -0.4)',
+              }
+            },
+            otherColor: 'green'
+          });
+        `,
+          options,
+        );
+
+        expect(code).toMatchInlineSnapshot(`
+          "import * as stylex from '@stylexjs/stylex';
+          export const vars = {
+            color: "var(--color-xwx8imx)",
+            otherColor: "var(--otherColor-xaaua2w)",
+            __themeName__: "xop34xu"
+          };"
+        `);
+
+        expect(metadata).toMatchInlineSnapshot(`
+          {
+            "stylex": [
+              [
+                "xop34xu",
+                {
+                  "ltr": ":root, .xop34xu{--color-xwx8imx:blue;--otherColor-xaaua2w:green;}",
+                  "rtl": null,
+                },
+                0,
+              ],
+              [
+                "xop34xu-1lveb7",
+                {
+                  "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--color-xwx8imx:lightblue;}}",
+                  "rtl": null,
+                },
+                0.1,
+              ],
+              [
+                "xop34xu-1e6ryz3",
+                {
+                  "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xop34xu{--color-xwx8imx:oklab(0.7 -0.3 -0.4);}}}",
+                  "rtl": null,
+                },
+                0.2,
+              ],
+            ],
+          }
+        `);
+      });
+
+      test('tokens object includes debug data (keys with special characters)', () => {
+        const options = { debug: true };
+        const { code, metadata } = transform(
+          `
+          import * as stylex from '@stylexjs/stylex';
+          export const vars = stylex.defineVars({
             '10': 'green',
             '1.5 pixels': 'blue',
             'corner#radius': 'purple',
@@ -542,12 +702,11 @@ describe('@stylexjs/babel-plugin', () => {
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const vars = {
-            "10": "var(--_10-x1iss122)",
-            color: "var(--color-xjrzwe6)",
-            "1.5 pixels": "var(--_1_5_pixels-x18nvhj0)",
-            "corner#radius": "var(--corner_radius-x1rt8ac5)",
-            "@@primary": "var(--__primary-xxp23oy)",
-            __themeName__: "xm1nzai"
+            "10": "var(--_10-x187fpdw)",
+            "1.5 pixels": "var(--_1_5_pixels-x15ahj5d)",
+            "corner#radius": "var(--corner_radius-x2ajqv2)",
+            "@@primary": "var(--__primary-x13tvx0f)",
+            __themeName__: "xop34xu"
           };"
         `);
 
@@ -555,9 +714,9 @@ describe('@stylexjs/babel-plugin', () => {
           {
             "stylex": [
               [
-                "xm1nzai",
+                "xop34xu",
                 {
-                  "ltr": ":root, .xm1nzai{--_10-x1iss122:green;--color-xjrzwe6:red;--_1_5_pixels-x18nvhj0:blue;--corner_radius-x1rt8ac5:purple;--__primary-xxp23oy:pink;}",
+                  "ltr": ":root, .xop34xu{--_10-x187fpdw:green;--_1_5_pixels-x15ahj5d:blue;--corner_radius-x2ajqv2:purple;--__primary-x13tvx0f:pink;}",
                   "rtl": null,
                 },
                 0,
@@ -587,12 +746,12 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import * as stylex from '@stylexjs/stylex';
-          _inject2(":root, .xm1nzai{--color-xjrzwe6:red;--nextColor-x1ybzi8d:green;--otherColor-x1o4mfbm:blue;}", 0);
+          _inject2(":root, .xop34xu{--color-xwx8imx:red;--nextColor-xk6xtqk:green;--otherColor-xaaua2w:blue;}", 0);
           export const vars = {
-            color: "var(--color-xjrzwe6)",
-            nextColor: "var(--nextColor-x1ybzi8d)",
-            otherColor: "var(--otherColor-x1o4mfbm)",
-            __themeName__: "xm1nzai"
+            color: "var(--color-xwx8imx)",
+            nextColor: "var(--nextColor-xk6xtqk)",
+            otherColor: "var(--otherColor-xaaua2w)",
+            __themeName__: "xop34xu"
           };"
         `);
 
@@ -600,9 +759,58 @@ describe('@stylexjs/babel-plugin', () => {
           {
             "stylex": [
               [
-                "xm1nzai",
+                "xop34xu",
                 {
-                  "ltr": ":root, .xm1nzai{--color-xjrzwe6:red;--nextColor-x1ybzi8d:green;--otherColor-x1o4mfbm:blue;}",
+                  "ltr": ":root, .xop34xu{--color-xwx8imx:red;--nextColor-xk6xtqk:green;--otherColor-xaaua2w:blue;}",
+                  "rtl": null,
+                },
+                0,
+              ],
+            ],
+          }
+        `);
+      });
+    });
+
+    describe('options `themeFileExtension`', () => {
+      test('processes tokens in files with configured extension', () => {
+        const options = {
+          dev: true,
+          filename: '/stylex/packages/src/vars/default.cssvars.js',
+          unstable_moduleResolution: {
+            rootDir: '/stylex/packages/',
+            themeFileExtension: 'cssvars',
+            type: 'commonJS',
+          },
+        };
+        const { code, metadata } = transform(
+          `
+          import * as stylex from '@stylexjs/stylex';
+          export const vars = stylex.defineVars({
+            color: 'red'
+          });
+        `,
+          options,
+        );
+
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(":root, .x1bxutiz{--color-x1lzcbr1:red;}", 0);
+          export const vars = {
+            color: "var(--color-x1lzcbr1)",
+            __themeName__: "x1bxutiz"
+          };"
+        `);
+
+        expect(metadata).toMatchInlineSnapshot(`
+          {
+            "stylex": [
+              [
+                "x1bxutiz",
+                {
+                  "ltr": ":root, .x1bxutiz{--color-x1lzcbr1:red;}",
                   "rtl": null,
                 },
                 0,

--- a/packages/babel-plugin/__tests__/validation-stylex-createTheme-test.js
+++ b/packages/babel-plugin/__tests__/validation-stylex-createTheme-test.js
@@ -53,18 +53,21 @@ describe('@stylexjs/babel-plugin', () => {
           const variables = stylex.createTheme();
         `);
       }).toThrow(messages.ILLEGAL_ARGUMENT_LENGTH);
+
       expect(() => {
         transform(`
           import stylex from 'stylex';
           const variables = stylex.createTheme({});
         `);
       }).toThrow(messages.ILLEGAL_ARGUMENT_LENGTH);
+
       expect(() => {
         transform(`
           import stylex from 'stylex';
           const variables = stylex.createTheme(genStyles(), {});
         `);
       }).toThrow(messages.NON_STATIC_VALUE);
+
       expect(() => {
         transform(`
           import stylex from 'stylex';
@@ -73,12 +76,14 @@ describe('@stylexjs/babel-plugin', () => {
       }).toThrow(
         'Can only override variables theme created with stylex.defineVars().',
       );
+
       expect(() => {
         transform(`
           import stylex from 'stylex';
           const variables = stylex.createTheme({__themeName__: 'x568ih9'}, genStyles());
         `);
       }).toThrow(messages.NON_STATIC_VALUE);
+
       expect(() => {
         transform(`
           import stylex from 'stylex';
@@ -113,6 +118,7 @@ describe('@stylexjs/babel-plugin', () => {
           );
         `);
       }).not.toThrow();
+
       // string
       expect(() => {
         transform(`
@@ -123,6 +129,7 @@ describe('@stylexjs/babel-plugin', () => {
           );
         `);
       }).not.toThrow();
+
       // not static
       expect(() => {
         transform(`
@@ -133,6 +140,7 @@ describe('@stylexjs/babel-plugin', () => {
           );
         `);
       }).toThrow(messages.NON_STATIC_VALUE);
+
       expect(() => {
         transform(`
           import stylex from 'stylex';

--- a/packages/babel-plugin/src/visitors/parse-stylex-create-arg.js
+++ b/packages/babel-plugin/src/visitors/parse-stylex-create-arg.js
@@ -18,7 +18,7 @@ import {
   timeUnits,
   lengthUnits,
   getNumberSuffix,
-} from '@stylexjs/shared/lib/transform-value';
+} from '@stylexjs/shared/lib/utils/transform-value';
 
 type TInlineStyles = {
   [string]: {

--- a/packages/shared/src/preprocess-rules/PreRule.js
+++ b/packages/shared/src/preprocess-rules/PreRule.js
@@ -9,7 +9,7 @@
 
 import type { InjectableStyle, StyleXOptions } from '../common-types';
 
-import { convertStyleToClassName } from '../convert-to-className';
+import { convertStyleToClassName } from '../utils/convert-to-className';
 import { arrayEquals } from '../utils/object-utils';
 import { sortAtRules, sortPseudos } from '../utils/rule-utils';
 

--- a/packages/shared/src/preprocess-rules/__tests__/PreRule-test.js
+++ b/packages/shared/src/preprocess-rules/__tests__/PreRule-test.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import { PreRule } from '../src/preprocess-rules/PreRule';
+import { PreRule } from '../PreRule';
 
 const options = {
   classNamePrefix: 'x',

--- a/packages/shared/src/preprocess-rules/__tests__/flatten-raw-style-obj-test.js
+++ b/packages/shared/src/preprocess-rules/__tests__/flatten-raw-style-obj-test.js
@@ -7,12 +7,8 @@
  * @flow strict
  */
 
-import {
-  NullPreRule,
-  PreRule,
-  PreRuleSet,
-} from '../../src/preprocess-rules/PreRule';
-import { flattenRawStyleObject } from '../../src/preprocess-rules/flatten-raw-style-obj';
+import { NullPreRule, PreRule, PreRuleSet } from '../PreRule';
+import { flattenRawStyleObject } from '../flatten-raw-style-obj';
 
 const options = {
   classNamePrefix: 'x',

--- a/packages/shared/src/stylex-keyframes.js
+++ b/packages/shared/src/stylex-keyframes.js
@@ -13,7 +13,7 @@ import createHash from './hash';
 import expandShorthands from './preprocess-rules/index';
 import generateLtr from './physical-rtl/generate-ltr';
 import generateRtl from './physical-rtl/generate-rtl';
-import transformValue from './transform-value';
+import transformValue from './utils/transform-value';
 import dashify from './utils/dashify';
 import {
   objFromEntries,

--- a/packages/shared/src/utils/__tests__/convert-to-className-test.js
+++ b/packages/shared/src/utils/__tests__/convert-to-className-test.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import { convertStyleToClassName } from '../src/convert-to-className';
+import { convertStyleToClassName } from '../convert-to-className';
 
 const extractBody = (str: string) => str.slice(str.indexOf('{') + 1, -1);
 

--- a/packages/shared/src/utils/__tests__/split-css-value-test.js
+++ b/packages/shared/src/utils/__tests__/split-css-value-test.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import splitValue from '../src/utils/split-css-value';
+import splitValue from '../split-css-value';
 
 describe('Ensure CSS values are split correctly', () => {
   test('simple space-separated numbers', () => {

--- a/packages/shared/src/utils/__tests__/transform-value-test.js
+++ b/packages/shared/src/utils/__tests__/transform-value-test.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import transformValue from '../src/transform-value';
+import transformValue from '../transform-value';
 
 describe('transformValue content property tests', () => {
   test('preserves CSS functions without quotes', () => {

--- a/packages/shared/src/utils/convert-to-className.js
+++ b/packages/shared/src/utils/convert-to-className.js
@@ -7,14 +7,14 @@
  * @flow strict
  */
 
-import createHash from './hash';
-import type { TRawValue, StyleRule, StyleXOptions } from './common-types';
-import dashify from './utils/dashify';
+import createHash from '../hash';
+import type { TRawValue, StyleRule, StyleXOptions } from '../common-types';
+import dashify from './dashify';
 import transformValue from './transform-value';
 import { generateRule } from './generate-css-rule';
-import { defaultOptions } from './utils/default-options';
-import * as messages from './messages';
-import { sortAtRules, sortPseudos } from './utils/rule-utils';
+import { defaultOptions } from './default-options';
+import * as messages from '../messages';
+import { sortAtRules, sortPseudos } from './rule-utils';
 
 // This function takes a single style rule and transforms it into a CSS rule.
 // [color: 'red'] => ['color', 'classname-for-color-red', CSSRULE{ltr, rtl, priority}]

--- a/packages/shared/src/utils/generate-css-rule.js
+++ b/packages/shared/src/utils/generate-css-rule.js
@@ -7,11 +7,11 @@
  * @flow strict
  */
 
-import generateLtr from './physical-rtl/generate-ltr';
-import generateRtl from './physical-rtl/generate-rtl';
-import { genCSSRule } from './utils/genCSSRule';
-import type { InjectableStyle } from './common-types';
-import getPriority from './utils/property-priorities';
+import generateLtr from '../physical-rtl/generate-ltr';
+import generateRtl from '../physical-rtl/generate-rtl';
+import { genCSSRule } from './genCSSRule';
+import type { InjectableStyle } from '../common-types';
+import getPriority from './property-priorities';
 
 export function generateRule(
   className: string,

--- a/packages/shared/src/utils/transform-value.js
+++ b/packages/shared/src/utils/transform-value.js
@@ -7,9 +7,9 @@
  * @flow strict
  */
 
-import type { StyleXOptions } from './common-types';
+import type { StyleXOptions } from '../common-types';
 
-import normalizeValue from './utils/normalize-value';
+import normalizeValue from './normalize-value';
 
 /**
  * Convert a CSS value in JS to the final CSS string value


### PR DESCRIPTION
A bit of housekeeping within the "shared" package.

* Add some test cases from "shared" to "babel-plugin".
* Colocate some "shared" tests with their internal modules.