### PR TITLE
stylex/fix: fix path resolve for config in ESM

### DIFF
--- a/packages/stylex/rollup.config.mjs
+++ b/packages/stylex/rollup.config.mjs
@@ -7,14 +7,14 @@
  *
  */
 
+import { fileURLToPath } from 'url';
 import { babel } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import path from 'path';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const BABEL_ENV = process.env['BABEL_ENV'];
-
-const __dirname = import.meta.dirname;
 
 const config = {
   input: {
@@ -29,10 +29,10 @@ const config = {
   plugins: [
     babel({
       babelHelpers: 'bundled',
-      configFile: path.resolve(__dirname, '.babelrc.js')
+      configFile: path.resolve(__dirname, '.babelrc.js'),
     }),
     resolve(),
-    commonjs()
+    commonjs(),
   ],
 };
 


### PR DESCRIPTION
Fixes a crash in the rollup config caused by __dirname being undefined in .mjs files. Added workaround using fileURLToPath(import.meta.url) to safely resolve paths

```
[!] TypeError: The "paths[0]" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at Object.resolve (node:path:1115:7)
    at file:///Users/mellyeliu/stylex/packages/stylex/rollup.config.mjs:32:24
```