### PR TITLE
fix: Typescript type fixes for themes and types functions

### DIFF
--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
@@ -233,11 +233,11 @@ export type VarGroup<
 
 export type TokensFromVarGroup<T extends VarGroup<{}>> = T['__tokens'];
 
-export type IDFromVarGroup<T extends VarGroup<unknown, unknown>> =
+export type IDFromVarGroup<T extends VarGroup<{}>> =
   T['__opaqueId'];
 
 type TTokens = Readonly<{
-  [key: string]: CSSType | string | { [key: string]: string };
+  [key: string]: CSSType<null | string | number> | string | { [key: string]: string };
 }>;
 
 type UnwrapVars<T> = T extends StyleXVar<infer U> ? U : T;
@@ -254,6 +254,13 @@ type NestedVarObject<T> =
       [key: `@${string}`]: NestedVarObject<T>;
     }>;
 
+export type StyleX$DefineConsts = <
+  DefaultTokens extends TTokens,
+  ID extends symbol = symbol,
+>(
+  tokens: DefaultTokens,
+) => VarGroup<FlattenTokens<DefaultTokens>, ID>;
+
 export type StyleX$DefineVars = <
   DefaultTokens extends TTokens,
   ID extends symbol = symbol,
@@ -261,11 +268,11 @@ export type StyleX$DefineVars = <
   tokens: DefaultTokens,
 ) => VarGroup<FlattenTokens<DefaultTokens>, ID>;
 
-declare class ThemeKey<out VG extends VarGroup> extends String {
+declare class ThemeKey<out VG extends VarGroup<{}>> extends String {
   private varGroup: VG;
 }
 export type Theme<
-  T extends VarGroup<unknown, symbol>,
+  T extends VarGroup<{}>,
   Tag extends symbol = symbol,
 > = Tag &
   Readonly<{
@@ -277,7 +284,7 @@ type OverridesForTokenType<Config extends { [key: string]: unknown }> = {
 };
 
 export type StyleX$CreateTheme = <
-  TVars extends VarGroup<unknown, unknown>,
+  TVars extends VarGroup<{}>,
   ThemeID extends symbol = symbol,
 >(
   baseTokens: TVars,

--- a/packages/@stylexjs/stylex/src/types/VarTypes.js
+++ b/packages/@stylexjs/stylex/src/types/VarTypes.js
@@ -27,68 +27,66 @@ export type CSSSyntax =
   | '<transform-list>';
 
 type CSSSyntaxType = CSSSyntax;
+type InnerValue = null | string | number;
 
-interface ICSSType<+_T: string | number> {
+interface ICSSType<+_T: InnerValue> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-
-declare export class Angle<+T: string | 0> implements ICSSType<T> {
+declare export class Angle<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class Color<+T: string> implements ICSSType<T> {
+declare export class Color<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class Url<+T: string> implements ICSSType<T> {
+declare export class Url<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class Image<+T: string> implements ICSSType<T> {
+declare export class Image<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class Integer<+T: string | number> implements ICSSType<T> {
+declare export class Integer<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class LengthPercentage<+T: string | number>
-  implements ICSSType<T>
-{
+declare export class LengthPercentage<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class Length<+T: string | number> implements ICSSType<T> {
+declare export class Length<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class Percentage<+T: string | number> implements ICSSType<T> {
+declare export class Percentage<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class Num<+T: string | number> implements ICSSType<T> {
+declare export class Num<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class Resolution<+T: string> implements ICSSType<T> {
+declare export class Resolution<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class Time<+T: string | 0> implements ICSSType<T> {
+declare export class Time<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class TransformFunction<+T: string> implements ICSSType<T> {
+declare export class TransformFunction<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class TransformList<+T: string> implements ICSSType<T> {
+declare export class TransformList<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
 
-export type CSSType<+T: null | string | number> =
+export type CSSType<+T: InnerValue> =
   | Angle<T>
   | Color<T>
   | Url<T>


### PR DESCRIPTION
## What changed / motivation ?

Made some changes to the Flow types so that the generated Typescript types are valid.

Also made some changes to a typescript `.d.ts` file to make it valid.

## Linked PR/Issues

Fixes #969 

## Additional Context

Some type constraints loosened up so various `stylex.types.*` classes would have the same constraints to make things work correctly in Typescript.

This doesn't actually make the types less strict because the type constraints on the actual functions are unchanged.
