### PR TITLE
[chore] add flow types for anchor positioning css properties to StyleXCSSTypes.js

### DIFF
--- a/packages/stylex/src/types/StyleXCSSTypes.js
+++ b/packages/stylex/src/types/StyleXCSSTypes.js
@@ -577,6 +577,21 @@ type pointerEvents =
   | 'all'
   | 'inherit';
 type position = 'static' | 'relative' | 'absolute' | 'sticky' | 'fixed';
+type positionArea =
+  | 'top'
+  | 'left'
+  | 'bottom'
+  | 'right'
+  | 'center'
+  | 'start'
+  | 'end'
+  | 'span-start'
+  | 'span-end'
+  | 'block-start'
+  | 'block-end'
+  | 'inline-start'
+  | 'inline-end';
+type positionVisibility = 'always' | 'anchors-visible' | 'no-overflow';
 type quotes = string | 'none';
 type resize = 'none' | 'both' | 'horizontal' | 'vertical';
 type rowGap = number | string;
@@ -983,6 +998,8 @@ export type CSSProperties = $ReadOnly<{
   alignTracks?: all | string,
   justifyTracks?: all | string,
   masonryAutoFlow?: all | string,
+
+  anchorName?: all | string,
 
   // Not Allowed:
   // all?: all | all,
@@ -1395,6 +1412,14 @@ export type CSSProperties = $ReadOnly<{
   perspectiveOrigin?: all | perspectiveOrigin,
   pointerEvents?: all | pointerEvents,
   position?: all | position,
+
+  positionAnchor?: all | string,
+  positionArea?: all | positionArea,
+  positionTry?: all | string,
+  positionTryFallbacks?: all | string,
+  positionTryOptions?: all | string,
+  positionVisibility?: all | positionVisibility,
+
   quotes?: all | quotes,
   resize?: all | resize,
   rest?: all | rest,

--- a/packages/stylex/src/types/StyleXCSSTypes.js
+++ b/packages/stylex/src/types/StyleXCSSTypes.js
@@ -583,14 +583,14 @@ type positionArea =
   | 'bottom'
   | 'right'
   | 'center'
-  | 'start'
-  | 'end'
-  | 'span-start'
-  | 'span-end'
   | 'block-start'
   | 'block-end'
   | 'inline-start'
-  | 'inline-end';
+  | 'inline-end'
+  | 'span-inline-start'
+  | 'span-inline-end'
+  | 'span-block-start'
+  | 'span-block-end';
 type positionVisibility = 'always' | 'anchors-visible' | 'no-overflow';
 type quotes = string | 'none';
 type resize = 'none' | 'both' | 'horizontal' | 'vertical';


### PR DESCRIPTION
## What changed / motivation ?

This PR adds flow types for CSS-based anchor positioning properties. Prevents the need to $FlowFixMe when using these properties.

I saw that @nmn currently has a PR up for supporting @position-try. This would also be useful for me internally in the short to medium term future.