### PR TITLE
style-value-parser/feat: implement toString function in calc parser

### DIFF
--- a/packages/style-value-parser/src/css-types-from-tokens/__tests__/calc-test.js
+++ b/packages/style-value-parser/src/css-types-from-tokens/__tests__/calc-test.js
@@ -243,8 +243,36 @@ describe('Test CSS Type: calc()', () => {
   test('rejects invalid calc expressions', () => {
     expect(() => Calc.parser.parseToEnd('calc()')).toThrow();
     expect(() => Calc.parser.parseToEnd('calc(10 + )')).toThrow();
+    expect(() => Calc.parser.parseToEnd('calc(10 +5 )')).toThrow();
+    expect(() => Calc.parser.parseToEnd('calc(10+5 )')).toThrow();
     expect(() => Calc.parser.parseToEnd('calc(10 @ 5)')).toThrow();
     expect(() => Calc.parser.parseToEnd('calc(10px + 5em)')).not.toThrow();
     expect(() => Calc.parser.parseToEnd('notcalc(10 + 5)')).toThrow();
+  });
+
+  test('toString round‑trips calc expressions', () => {
+    const cases = [
+      'calc(10)',
+      'calc(3.14)',
+      'calc(-5)',
+      'calc(50%)',
+      'calc(20px)',
+      'calc(10 + 5)',
+      'calc(20px + 10%)',
+      'calc(10 - 5)',
+      'calc(10 * 5)',
+      'calc(10 / 2)',
+      'calc((10 + 5) * 2)',
+      'calc(100% - 20px * 2 + 10px)',
+      'calc((100% - (30px / 2)))',
+    ];
+    cases.forEach((str) => {
+      expect(Calc.parser.parse(str).toString()).toBe(str);
+    });
+  });
+
+  test.skip('rejects invalid calc spacing', () => {
+    // TODO: Parser does not enforce this edge case properly, need to fix
+    expect(() => Calc.parser.parseToEnd('calc(10+ 5 )')).toThrow();
   });
 });

--- a/packages/style-value-parser/src/css-types-from-tokens/__tests__/calc-test.js
+++ b/packages/style-value-parser/src/css-types-from-tokens/__tests__/calc-test.js
@@ -136,9 +136,12 @@ describe('Test CSS Type: calc()', () => {
       new Calc({
         type: '*',
         left: {
-          type: '+',
-          left: 10,
-          right: 5,
+          type: 'group',
+          expr: {
+            type: '+',
+            left: 10,
+            right: 5,
+          },
         },
         right: 2,
       }),
@@ -148,13 +151,16 @@ describe('Test CSS Type: calc()', () => {
         type: '-',
         left: new Percentage(100),
         right: {
-          type: '/',
-          left: {
-            type: NumberType.Integer,
-            value: 30,
-            unit: 'px',
+          type: 'group',
+          expr: {
+            type: '/',
+            left: {
+              type: NumberType.Integer,
+              value: 30,
+              unit: 'px',
+            },
+            right: 2,
           },
-          right: 2,
         },
       }),
     );


### PR DESCRIPTION
This is a dependency to support media queries with `calc` and other uses

Two main changes:
- Added a new `group` node type to preserve user written parentheses in `calc()` expressions. We wrap all explicitly parenthesized expressions (like `(10 + 5)`) in a `{ type: 'group', expr }` node.
- Updated the parser to support nested groups and maintain correct order of operations

Implemented:
- toString()` method reconstructs the original `calc(...)` string exactly, including parentheses
   - We can work on simplication afterwards (ie. collapsing stuff like parentheses implied by order of operation)
- Added test for round trip accuracy: `parse -> toString` returns the original string for all valid inputs

Known further improvements:
- Parser does not flag `calc(a+ b )` as invalid (flags other instances). Will fix in follow up
