### PR TITLE
fix: invalid wrapping of variables as values for content

### DIFF
--- a/packages/babel-plugin/src/shared/utils/__tests__/transform-value-test.js
+++ b/packages/babel-plugin/src/shared/utils/__tests__/transform-value-test.js
@@ -18,6 +18,8 @@ describe('transformValue content property tests', () => {
       'image-set("image1x.png" 1x, "image2x.png" 2x)',
       '"prefix"attr(href)',
       'url(foo.jpg)attr(alt)',
+      'var(--test)',
+      'var(--test, "default")',
     ];
 
     functions.forEach((input) => {

--- a/packages/babel-plugin/src/shared/utils/transform-value.js
+++ b/packages/babel-plugin/src/shared/utils/transform-value.js
@@ -39,6 +39,7 @@ export default function transformValue(
       'url(',
       'linear-gradient(',
       'image-set(',
+      'var(--',
     ];
 
     const cssContentKeywords = new Set([


### PR DESCRIPTION
## What changed / motivation ?

Fix the logic for automatically adding quotes around values for the `content` property, (often used within `::before` and `::after`)

The fix was to simply add `var(--` to the list of function strings the code uses to opt out of quotes today.

## Linked PR/Issues

Fixes #1004