### PR TITLE
feat: Add new stylex.positionTry for @property-try declarations

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-import-export-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-import-export-test.js
@@ -52,6 +52,7 @@ const defaultImportMap = {
   defineVars: 'stylex.defineVars',
   firstThatWorks: 'stylex.firstThatWorks',
   keyframes: 'stylex.keyframes',
+  positionTry: 'stylex.positionTry',
   props: 'stylex.props',
 };
 
@@ -74,6 +75,7 @@ function createStylesFixture({
     defineVars,
     firstThatWorks,
     keyframes,
+    positionTry,
     props,
   } = importMap;
 
@@ -99,6 +101,15 @@ function createStylesFixture({
 
   return `
     ${defineConstsAndVarsOutput}
+    const fallback1 = ${positionTry}({
+      anchorName: '--myAnchor',
+      positionArea: 'top left',
+    });
+    const fallback2 = ${positionTry}({
+      anchorName: '--otherAnchor',
+      top: 'anchor(bottom)',
+      insetInlineStart: 'anchor(start)',
+    });
     const styles = ${create}({
       root: {
         animationName: ${keyframes}({
@@ -109,6 +120,7 @@ function createStylesFixture({
             backgroundColor: 'orange'
           },
         }),
+        positionTryFallbacks: \`\${fallback1}, \${fallback2}\`,
         color: {
           default: 'red',
           [constants.mediaQuery]: 'blue'
@@ -210,9 +222,12 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const fallback1 = "--x5jppmd";
+        const fallback2 = "--x17pzx6";
         const styles = {
           root: {
             kKVMdj: "x1qar0u3",
+            k9M3vk: "x7cint9",
             kMwMTN: "x1e2nbdu x14693no",
             kVAEAm: "x15oojuh",
             $$css: true
@@ -229,6 +244,22 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
+              "--x5jppmd",
+              {
+                "ltr": "@position-try --x5jppmd {anchor-name:anchor-name;anchor-name:--myAnchor;position-area:position-area;position-area:top left;}",
+                "rtl": "@position-try --x5jppmd {anchor-name:--myAnchor;position-area:top left;}",
+              },
+              1,
+            ],
+            [
+              "--x17pzx6",
+              {
+                "ltr": "@position-try --x17pzx6 {anchor-name:anchor-name;anchor-name:--otherAnchor;inset-inline-start:inset-inline-start;inset-inline-start:anchor(start);top:top;top:anchor(bottom);}",
+                "rtl": "@position-try --x17pzx6 {anchor-name:--otherAnchor;inset-inline-start:anchor(start);top:anchor(bottom);}",
+              },
+              1,
+            ],
+            [
               "xjx6k13-B",
               {
                 "ltr": "@keyframes xjx6k13-B{from{background-color:yellow;}to{background-color:orange;}}",
@@ -240,6 +271,14 @@ describe('@stylexjs/babel-plugin', () => {
               "x1qar0u3",
               {
                 "ltr": ".x1qar0u3{animation-name:xjx6k13-B}",
+                "rtl": null,
+              },
+              3000,
+            ],
+            [
+              "x7cint9",
+              {
+                "ltr": ".x7cint9{position-try-fallbacks:--x5jppmd,--x17pzx6}",
                 "rtl": null,
               },
               3000,
@@ -292,6 +331,7 @@ describe('@stylexjs/babel-plugin', () => {
           defineVars: 'foo.defineVars',
           firstThatWorks: 'foo.firstThatWorks',
           keyframes: 'foo.keyframes',
+          positionTry: 'foo.positionTry',
           props: 'foo.props',
         },
       });
@@ -307,9 +347,12 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const fallback1 = "--x5jppmd";
+        const fallback2 = "--x17pzx6";
         const styles = {
           root: {
             kKVMdj: "x1qar0u3",
+            k9M3vk: "x7cint9",
             kMwMTN: "x1e2nbdu x14693no",
             kVAEAm: "x15oojuh",
             $$css: true
@@ -328,7 +371,7 @@ describe('@stylexjs/babel-plugin', () => {
     test('import: named', () => {
       const fixture = createStylesFixture({
         importText:
-          '{create, createTheme, defineConsts, defineVars, firstThatWorks, keyframes, props}',
+          '{create, createTheme, defineConsts, defineVars, firstThatWorks, keyframes, positionTry, props}',
         importMap: {
           create: 'create',
           createTheme: 'createTheme',
@@ -336,6 +379,7 @@ describe('@stylexjs/babel-plugin', () => {
           defineVars: 'defineVars',
           firstThatWorks: 'firstThatWorks',
           keyframes: 'keyframes',
+          positionTry: 'positionTry',
           props: 'props',
         },
       });
@@ -343,7 +387,7 @@ describe('@stylexjs/babel-plugin', () => {
       const { code, metadata } = transform(fixture);
 
       expect(code).toMatchInlineSnapshot(`
-        "import { create, createTheme, defineConsts, defineVars, firstThatWorks, keyframes, props } from '@stylexjs/stylex';
+        "import { create, createTheme, defineConsts, defineVars, firstThatWorks, keyframes, positionTry, props } from '@stylexjs/stylex';
         export const constants = {
           mediaQuery: "@media (min-width: 768px)"
         };
@@ -351,9 +395,12 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const fallback1 = "--x5jppmd";
+        const fallback2 = "--x17pzx6";
         const styles = {
           root: {
             kKVMdj: "x1qar0u3",
+            k9M3vk: "x7cint9",
             kMwMTN: "x1e2nbdu x14693no",
             kVAEAm: "x15oojuh",
             $$css: true
@@ -378,6 +425,7 @@ describe('@stylexjs/babel-plugin', () => {
           defineVars as _defineVars,
           firstThatWorks as _firstThatWorks,
           keyframes as _keyframes,
+          positionTry as _positionTry,
           props as _props
         }`,
         importMap: {
@@ -387,6 +435,7 @@ describe('@stylexjs/babel-plugin', () => {
           defineVars: '_defineVars',
           firstThatWorks: '_firstThatWorks',
           keyframes: '_keyframes',
+          positionTry: '_positionTry',
           props: '_props',
         },
       });
@@ -394,7 +443,7 @@ describe('@stylexjs/babel-plugin', () => {
       const { code, metadata } = transform(fixture);
 
       expect(code).toMatchInlineSnapshot(`
-        "import { create as _create, createTheme as _createTheme, defineConsts as _defineConsts, defineVars as _defineVars, firstThatWorks as _firstThatWorks, keyframes as _keyframes, props as _props } from '@stylexjs/stylex';
+        "import { create as _create, createTheme as _createTheme, defineConsts as _defineConsts, defineVars as _defineVars, firstThatWorks as _firstThatWorks, keyframes as _keyframes, positionTry as _positionTry, props as _props } from '@stylexjs/stylex';
         export const constants = {
           mediaQuery: "@media (min-width: 768px)"
         };
@@ -402,9 +451,12 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const fallback1 = "--x5jppmd";
+        const fallback2 = "--x17pzx6";
         const styles = {
           root: {
             kKVMdj: "x1qar0u3",
+            k9M3vk: "x7cint9",
             kMwMTN: "x1e2nbdu x14693no",
             kVAEAm: "x15oojuh",
             $$css: true
@@ -439,9 +491,12 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const fallback1 = "--x5jppmd";
+        const fallback2 = "--x17pzx6";
         const styles = {
           root: {
             kKVMdj: "x1qar0u3",
+            k9M3vk: "x7cint9",
             kMwMTN: "x1e2nbdu x14693no",
             kVAEAm: "x15oojuh",
             $$css: true
@@ -469,6 +524,7 @@ describe('@stylexjs/babel-plugin', () => {
           defineVars: 'css.defineVars',
           firstThatWorks: 'css.firstThatWorks',
           keyframes: 'css.keyframes',
+          positionTry: 'css.positionTry',
           props: 'css.props',
         },
       });
@@ -487,9 +543,12 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const fallback1 = "--x5jppmd";
+        const fallback2 = "--x17pzx6";
         const styles = {
           root: {
             kKVMdj: "x1qar0u3",
+            k9M3vk: "x7cint9",
             kMwMTN: "x1e2nbdu x14693no",
             kVAEAm: "x15oojuh",
             $$css: true
@@ -524,9 +583,12 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const fallback1 = "--x5jppmd";
+        const fallback2 = "--x17pzx6";
         const styles = {
           root: {
             kKVMdj: "x1qar0u3",
+            k9M3vk: "x7cint9",
             kMwMTN: "x1e2nbdu x14693no",
             kVAEAm: "x15oojuh",
             $$css: true

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-positionTry-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-positionTry-test.js
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+jest.autoMockOff();
+
+const stylexPlugin = require('../src/index');
+const { transformSync } = require('@babel/core');
+
+function transform(source, opts = {}) {
+  const { code, metadata } = transformSync(source, {
+    filename: opts.filename,
+    parserOpts: {
+      flow: 'all',
+    },
+    plugins: [[stylexPlugin, { ...opts }]],
+  });
+
+  return { code, metadata };
+}
+
+describe('@stylexjs/babel-plugin', () => {
+  describe('[transform] stylex.positionTry', () => {
+    test('positionTry object', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const name = stylex.positionTry({
+          positionAnchor: '--anchor',
+          top: '0',
+          left: '0',
+          width: '100px',
+          height: '100px'
+        });
+      `);
+
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        export const name = "--xhs37kq";"
+      `);
+
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "--xhs37kq",
+              {
+                "ltr": "@position-try --xhs37kq {height:height;height:100px;left:left;left:0;position-anchor:position-anchor;position-anchor:--anchor;top:top;top:0;width:width;width:100px;}",
+                "rtl": "@position-try --xhs37kq {height:100px;left:0;position-anchor:--anchor;top:0;width:100px;}",
+              },
+              1,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('local constants used in positionTry object', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        const SIZE = '100px';
+        export const name = stylex.positionTry({
+          positionAnchor: '--anchor',
+          top: '0',
+          left: '0',
+          width: SIZE,
+          height: SIZE
+        });
+      `);
+
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        const SIZE = '100px';
+        export const name = "--xhs37kq";"
+      `);
+
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "--xhs37kq",
+              {
+                "ltr": "@position-try --xhs37kq {height:height;height:100px;left:left;left:0;position-anchor:position-anchor;position-anchor:--anchor;top:top;top:0;width:width;width:100px;}",
+                "rtl": "@position-try --xhs37kq {height:100px;left:0;position-anchor:--anchor;top:0;width:100px;}",
+              },
+              1,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('positionTry value used within create', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        const SIZE = '100px';
+        const name = stylex.positionTry({
+          top: '0',
+          left: '0',
+          width: SIZE,
+          height: SIZE
+        });
+        export const styles = stylex.create({
+          root: {
+            positionTryFallbacks: name,
+          }
+        });
+      `);
+
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        const SIZE = '100px';
+        const name = "--x1oyda6q";
+        export const styles = {
+          root: {
+            k9M3vk: "x4uh2cz",
+            $$css: true
+          }
+        };"
+      `);
+
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "--x1oyda6q",
+              {
+                "ltr": "@position-try --x1oyda6q {height:height;height:100px;left:left;left:0;top:top;top:0;width:width;width:100px;}",
+                "rtl": "@position-try --x1oyda6q {height:100px;left:0;top:0;width:100px;}",
+              },
+              1,
+            ],
+            [
+              "x4uh2cz",
+              {
+                "ltr": ".x4uh2cz{position-try-fallbacks:--x1oyda6q}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('positionTry object used inline', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({
+          root: {
+            positionTryFallbacks: stylex.positionTry({
+              positionAnchor: '--anchor',
+              top: '0',
+              left: '0',
+              width: '100px',
+              height: '100px'
+            }),
+          },
+        });
+      `);
+
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        export const styles = {
+          root: {
+            k9M3vk: "xlj2pck",
+            $$css: true
+          }
+        };"
+      `);
+
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "--xhs37kq",
+              {
+                "ltr": "@position-try --xhs37kq {height:height;height:100px;left:left;left:0;position-anchor:position-anchor;position-anchor:--anchor;top:top;top:0;width:width;width:100px;}",
+                "rtl": "@position-try --xhs37kq {height:100px;left:0;position-anchor:--anchor;top:0;width:100px;}",
+              },
+              1,
+            ],
+            [
+              "xlj2pck",
+              {
+                "ltr": ".xlj2pck{position-try-fallbacks:--xhs37kq}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+  });
+});

--- a/packages/@stylexjs/babel-plugin/__tests__/validation-import-export-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/validation-import-export-test.js
@@ -52,5 +52,23 @@ describe('@stylexjs/babel-plugin', () => {
         `);
       }).not.toThrow();
     });
+
+    test('valid import: positionTry named import', () => {
+      expect(() => {
+        transform(`
+          import { positionTry } from '@stylexjs/stylex';
+          const positionName = positionTry({});
+        `);
+      }).not.toThrow();
+    });
+
+    test('valid import: positionTry from namespace import', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          const positionName = stylex.positionTry({});
+        `);
+      }).not.toThrow();
+    });
   });
 });

--- a/packages/@stylexjs/babel-plugin/src/shared/index.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/index.js
@@ -32,6 +32,7 @@ import styleXDefineVars from './stylex-define-vars';
 import styleXDefineConsts from './stylex-define-consts';
 import styleXCreateTheme from './stylex-create-theme';
 import stylexKeyframes from './stylex-keyframes';
+import stylexPositionTry from './stylex-position-try';
 import stylexFirstThatWorks from './stylex-first-that-works';
 import hash from './hash';
 import genFileBasedIdentifier from './utils/file-based-identifier';
@@ -48,6 +49,7 @@ export const defineVars: typeof styleXDefineVars = styleXDefineVars;
 export const defineConsts: typeof styleXDefineConsts = styleXDefineConsts;
 export const createTheme: typeof styleXCreateTheme = styleXCreateTheme;
 export const keyframes: typeof stylexKeyframes = stylexKeyframes;
+export const positionTry: typeof stylexPositionTry = stylexPositionTry;
 export const utils: {
   hash: typeof hash,
   genFileBasedIdentifier: typeof genFileBasedIdentifier,

--- a/packages/@stylexjs/babel-plugin/src/shared/messages.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/messages.js
@@ -51,3 +51,6 @@ export const ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS =
 export const ONLY_TOP_LEVEL =
   'create() is only allowed at the root of a program.';
 export const UNKNOWN_PROP_KEY = 'Unknown property key';
+
+export const POSITION_TRY_INVALID_PROPERTY =
+  'Invalid property in `positionTry()` call. It may only contain, positionAnchor, positionArea, inset properties (top, left, insetInline etc.), margin properties, size properties (height, inlineSize, etc.), and self-alignment properties (alignSelf, justifySelf, placeSelf)';

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-position-try.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-position-try.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type { InjectableStyle, StyleXOptions } from './common-types';
+
+import createHash from './hash';
+import flatMapProperties from './preprocess-rules/index';
+import generateLtr from './physical-rtl/generate-ltr';
+import generateRtl from './physical-rtl/generate-rtl';
+import transformValue from './utils/transform-value';
+import dashify from './utils/dashify';
+import {
+  objFromEntries,
+  objEntries,
+  objMapKeys,
+  objMap,
+  Pipe,
+} from './utils/object-utils';
+import { defaultOptions } from './utils/default-options';
+
+// Similar to `stylex.keyframes` but for position-try-fallbacks
+// Takes an object of positioning properties and returns a string after hashing it
+// The generated string must be prefixed with -- for anchor positioning
+export default function styleXPositionTry(
+  styles: { +[string]: string | number },
+  options: StyleXOptions = defaultOptions,
+): [string, InjectableStyle] {
+  const { classNamePrefix = 'x' } = options;
+  const expandedObject = Pipe.create(styles)
+    .pipe((styles) => preprocessProperties(styles, options))
+    .pipe((x) => objMapKeys(x, dashify))
+    .pipe((x) => objMap(x, (value, key) => transformValue(key, value, options)))
+    .done();
+
+  const ltrStyles = objMap(expandedObject, (value, key) =>
+    generateLtr([key, value]),
+  );
+  const rtlStyles = objMap(
+    expandedObject,
+    (value, key) => generateRtl([key, value]) ?? value,
+  );
+
+  const ltrString = constructPositionTryObj(ltrStyles);
+  const rtlString = constructPositionTryObj(rtlStyles);
+
+  const positionTryName = '--' + classNamePrefix + createHash(ltrString);
+
+  const ltr = `@position-try ${positionTryName} {${ltrString}}`;
+  const rtl =
+    ltrString === rtlString
+      ? null
+      : `@position-try ${positionTryName} {${rtlString}}`;
+
+  return [positionTryName, { ltr, rtl, priority: 1 }];
+}
+
+function preprocessProperties(
+  styles: { +[key: string]: string | number },
+  options: StyleXOptions,
+): {
+  +[key: string]: string | number,
+} {
+  return objFromEntries(
+    objEntries(styles)
+      .flatMap((pair): $ReadOnlyArray<[string, string | number]> =>
+        flatMapProperties(pair, options)
+          .map(([key, value]) => {
+            if (typeof value === 'string' || typeof value === 'number') {
+              return [key, value];
+            }
+            return null;
+          })
+          .filter(Boolean),
+      )
+      .filter(([_key, value]) => value != null),
+  );
+}
+
+// NOTE: This implementation does not account for different values within
+// `@position-try` for pseudo-classes and media queries.
+// Instead, we suggest defining multiple `@position-try` at-rules for each
+// pseudo-class or media query, and using different values for `positionTryFallsbacks`
+// instead.
+function constructPositionTryObj(styles: {
+  +[string]: string | $ReadOnlyArray<string>,
+}): string {
+  return (
+    Object.keys(styles)
+      // Sorting keys to ensure a deterministic output for the same styles.
+      .sort()
+      .map((k) => {
+        const v = styles[k];
+        return (Array.isArray(v) ? v : [v])
+          .map((val) => `${k}:${val};`)
+          .join('');
+      })
+      .join('')
+  );
+}

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -128,6 +128,7 @@ export default class StateManager {
   +stylexIncludeImport: Set<string> = new Set();
   +stylexFirstThatWorksImport: Set<string> = new Set();
   +stylexKeyframesImport: Set<string> = new Set();
+  +stylexPositionTryImport: Set<string> = new Set();
   +stylexDefineVarsImport: Set<string> = new Set();
   +stylexDefineConstsImport: Set<string> = new Set();
   +stylexCreateThemeImport: Set<string> = new Set();

--- a/packages/@stylexjs/babel-plugin/src/visitors/imports.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/imports.js
@@ -64,6 +64,9 @@ export function readImportDeclarations(
             if (importedName === 'keyframes') {
               state.stylexKeyframesImport.add(localName);
             }
+            if (importedName === 'positionTry') {
+              state.stylexPositionTryImport.add(localName);
+            }
             if (importedName === 'include') {
               state.stylexIncludeImport.add(localName);
             }
@@ -130,6 +133,9 @@ export function readRequires(
           }
           if (prop.key.name === 'keyframes') {
             state.stylexKeyframesImport.add(value.name);
+          }
+          if (prop.key.name === 'positionTry') {
+            state.stylexPositionTryImport.add(value.name);
           }
           if (prop.key.name === 'include') {
             state.stylexIncludeImport.add(value.name);

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-keyframes.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-keyframes.js
@@ -52,6 +52,7 @@ export default function transformStyleXKeyframes(
         SyntaxError,
       );
     }
+    // TODO: We should allow using references to local constants here.
     if (nodeInit.arguments[0].type !== 'ObjectExpression') {
       throw path.buildCodeFrameError(
         messages.nonStyleObject('keyframes'),

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-position-try.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-position-try.js
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type { NodePath } from '@babel/traverse';
+import type { FunctionConfig } from '../utils/evaluate-path';
+
+import * as t from '@babel/types';
+import StateManager from '../utils/state-manager';
+import styleXPositionTry from '../shared/stylex-position-try';
+import { evaluate } from '../utils/evaluate-path';
+import { firstThatWorks as stylexFirstThatWorks } from '../shared';
+import * as messages from '../shared/messages';
+
+/// This function looks for `stylex.positionTry` calls within variable declarations and transforms them.
+/// 1. It finds the first argument to `stylex.positionTry` and validates it.
+/// 2. It evaluates the style object to get a JS object. This also handles local constants automatically.
+/// 3. The actual transformation is done by `stylexPositionTry` from `../shared`
+/// 4. The results are replaced, and generated CSS rules are injected as needed.
+
+export default function transformStyleXPositionTry(
+  path: NodePath<t.VariableDeclarator>,
+  state: StateManager,
+) {
+  const initPath = path.get('init');
+  if (!initPath.isCallExpression()) {
+    return;
+  }
+
+  const callExpressionPath: NodePath<t.CallExpression> = initPath;
+  const idPath = path.get('id');
+  if (!idPath.isIdentifier()) {
+    return;
+  }
+
+  const nodeInit: t.CallExpression = callExpressionPath.node;
+
+  if (
+    (nodeInit.callee.type === 'Identifier' &&
+      state.stylexPositionTryImport.has(nodeInit.callee.name)) ||
+    (nodeInit.callee.type === 'MemberExpression' &&
+      nodeInit.callee.object.type === 'Identifier' &&
+      nodeInit.callee.property.name === 'positionTry' &&
+      nodeInit.callee.property.type === 'Identifier' &&
+      state.stylexImport.has(nodeInit.callee.object.name))
+  ) {
+    const init: ?NodePath<t.Expression> = path.get('init');
+    if (init == null || !init.isCallExpression()) {
+      throw path.buildCodeFrameError(
+        messages.nonStaticValue('positionTry'),
+        SyntaxError,
+      );
+    }
+    if (nodeInit.arguments.length !== 1) {
+      throw path.buildCodeFrameError(
+        messages.illegalArgumentLength('positionTry', 1),
+        SyntaxError,
+      );
+    }
+    const args: $ReadOnlyArray<NodePath<>> = init.get('arguments');
+    const firstArgPath = args[0];
+
+    const identifiers: FunctionConfig['identifiers'] = {};
+    const memberExpressions: FunctionConfig['memberExpressions'] = {};
+    state.stylexFirstThatWorksImport.forEach((name) => {
+      identifiers[name] = { fn: stylexFirstThatWorks };
+    });
+    state.stylexImport.forEach((name) => {
+      if (memberExpressions[name] == null) {
+        memberExpressions[name] = {};
+      }
+      memberExpressions[name].firstThatWorks = { fn: stylexFirstThatWorks };
+    });
+
+    const { confident, value } = evaluate(firstArgPath, state, {
+      identifiers,
+      memberExpressions,
+    });
+    if (!confident) {
+      throw callExpressionPath.buildCodeFrameError(
+        messages.nonStaticValue('positionTry'),
+        SyntaxError,
+      );
+    }
+    const plainObject = value;
+    assertValidPositionTry(firstArgPath, plainObject);
+    assertValidProperties(firstArgPath, plainObject);
+
+    const [positionTryName, { ltr, priority, rtl }] = styleXPositionTry(
+      plainObject,
+      state.options,
+    );
+
+    // This should be a string
+    init.replaceWith(t.stringLiteral(positionTryName));
+
+    state.registerStyles([[positionTryName, { ltr, rtl }, priority]], path);
+  }
+}
+
+// Validation of `stylex.positionTry` function call.
+function assertValidPositionTry(path: NodePath<>, obj: mixed) {
+  if (typeof obj !== 'object' || Array.isArray(obj) || obj == null) {
+    throw path.buildCodeFrameError(
+      messages.nonStyleObject('positionTry'),
+      SyntaxError,
+    );
+  }
+}
+
+// TODO: Once we have a reliable validator, these property checks should be replaced with
+// validators that can also validate the values.
+const VALID_POSITION_TRY_PROPERTIES = [
+  // anchor Properties
+  'anchorName',
+  // position Properties
+  'positionAnchor',
+  'positionArea',
+  // inset Properties
+  'top',
+  'right',
+  'bottom',
+  'left',
+  'inset',
+  'insetBlock',
+  'insetBlockEnd',
+  'insetBlockStart',
+  'insetInline',
+  'insetInlineEnd',
+  'insetInlineStart',
+  // margin Properties
+  'margin',
+  'marginBlock',
+  'marginBlockEnd',
+  'marginBlockStart',
+  'marginInline',
+  'marginInlineEnd',
+  'marginInlineStart',
+  'marginTop',
+  'marginBottom',
+  'marginLeft',
+  'marginRight',
+  // size properties
+  'width',
+  'height',
+  'minWidth',
+  'minHeight',
+  'maxWidth',
+  'maxHeight',
+  'blockSize',
+  'inlineSize',
+  'minBlockSize',
+  'minInlineSize',
+  'maxBlockSize',
+  'maxInlineSize',
+  // self alignment properties
+  'alignSelf',
+  'justifySelf',
+  'placeSelf',
+];
+function assertValidProperties(path: NodePath<>, obj: Object) {
+  const keys = Object.keys(obj);
+  if (keys.some((key) => !VALID_POSITION_TRY_PROPERTIES.includes(key))) {
+    throw path.buildCodeFrameError(
+      messages.POSITION_TRY_INVALID_PROPERTY,
+      SyntaxError,
+    );
+  }
+}

--- a/packages/@stylexjs/stylex/__tests__/inject-test.js
+++ b/packages/@stylexjs/stylex/__tests__/inject-test.js
@@ -16,6 +16,14 @@ describe('inject', () => {
     );
   });
 
+  test('@positionTry', () => {
+    const cssText =
+      '@position-try --name { top: anchor(bottom); left: anchor(left); }';
+    expect(inject(cssText, 10)).toMatchInlineSnapshot(
+      '"@position-try --name { top: anchor(bottom); left: anchor(left); }"',
+    );
+  });
+
   test('@media', () => {
     const cssText = '@media (min-width: 320px) { .color { color: red } }';
     expect(inject(cssText, 200)).toMatchInlineSnapshot(

--- a/packages/@stylexjs/stylex/__tests__/stylex-test.js
+++ b/packages/@stylexjs/stylex/__tests__/stylex-test.js
@@ -20,6 +20,7 @@ describe('stylex', () => {
       'defineVars',
       'firstThatWorks',
       'keyframes',
+      'positionTry',
     ].forEach((api) => {
       test(`stylex.${api}`, () => {
         expect(() => stylex[api]()).toThrow();

--- a/packages/@stylexjs/stylex/src/stylex.js
+++ b/packages/@stylexjs/stylex/src/stylex.js
@@ -25,6 +25,7 @@ import type {
   StyleXStylesWithout,
   Theme,
   VarGroup,
+  PositionTry,
 } from './types/StyleXTypes';
 import type { ValueWithDefault } from './types/StyleXUtils';
 import * as Types from './types/VarTypes';
@@ -77,6 +78,10 @@ export const firstThatWorks = <T: string | number>(
 
 export const keyframes = (_keyframes: Keyframes): string => {
   throw errorForFn('keyframes');
+};
+
+export const positionTry = (_positionTry: PositionTry): string => {
+  throw errorForFn('positionTry');
 };
 
 export function props(
@@ -184,6 +189,7 @@ type IStyleX = {
     ...v: $ReadOnlyArray<T>
   ) => $ReadOnlyArray<T>,
   keyframes: (keyframes: Keyframes) => string,
+  positionTry: (positionTry: PositionTry) => string,
   props: (
     this: ?mixed,
     ...styles: $ReadOnlyArray<
@@ -213,6 +219,7 @@ _legacyMerge.createTheme = createTheme;
 _legacyMerge.defineVars = defineVars;
 _legacyMerge.firstThatWorks = firstThatWorks;
 _legacyMerge.keyframes = keyframes;
+_legacyMerge.positionTry = positionTry;
 _legacyMerge.props = props;
 _legacyMerge.types = types;
 

--- a/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.js
@@ -1411,8 +1411,8 @@ export type CSSProperties = $ReadOnly<{
   perspective?: all | perspective,
   perspectiveOrigin?: all | perspectiveOrigin,
   pointerEvents?: all | pointerEvents,
-  position?: all | position,
 
+  position?: all | position,
   positionAnchor?: all | string,
   positionArea?: all | positionArea,
   positionTry?: all | string,

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
@@ -91,6 +91,54 @@ export type StyleXSingleStyle = false | (null | undefined | NestedCSSPropTypes);
 // NOTE: `XStyle` has been deprecated in favor of `StaticStyles` and `StyleXStyles`.
 
 export type Keyframes = Readonly<{ [name: string]: CSSProperties }>;
+
+export type PositionTry = Readonly<{
+  // Anchor Positioning Properties
+  positionAnchor?: CSSProperties['positionAnchor'],
+  positionArea?: CSSProperties['positionArea'],
+  // inset Properties
+  top?: CSSProperties['top'],
+  right?: CSSProperties['right'],
+  bottom?: CSSProperties['bottom'],
+  left?: CSSProperties['left'],
+  inset?: CSSProperties['inset'],
+  insetBlock?: CSSProperties['insetBlock'],
+  insetBlockEnd?: CSSProperties['insetBlockEnd'],
+  insetBlockStart?: CSSProperties['insetBlockStart'],
+  insetInline?: CSSProperties['insetInline'],
+  insetInlineEnd?: CSSProperties['insetInlineEnd'],
+  insetInlineStart?: CSSProperties['insetInlineStart'],
+  // margin Properties
+  margin?: CSSProperties['margin'],
+  marginBlock?: CSSProperties['marginBlock'],
+  marginBlockEnd?: CSSProperties['marginBlockEnd'],
+  marginBlockStart?: CSSProperties['marginBlockStart'],
+  marginInline?: CSSProperties['marginInline'],
+  marginInlineEnd?: CSSProperties['marginInlineEnd'],
+  marginInlineStart?: CSSProperties['marginInlineStart'],
+  marginTop?: CSSProperties['marginTop'],
+  marginBottom?: CSSProperties['marginBottom'],
+  marginLeft?: CSSProperties['marginLeft'],
+  marginRight?: CSSProperties['marginRight'],
+  // size properties
+  width?: CSSProperties['width'],
+  height?: CSSProperties['height'],
+  minWidth?: CSSProperties['minWidth'],
+  minHeight?: CSSProperties['minHeight'],
+  maxWidth?: CSSProperties['maxWidth'],
+  maxHeight?: CSSProperties['maxHeight'],
+  blockSize?: CSSProperties['blockSize'],
+  inlineSize?: CSSProperties['inlineSize'],
+  minBlockSize?: CSSProperties['minBlockSize'],
+  minInlineSize?: CSSProperties['minInlineSize'],
+  maxBlockSize?: CSSProperties['maxBlockSize'],
+  maxInlineSize?: CSSProperties['maxInlineSize'],
+  // self alignment properties
+  alignSelf?: CSSProperties['alignSelf'],
+  justifySelf?: CSSProperties['justifySelf'],
+  placeSelf?: CSSProperties['placeSelf'],
+}>;
+
 export type LegacyThemeStyles = Readonly<{ [constantName: string]: string }>;
 
 type ComplexStyleValueType<T> =

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.js
@@ -61,6 +61,53 @@ export type XStyleWithout<+T: { +[_K in keyof NestedCSSPropTypes]?: mixed }> =
 
 export type Keyframes = $ReadOnly<{ [name: string]: CSSProperties, ... }>;
 
+export type PositionTry = $ReadOnly<{
+  // Anchor Positioning Properties
+  positionAnchor?: CSSProperties['positionAnchor'],
+  positionArea?: CSSProperties['positionArea'],
+  // inset Properties
+  top?: CSSProperties['top'],
+  right?: CSSProperties['right'],
+  bottom?: CSSProperties['bottom'],
+  left?: CSSProperties['left'],
+  inset?: CSSProperties['inset'],
+  insetBlock?: CSSProperties['insetBlock'],
+  insetBlockEnd?: CSSProperties['insetBlockEnd'],
+  insetBlockStart?: CSSProperties['insetBlockStart'],
+  insetInline?: CSSProperties['insetInline'],
+  insetInlineEnd?: CSSProperties['insetInlineEnd'],
+  insetInlineStart?: CSSProperties['insetInlineStart'],
+  // margin Properties
+  margin?: CSSProperties['margin'],
+  marginBlock?: CSSProperties['marginBlock'],
+  marginBlockEnd?: CSSProperties['marginBlockEnd'],
+  marginBlockStart?: CSSProperties['marginBlockStart'],
+  marginInline?: CSSProperties['marginInline'],
+  marginInlineEnd?: CSSProperties['marginInlineEnd'],
+  marginInlineStart?: CSSProperties['marginInlineStart'],
+  marginTop?: CSSProperties['marginTop'],
+  marginBottom?: CSSProperties['marginBottom'],
+  marginLeft?: CSSProperties['marginLeft'],
+  marginRight?: CSSProperties['marginRight'],
+  // size properties
+  width?: CSSProperties['width'],
+  height?: CSSProperties['height'],
+  minWidth?: CSSProperties['minWidth'],
+  minHeight?: CSSProperties['minHeight'],
+  maxWidth?: CSSProperties['maxWidth'],
+  maxHeight?: CSSProperties['maxHeight'],
+  blockSize?: CSSProperties['blockSize'],
+  inlineSize?: CSSProperties['inlineSize'],
+  minBlockSize?: CSSProperties['minBlockSize'],
+  minInlineSize?: CSSProperties['minInlineSize'],
+  maxBlockSize?: CSSProperties['maxBlockSize'],
+  maxInlineSize?: CSSProperties['maxInlineSize'],
+  // self alignment properties
+  alignSelf?: CSSProperties['alignSelf'],
+  justifySelf?: CSSProperties['justifySelf'],
+  placeSelf?: CSSProperties['placeSelf'],
+}>;
+
 export type LegacyThemeStyles = $ReadOnly<{
   [constantName: string]: string,
   ...


### PR DESCRIPTION
## What changed / motivation ?

Adds a new `stylex.positionTry` API that lets you create `@position-try` rules.
It works pretty much just like `stylex.keyframes`.

## Linked PR/Issues

Fixes #1003 

## Additional Context

New test file is included which shows the new feature working.