### PR TITLE
style-value-parser/chore: refactor media query tests

### DIFF
--- a/packages/style-value-parser/src/at-queries/__tests__/media-query-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/media-query-test.js
@@ -7,673 +7,483 @@
  * @flow strict
  */
 
-import { mediaInequalityRuleParser } from '../media-query.js';
 import { MediaQuery } from '../media-query.js';
 
-describe('Test CSS Type: @media queries', () => {
-  test('@media screen', () => {
-    const query = '@media screen';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "screen",
-          "not": false,
-          "only": false,
-          "type": "media-keyword",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+describe('@style-value-parser/at-queries', () => {
+  describe('[parse] media queries', () => {
+    describe('keywords', () => {
+      test('@media screen', () => {
+        const parsed = MediaQuery.parser.parseToEnd('@media screen');
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "screen",
+              "not": false,
+              "only": false,
+              "type": "media-keyword",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot('"@media screen"');
+      });
 
-  test('@media print', () => {
-    const query = '@media print';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "print",
-          "not": false,
-          "only": false,
-          "type": "media-keyword",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+      test('@media print', () => {
+        const parsed = MediaQuery.parser.parseToEnd('@media print');
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "print",
+              "not": false,
+              "only": false,
+              "type": "media-keyword",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot('"@media print"');
+      });
 
-  test('@media (width: 100px)', () => {
-    const query = '@media (width: 100px)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "width",
-          "type": "pair",
-          "value": {
-            "signCharacter": undefined,
-            "type": "integer",
-            "unit": "px",
-            "value": 100,
-          },
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (max-width: 50em)', () => {
-    const query = '@media (max-width: 50em)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "max-width",
-          "type": "pair",
-          "value": {
-            "signCharacter": undefined,
-            "type": "integer",
-            "unit": "em",
-            "value": 50,
-          },
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (orientation: landscape)', () => {
-    const query = '@media (orientation: landscape)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "orientation",
-          "type": "pair",
-          "value": "landscape",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media not all and (monochrome)', () => {
-    const query = '@media not all and (monochrome)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
+      test('@media all', () => {
+        const parsed = MediaQuery.parser.parseToEnd('@media all');
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "key": "all",
+              "not": false,
+              "only": false,
+              "type": "media-keyword",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot('"@media all"');
+      });
+
+      test('@media only screen', () => {
+        const parsed = MediaQuery.parser.parseToEnd('@media only screen');
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "screen",
+              "not": false,
+              "only": true,
+              "type": "media-keyword",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot('"@media only screen"');
+      });
+
+      test('@media only print and (color)', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media only print and (color)',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "print",
+                  "not": false,
+                  "only": true,
+                  "type": "media-keyword",
+                },
+                {
+                  "keyValue": "color",
+                  "type": "word-rule",
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media only print and (color)"',
+        );
+      });
+
+      test('@media not screen', () => {
+        const parsed = MediaQuery.parser.parseToEnd('@media not screen');
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "screen",
               "not": true,
               "only": false,
               "type": "media-keyword",
             },
-            {
-              "keyValue": "monochrome",
-              "type": "word-rule",
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot('"@media not screen"');
+      });
 
-  test('@media screen and (min-width: 400px)', () => {
-    const query = '@media screen and (min-width: 400px)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "screen",
-              "not": false,
-              "only": false,
-              "type": "media-keyword",
-            },
-            {
-              "key": "min-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 400,
-              },
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (min-height: 600px) and (orientation: landscape)', () => {
-    const query = '@media (min-height: 600px) and (orientation: landscape)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "min-height",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 600,
-              },
-            },
-            {
-              "key": "orientation",
-              "type": "pair",
-              "value": "landscape",
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media screen and (device-aspect-ratio: 16/9)', () => {
-    const query = '@media screen and (device-aspect-ratio: 16/9)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "screen",
-              "not": false,
-              "only": false,
-              "type": "media-keyword",
-            },
-            {
-              "key": "device-aspect-ratio",
-              "type": "pair",
-              "value": [
-                16,
-                "/",
-                9,
+      test('@media not all and (monochrome)', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media not all and (monochrome)',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "all",
+                  "not": true,
+                  "only": false,
+                  "type": "media-keyword",
+                },
+                {
+                  "keyValue": "monochrome",
+                  "type": "word-rule",
+                },
               ],
+              "type": "and",
             },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(
-      '@media screen and (device-aspect-ratio: 16 / 9)',
-    );
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media not all and (monochrome)"',
+        );
+      });
+    });
 
-  test('@media (device-height: 500px)', () => {
-    const query = '@media (device-height: 500px)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "device-height",
-          "type": "pair",
-          "value": {
-            "signCharacter": undefined,
-            "type": "integer",
-            "unit": "px",
-            "value": 500,
-          },
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (color)', () => {
-    const query = '@media (color)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "keyValue": "color",
-          "type": "word-rule",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (color-index)', () => {
-    const query = '@media (color-index)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "keyValue": "color-index",
-          "type": "word-rule",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (monochrome)', () => {
-    const query = '@media (monochrome)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "keyValue": "monochrome",
-          "type": "word-rule",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (grid)', () => {
-    const query = '@media (grid)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "keyValue": "grid",
-          "type": "word-rule",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (update: fast)', () => {
-    const query = '@media (update: fast)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "update",
-          "type": "pair",
-          "value": "fast",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (overflow-block: scroll)', () => {
-    const query = '@media (overflow-block: scroll)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "overflow-block",
-          "type": "pair",
-          "value": "scroll",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (display-mode: fullscreen)', () => {
-    const query = '@media (display-mode: fullscreen)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "display-mode",
-          "type": "pair",
-          "value": "fullscreen",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (scripting: enabled)', () => {
-    const query = '@media (scripting: enabled)';
-    expect(MediaQuery.parser.parseToEnd('@media (scripting: enabled)'))
-      .toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "scripting",
-          "type": "pair",
-          "value": "enabled",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (hover: hover)', () => {
-    const query = '@media (hover: hover)';
-    expect(MediaQuery.parser.parseToEnd('@media (hover: hover)'))
-      .toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "hover",
-          "type": "pair",
-          "value": "hover",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (any-hover: none)', () => {
-    const query = '@media (any-hover: none)';
-    expect(MediaQuery.parser.parseToEnd('@media (any-hover: none)'))
-      .toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "any-hover",
-          "type": "pair",
-          "value": "none",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (pointer: coarse)', () => {
-    const query = '@media (pointer: coarse)';
-    expect(MediaQuery.parser.parseToEnd('@media (pointer: coarse)'))
-      .toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "pointer",
-          "type": "pair",
-          "value": "coarse",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (any-pointer: fine)', () => {
-    const query = '@media (any-pointer: fine)';
-    expect(MediaQuery.parser.parseToEnd('@media (any-pointer: fine)'))
-      .toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "any-pointer",
-          "type": "pair",
-          "value": "fine",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (light-level: dim)', () => {
-    const query = '@media (light-level: dim)';
-    expect(MediaQuery.parser.parseToEnd('@media (light-level: dim)'))
-      .toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "light-level",
-          "type": "pair",
-          "value": "dim",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (inverted-colors: inverted)', () => {
-    const query = '@media (inverted-colors: inverted)';
-    expect(MediaQuery.parser.parseToEnd('@media (inverted-colors: inverted)'))
-      .toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "inverted-colors",
-          "type": "pair",
-          "value": "inverted",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (prefers-reduced-motion: reduce)', () => {
-    const query = '@media (prefers-reduced-motion: reduce)';
-    expect(
-      MediaQuery.parser.parseToEnd('@media (prefers-reduced-motion: reduce)'),
-    ).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "prefers-reduced-motion",
-          "type": "pair",
-          "value": "reduce",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (prefers-contrast: more)', () => {
-    const query = '@media (prefers-contrast: more)';
-    expect(MediaQuery.parser.parseToEnd('@media (prefers-contrast: more)'))
-      .toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "prefers-contrast",
-          "type": "pair",
-          "value": "more",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (forced-colors: active)', () => {
-    const query = '@media (forced-colors: active)';
-    expect(MediaQuery.parser.parseToEnd('@media (forced-colors: active)'))
-      .toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "forced-colors",
-          "type": "pair",
-          "value": "active",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (prefers-reduced-transparency: reduce)', () => {
-    const query = '@media (prefers-reduced-transparency: reduce)';
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (prefers-reduced-transparency: reduce)',
-      ),
-    ).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "prefers-reduced-transparency",
-          "type": "pair",
-          "value": "reduce",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (orientation: portrait), (orientation: landscape)', () => {
-    const query = '@media (orientation: portrait), (orientation: landscape)';
-    expect(
-      MediaQuery.parser.parseToEnd(
-        '@media (orientation: portrait), (orientation: landscape)',
-      ),
-    ).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "orientation",
+    describe('pair rule', () => {
+      test('@media (width: 100px)', () => {
+        const input = '@media (width: 100px)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "width",
               "type": "pair",
-              "value": "portrait",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "px",
+                "value": 100,
+              },
             },
-            {
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (width: 100px)"',
+        );
+      });
+
+      test('@media (max-width: 50em)', () => {
+        const input = '@media (max-width: 50em)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "max-width",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "em",
+                "value": 50,
+              },
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (max-width: 50em)"',
+        );
+      });
+
+      test('@media (orientation: landscape)', () => {
+        const input = '@media (orientation: landscape)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "key": "orientation",
               "type": "pair",
               "value": "landscape",
             },
-          ],
-          "type": "or",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (orientation: landscape)"',
+        );
+      });
 
-  test('@media (min-width: 500px) or (max-width: 600px)', () => {
-    const query = '@media (min-width: 500px) or (max-width: 600px)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
+      test('@media (update: fast)', () => {
+        const input = '@media (update: fast)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "update",
+              "type": "pair",
+              "value": "fast",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (update: fast)"',
+        );
+      });
+
+      test('@media (overflow-block: scroll)', () => {
+        const input = '@media (overflow-block: scroll)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "overflow-block",
+              "type": "pair",
+              "value": "scroll",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (overflow-block: scroll)"',
+        );
+      });
+
+      test('@media (display-mode: fullscreen)', () => {
+        const input = '@media (display-mode: fullscreen)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "display-mode",
+              "type": "pair",
+              "value": "fullscreen",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (display-mode: fullscreen)"',
+        );
+      });
+
+      test('@media (scripting: enabled)', () => {
+        const input = '@media (scripting: enabled)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "scripting",
+              "type": "pair",
+              "value": "enabled",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (scripting: enabled)"',
+        );
+      });
+
+      test('@media (hover: hover)', () => {
+        const input = '@media (hover: hover)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "hover",
+              "type": "pair",
+              "value": "hover",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (hover: hover)"',
+        );
+      });
+
+      test('@media (any-hover: none)', () => {
+        const input = '@media (any-hover: none)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "any-hover",
+              "type": "pair",
+              "value": "none",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (any-hover: none)"',
+        );
+      });
+
+      test('@media (pointer: coarse)', () => {
+        const input = '@media (pointer: coarse)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "pointer",
+              "type": "pair",
+              "value": "coarse",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (pointer: coarse)"',
+        );
+      });
+
+      test('@media (any-pointer: fine)', () => {
+        const input = '@media (any-pointer: fine)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "any-pointer",
+              "type": "pair",
+              "value": "fine",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (any-pointer: fine)"',
+        );
+      });
+
+      test('@media (light-level: dim)', () => {
+        const input = '@media (light-level: dim)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "light-level",
+              "type": "pair",
+              "value": "dim",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (light-level: dim)"',
+        );
+      });
+
+      test('@media (inverted-colors: inverted)', () => {
+        const input = '@media (inverted-colors: inverted)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "inverted-colors",
+              "type": "pair",
+              "value": "inverted",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (inverted-colors: inverted)"',
+        );
+      });
+
+      test('@media (prefers-reduced-motion: reduce)', () => {
+        const input = '@media (prefers-reduced-motion: reduce)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "prefers-reduced-motion",
+              "type": "pair",
+              "value": "reduce",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (prefers-reduced-motion: reduce)"',
+        );
+      });
+
+      test('@media (prefers-contrast: more)', () => {
+        const input = '@media (prefers-contrast: more)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "prefers-contrast",
+              "type": "pair",
+              "value": "more",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (prefers-contrast: more)"',
+        );
+      });
+
+      test('@media (forced-colors: active)', () => {
+        const input = '@media (forced-colors: active)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "forced-colors",
+              "type": "pair",
+              "value": "active",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (forced-colors: active)"',
+        );
+      });
+
+      test('@media (prefers-reduced-transparency: reduce)', () => {
+        const input = '@media (prefers-reduced-transparency: reduce)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "prefers-reduced-transparency",
+              "type": "pair",
+              "value": "reduce",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (prefers-reduced-transparency: reduce)"',
+        );
+      });
+
+      test('@media (min-width: calc(300px + 5em))', () => {
+        const input = '@media (min-width: calc(300px + 5em))';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "key": "min-width",
               "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 500,
-              },
+              "value": "calc(300px + 5em)",
             },
-            {
-              "key": "max-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 600,
-              },
-            },
-          ],
-          "type": "or",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(
-      '@media (min-width: 500px), (max-width: 600px)',
-    );
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: calc(300px + 5em))"',
+        );
+      });
 
-  test('(width > 400px)', () => {
-    const query = '(width > 400px)';
-    expect(mediaInequalityRuleParser.parseToEnd(query)).toMatchInlineSnapshot(`
-      {
-        "key": "min-width",
-        "type": "pair",
-        "value": {
-          "signCharacter": undefined,
-          "type": "integer",
-          "unit": "px",
-          "value": 400.01,
-        },
-      }
-    `);
-  });
-  test('(width >= 400px)', () => {
-    const query = '(width >= 400px)';
+      test('@media (max-height: calc(100vh - 50px))', () => {
+        const input = '@media (max-height: calc(100vh - 50px))';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "max-height",
+              "type": "pair",
+              "value": "calc(100vh - 50px)",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (max-height: calc(100vh - 50px))"',
+        );
+      });
 
-    expect(mediaInequalityRuleParser.parseToEnd(query)).toMatchInlineSnapshot(`
-      {
-        "key": "min-width",
-        "type": "pair",
-        "value": {
-          "signCharacter": undefined,
-          "type": "integer",
-          "unit": "px",
-          "value": 400,
-        },
-      }
-    `);
-  });
-
-  test('@media (width >= 400px) and (width <= 700px)', () => {
-    const query = '@media (width >= 400px) and (width <= 700px)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "min-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 400,
-              },
-            },
-            {
-              "key": "max-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 700,
-              },
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(
-      '@media (min-width: 400px) and (max-width: 700px)',
-    );
-  });
-
-  test('@media (768px <= width <= 1280px)', () => {
-    const query = '@media (768px <= width <= 1280px)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "min-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 768,
-              },
-            },
-            {
-              "key": "max-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 1280,
-              },
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(
-      '@media (min-width: 768px) and (max-width: 1280px)',
-    );
-  });
-
-  test('@media (height > 500px) and (aspect-ratio: 16/9)', () => {
-    const query = '@media (height > 500px) and (aspect-ratio: 16/9)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "min-height",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 500.01,
-              },
-            },
-            {
+      test('@media (aspect-ratio: 16 / 9)', () => {
+        const input = '@media (aspect-ratio: 16 / 9)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "key": "aspect-ratio",
               "type": "pair",
               "value": [
@@ -682,28 +492,470 @@ describe('Test CSS Type: @media queries', () => {
                 9,
               ],
             },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(
-      '@media (min-height: 500.01px) and (aspect-ratio: 16 / 9)',
-    );
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (aspect-ratio: 16 / 9)"',
+        );
+      });
 
-  test('@media (color) and (min-width: 400px), screen and (max-width: 700px)', () => {
-    const query =
-      '@media (color) and (min-width: 400px), screen and (max-width: 700px)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
+      test('@media (device-aspect-ratio: 16 / 9)', () => {
+        const input = '@media (device-aspect-ratio: 16 / 9)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "device-aspect-ratio",
+              "type": "pair",
+              "value": [
+                16,
+                "/",
+                9,
+              ],
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (device-aspect-ratio: 16 / 9)"',
+        );
+      });
+
+      test('@media (min-resolution: 150dpi)', () => {
+        const input = '@media (min-resolution: 150dpi)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "min-resolution",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "dpi",
+                "value": 150,
+              },
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-resolution: 150dpi)"',
+        );
+      });
+
+      test('@media (max-resolution: 600dppx)', () => {
+        const input = '@media (max-resolution: 600dppx)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "max-resolution",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "dppx",
+                "value": 600,
+              },
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (max-resolution: 600dppx)"',
+        );
+      });
+
+      test('@media (color-gamut: srgb)', () => {
+        const input = '@media (color-gamut: srgb)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "color-gamut",
+              "type": "pair",
+              "value": "srgb",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (color-gamut: srgb)"',
+        );
+      });
+
+      test('@media (display-mode: standalone)', () => {
+        const input = '@media (display-mode: standalone)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "display-mode",
+              "type": "pair",
+              "value": "standalone",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (display-mode: standalone)"',
+        );
+      });
+
+      test('@media (prefers-color-scheme: dark)', () => {
+        const input = '@media (prefers-color-scheme: dark)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "prefers-color-scheme",
+              "type": "pair",
+              "value": "dark",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (prefers-color-scheme: dark)"',
+        );
+      });
+
+      test('@media (scripting: none)', () => {
+        const input = '@media (scripting: none)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "scripting",
+              "type": "pair",
+              "value": "none",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (scripting: none)"',
+        );
+      });
+
+      test('@media (update: slow)', () => {
+        const input = '@media (update: slow)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "update",
+              "type": "pair",
+              "value": "slow",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (update: slow)"',
+        );
+      });
+
+      test('@media (overflow-inline: none)', () => {
+        const input = '@media (overflow-inline: none)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "overflow-inline",
+              "type": "pair",
+              "value": "none",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (overflow-inline: none)"',
+        );
+      });
+
+      test('@media (display-mode: minimal-ui)', () => {
+        const input = '@media (display-mode: minimal-ui)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "display-mode",
+              "type": "pair",
+              "value": "minimal-ui",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (display-mode: minimal-ui)"',
+        );
+      });
+
+      test('@media (hover: none)', () => {
+        const input = '@media (hover: none)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "hover",
+              "type": "pair",
+              "value": "none",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (hover: none)"',
+        );
+      });
+
+      test('@media (any-hover: hover)', () => {
+        const input = '@media (any-hover: hover)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "any-hover",
+              "type": "pair",
+              "value": "hover",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (any-hover: hover)"',
+        );
+      });
+
+      test('@media (pointer: none)', () => {
+        const input = '@media (pointer: none)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "pointer",
+              "type": "pair",
+              "value": "none",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (pointer: none)"',
+        );
+      });
+
+      test('@media (any-pointer: none)', () => {
+        const input = '@media (any-pointer: none)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "any-pointer",
+              "type": "pair",
+              "value": "none",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (any-pointer: none)"',
+        );
+      });
+
+      test('@media (light-level: washed)', () => {
+        const input = '@media (light-level: washed)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "light-level",
+              "type": "pair",
+              "value": "washed",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (light-level: washed)"',
+        );
+      });
+
+      test('@media (inverted-colors: none)', () => {
+        const input = '@media (inverted-colors: none)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "inverted-colors",
+              "type": "pair",
+              "value": "none",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (inverted-colors: none)"',
+        );
+      });
+
+      test('@media (prefers-reduced-motion: no-preference)', () => {
+        const input = '@media (prefers-reduced-motion: no-preference)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "prefers-reduced-motion",
+              "type": "pair",
+              "value": "no-preference",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (prefers-reduced-motion: no-preference)"',
+        );
+      });
+
+      test('@media (prefers-contrast: no-preference)', () => {
+        const input = '@media (prefers-contrast: no-preference)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "prefers-contrast",
+              "type": "pair",
+              "value": "no-preference",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (prefers-contrast: no-preference)"',
+        );
+      });
+
+      test('@media (forced-colors: none)', () => {
+        const input = '@media (forced-colors: none)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "forced-colors",
+              "type": "pair",
+              "value": "none",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (forced-colors: none)"',
+        );
+      });
+
+      test('@media (prefers-reduced-transparency: no-preference)', () => {
+        const input = '@media (prefers-reduced-transparency: no-preference)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "prefers-reduced-transparency",
+              "type": "pair",
+              "value": "no-preference",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (prefers-reduced-transparency: no-preference)"',
+        );
+      });
+    });
+
+    describe('word-rule', () => {
+      test('@media (color)', () => {
+        const input = '@media (color)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "keyValue": "color",
+              "type": "word-rule",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot('"@media (color)"');
+      });
+
+      test('@media (color-index)', () => {
+        const input = '@media (color-index)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "keyValue": "color-index",
+              "type": "word-rule",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (color-index)"',
+        );
+      });
+
+      test('@media (monochrome)', () => {
+        const input = '@media (monochrome)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "keyValue": "monochrome",
+              "type": "word-rule",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (monochrome)"',
+        );
+      });
+
+      test('@media (grid)', () => {
+        const input = '@media (grid)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "keyValue": "grid",
+              "type": "word-rule",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot('"@media (grid)"');
+      });
+    });
+
+    describe('and combinator', () => {
+      test('@media not all and (monochrome)', () => {
+        const input = '@media not all and (monochrome)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "rules": [
                 {
-                  "keyValue": "color",
+                  "key": "all",
+                  "not": true,
+                  "only": false,
+                  "type": "media-keyword",
+                },
+                {
+                  "keyValue": "monochrome",
                   "type": "word-rule",
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media not all and (monochrome)"',
+        );
+      });
+
+      test('@media screen and (min-width: 400px)', () => {
+        const input = '@media screen and (min-width: 400px)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "screen",
+                  "not": false,
+                  "only": false,
+                  "type": "media-keyword",
                 },
                 {
                   "key": "min-width",
@@ -718,7 +970,51 @@ describe('Test CSS Type: @media queries', () => {
               ],
               "type": "and",
             },
-            {
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media screen and (min-width: 400px)"',
+        );
+      });
+
+      test('@media (min-height: 600px) and (orientation: landscape)', () => {
+        const input = '@media (min-height: 600px) and (orientation: landscape)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "min-height",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 600,
+                  },
+                },
+                {
+                  "key": "orientation",
+                  "type": "pair",
+                  "value": "landscape",
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-height: 600px) and (orientation: landscape)"',
+        );
+      });
+
+      test('@media screen and (device-aspect-ratio: 16/9)', () => {
+        const input = '@media screen and (device-aspect-ratio: 16/9)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "rules": [
                 {
                   "key": "screen",
@@ -727,773 +1023,104 @@ describe('Test CSS Type: @media queries', () => {
                   "type": "media-keyword",
                 },
                 {
-                  "key": "max-width",
+                  "key": "device-aspect-ratio",
                   "type": "pair",
-                  "value": {
-                    "signCharacter": undefined,
-                    "type": "integer",
-                    "unit": "px",
-                    "value": 700,
-                  },
+                  "value": [
+                    16,
+                    "/",
+                    9,
+                  ],
                 },
               ],
               "type": "and",
             },
-          ],
-          "type": "or",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media screen and (device-aspect-ratio: 16 / 9)"',
+        );
+      });
 
-  test('@media not all and (monochrome)', () => {
-    const query = '@media not all and (monochrome)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "all",
-              "not": true,
-              "only": false,
-              "type": "media-keyword",
-            },
-            {
-              "keyValue": "monochrome",
-              "type": "word-rule",
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (min-aspect-ratio: 3/2) and (max-aspect-ratio: 16/9)', () => {
-    const query =
-      '@media (min-aspect-ratio: 3 / 2) and (max-aspect-ratio: 16 / 9)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "min-aspect-ratio",
-              "type": "pair",
-              "value": [
-                3,
-                "/",
-                2,
-              ],
-            },
-            {
-              "key": "max-aspect-ratio",
-              "type": "pair",
-              "value": [
-                16,
-                "/",
-                9,
-              ],
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (min-resolution: 300dpi) and (max-resolution: 600dpi)', () => {
-    const query =
-      '@media (min-resolution: 300dpi) and (max-resolution: 600dpi)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "min-resolution",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "dpi",
-                "value": 300,
-              },
-            },
-            {
-              "key": "max-resolution",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "dpi",
-                "value": 600,
-              },
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (scripting: none)', () => {
-    const query = '@media (scripting: none)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "scripting",
-          "type": "pair",
-          "value": "none",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (update: slow)', () => {
-    const query = '@media (update: slow)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "update",
-          "type": "pair",
-          "value": "slow",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (overflow-inline: none)', () => {
-    const query = '@media (overflow-inline: none)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "overflow-inline",
-          "type": "pair",
-          "value": "none",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (display-mode: minimal-ui)', () => {
-    const query = '@media (display-mode: minimal-ui)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "display-mode",
-          "type": "pair",
-          "value": "minimal-ui",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (hover: none)', () => {
-    const query = '@media (hover: none)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "hover",
-          "type": "pair",
-          "value": "none",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (any-hover: hover)', () => {
-    const query = '@media (any-hover: hover)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "any-hover",
-          "type": "pair",
-          "value": "hover",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (pointer: none)', () => {
-    const query = '@media (pointer: none)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "pointer",
-          "type": "pair",
-          "value": "none",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (any-pointer: none)', () => {
-    const query = '@media (any-pointer: none)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "any-pointer",
-          "type": "pair",
-          "value": "none",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (light-level: washed)', () => {
-    const query = '@media (light-level: washed)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "light-level",
-          "type": "pair",
-          "value": "washed",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (inverted-colors: none)', () => {
-    const query = '@media (inverted-colors: none)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "inverted-colors",
-          "type": "pair",
-          "value": "none",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (prefers-reduced-motion: no-preference)', () => {
-    const query = '@media (prefers-reduced-motion: no-preference)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "prefers-reduced-motion",
-          "type": "pair",
-          "value": "no-preference",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (prefers-contrast: no-preference)', () => {
-    const query = '@media (prefers-contrast: no-preference)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "prefers-contrast",
-          "type": "pair",
-          "value": "no-preference",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (forced-colors: none)', () => {
-    const query = '@media (forced-colors: none)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "forced-colors",
-          "type": "pair",
-          "value": "none",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (prefers-reduced-transparency: no-preference)', () => {
-    const query = '@media (prefers-reduced-transparency: no-preference)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "prefers-reduced-transparency",
-          "type": "pair",
-          "value": "no-preference",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (min-width: calc(300px + 5em))', () => {
-    const query = '@media (min-width: calc(300px + 5em))';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "min-width",
-          "type": "pair",
-          "value": "calc(300px + 5em)",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (max-height: calc(100vh - 50px))', () => {
-    const query = '@media (max-height: calc(100vh - 50px))';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "max-height",
-          "type": "pair",
-          "value": "calc(100vh - 50px)",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (aspect-ratio: 16 / 9)', () => {
-    const query = '@media (aspect-ratio: 16 / 9)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "aspect-ratio",
-          "type": "pair",
-          "value": [
-            16,
-            "/",
-            9,
-          ],
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (device-aspect-ratio: 16 / 9)', () => {
-    const query = '@media (device-aspect-ratio: 16 / 9)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "device-aspect-ratio",
-          "type": "pair",
-          "value": [
-            16,
-            "/",
-            9,
-          ],
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (min-resolution: 150dpi)', () => {
-    const query = '@media (min-resolution: 150dpi)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "min-resolution",
-          "type": "pair",
-          "value": {
-            "signCharacter": undefined,
-            "type": "integer",
-            "unit": "dpi",
-            "value": 150,
-          },
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (max-resolution: 600dppx)', () => {
-    const query = '@media (max-resolution: 600dppx)';
-
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-        MediaQuery {
-          "queries": {
-            "key": "max-resolution",
-            "type": "pair",
-            "value": {
-              "signCharacter": undefined,
-              "type": "integer",
-              "unit": "dppx",
-              "value": 600,
-            },
-          },
-        }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (color-gamut: srgb)', () => {
-    const query = '@media (color-gamut: srgb)';
-
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "color-gamut",
-          "type": "pair",
-          "value": "srgb",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (display-mode: standalone)', () => {
-    const query = '@media (display-mode: standalone)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "display-mode",
-          "type": "pair",
-          "value": "standalone",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (orientation: landscape) and (pointer: fine)', () => {
-    const query = '@media (orientation: landscape) and (pointer: fine)';
-
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "orientation",
-              "type": "pair",
-              "value": "landscape",
-            },
-            {
-              "key": "pointer",
-              "type": "pair",
-              "value": "fine",
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (prefers-color-scheme: dark)', () => {
-    const query = '@media (prefers-color-scheme: dark)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "prefers-color-scheme",
-          "type": "pair",
-          "value": "dark",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (prefers-reduced-motion: reduce) and (update: slow)', () => {
-    const query = '@media (prefers-reduced-motion: reduce) and (update: slow)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "prefers-reduced-motion",
-              "type": "pair",
-              "value": "reduce",
-            },
-            {
-              "key": "update",
-              "type": "pair",
-              "value": "slow",
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (width: 500px), (height: 400px)', () => {
-    const query = '@media (width: 500px), (height: 400px)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 500,
-              },
-            },
-            {
-              "key": "height",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 400,
-              },
-            },
-          ],
-          "type": "or",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media not all and (monochrome) and (min-width: 600px)', () => {
-    const query = '@media not all and (monochrome) and (min-width: 600px)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "all",
-              "not": true,
-              "only": false,
-              "type": "media-keyword",
-            },
-            {
-              "keyValue": "monochrome",
-              "type": "word-rule",
-            },
-            {
-              "key": "min-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 600,
-              },
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (min-width: 768px) and (max-width: 991px)', () => {
-    const query = '@media (min-width: 768px) and (max-width: 991px)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "min-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 768,
-              },
-            },
-            {
-              "key": "max-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 991,
-              },
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (min-width: 1200px) and (orientation: landscape)', () => {
-    const query = '@media (min-width: 1200px) and (orientation: landscape)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "min-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 1200,
-              },
-            },
-            {
-              "key": "orientation",
-              "type": "pair",
-              "value": "landscape",
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (min-width: 992px) and (max-width: 1199px) and (pointer: fine)', () => {
-    const query =
-      '@media (min-width: 992px) and (max-width: 1199px) and (pointer: fine)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "min-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 992,
-              },
-            },
-            {
-              "key": "max-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 1199,
-              },
-            },
-            {
-              "key": "pointer",
-              "type": "pair",
-              "value": "fine",
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (min-width: 576px) and (max-width: 767px) and (hover: none)', () => {
-    const query =
-      '@media (min-width: 576px) and (max-width: 767px) and (hover: none)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "min-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 576,
-              },
-            },
-            {
-              "key": "max-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 767,
-              },
-            },
-            {
-              "key": "hover",
-              "type": "pair",
-              "value": "none",
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
-
-  test('@media (min-width: 576px), (orientation: portrait) and (max-width: 767px)', () => {
-    const query =
-      '@media (min-width: 576px), (orientation: portrait) and (max-width: 767px)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "min-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 576,
-              },
-            },
-            {
+      test('@media (min-aspect-ratio: 3/2) and (max-aspect-ratio: 16/9)', () => {
+        const input =
+          '@media (min-aspect-ratio: 3/2) and (max-aspect-ratio: 16/9)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "rules": [
                 {
-                  "key": "orientation",
+                  "key": "min-aspect-ratio",
                   "type": "pair",
-                  "value": "portrait",
+                  "value": [
+                    3,
+                    "/",
+                    2,
+                  ],
                 },
                 {
-                  "key": "max-width",
+                  "key": "max-aspect-ratio",
+                  "type": "pair",
+                  "value": [
+                    16,
+                    "/",
+                    9,
+                  ],
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-aspect-ratio: 3 / 2) and (max-aspect-ratio: 16 / 9)"',
+        );
+      });
+
+      test('@media (min-resolution: 300dpi) and (max-resolution: 600dpi)', () => {
+        const input =
+          '@media (min-resolution: 300dpi) and (max-resolution: 600dpi)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "min-resolution",
                   "type": "pair",
                   "value": {
                     "signCharacter": undefined,
                     "type": "integer",
-                    "unit": "px",
-                    "value": 767,
+                    "unit": "dpi",
+                    "value": 300,
+                  },
+                },
+                {
+                  "key": "max-resolution",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "dpi",
+                    "value": 600,
                   },
                 },
               ],
               "type": "and",
             },
-          ],
-          "type": "or",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-resolution: 300dpi) and (max-resolution: 600dpi)"',
+        );
+      });
 
-  test('@media (min-width: 768px) and (max-width: 991px), (orientation: landscape)', () => {
-    const query =
-      '@media (min-width: 768px) and (max-width: 991px), (orientation: landscape)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
+      test('@media (min-width: 768px) and (max-width: 991px)', () => {
+        const input = '@media (min-width: 768px) and (max-width: 991px)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "rules": [
                 {
                   "key": "min-width",
@@ -1518,27 +1145,52 @@ describe('Test CSS Type: @media queries', () => {
               ],
               "type": "and",
             },
-            {
-              "key": "orientation",
-              "type": "pair",
-              "value": "landscape",
-            },
-          ],
-          "type": "or",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 768px) and (max-width: 991px)"',
+        );
+      });
 
-  test('@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover)', () => {
-    const query =
-      '@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
+      test('@media (min-width: 1200px) and (orientation: landscape)', () => {
+        const input = '@media (min-width: 1200px) and (orientation: landscape)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 1200,
+                  },
+                },
+                {
+                  "key": "orientation",
+                  "type": "pair",
+                  "value": "landscape",
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 1200px) and (orientation: landscape)"',
+        );
+      });
+
+      test('@media (min-width: 992px) and (max-width: 1199px) and (pointer: fine)', () => {
+        const input =
+          '@media (min-width: 992px) and (max-width: 1199px) and (pointer: fine)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "rules": [
                 {
                   "key": "min-width",
@@ -1560,40 +1212,28 @@ describe('Test CSS Type: @media queries', () => {
                     "value": 1199,
                   },
                 },
-              ],
-              "type": "and",
-            },
-            {
-              "rules": [
                 {
                   "key": "pointer",
                   "type": "pair",
                   "value": "fine",
                 },
-                {
-                  "key": "hover",
-                  "type": "pair",
-                  "value": "hover",
-                },
               ],
               "type": "and",
             },
-          ],
-          "type": "or",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 992px) and (max-width: 1199px) and (pointer: fine)"',
+        );
+      });
 
-  test('@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse)', () => {
-    const query =
-      '@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
+      test('@media (min-width: 576px) and (max-width: 767px) and (hover: none)', () => {
+        const input =
+          '@media (min-width: 576px) and (max-width: 767px) and (hover: none)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "rules": [
                 {
                   "key": "min-width",
@@ -1615,115 +1255,82 @@ describe('Test CSS Type: @media queries', () => {
                     "value": 767,
                   },
                 },
-              ],
-              "type": "and",
-            },
-            {
-              "rules": [
                 {
                   "key": "hover",
                   "type": "pair",
                   "value": "none",
                 },
-                {
-                  "key": "any-pointer",
-                  "type": "pair",
-                  "value": "coarse",
-                },
               ],
               "type": "and",
             },
-          ],
-          "type": "or",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 576px) and (max-width: 767px) and (hover: none)"',
+        );
+      });
 
-  test('@media (min-width: 576px), (orientation: portrait) and (max-width: 767px), (prefers-color-scheme: dark)', () => {
-    const query =
-      '@media (min-width: 576px), (orientation: portrait) and (max-width: 767px), (prefers-color-scheme: dark)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
-              "key": "min-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 576,
-              },
-            },
-            {
+      test('@media (orientation: landscape) and (pointer: fine)', () => {
+        const input = '@media (orientation: landscape) and (pointer: fine)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "rules": [
                 {
                   "key": "orientation",
                   "type": "pair",
-                  "value": "portrait",
+                  "value": "landscape",
                 },
                 {
-                  "key": "max-width",
+                  "key": "pointer",
                   "type": "pair",
-                  "value": {
-                    "signCharacter": undefined,
-                    "type": "integer",
-                    "unit": "px",
-                    "value": 767,
-                  },
+                  "value": "fine",
                 },
               ],
               "type": "and",
             },
-            {
-              "key": "prefers-color-scheme",
-              "type": "pair",
-              "value": "dark",
-            },
-          ],
-          "type": "or",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (orientation: landscape) and (pointer: fine)"',
+        );
+      });
 
-  test('@media (min-width: 768px) and (max-width: 991px), (orientation: landscape) and (update: fast), (prefers-reduced-motion: reduce)', () => {
-    const query =
-      '@media (min-width: 768px) and (max-width: 991px), (orientation: landscape) and (update: fast), (prefers-reduced-motion: reduce)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
+      test('@media (prefers-reduced-motion: reduce) and (update: slow)', () => {
+        const input =
+          '@media (prefers-reduced-motion: reduce) and (update: slow)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "rules": [
                 {
-                  "key": "min-width",
+                  "key": "prefers-reduced-motion",
                   "type": "pair",
-                  "value": {
-                    "signCharacter": undefined,
-                    "type": "integer",
-                    "unit": "px",
-                    "value": 768,
-                  },
+                  "value": "reduce",
                 },
                 {
-                  "key": "max-width",
+                  "key": "update",
                   "type": "pair",
-                  "value": {
-                    "signCharacter": undefined,
-                    "type": "integer",
-                    "unit": "px",
-                    "value": 991,
-                  },
+                  "value": "slow",
                 },
               ],
               "type": "and",
             },
-            {
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (prefers-reduced-motion: reduce) and (update: slow)"',
+        );
+      });
+
+      test('@media (orientation: landscape) and (update: fast)', () => {
+        const input = '@media (orientation: landscape) and (update: fast)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "rules": [
                 {
                   "key": "orientation",
@@ -1738,27 +1345,49 @@ describe('Test CSS Type: @media queries', () => {
               ],
               "type": "and",
             },
-            {
-              "key": "prefers-reduced-motion",
-              "type": "pair",
-              "value": "reduce",
-            },
-          ],
-          "type": "or",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (orientation: landscape) and (update: fast)"',
+        );
+      });
+    });
 
-  test('@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover), (any-pointer: coarse) and (any-hover: none)', () => {
-    const query =
-      '@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover), (any-pointer: coarse) and (any-hover: none)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
+    describe('or combinator', () => {
+      test('@media (orientation: portrait), (orientation: landscape)', () => {
+        const input =
+          '@media (orientation: portrait), (orientation: landscape)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "orientation",
+                  "type": "pair",
+                  "value": "portrait",
+                },
+                {
+                  "key": "orientation",
+                  "type": "pair",
+                  "value": "landscape",
+                },
+              ],
+              "type": "or",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (orientation: portrait), (orientation: landscape)"',
+        );
+      });
+
+      test('@media (min-width: 500px) or (max-width: 600px)', () => {
+        const input = '@media (min-width: 500px) or (max-width: 600px)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "rules": [
                 {
                   "key": "min-width",
@@ -1767,7 +1396,7 @@ describe('Test CSS Type: @media queries', () => {
                     "signCharacter": undefined,
                     "type": "integer",
                     "unit": "px",
-                    "value": 992,
+                    "value": 500,
                   },
                 },
                 {
@@ -1777,58 +1406,63 @@ describe('Test CSS Type: @media queries', () => {
                     "signCharacter": undefined,
                     "type": "integer",
                     "unit": "px",
-                    "value": 1199,
+                    "value": 600,
                   },
                 },
               ],
-              "type": "and",
+              "type": "or",
             },
-            {
-              "rules": [
-                {
-                  "key": "pointer",
-                  "type": "pair",
-                  "value": "fine",
-                },
-                {
-                  "key": "hover",
-                  "type": "pair",
-                  "value": "hover",
-                },
-              ],
-              "type": "and",
-            },
-            {
-              "rules": [
-                {
-                  "key": "any-pointer",
-                  "type": "pair",
-                  "value": "coarse",
-                },
-                {
-                  "key": "any-hover",
-                  "type": "pair",
-                  "value": "none",
-                },
-              ],
-              "type": "and",
-            },
-          ],
-          "type": "or",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 500px), (max-width: 600px)"',
+        );
+      });
 
-  test('@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse), (prefers-reduced-transparency: reduce) and (forced-colors: active)', () => {
-    const query =
-      '@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse), (prefers-reduced-transparency: reduce) and (forced-colors: active)';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
+      test('@media (width: 500px), (height: 400px)', () => {
+        const input = '@media (width: 500px), (height: 400px)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 500,
+                  },
+                },
+                {
+                  "key": "height",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 400,
+                  },
+                },
+              ],
+              "type": "or",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (width: 500px), (height: 400px)"',
+        );
+      });
+
+      test('@media (min-width: 576px), (orientation: portrait) and (max-width: 767px)', () => {
+        const input =
+          '@media (min-width: 576px), (orientation: portrait) and (max-width: 767px)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "rules": [
                 {
                   "key": "min-width",
@@ -1841,109 +1475,529 @@ describe('Test CSS Type: @media queries', () => {
                   },
                 },
                 {
-                  "key": "max-width",
+                  "rules": [
+                    {
+                      "key": "orientation",
+                      "type": "pair",
+                      "value": "portrait",
+                    },
+                    {
+                      "key": "max-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 767,
+                      },
+                    },
+                  ],
+                  "type": "and",
+                },
+              ],
+              "type": "or",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 576px), (orientation: portrait) and (max-width: 767px)"',
+        );
+      });
+
+      test('@media (min-width: 768px) and (max-width: 991px), (orientation: landscape)', () => {
+        const input =
+          '@media (min-width: 768px) and (max-width: 991px), (orientation: landscape)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "rules": [
+                    {
+                      "key": "min-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 768,
+                      },
+                    },
+                    {
+                      "key": "max-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 991,
+                      },
+                    },
+                  ],
+                  "type": "and",
+                },
+                {
+                  "key": "orientation",
+                  "type": "pair",
+                  "value": "landscape",
+                },
+              ],
+              "type": "or",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 768px) and (max-width: 991px), (orientation: landscape)"',
+        );
+      });
+
+      test('@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover)', () => {
+        const input =
+          '@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "rules": [
+                    {
+                      "key": "min-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 992,
+                      },
+                    },
+                    {
+                      "key": "max-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 1199,
+                      },
+                    },
+                  ],
+                  "type": "and",
+                },
+                {
+                  "rules": [
+                    {
+                      "key": "pointer",
+                      "type": "pair",
+                      "value": "fine",
+                    },
+                    {
+                      "key": "hover",
+                      "type": "pair",
+                      "value": "hover",
+                    },
+                  ],
+                  "type": "and",
+                },
+              ],
+              "type": "or",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover)"',
+        );
+      });
+
+      test('@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse)', () => {
+        const input =
+          '@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "rules": [
+                    {
+                      "key": "min-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 576,
+                      },
+                    },
+                    {
+                      "key": "max-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 767,
+                      },
+                    },
+                  ],
+                  "type": "and",
+                },
+                {
+                  "rules": [
+                    {
+                      "key": "hover",
+                      "type": "pair",
+                      "value": "none",
+                    },
+                    {
+                      "key": "any-pointer",
+                      "type": "pair",
+                      "value": "coarse",
+                    },
+                  ],
+                  "type": "and",
+                },
+              ],
+              "type": "or",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse)"',
+        );
+      });
+
+      test('@media (min-width: 576px), (orientation: portrait) and (max-width: 767px), (prefers-color-scheme: dark)', () => {
+        const input =
+          '@media (min-width: 576px), (orientation: portrait) and (max-width: 767px), (prefers-color-scheme: dark)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "min-width",
                   "type": "pair",
                   "value": {
                     "signCharacter": undefined,
                     "type": "integer",
                     "unit": "px",
-                    "value": 767,
+                    "value": 576,
                   },
                 },
-              ],
-              "type": "and",
-            },
-            {
-              "rules": [
                 {
-                  "key": "hover",
-                  "type": "pair",
-                  "value": "none",
+                  "rules": [
+                    {
+                      "key": "orientation",
+                      "type": "pair",
+                      "value": "portrait",
+                    },
+                    {
+                      "key": "max-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 767,
+                      },
+                    },
+                  ],
+                  "type": "and",
                 },
                 {
-                  "key": "any-pointer",
+                  "key": "prefers-color-scheme",
                   "type": "pair",
-                  "value": "coarse",
+                  "value": "dark",
                 },
               ],
-              "type": "and",
+              "type": "or",
             },
-            {
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 576px), (orientation: portrait) and (max-width: 767px), (prefers-color-scheme: dark)"',
+        );
+      });
+
+      test('@media (min-width: 768px) and (max-width: 991px), (orientation: landscape) and (update: fast), (prefers-reduced-motion: reduce)', () => {
+        const input =
+          '@media (min-width: 768px) and (max-width: 991px), (orientation: landscape) and (update: fast), (prefers-reduced-motion: reduce)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "rules": [
                 {
-                  "key": "prefers-reduced-transparency",
+                  "rules": [
+                    {
+                      "key": "min-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 768,
+                      },
+                    },
+                    {
+                      "key": "max-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 991,
+                      },
+                    },
+                  ],
+                  "type": "and",
+                },
+                {
+                  "rules": [
+                    {
+                      "key": "orientation",
+                      "type": "pair",
+                      "value": "landscape",
+                    },
+                    {
+                      "key": "update",
+                      "type": "pair",
+                      "value": "fast",
+                    },
+                  ],
+                  "type": "and",
+                },
+                {
+                  "key": "prefers-reduced-motion",
                   "type": "pair",
                   "value": "reduce",
                 },
+              ],
+              "type": "or",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 768px) and (max-width: 991px), (orientation: landscape) and (update: fast), (prefers-reduced-motion: reduce)"',
+        );
+      });
+
+      test('@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover), (any-pointer: coarse) and (any-hover: none)', () => {
+        const input =
+          '@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover), (any-pointer: coarse) and (any-hover: none)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
                 {
-                  "key": "forced-colors",
-                  "type": "pair",
-                  "value": "active",
+                  "rules": [
+                    {
+                      "key": "min-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 992,
+                      },
+                    },
+                    {
+                      "key": "max-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 1199,
+                      },
+                    },
+                  ],
+                  "type": "and",
+                },
+                {
+                  "rules": [
+                    {
+                      "key": "pointer",
+                      "type": "pair",
+                      "value": "fine",
+                    },
+                    {
+                      "key": "hover",
+                      "type": "pair",
+                      "value": "hover",
+                    },
+                  ],
+                  "type": "and",
+                },
+                {
+                  "rules": [
+                    {
+                      "key": "any-pointer",
+                      "type": "pair",
+                      "value": "coarse",
+                    },
+                    {
+                      "key": "any-hover",
+                      "type": "pair",
+                      "value": "none",
+                    },
+                  ],
+                  "type": "and",
                 },
               ],
-              "type": "and",
+              "type": "or",
             },
-          ],
-          "type": "or",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(query);
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 992px) and (max-width: 1199px), (pointer: fine) and (hover: hover), (any-pointer: coarse) and (any-hover: none)"',
+        );
+      });
 
-  test('@media not (not (not (min-width: 400px)))', () => {
-    const query = '@media not (not (not (min-width: 400px)))';
-    const mediaQuery = MediaQuery.parser.parseToEnd(query);
-    expect(mediaQuery).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rule": {
-            "key": "min-width",
-            "type": "pair",
-            "value": {
-              "signCharacter": undefined,
-              "type": "integer",
-              "unit": "px",
-              "value": 400,
+      test('@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse), (prefers-reduced-transparency: reduce) and (forced-colors: active)', () => {
+        const input =
+          '@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse), (prefers-reduced-transparency: reduce) and (forced-colors: active)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "rules": [
+                    {
+                      "key": "min-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 576,
+                      },
+                    },
+                    {
+                      "key": "max-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 767,
+                      },
+                    },
+                  ],
+                  "type": "and",
+                },
+                {
+                  "rules": [
+                    {
+                      "key": "hover",
+                      "type": "pair",
+                      "value": "none",
+                    },
+                    {
+                      "key": "any-pointer",
+                      "type": "pair",
+                      "value": "coarse",
+                    },
+                  ],
+                  "type": "and",
+                },
+                {
+                  "rules": [
+                    {
+                      "key": "prefers-reduced-transparency",
+                      "type": "pair",
+                      "value": "reduce",
+                    },
+                    {
+                      "key": "forced-colors",
+                      "type": "pair",
+                      "value": "active",
+                    },
+                  ],
+                  "type": "and",
+                },
+              ],
+              "type": "or",
             },
-          },
-          "type": "not",
-        },
-      }
-    `);
-    expect(mediaQuery.toString()).toEqual('@media (not (min-width: 400px))');
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 576px) and (max-width: 767px), (hover: none) and (any-pointer: coarse), (prefers-reduced-transparency: reduce) and (forced-colors: active)"',
+        );
+      });
 
-  test('@media not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px))', () => {
-    const query =
-      '@media not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px))';
-    expect(MediaQuery.parser.parseToEnd(query)).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rule": {
-            "rules": [
-              {
+      test('@media (color) and (min-width: 400px), screen and (max-width: 700px)', () => {
+        const input =
+          '@media (color) and (min-width: 400px), screen and (max-width: 700px)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "rules": [
+                    {
+                      "keyValue": "color",
+                      "type": "word-rule",
+                    },
+                    {
+                      "key": "min-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 400,
+                      },
+                    },
+                  ],
+                  "type": "and",
+                },
+                {
+                  "rules": [
+                    {
+                      "key": "screen",
+                      "not": false,
+                      "only": false,
+                      "type": "media-keyword",
+                    },
+                    {
+                      "key": "max-width",
+                      "type": "pair",
+                      "value": {
+                        "signCharacter": undefined,
+                        "type": "integer",
+                        "unit": "px",
+                        "value": 700,
+                      },
+                    },
+                  ],
+                  "type": "and",
+                },
+              ],
+              "type": "or",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (color) and (min-width: 400px), screen and (max-width: 700px)"',
+        );
+      });
+    });
+
+    describe('not combinator', () => {
+      test('@media not (not (not (min-width: 400px)))', () => {
+        const input = '@media not (not (not (min-width: 400px)))';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rule": {
                 "key": "min-width",
-                "type": "pair",
-                "value": {
-                  "signCharacter": undefined,
-                  "type": "integer",
-                  "unit": "px",
-                  "value": 500,
-                },
-              },
-              {
-                "key": "max-width",
-                "type": "pair",
-                "value": {
-                  "signCharacter": undefined,
-                  "type": "integer",
-                  "unit": "px",
-                  "value": 600,
-                },
-              },
-              {
-                "key": "max-width",
                 "type": "pair",
                 "value": {
                   "signCharacter": undefined,
@@ -1952,26 +2006,364 @@ describe('Test CSS Type: @media queries', () => {
                   "value": 400,
                 },
               },
-            ],
-            "type": "and",
-          },
-          "type": "not",
-        },
-      }
-    `);
-    expect(MediaQuery.parser.parseToEnd(query).toString()).toEqual(
-      '@media (not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px)))',
-    );
+              "type": "not",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (not (min-width: 400px))"',
+        );
+      });
+
+      test('@media not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px))', () => {
+        const input =
+          '@media not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px))';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rule": {
+                "rules": [
+                  {
+                    "key": "min-width",
+                    "type": "pair",
+                    "value": {
+                      "signCharacter": undefined,
+                      "type": "integer",
+                      "unit": "px",
+                      "value": 500,
+                    },
+                  },
+                  {
+                    "key": "max-width",
+                    "type": "pair",
+                    "value": {
+                      "signCharacter": undefined,
+                      "type": "integer",
+                      "unit": "px",
+                      "value": 600,
+                    },
+                  },
+                  {
+                    "key": "max-width",
+                    "type": "pair",
+                    "value": {
+                      "signCharacter": undefined,
+                      "type": "integer",
+                      "unit": "px",
+                      "value": 400,
+                    },
+                  },
+                ],
+                "type": "and",
+              },
+              "type": "not",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (not ((min-width: 500px) and (max-width: 600px) and (max-width: 400px)))"',
+        );
+      });
+
+      test('@media not all and (monochrome) and (min-width: 600px)', () => {
+        const input = '@media not all and (monochrome) and (min-width: 600px)';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "all",
+                  "not": true,
+                  "only": false,
+                  "type": "media-keyword",
+                },
+                {
+                  "keyValue": "monochrome",
+                  "type": "word-rule",
+                },
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 600,
+                  },
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media not all and (monochrome) and (min-width: 600px)"',
+        );
+      });
+
+      test('@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px)) and (not (max-width: 458px))', () => {
+        const input =
+          '@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px)) and (not (max-width: 458px))';
+        const parsed = MediaQuery.parser.parseToEnd(input);
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 1440,
+                  },
+                },
+                {
+                  "rule": {
+                    "key": "max-width",
+                    "type": "pair",
+                    "value": {
+                      "signCharacter": undefined,
+                      "type": "integer",
+                      "unit": "px",
+                      "value": 1024,
+                    },
+                  },
+                  "type": "not",
+                },
+                {
+                  "rule": {
+                    "key": "max-width",
+                    "type": "pair",
+                    "value": {
+                      "signCharacter": undefined,
+                      "type": "integer",
+                      "unit": "px",
+                      "value": 768,
+                    },
+                  },
+                  "type": "not",
+                },
+                {
+                  "rule": {
+                    "key": "max-width",
+                    "type": "pair",
+                    "value": {
+                      "signCharacter": undefined,
+                      "type": "integer",
+                      "unit": "px",
+                      "value": 458,
+                    },
+                  },
+                  "type": "not",
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px)) and (not (max-width: 458px))"',
+        );
+      });
+    });
   });
-  test('flattens nested and rules', () => {
-    const query =
-      '@media (min-width: 400px) and ((max-width: 700px) and (orientation: landscape))';
-    const mediaQuery = MediaQuery.parser.parseToEnd(query);
-    expect(mediaQuery).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
+  describe('[normalize] media queries', () => {
+    describe('flatten and combinator logic', () => {
+      test('flattens nested and rules', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media (min-width: 400px) and ((max-width: 700px) and (orientation: landscape))',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 400,
+                  },
+                },
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 700,
+                  },
+                },
+                {
+                  "key": "orientation",
+                  "type": "pair",
+                  "value": "landscape",
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 400px) and (max-width: 700px) and (orientation: landscape)"',
+        );
+      });
+
+      test('flattens complex nested and rules', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media ((min-width: 400px) and ((max-width: 700px) and (orientation: landscape)))',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 400,
+                  },
+                },
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 700,
+                  },
+                },
+                {
+                  "key": "orientation",
+                  "type": "pair",
+                  "value": "landscape",
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 400px) and (max-width: 700px) and (orientation: landscape)"',
+        );
+      });
+
+      test('flattens deeply nested and chains', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media (((min-width: 400px) and (max-width: 700px)) and ((orientation: landscape) and (hover: hover)))',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 400,
+                  },
+                },
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 700,
+                  },
+                },
+                {
+                  "key": "orientation",
+                  "type": "pair",
+                  "value": "landscape",
+                },
+                {
+                  "key": "hover",
+                  "type": "pair",
+                  "value": "hover",
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 400px) and (max-width: 700px) and (orientation: landscape) and (hover: hover)"',
+        );
+      });
+
+      test('handles top-level and and nested and', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media screen and ((min-width: 500px) and ((max-width: 800px) and (color)))',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "screen",
+                  "not": false,
+                  "only": false,
+                  "type": "media-keyword",
+                },
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 500,
+                  },
+                },
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 800,
+                  },
+                },
+                {
+                  "keyValue": "color",
+                  "type": "word-rule",
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media screen and (min-width: 500px) and (max-width: 800px) and (color)"',
+        );
+      });
+    });
+
+    describe('simplify not combinator logic', () => {
+      test('removes duplicate nots', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media not (not (min-width: 400px))',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "key": "min-width",
               "type": "pair",
               "value": {
@@ -1981,40 +2373,152 @@ describe('Test CSS Type: @media queries', () => {
                 "value": 400,
               },
             },
-            {
-              "key": "max-width",
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 400px)"',
+        );
+      });
+
+      test('removes triple negation', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media not (not (not (hover: hover)))',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rule": {
+                "key": "hover",
+                "type": "pair",
+                "value": "hover",
+              },
+              "type": "not",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (not (hover: hover))"',
+        );
+      });
+
+      test('normalizes not with compound expression', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media not ((min-width: 600px) and (max-width: 900px))',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rule": {
+                "rules": [
+                  {
+                    "key": "min-width",
+                    "type": "pair",
+                    "value": {
+                      "signCharacter": undefined,
+                      "type": "integer",
+                      "unit": "px",
+                      "value": 600,
+                    },
+                  },
+                  {
+                    "key": "max-width",
+                    "type": "pair",
+                    "value": {
+                      "signCharacter": undefined,
+                      "type": "integer",
+                      "unit": "px",
+                      "value": 900,
+                    },
+                  },
+                ],
+                "type": "and",
+              },
+              "type": "not",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (not ((min-width: 600px) and (max-width: 900px)))"',
+        );
+      });
+
+      test('removes even number of nots', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media not (not (not (not (update: fast))))',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "update",
+              "type": "pair",
+              "value": "fast",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (update: fast)"',
+        );
+      });
+
+      test('preserves single not over group', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media not ((pointer: fine) and (hover: hover))',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rule": {
+                "rules": [
+                  {
+                    "key": "pointer",
+                    "type": "pair",
+                    "value": "fine",
+                  },
+                  {
+                    "key": "hover",
+                    "type": "pair",
+                    "value": "hover",
+                  },
+                ],
+                "type": "and",
+              },
+              "type": "not",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (not ((pointer: fine) and (hover: hover)))"',
+        );
+      });
+    });
+
+    describe('inequality rule tests', () => {
+      test('@media (width > 400px)', () => {
+        const parsed = MediaQuery.parser.parseToEnd('@media (width > 400px)');
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "min-width",
               "type": "pair",
               "value": {
                 "signCharacter": undefined,
                 "type": "integer",
                 "unit": "px",
-                "value": 700,
+                "value": 400.01,
               },
             },
-            {
-              "key": "orientation",
-              "type": "pair",
-              "value": "landscape",
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(mediaQuery.toString()).toEqual(
-      '@media (min-width: 400px) and (max-width: 700px) and (orientation: landscape)',
-    );
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 400.01px)"',
+        );
+      });
 
-  test('flattens complex nested and rules', () => {
-    const query =
-      '@media ((min-width: 400px) and ((max-width: 700px) and (orientation: landscape)))';
-    const mediaQuery = MediaQuery.parser.parseToEnd(query);
-    expect(mediaQuery).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "rules": [
-            {
+      test('@media (width >= 400px)', () => {
+        const parsed = MediaQuery.parser.parseToEnd('@media (width >= 400px)');
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
               "key": "min-width",
               "type": "pair",
               "value": {
@@ -2024,234 +2528,320 @@ describe('Test CSS Type: @media queries', () => {
                 "value": 400,
               },
             },
-            {
-              "key": "max-width",
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 400px)"',
+        );
+      });
+
+      test('@media (400px < width)', () => {
+        const parsed = MediaQuery.parser.parseToEnd('@media (400px < width)');
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "min-width",
               "type": "pair",
               "value": {
                 "signCharacter": undefined,
                 "type": "integer",
                 "unit": "px",
-                "value": 700,
+                "value": 400.01,
               },
             },
-            {
-              "key": "orientation",
-              "type": "pair",
-              "value": "landscape",
-            },
-          ],
-          "type": "and",
-        },
-      }
-    `);
-    expect(mediaQuery.toString()).toEqual(
-      '@media (min-width: 400px) and (max-width: 700px) and (orientation: landscape)',
-    );
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 400.01px)"',
+        );
+      });
 
-  test('removes duplicate nots', () => {
-    const query = '@media not (not (min-width: 400px))';
-    const mediaQuery = MediaQuery.parser.parseToEnd(query);
-    expect(mediaQuery).toMatchInlineSnapshot(`
-      MediaQuery {
-        "queries": {
-          "key": "min-width",
-          "type": "pair",
-          "value": {
-            "signCharacter": undefined,
-            "type": "integer",
-            "unit": "px",
-            "value": 400,
-          },
-        },
-      }
-    `);
-    expect(mediaQuery.toString()).toEqual('@media (min-width: 400px)');
-  });
-
-  test('@media only screen', () => {
-    const query = '@media only screen';
-    const parsed = MediaQuery.parser.parseToEnd(query);
-    expect(parsed.queries).toMatchInlineSnapshot(`
-      {
-        "key": "screen",
-        "not": false,
-        "only": true,
-        "type": "media-keyword",
-      }
-    `);
-    expect(parsed.toString()).toBe('@media only screen');
-  });
-
-  test('@media only print and (color)', () => {
-    const query = '@media only print and (color)';
-    const parsed = MediaQuery.parser.parseToEnd(query);
-    expect(parsed.toString()).toBe('@media only print and (color)');
-  });
-
-  test('@media not screen', () => {
-    const query = '@media not screen';
-    const parsed = MediaQuery.parser.parseToEnd(query);
-    expect(parsed.queries).toMatchInlineSnapshot(`
-      {
-        "key": "screen",
-        "not": true,
-        "only": false,
-        "type": "media-keyword",
-      }
-    `);
-    expect(parsed.toString()).toBe('@media not screen');
-  });
-
-  test('@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px)) and (not (max-width: 458px))', () => {
-    const query =
-      '@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px)) and (not (max-width: 458px))';
-    const parsed = MediaQuery.parser.parseToEnd(query);
-    expect(parsed.queries).toMatchInlineSnapshot(`
-      {
-        "rules": [
-          {
-            "key": "max-width",
-            "type": "pair",
-            "value": {
-              "signCharacter": undefined,
-              "type": "integer",
-              "unit": "px",
-              "value": 1440,
-            },
-          },
-          {
-            "rule": {
-              "key": "max-width",
+      test('@media (400px <= width)', () => {
+        const parsed = MediaQuery.parser.parseToEnd('@media (400px <= width)');
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "min-width",
               "type": "pair",
               "value": {
                 "signCharacter": undefined,
                 "type": "integer",
                 "unit": "px",
-                "value": 1024,
+                "value": 400,
               },
             },
-            "type": "not",
-          },
-          {
-            "rule": {
-              "key": "max-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 768,
-              },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 400px)"',
+        );
+      });
+
+      test('@media (400px <= width <= 700px)', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media (400px <= width <= 700px)',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 400,
+                  },
+                },
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 700,
+                  },
+                },
+              ],
+              "type": "and",
             },
-            "type": "not",
-          },
-          {
-            "rule": {
-              "key": "max-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 458,
-              },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 400px) and (max-width: 700px)"',
+        );
+      });
+
+      test('@media (400px < width <= 700px)', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media (400px < width <= 700px)',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 399.99,
+                  },
+                },
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 700,
+                  },
+                },
+              ],
+              "type": "and",
             },
-            "type": "not",
-          },
-        ],
-        "type": "and",
-      }
-    `);
-    expect(parsed.toString()).toBe(
-      '@media (max-width: 1440px) and (not (max-width: 1024px)) and (not (max-width: 768px)) and (not (max-width: 458px))',
-    );
-  });
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 399.99px) and (max-width: 700px)"',
+        );
+      });
 
-  test('rejects invalid media queries', () => {
-    const parse = (str: string) => MediaQuery.parser.parseToEnd(str);
+      test('@media (400px <= width <= 700px)', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media (400px <= width <= 700px)',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 400,
+                  },
+                },
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 700,
+                  },
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (min-width: 400px) and (max-width: 700px)"',
+        );
+      });
 
-    // empty / missing rules
-    expect(() => parse('@media')).toThrow();
-    expect(() => parse('@media ')).toThrow();
-    expect(() => parse('@media ()')).toThrow();
+      test('@media (400px >= width >= 700px)', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media (400px >= width >= 700px)',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 400,
+                  },
+                },
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 700,
+                  },
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (max-width: 400px) and (min-width: 700px)"',
+        );
+      });
 
-    // incorrect operators or delimiters
-    expect(() => parse('@media (width > )')).toThrow();
-    expect(() => parse('@media ( > 600px)')).toThrow();
-    expect(() => parse('@media (600px > width) or')).toThrow();
-    expect(() => parse('@media (width < )')).toThrow();
-    expect(() => parse('@media (width <=)')).toThrow();
-    expect(() => parse('@media (>= width)')).toThrow();
-    expect(() => parse('@media (width :)')).toThrow();
-    expect(() => parse('@media (: 600px)')).toThrow();
-    expect(() => parse('@media (min-width 600px)')).toThrow();
+      test('@media (400px > width >= 700px)', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media (400px > width >= 700px)',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 400.01,
+                  },
+                },
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 700,
+                  },
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (max-width: 400.01px) and (min-width: 700px)"',
+        );
+      });
 
-    // illegal identifiers or token types
-    expect(() => parse('@media (width @ 600px)')).toThrow();
-    expect(() => parse('@media (width: #$%)')).toThrow();
-    expect(() => parse('@media (width: [])')).toThrow();
+      test('@media (400px >= width > 700px)', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media (400px >= width > 700px)',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 400,
+                  },
+                },
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 700.01,
+                  },
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (max-width: 400px) and (min-width: 700.01px)"',
+        );
+      });
 
-    // unmatched or misnested parens
-    expect(() => parse('@media (width < 600px')).toThrow();
-    expect(() => parse('@media ((min-width: 600px)')).toThrow();
-    expect(() => parse('@media (min-width: 600px))')).toThrow();
-    expect(() =>
-      parse('@media ((min-width: 600px) and (max-width: 1200px)) and )'),
-    ).toThrow();
-    expect(() =>
-      parse('@media (min-width: 600px and max-width: 1200px)'),
-    ).toThrow();
-
-    // bad logical structure
-    expect(() => parse('@media and (min-width: 600px)')).toThrow();
-    expect(() => parse('@media or (max-width: 1200px)')).toThrow();
-    expect(() => parse('@media not and (print)')).toThrow();
-    expect(() => parse('@media not or (print)')).toThrow();
-    expect(() => parse('@media (min-width: 600px) or')).toThrow();
-    expect(() => parse('@media and')).toThrow();
-    expect(() => parse('@media (color) and')).toThrow();
-    expect(() =>
-      parse('@media (width > 1024px), and (height > 1024px)'),
-    ).toThrow();
-
-    // illegal use of variables in media queries
-    expect(() => parse('@media (min-width: var(--test))')).toThrow();
-    expect(() =>
-      parse('@media (min-width: var(--foo) and (max-width: 700px))'),
-    ).toThrow();
-    expect(() =>
-      parse('@media (min-width: var(foo) and (max-width: 700px))'),
-    ).toThrow();
-
-    // invalid `not` usage
-    expect(() => parse('@media not')).toThrow();
-    expect(() => parse('@media not (min-width: )')).toThrow();
-    expect(() => parse('@media (not)')).toThrow();
-    expect(() => parse('@media ((not (min-width: 600px))')).toThrow();
-
-    // incomplete rules
-    expect(() => parse('@media (width:)')).toThrow();
-    expect(() => parse('@media (min-width:)')).toThrow();
-    expect(() => parse('@media (max-width: )')).toThrow();
-
-    // unknown keyword or media types
-    expect(() => parse('@media 100gecs')).toThrow();
-    expect(() => parse('@media only 100gecs')).toThrow();
-    expect(() => parse('@media not 100gecs')).toThrow();
-
-    // malformed double inequalities
-    expect(() => parse('@media (300px < width <)')).toThrow();
-    expect(() => parse('@media (< width < 700px)')).toThrow();
-    expect(() => parse('@media (300px > > width < 700px)')).toThrow();
-
-    // broken groupings
-    expect(() => parse('@media ((width: 600px) and)')).toThrow();
-    expect(() => parse('@media ((and (width: 600px)))')).toThrow();
-    expect(() => parse('@media (())')).toThrow();
-
-    expect(() => parse('@media (only max-width: 500px)')).toThrow();
-    expect(() => parse('@media screen and (only screen) ')).toThrow();
-    expect(() => parse('@media not (only (screen))')).toThrow();
+      test('@media (400px > width > 700px)', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media (400px > width > 700px)',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 400.01,
+                  },
+                },
+                {
+                  "key": "min-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 700.01,
+                  },
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (max-width: 400.01px) and (min-width: 700.01px)"',
+        );
+      });
+    });
   });
 });

--- a/packages/style-value-parser/src/at-queries/media-query.js
+++ b/packages/style-value-parser/src/at-queries/media-query.js
@@ -135,7 +135,7 @@ const simplePairParser: TokenParser<MediaRulePair> = TokenParser.sequence(
   }));
 
 // forward inequality: (width <= 1250px) or (width < 1250px)
-export const mediaInequalityRuleParser: TokenParser<MediaRulePair> =
+const mediaInequalityRuleParser: TokenParser<MediaRulePair> =
   TokenParser.sequence(
     TokenParser.tokens.OpenParen,
     TokenParser.tokens.Ident.map(


### PR DESCRIPTION
Refactor tests and gauge spec gaps. I think we support pretty much all the query types we'd expect to see in internal now, and can start using it in the compiler and linter
- Mostly rearranging tests
- Added new tests for double inequalities, normalization tests, etc

Not supported: 
- niche keywords like horizontal-viewport-segments, vertical-viewport-segments, environment-blending, video-* media features, dynamic-range, prefers-reduced-data

<img width="516" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/320bb3d1-711b-4fd9-881b-1c16c17c1aa0" />


<img width="537" alt="image" src="https://github.com/user-attachments/assets/c613a1f4-82f8-4137-a564-5adb0f0617c0" />
