### PR TITLE
babel-plugin/chore: convert static error messages to template functions

### DIFF
--- a/packages/babel-plugin/__tests__/validation-stylex-create-test.js
+++ b/packages/babel-plugin/__tests__/validation-stylex-create-test.js
@@ -60,7 +60,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           stylex.create({});
         `);
-      }).toThrow(messages.UNBOUND_STYLEX_CALL_VALUE);
+      }).toThrow(messages.unboundCallValue('create'));
     });
 
     test('invalid use: not called at top level', () => {
@@ -80,7 +80,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const styles = stylex.create();
         `);
-      }).toThrow(messages.ILLEGAL_ARGUMENT_LENGTH);
+      }).toThrow(messages.illegalArgumentLength('create', 1));
     });
 
     test('invalid argument: too many', () => {
@@ -89,7 +89,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const styles = stylex.create({}, {});
         `);
-      }).toThrow(messages.ILLEGAL_ARGUMENT_LENGTH);
+      }).toThrow(messages.illegalArgumentLength('create', 1));
     });
 
     test('invalid argument: non-static', () => {
@@ -98,7 +98,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const styles = stylex.create(genStyles());
         `);
-      }).toThrow(messages.NON_OBJECT_FOR_STYLEX_CALL);
+      }).toThrow(messages.nonStyleObject('create'));
     });
 
     test('valid argument: object', () => {
@@ -123,7 +123,7 @@ describe('@stylexjs/babel-plugin', () => {
             }
           });
         `);
-        }).toThrow(messages.NON_STATIC_VALUE);
+        }).toThrow(messages.nonStaticValue('create'));
       });
 
       /* Style rules */

--- a/packages/babel-plugin/__tests__/validation-stylex-createTheme-test.js
+++ b/packages/babel-plugin/__tests__/validation-stylex-createTheme-test.js
@@ -43,7 +43,7 @@ describe('@stylexjs/babel-plugin', () => {
           import stylex from 'stylex';
           stylex.createTheme({__themeName__: 'x568ih9'}, {});
         `);
-      }).toThrow(messages.UNBOUND_STYLEX_CALL_VALUE);
+      }).toThrow(messages.unboundCallValue('createTheme'));
     });
 
     test('it must have two arguments', () => {
@@ -52,21 +52,21 @@ describe('@stylexjs/babel-plugin', () => {
           import stylex from 'stylex';
           const variables = stylex.createTheme();
         `);
-      }).toThrow(messages.ILLEGAL_ARGUMENT_LENGTH);
+      }).toThrow(messages.illegalArgumentLength('createTheme', 2));
 
       expect(() => {
         transform(`
           import stylex from 'stylex';
           const variables = stylex.createTheme({});
         `);
-      }).toThrow(messages.ILLEGAL_ARGUMENT_LENGTH);
+      }).toThrow(messages.illegalArgumentLength('createTheme', 2));
 
       expect(() => {
         transform(`
           import stylex from 'stylex';
           const variables = stylex.createTheme(genStyles(), {});
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('createTheme'));
 
       expect(() => {
         transform(`
@@ -82,7 +82,7 @@ describe('@stylexjs/babel-plugin', () => {
           import stylex from 'stylex';
           const variables = stylex.createTheme({__themeName__: 'x568ih9'}, genStyles());
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('createTheme'));
 
       expect(() => {
         transform(`
@@ -102,7 +102,7 @@ describe('@stylexjs/babel-plugin', () => {
             {__themeName__: 'x568ih9', labelColor: 'var(--labelColorHash)'},
             {[labelColor]: 'red',});
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('createTheme'));
     });
 
     /* Values */
@@ -139,7 +139,7 @@ describe('@stylexjs/babel-plugin', () => {
             {labelColor: labelColor,}
           );
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('createTheme'));
 
       expect(() => {
         transform(`
@@ -149,7 +149,7 @@ describe('@stylexjs/babel-plugin', () => {
             {labelColor: labelColor(),}
           );
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('createTheme'));
     });
   });
 });

--- a/packages/babel-plugin/__tests__/validation-stylex-defineConsts-test.js
+++ b/packages/babel-plugin/__tests__/validation-stylex-defineConsts-test.js
@@ -46,14 +46,14 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           const constants = stylex.defineConsts({});
         `);
-      }).toThrow(messages.NON_EXPORT_NAMED_DECLARATION);
+      }).toThrow(messages.nonExportNamedDeclaration('defineConsts'));
 
       expect(() => {
         transform(`
           import * as stylex from '@stylexjs/stylex';
           stylex.defineConsts({});
         `);
-      }).toThrow(messages.UNBOUND_STYLEX_CALL_VALUE);
+      }).toThrow(messages.unboundCallValue('defineConsts'));
     });
 
     test('invalid argument: none', () => {
@@ -62,7 +62,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const constants = stylex.defineConsts();
         `);
-      }).toThrow(messages.ILLEGAL_ARGUMENT_LENGTH);
+      }).toThrow(messages.illegalArgumentLength('defineConsts', 1));
     });
 
     test('invalid argument: too many', () => {
@@ -71,7 +71,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const constants = stylex.defineConsts({}, {});
         `);
-      }).toThrow(messages.ILLEGAL_ARGUMENT_LENGTH);
+      }).toThrow(messages.illegalArgumentLength('defineConsts', 1));
     });
 
     test('invalid argument: number', () => {
@@ -80,7 +80,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const constants = stylex.defineConsts(1);
         `);
-      }).toThrow(messages.NON_OBJECT_FOR_STYLEX_CALL);
+      }).toThrow(messages.nonStyleObject('defineConsts'));
     });
 
     test('invalid argument: string', () => {
@@ -89,7 +89,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const constants = stylex.defineConsts('1');
         `);
-      }).toThrow(messages.NON_OBJECT_FOR_STYLEX_CALL);
+      }).toThrow(messages.nonStyleObject('defineConsts'));
     });
 
     test('invalid argument: non-static', () => {
@@ -98,7 +98,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const constants = stylex.defineConsts(genStyles());
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('defineConsts'));
     });
 
     test('valid argument: object', () => {
@@ -131,7 +131,7 @@ describe('@stylexjs/babel-plugin', () => {
             [labelColor]: 'red',
           });
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('defineConsts'));
     });
 
     /* Values */
@@ -144,7 +144,7 @@ describe('@stylexjs/babel-plugin', () => {
             labelColor: labelColor,
           });
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('defineConsts'));
 
       expect(() => {
         transform(`
@@ -153,7 +153,7 @@ describe('@stylexjs/babel-plugin', () => {
             labelColor: labelColor(),
           });
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('defineConsts'));
     });
 
     test('valid value: number', () => {

--- a/packages/babel-plugin/__tests__/validation-stylex-defineVars-test.js
+++ b/packages/babel-plugin/__tests__/validation-stylex-defineVars-test.js
@@ -39,14 +39,14 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           const styles = stylex.defineVars({});
         `);
-      }).toThrow(messages.NON_EXPORT_NAMED_DECLARATION);
+      }).toThrow(messages.nonExportNamedDeclaration('defineVars'));
 
       expect(() => {
         transform(`
           import * as stylex from '@stylexjs/stylex';
           stylex.defineVars({});
         `);
-      }).toThrow(messages.UNBOUND_STYLEX_CALL_VALUE);
+      }).toThrow(messages.unboundCallValue('defineVars'));
     });
 
     test('invalid argument: none', () => {
@@ -55,7 +55,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const vars = stylex.defineVars();
         `);
-      }).toThrow(messages.ILLEGAL_ARGUMENT_LENGTH);
+      }).toThrow(messages.illegalArgumentLength('defineVars', 1));
     });
 
     test('invalid argument: too many', () => {
@@ -64,7 +64,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const vars = stylex.defineVars({}, {});
         `);
-      }).toThrow(messages.ILLEGAL_ARGUMENT_LENGTH);
+      }).toThrow(messages.illegalArgumentLength('defineVars', 1));
     });
 
     test('invalid argument: number', () => {
@@ -73,7 +73,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const vars = stylex.defineVars(1);
         `);
-      }).toThrow(messages.NON_OBJECT_FOR_STYLEX_CALL);
+      }).toThrow(messages.nonStyleObject('defineVars'));
     });
 
     test('invalid argument: string', () => {
@@ -82,7 +82,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const vars = stylex.defineVars('1');
         `);
-      }).toThrow(messages.NON_OBJECT_FOR_STYLEX_CALL);
+      }).toThrow(messages.nonStyleObject('defineVars'));
     });
 
     test('invalid argument: non-static', () => {
@@ -91,7 +91,7 @@ describe('@stylexjs/babel-plugin', () => {
           import * as stylex from '@stylexjs/stylex';
           export const vars = stylex.defineVars(genStyles());
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('defineVars'));
     });
 
     test('valid argument: object', () => {
@@ -113,7 +113,7 @@ describe('@stylexjs/babel-plugin', () => {
             [labelColor]: 'red',
           });
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('defineVars'));
     });
 
     /* Values */
@@ -126,7 +126,7 @@ describe('@stylexjs/babel-plugin', () => {
             labelColor: labelColor,
           });
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('defineVars'));
 
       expect(() => {
         transform(`
@@ -135,7 +135,7 @@ describe('@stylexjs/babel-plugin', () => {
             labelColor: labelColor(),
           });
         `);
-      }).toThrow(messages.NON_STATIC_VALUE);
+      }).toThrow(messages.nonStaticValue('defineVars'));
     });
 
     test('valid value: number', () => {

--- a/packages/babel-plugin/__tests__/validation-stylex-keyframes-test.js
+++ b/packages/babel-plugin/__tests__/validation-stylex-keyframes-test.js
@@ -50,7 +50,7 @@ describe('@stylexjs/babel-plugin', () => {
           import stylex from 'stylex';
           const name = stylex.keyframes(null);
         `);
-      }).toThrow(messages.NON_OBJECT_FOR_STYLEX_KEYFRAMES_CALL);
+      }).toThrow(messages.nonStyleObject('keyframes'));
 
       expect(() => {
         transform(`

--- a/packages/babel-plugin/src/shared/messages.js
+++ b/packages/babel-plugin/src/shared/messages.js
@@ -12,64 +12,42 @@
 // This file contains constants to be used within Error messages.
 // The URLs within will eventually be replaced by links to the documentation website for Stylex.
 
-export const ILLEGAL_ARGUMENT_LENGTH =
-  'stylex.create() should have 1 argument.';
-export const ILLEGAL_ARG_LENGTH_FOR_KEYFRAMES =
-  'stylex.keyframes() should have 1 argument.';
-export const NON_STATIC_VALUE =
-  'Only static values are allowed inside of a stylex.create() call.';
-export const NON_STATIC_KEYFRAME_VALUE =
-  'Only static values are allowed inside of a stylex.keyframes() call.';
-export const ESCAPED_STYLEX_VALUE =
-  'Escaping a stylex.create() value is not allowed.';
-export const UNBOUND_STYLEX_CALL_VALUE =
-  'stylex.create calls must be bound to a bare variable.';
-export const ONLY_TOP_LEVEL =
-  'stylex.create() is only allowed at the root of a program.';
-export const NON_OBJECT_FOR_STYLEX_CALL =
-  'stylex.create() can only accept a style object.';
-export const NON_OBJECT_FOR_STYLEX_KEYFRAMES_CALL =
-  'stylex.keyframes() can only accept an object.';
-export const UNKNOWN_PROP_KEY = 'Unknown property key';
-export const INVALID_PSEUDO = 'Invalid pseudo selector, not on the whitelist.';
-export const INVALID_PSEUDO_OR_AT_RULE = 'Invalid pseudo or at-rule.';
-export const NO_CONDITIONAL_SHORTHAND =
-  'You cannot use conditional style values for a shorthand property.';
-export const ILLEGAL_NAMESPACE_TYPE =
-  'Only a string literal namespace is allowed here.';
-export const UNKNOWN_NAMESPACE = 'Unknown namespace';
+export const illegalArgumentLength = (fn: string, argLength: number): string =>
+  `${fn}() should have ${argLength} argument${argLength === 1 ? '' : 's'}.`;
+export const nonStaticValue = (fn: string): string =>
+  `Only static values are allowed inside of a ${fn}() call.`;
+export const nonStyleObject = (fn: string): string =>
+  `${fn}() can only accept an object.`;
+export const nonExportNamedDeclaration = (fn: string): string =>
+  `The return value of ${fn}() must be bound to a named export.`;
+export const unboundCallValue = (fn: string): string =>
+  `${fn}() calls must be bound to a bare variable.`;
+
+export const DUPLICATE_CONDITIONAL =
+  'The same pseudo selector or at-rule cannot be used more than once.';
+export const ESCAPED_STYLEX_VALUE = 'Escaping a create() value is not allowed.';
 export const ILLEGAL_NESTED_PSEUDO =
   "Pseudo objects can't be nested more than one level deep.";
 export const ILLEGAL_PROP_VALUE =
   'A style value can only contain an array, string or number.';
 export const ILLEGAL_PROP_ARRAY_VALUE =
   'A style array value can only contain strings or numbers.';
-export const ILLEGAL_NAMESPACE_VALUE = 'A stylex namespace must be an object.';
-export const NON_OBJECT_KEYFRAME =
-  'Every frame within a stylex.keyframes() call must be an object.';
-export const INVALID_SPREAD =
-  'Imported styles spread with a stylex.create call must be type cast as `XStyle<>` to verify their type.';
-export const LINT_UNCLOSED_FUNCTION = 'Rule contains an unclosed function';
-export const LOCAL_ONLY =
-  'The return value of stylex.create() should not be exported.';
-export const UNEXPECTED_ARGUMENT =
-  'Unexpected argument passed to the stylex() function.';
-export const EXPECTED_FUNCTION_CALL =
-  'Expected a simple function call but found something else.';
-export const NO_PARENT_PATH = 'Unexpected AST node without a parent path.';
-export const DUPLICATE_CONDITIONAL =
-  'The same pseudo selector or at-rule cannot be used more than once.';
-export const NO_PROJECT_ROOT_DIRECTORY =
-  'The project root directory `rootDir` is not configured.';
-export const NON_EXPORT_NAMED_DECLARATION =
-  'The return value of stylex.defineVars() must be bound to a named export.';
-export const ANONYMOUS_THEME =
-  'stylex.createTheme() must be bound to a named constant.';
-export const ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS =
-  'Only named parameters are allowed in Dynamic Style functions. Destructuring, spreading or default values are not allowed.';
-export const NON_CONTIGUOUS_VARS =
-  'All variables passed to `stylex.firstThatWorks` must be contiguous.';
-export const NO_OBJECT_SPREADS =
-  'Object spreads are not allowed in stylex.create call.';
+export const ILLEGAL_NAMESPACE_VALUE = 'A StyleX namespace must be an object.';
 export const INVALID_CONST_KEY =
   'Keys in defineConsts() cannot start with "--".';
+export const INVALID_PSEUDO = 'Invalid pseudo selector, not on the whitelist.';
+export const INVALID_PSEUDO_OR_AT_RULE = 'Invalid pseudo or at-rule.';
+export const LINT_UNCLOSED_FUNCTION = 'Rule contains an unclosed function';
+export const LOCAL_ONLY =
+  'The return value of create() should not be exported.';
+export const NON_OBJECT_KEYFRAME =
+  'Every frame within a keyframes() call must be an object.';
+export const NON_CONTIGUOUS_VARS =
+  'All variables passed to firstThatWorks() must be contiguous.';
+export const NO_OBJECT_SPREADS =
+  'Object spreads are not allowed in create() calls.';
+export const ONLY_NAMED_PARAMETERS_IN_DYNAMIC_STYLE_FUNCTIONS =
+  'Only named parameters are allowed in Dynamic Style functions. Destructuring, spreading or default values are not allowed.';
+export const ONLY_TOP_LEVEL =
+  'create() is only allowed at the root of a program.';
+export const UNKNOWN_PROP_KEY = 'Unknown property key';

--- a/packages/babel-plugin/src/visitors/stylex-create-theme.js
+++ b/packages/babel-plugin/src/visitors/stylex-create-theme.js
@@ -73,7 +73,7 @@ export default function transformStyleXCreateTheme(
     );
     if (!confident1) {
       throw callExpressionPath.buildCodeFrameError(
-        messages.NON_STATIC_VALUE,
+        messages.nonStaticValue('createTheme'),
         SyntaxError,
       );
     }
@@ -121,13 +121,13 @@ export default function transformStyleXCreateTheme(
     );
     if (!confident2) {
       throw callExpressionPath.buildCodeFrameError(
-        messages.NON_STATIC_VALUE,
+        messages.nonStaticValue('createTheme'),
         SyntaxError,
       );
     }
     if (typeof overrides !== 'object' || overrides == null) {
       throw callExpressionPath.buildCodeFrameError(
-        messages.NON_OBJECT_FOR_STYLEX_CALL,
+        messages.nonStyleObject('createTheme'),
         SyntaxError,
       );
     }
@@ -194,14 +194,14 @@ function validateStyleXCreateTheme(
     variableDeclaratorPath.node.id.type !== 'Identifier'
   ) {
     throw callExpressionPath.buildCodeFrameError(
-      messages.UNBOUND_STYLEX_CALL_VALUE,
+      messages.unboundCallValue('createTheme'),
       SyntaxError,
     );
   }
 
   if (callExpressionPath.node.arguments.length !== 2) {
     throw callExpressionPath.buildCodeFrameError(
-      messages.ILLEGAL_ARGUMENT_LENGTH,
+      messages.illegalArgumentLength('createTheme', 2),
       SyntaxError,
     );
   }

--- a/packages/babel-plugin/src/visitors/stylex-create.js
+++ b/packages/babel-plugin/src/visitors/stylex-create.js
@@ -115,7 +115,7 @@ export default function transformStyleXCreate(
 
     if (!confident) {
       throw (deopt ?? path).buildCodeFrameError(
-        reason ?? messages.NON_STATIC_VALUE,
+        reason ?? messages.nonStaticValue('create'),
         SyntaxError,
       );
     }
@@ -343,7 +343,7 @@ export default function transformStyleXCreate(
 function validateStyleXCreate(path: NodePath<t.CallExpression>) {
   if (path.parentPath == null || path.parentPath.isExpressionStatement()) {
     throw path.buildCodeFrameError(
-      messages.UNBOUND_STYLEX_CALL_VALUE,
+      messages.unboundCallValue('create'),
       SyntaxError,
     );
   }
@@ -356,7 +356,7 @@ function validateStyleXCreate(path: NodePath<t.CallExpression>) {
   }
   if (path.node.arguments.length !== 1) {
     throw path.buildCodeFrameError(
-      messages.ILLEGAL_ARGUMENT_LENGTH,
+      messages.illegalArgumentLength('create', 1),
       SyntaxError,
     );
   }
@@ -364,7 +364,7 @@ function validateStyleXCreate(path: NodePath<t.CallExpression>) {
   const arg = path.node.arguments[0];
   if (arg.type !== 'ObjectExpression') {
     throw path.buildCodeFrameError(
-      messages.NON_OBJECT_FOR_STYLEX_CALL,
+      messages.nonStyleObject('create'),
       SyntaxError,
     );
   }

--- a/packages/babel-plugin/src/visitors/stylex-define-consts.js
+++ b/packages/babel-plugin/src/visitors/stylex-define-consts.js
@@ -45,13 +45,13 @@ export default function transformStyleXDefineConsts(
     const { confident, value } = evaluate(firstArg, state);
     if (!confident) {
       throw callExpressionPath.buildCodeFrameError(
-        messages.NON_STATIC_VALUE,
+        messages.nonStaticValue('defineConsts'),
         SyntaxError,
       );
     }
     if (typeof value !== 'object' || value == null) {
       throw callExpressionPath.buildCodeFrameError(
-        messages.NON_OBJECT_FOR_STYLEX_CALL,
+        messages.nonStyleObject('defineConsts'),
         SyntaxError,
       );
     }
@@ -99,7 +99,7 @@ function validateStyleXDefineConsts(
     variableDeclaratorPath.node.id.type !== 'Identifier'
   ) {
     throw callExpressionPath.buildCodeFrameError(
-      messages.UNBOUND_STYLEX_CALL_VALUE,
+      messages.unboundCallValue('defineConsts'),
       SyntaxError,
     );
   }
@@ -109,14 +109,14 @@ function validateStyleXDefineConsts(
     !exportNamedDeclarationPath.isExportNamedDeclaration()
   ) {
     throw callExpressionPath.buildCodeFrameError(
-      messages.NON_EXPORT_NAMED_DECLARATION,
+      messages.nonExportNamedDeclaration('defineConsts'),
       SyntaxError,
     );
   }
 
   if (callExpressionPath.node.arguments.length !== 1) {
     throw callExpressionPath.buildCodeFrameError(
-      messages.ILLEGAL_ARGUMENT_LENGTH,
+      messages.illegalArgumentLength('defineConsts', 1),
       SyntaxError,
     );
   }

--- a/packages/babel-plugin/src/visitors/stylex-define-vars.js
+++ b/packages/babel-plugin/src/visitors/stylex-define-vars.js
@@ -113,13 +113,13 @@ export default function transformStyleXDefineVars(
     });
     if (!confident) {
       throw callExpressionPath.buildCodeFrameError(
-        messages.NON_STATIC_VALUE,
+        messages.nonStaticValue('defineVars'),
         SyntaxError,
       );
     }
     if (typeof value !== 'object' || value == null) {
       throw callExpressionPath.buildCodeFrameError(
-        messages.NON_OBJECT_FOR_STYLEX_CALL,
+        messages.nonStyleObject('defineVars'),
         SyntaxError,
       );
     }
@@ -170,7 +170,7 @@ function validateStyleXDefineVars(
     variableDeclaratorPath.node.id.type !== 'Identifier'
   ) {
     throw callExpressionPath.buildCodeFrameError(
-      messages.UNBOUND_STYLEX_CALL_VALUE,
+      messages.unboundCallValue('defineVars'),
       SyntaxError,
     );
   }
@@ -180,14 +180,14 @@ function validateStyleXDefineVars(
     !exportNamedDeclarationPath.isExportNamedDeclaration()
   ) {
     throw callExpressionPath.buildCodeFrameError(
-      messages.NON_EXPORT_NAMED_DECLARATION,
+      messages.nonExportNamedDeclaration('defineVars'),
       SyntaxError,
     );
   }
 
   if (callExpressionPath.node.arguments.length !== 1) {
     throw callExpressionPath.buildCodeFrameError(
-      messages.ILLEGAL_ARGUMENT_LENGTH,
+      messages.illegalArgumentLength('defineVars', 1),
       SyntaxError,
     );
   }

--- a/packages/babel-plugin/src/visitors/stylex-keyframes.js
+++ b/packages/babel-plugin/src/visitors/stylex-keyframes.js
@@ -48,13 +48,13 @@ export default function transformStyleXKeyframes(
   ) {
     if (nodeInit.arguments.length !== 1) {
       throw path.buildCodeFrameError(
-        messages.ILLEGAL_ARGUMENT_LENGTH,
+        messages.illegalArgumentLength('keyframes', 1),
         SyntaxError,
       );
     }
     if (nodeInit.arguments[0].type !== 'ObjectExpression') {
       throw path.buildCodeFrameError(
-        messages.NON_OBJECT_FOR_STYLEX_KEYFRAMES_CALL,
+        messages.nonStyleObject('keyframes'),
         SyntaxError,
       );
     }
@@ -62,7 +62,7 @@ export default function transformStyleXKeyframes(
     const init: ?NodePath<t.Expression> = path.get('init');
     if (init == null || !init.isCallExpression()) {
       throw path.buildCodeFrameError(
-        messages.NON_STATIC_KEYFRAME_VALUE,
+        messages.nonStaticValue('keyframes'),
         SyntaxError,
       );
     }
@@ -86,7 +86,10 @@ export default function transformStyleXKeyframes(
       memberExpressions,
     });
     if (!confident) {
-      throw path.buildCodeFrameError(messages.NON_STATIC_VALUE, SyntaxError);
+      throw path.buildCodeFrameError(
+        messages.nonStaticValue('keyframes'),
+        SyntaxError,
+      );
     }
     const plainObject = value;
     assertValidKeyframes(path, plainObject);
@@ -109,7 +112,7 @@ function assertValidKeyframes(
 ) {
   if (typeof obj !== 'object' || Array.isArray(obj) || obj == null) {
     throw path.buildCodeFrameError(
-      messages.NON_OBJECT_FOR_STYLEX_KEYFRAMES_CALL,
+      messages.nonStyleObject('keyframes'),
       SyntaxError,
     );
   }


### PR DESCRIPTION
Fixes https://github.com/facebook/stylex/issues/1028

- Refactors hardcoded error strings into template functions for consistency and reuse across different APIs (previously many were incorrectly referencing `stylex.create()` calls
- Removes some unused error messages