### PR TITLE
fix: fix first that works bug where last value is a variable

### DIFF
--- a/packages/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -1172,8 +1172,8 @@ describe('@stylexjs/babel-plugin', () => {
       });
 
       describe('function value: stylex.firstThatWorks()', () => {
+        // Check various combinations of fallbacks
         test('args: value, value', () => {
-          // Checks various combinations of fallbacks
           const { code, metadata } = transform(`
             import * as stylex from '@stylexjs/stylex';
             export const styles = stylex.create({
@@ -1207,9 +1207,7 @@ describe('@stylexjs/babel-plugin', () => {
           `);
         });
 
-        // TODO: Fix parser bug
-        test.skip('args: value, var', () => {
-          // Checks various combinations of fallbacks
+        test('args: value, var', () => {
           const { code, metadata } = transform(`
             import * as stylex from '@stylexjs/stylex';
             export const styles = stylex.create({
@@ -1218,12 +1216,32 @@ describe('@stylexjs/babel-plugin', () => {
               }
             });
           `);
-          expect(code).toMatchInlineSnapshot();
-          expect(metadata).toMatchInlineSnapshot();
+          expect(code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: {
+                kMwMTN: "x1nv2f59",
+                $$css: true
+              }
+            };"
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x1nv2f59",
+                  {
+                    "ltr": ".x1nv2f59{color:var(--color);color:red}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+              ],
+            }
+          `);
         });
 
         test('args: var, value', () => {
-          // Checks various combinations of fallbacks
           const { code, metadata } = transform(`
             import * as stylex from '@stylexjs/stylex';
             export const styles = stylex.create({
@@ -1258,7 +1276,6 @@ describe('@stylexjs/babel-plugin', () => {
         });
 
         test('args: var, var', () => {
-          // Checks various combinations of fallbacks
           const { code, metadata } = transform(`
             import * as stylex from '@stylexjs/stylex';
             export const styles = stylex.create({
@@ -1292,8 +1309,41 @@ describe('@stylexjs/babel-plugin', () => {
           `);
         });
 
-        // TODO: Fix parser bug
-        test.skip('args: func, var, value', () => {
+        test('args: var, var, var', () => {
+          const { code, metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                color: stylex.firstThatWorks('var(--color)', 'var(--secondColor)', 'var(--thirdColor)'),
+              }
+            });
+          `);
+          expect(code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: {
+                kMwMTN: "xsrkhny",
+                $$css: true
+              }
+            };"
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "xsrkhny",
+                  {
+                    "ltr": ".xsrkhny{color:var(--color,var(--secondColor,var(--thirdColor)))}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+              ],
+            }
+          `);
+        });
+
+        test('args: func, var, value', () => {
           const { code, metadata } = transform(`
             import * as stylex from '@stylexjs/stylex';
             export const styles = stylex.create({
@@ -1302,12 +1352,32 @@ describe('@stylexjs/babel-plugin', () => {
               }
             });
           `);
-          expect(code).toMatchInlineSnapshot();
-          expect(metadata).toMatchInlineSnapshot();
+          expect(code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: {
+                kMwMTN: "x8vgp76",
+                $$css: true
+              }
+            };"
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x8vgp76",
+                  {
+                    "ltr": ".x8vgp76{color:var(--color,red);color:color-mix(in srgb,currentColor 20%,transparent)}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+              ],
+            }
+          `);
         });
 
-        // TODO: Fix parser bug
-        test.skip('args: func, var, value, value', () => {
+        test('args: func, var, value, value', () => {
           // Ignore simple fallbacks after the first one
           const { code, metadata } = transform(`
             import * as stylex from '@stylexjs/stylex';
@@ -1317,8 +1387,29 @@ describe('@stylexjs/babel-plugin', () => {
               }
             });
           `);
-          expect(code).toMatchInlineSnapshot();
-          expect(metadata).toMatchInlineSnapshot();
+          expect(code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: {
+                kMwMTN: "x8vgp76",
+                $$css: true
+              }
+            };"
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x8vgp76",
+                  {
+                    "ltr": ".x8vgp76{color:var(--color,red);color:color-mix(in srgb,currentColor 20%,transparent)}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+              ],
+            }
+          `);
         });
       });
 

--- a/packages/babel-plugin/src/shared/utils/__tests__/convert-to-className-test.js
+++ b/packages/babel-plugin/src/shared/utils/__tests__/convert-to-className-test.js
@@ -100,4 +100,19 @@ describe('convert-to-className test', () => {
       'height:var(--y,var(--x,500px));height:var(--y,var(--x,100vh));height:100dvh',
     );
   });
+  test('handles array with variable default and multiple constant fallbacks', () => {
+    expect(convert(['height', ['var(--x)', 500, '100dvh']])).toEqual(
+      'height:var(--x);height:500px;height:100dvh',
+    );
+  });
+  test('handles array with variable default and multiple variable and constant fallbacks', () => {
+    expect(
+      convert(['height', ['var(--x)', 'var(--y)', 'var(--z)', '100dvh']]),
+    ).toEqual('height:var(--z,var(--y,var(--x)));height:100dvh');
+  });
+  test('handles array of all variables', () => {
+    expect(
+      convert(['height', ['var(--w)', 'var(--x)', 'var(--y)', 'var(--z)']]),
+    ).toEqual('height:var(--z,var(--y,var(--x,var(--w))))');
+  });
 });

--- a/packages/babel-plugin/src/shared/utils/convert-to-className.js
+++ b/packages/babel-plugin/src/shared/utils/convert-to-className.js
@@ -94,7 +94,7 @@ export default function variableFallbacks(
   return [
     ...(valuesBeforeFirstVar.length > 0
       ? valuesBeforeFirstVar.map((val) => composeVars(...varValues, val))
-      : composeVars(...varValues)),
+      : [composeVars(...varValues)]),
     ...valuesAfterLastVar,
   ];
 }


### PR DESCRIPTION
`firstThatWorks(a, b, c)` turns into an array of values that eventually gets passed into some shared `stylex.create` utils. 
```
borderColor: stylex.firstThatWorks('blue', 'var(--accent)')
```
When a property value array started with a CSS variable (e.g. ["var(--x)", "sticky"]), variableFallbacks called composeVars(...) and mistakenly spread its string result into an array. 

Resulting in broken output like:  broken output like 
```
".borderColor-xnybe8l{border-color:v;border-color:a;border-color:r;border-color:(;border-color:-;border-color:-;border-color:a;border-color:c;border-color:c;border-color:e;border-color:n;border-color:t;border-color:);border-color:blue}"
```

This fix wraps the composeVars result in an array to keep the return value consistent.
```
.borderColor-xnybe8l{border-color:var(--accent);border-color:blue;}
```

we were never testing this, so this edge case was missed