### PR TITLE
[babel-plugin] Rename 'useRemForFontSize' to 'enableFontSizePxToRem'

### DIFF
--- a/packages/babel-plugin/__tests__/transform-value-normalization-test.js
+++ b/packages/babel-plugin/__tests__/transform-value-normalization-test.js
@@ -23,7 +23,6 @@ function transform(source, opts = {}) {
         stylexPlugin,
         {
           runtimeInjection: true,
-          useRemForFontSize: true,
           ...opts,
         },
       ],
@@ -268,10 +267,11 @@ describe('@stylexjs/babel-plugin', () => {
   });
 
   describe('[transform] fontSize with:', () => {
-    describe('useRemForFontSize: true', () => {
+    describe('enableFontSizePxToRem: true', () => {
       test('transforms font size from px to rem', () => {
         expect(
-          transform(`
+          transform(
+            `
             import stylex from 'stylex';
             const styles = stylex.create({
               foo: {
@@ -287,7 +287,9 @@ describe('@stylexjs/babel-plugin', () => {
                 fontSize: 'inherit',
               }
             });
-          `),
+          `,
+            { enableFontSizePxToRem: true },
+          ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
@@ -301,14 +303,17 @@ describe('@stylexjs/babel-plugin', () => {
 
       test('transforms font size from px to rem even with calc', () => {
         expect(
-          transform(`
+          transform(
+            `
             import stylex from 'stylex';
             const styles = stylex.create({
               foo: {
                 fontSize: 'calc(100% - 24px)',
               },
             });
-          `),
+          `,
+            { enableFontSizePxToRem: true },
+          ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
@@ -318,7 +323,7 @@ describe('@stylexjs/babel-plugin', () => {
       });
     });
 
-    describe('useRemForFontSize: false', () => {
+    describe('enableFontSizePxToRem: false', () => {
       test('ignores px font size', () => {
         expect(
           transform(
@@ -339,7 +344,6 @@ describe('@stylexjs/babel-plugin', () => {
               }
             });
           `,
-            { useRemForFontSize: false },
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
@@ -363,7 +367,6 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `,
-            { useRemForFontSize: false },
           ),
         ).toMatchInlineSnapshot(`
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";

--- a/packages/babel-plugin/src/shared/common-types.js
+++ b/packages/babel-plugin/src/shared/common-types.js
@@ -46,12 +46,13 @@ export type FlatCompiledStyles = $ReadOnly<{
 export type StyleXOptions = $ReadOnly<{
   classNamePrefix: string,
   debug: ?boolean,
+  definedStylexCSSVariables?: { [key: string]: mixed },
+  dev: boolean,
   enableDebugClassNames?: ?boolean,
   enableDebugDataProp?: ?boolean,
   enableDevClassNames?: ?boolean,
+  enableFontSizePxToRem?: ?boolean,
   enableMinifiedKeys?: ?boolean,
-  definedStylexCSSVariables?: { [key: string]: mixed },
-  dev: boolean,
   styleResolution:
     | 'application-order' // The last style applied wins.
     // More specific styles will win over less specific styles. (margin-top wins over margin)
@@ -60,7 +61,6 @@ export type StyleXOptions = $ReadOnly<{
     // This is not recommended, and will be removed in a future version.
     | 'legacy-expand-shorthands',
   test: boolean,
-  useRemForFontSize: boolean,
   ...
 }>;
 

--- a/packages/babel-plugin/src/shared/preprocess-rules/__tests__/PreRule-test.js
+++ b/packages/babel-plugin/src/shared/preprocess-rules/__tests__/PreRule-test.js
@@ -14,7 +14,7 @@ const options = {
   styleResolution: 'legacy-expand-shorthands',
   dev: false,
   debug: false,
-  useRemForFontSize: true,
+  enableFontSizePxToRem: true,
   runtimeInjection: false,
   test: false,
 };

--- a/packages/babel-plugin/src/shared/preprocess-rules/__tests__/flatten-raw-style-obj-test.js
+++ b/packages/babel-plugin/src/shared/preprocess-rules/__tests__/flatten-raw-style-obj-test.js
@@ -15,7 +15,6 @@ const options = {
   debug: false,
   styleResolution: 'legacy-expand-shorthands',
   runtimeInjection: false,
-  useRemForFontSize: true,
   dev: false,
   test: false,
 };

--- a/packages/babel-plugin/src/shared/utils/__tests__/convert-to-className-test.js
+++ b/packages/babel-plugin/src/shared/utils/__tests__/convert-to-className-test.js
@@ -25,7 +25,6 @@ describe('convert-to-className test', () => {
       debug: true,
       styleResolution: 'application-order',
       test: false,
-      useRemForFontSize: false,
     };
     const result = convertStyleToClassName(['margin', 10], [], [], options);
     const className = result[1];
@@ -39,7 +38,6 @@ describe('convert-to-className test', () => {
       enableDebugClassNames: false,
       styleResolution: 'application-order',
       test: false,
-      useRemForFontSize: false,
     };
     const result = convertStyleToClassName(['margin', 10], [], [], options);
     const className = result[1];
@@ -53,7 +51,6 @@ describe('convert-to-className test', () => {
       debug: false,
       styleResolution: 'application-order',
       test: false,
-      useRemForFontSize: false,
     };
     const result = convertStyleToClassName(['margin', 10], [], [], options);
     const className = result[1];

--- a/packages/babel-plugin/src/shared/utils/default-options.js
+++ b/packages/babel-plugin/src/shared/utils/default-options.js
@@ -15,8 +15,8 @@ export const defaultOptions: StyleXOptions = {
   debug: false,
   enableDebugClassNames: true,
   enableDebugDataProp: true,
+  enableFontSizePxToRem: true,
   enableMinifiedKeys: true,
-  useRemForFontSize: true,
   styleResolution: 'application-order',
   test: false,
 };

--- a/packages/babel-plugin/src/shared/utils/normalize-value.js
+++ b/packages/babel-plugin/src/shared/utils/normalize-value.js
@@ -38,13 +38,13 @@ const normalizers = [
 export default function normalizeValue(
   value: string,
   key: string,
-  { useRemForFontSize }: StyleXOptions,
+  { enableFontSizePxToRem }: StyleXOptions,
 ): string {
   if (value == null) {
     return value;
   }
   const parsedAST = parser(value);
-  const relevantNormalizers = useRemForFontSize
+  const relevantNormalizers = enableFontSizePxToRem
     ? [...normalizers, convertFontSizeToRem]
     : normalizers;
   return relevantNormalizers

--- a/packages/babel-plugin/src/utils/__tests__/state-manager-test.js
+++ b/packages/babel-plugin/src/utils/__tests__/state-manager-test.js
@@ -560,33 +560,33 @@ describe('StateManager config parsing', () => {
     });
   });
 
-  describe('"useRemForFontSize" option (boolean)', () => {
+  describe('"enableFontSizePxToRem" option (boolean)', () => {
     test('logs errors if invalid', () => {
-      const stateManager = makeState({ useRemForFontSize: 'true' });
-      expect(stateManager.options.useRemForFontSize).toBe(false);
+      const stateManager = makeState({ enableFontSizePxToRem: 'true' });
+      expect(stateManager.options.enableFontSizePxToRem).toBe(false);
       expect(warnings).toEqual([
         [
           '[@stylexjs/babel-plugin]',
-          'Expected (options.useRemForFontSize) to be a boolean, but got `"true"`.',
+          'Expected (options.enableFontSizePxToRem) to be a boolean, but got `"true"`.',
         ],
       ]);
     });
 
     test('default value', () => {
       const stateManager = makeState();
-      expect(stateManager.options.useRemForFontSize).toBe(false);
+      expect(stateManager.options.enableFontSizePxToRem).toBe(false);
       expect(warnings).toEqual([]);
     });
 
     test('false value', () => {
-      const stateManager = makeState({ useRemForFontSize: false });
-      expect(stateManager.options.useRemForFontSize).toBe(false);
+      const stateManager = makeState({ enableFontSizePxToRem: false });
+      expect(stateManager.options.enableFontSizePxToRem).toBe(false);
       expect(warnings).toEqual([]);
     });
 
     test('true value', () => {
-      const stateManager = makeState({ useRemForFontSize: true });
-      expect(stateManager.options.useRemForFontSize).toBe(true);
+      const stateManager = makeState({ enableFontSizePxToRem: true });
+      expect(stateManager.options.enableFontSizePxToRem).toBe(true);
       expect(warnings).toEqual([]);
     });
   });

--- a/packages/babel-plugin/src/utils/state-manager.js
+++ b/packages/babel-plugin/src/utils/state-manager.js
@@ -193,6 +193,14 @@ export default class StateManager {
         'options.enableDevClassNames',
       );
 
+    const enableFontSizePxToRem: StyleXStateOptions['enableFontSizePxToRem'] =
+      z.logAndDefault(
+        z.boolean(),
+        options.enableFontSizePxToRem ?? false,
+        false,
+        'options.enableFontSizePxToRem',
+      );
+
     const enableInlinedConditionalMerge: StyleXStateOptions['enableInlinedConditionalMerge'] =
       z.logAndDefault(
         z.boolean(),
@@ -256,14 +264,6 @@ export default class StateManager {
       ...configuredImportSources,
     ];
 
-    const useRemForFontSize: StyleXStateOptions['useRemForFontSize'] =
-      z.logAndDefault(
-        z.boolean(),
-        options.useRemForFontSize ?? false,
-        false,
-        'options.useRemForFontSize',
-      );
-
     const styleResolution: StyleXStateOptions['styleResolution'] =
       z.logAndDefault(
         z.unionOf3(
@@ -323,6 +323,7 @@ export default class StateManager {
       enableDebugClassNames,
       enableDebugDataProp,
       enableDevClassNames,
+      enableFontSizePxToRem,
       enableInlinedConditionalMerge,
       enableMinifiedKeys,
       importSources,
@@ -335,7 +336,6 @@ export default class StateManager {
       test,
       treeshakeCompensation,
       unstable_moduleResolution,
-      useRemForFontSize,
     };
     return opts;
   }

--- a/packages/docs/docs/api/configuration/babel-plugin.mdx
+++ b/packages/docs/docs/api/configuration/babel-plugin.mdx
@@ -146,15 +146,3 @@ This is required if you plan to use StyleX's theming APIs.
 
 **NOTE**: While theming APIs are stable, the shape of this configuration option
 may change in the future.
-
----
-
-### `useRemForFontSize`
-
-```ts
-useRemForFontSize: boolean // Default: false
-```
-
-Should `px` values for `fontSize` be converted to `rem`?
-It is considered a best practice to use `rem` for font sizes to allow
-users to scale the font size up or down.


### PR DESCRIPTION
* Rename this option to match other feature flags.
* Remove this option from the plugin docs.