### PR TITLE
Add jest coverage thresholds to packages

### DIFF
--- a/packages/babel-plugin/jest.config.js
+++ b/packages/babel-plugin/jest.config.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+module.exports = {
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.{js,jsx}',
+    // exclude
+    '!<rootDir>/src/**/__tests__/**',
+    '!<rootDir>/src/**/tests/**',
+    '!<rootDir>/src/**/types/**',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 74,
+      functions: 59,
+      lines: 78,
+      statements: 78,
+    },
+  },
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
+  verbose: true,
+};

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -13,7 +13,7 @@
     "build": "rollup --config ./rollup.config.mjs",
     "build-haste": "HASTE=true rollup --config ./rollup.config.mjs",
     "build-watch": "rollup --config ./rollup.config.mjs --watch",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@babel/helper-module-imports": "^7.25.9",
@@ -34,12 +34,6 @@
     "babel-plugin-syntax-hermes-parser": "^0.26.0",
     "rollup": "^4.24.0",
     "scripts": "0.12.0"
-  },
-  "jest": {
-    "verbose": true,
-    "snapshotFormat": {
-      "printBasicPrototype": false
-    }
   },
   "files": [
     "flow_modules/*",

--- a/packages/eslint-plugin/jest.config.js
+++ b/packages/eslint-plugin/jest.config.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+module.exports = {
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.{js,jsx}',
+    // exclude
+    '!<rootDir>/src/**/__tests__/**',
+    '!<rootDir>/src/**/tests/**',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 75,
+      functions: 90,
+      lines: 85,
+      statements: 85,
+    },
+  },
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
+  verbose: true,
+};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -13,7 +13,7 @@
     "build": "babel src/ --out-dir lib/",
     "prebuild-haste": "gen-types -i src/ -o lib/",
     "build-haste": "rollup --config ./rollup.config.mjs",
-    "test": "jest --detectOpenHandles"
+    "test": "jest --detectOpenHandles --coverage"
   },
   "dependencies": {
     "css-shorthand-expand": "^1.2.0",

--- a/packages/style-value-parser/jest.config.js
+++ b/packages/style-value-parser/jest.config.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+module.exports = {
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.{js,jsx}',
+    // exclude
+    '!<rootDir>/src/**/__tests__/**',
+    '!<rootDir>/src/**/tests/**',
+    '!<rootDir>/src/**/types/**',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 65,
+      functions: 75,
+      lines: 75,
+      statements: 75,
+    },
+  },
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
+  verbose: true,
+};

--- a/packages/style-value-parser/package.json
+++ b/packages/style-value-parser/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prebuild": "gen-types -i src/ -o lib/",
     "build": "babel src --out-dir lib --ignore \"**/__tests__/**\",\"**/__benchmarks__/**\"",
-    "test": "jest",
+    "test": "jest --coverage",
     "benchmark": "find ./__benchmarks__ -name '*.bench.mjs' -exec node {} \\;"
   },
   "dependencies": {
@@ -16,11 +16,6 @@
   "devDependencies": {
     "@babel/node": "^7.23.9",
     "benchmark": "^2.1.4"
-  },
-  "jest": {
-    "snapshotFormat": {
-      "printBasicPrototype": false
-    }
   },
   "files": [
     "lib/*"

--- a/packages/stylex/jest.config.js
+++ b/packages/stylex/jest.config.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+module.exports = {
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.{js,jsx}',
+    // exclude
+    '!<rootDir>/src/**/__tests__/**',
+    '!<rootDir>/src/**/tests/**',
+    '!<rootDir>/src/**/types/**',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 83,
+      functions: 97,
+      lines: 97,
+      statements: 97,
+    },
+  },
+  prettierPath: null,
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
+  testEnvironment: 'jsdom',
+  verbose: true,
+};

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -29,7 +29,7 @@
     "build:esm": "cross-env BABEL_ENV=esm rollup -c ./rollup.config.mjs",
     "build": "npm run build:cjs && npm run build:esm",
     "build-haste": "rimraf lib && rewrite-imports -i src/ -o lib/",
-    "test": "cross-env BABEL_ENV=test jest"
+    "test": "cross-env BABEL_ENV=test jest --coverage"
   },
   "dependencies": {
     "css-mediaquery": "^0.1.2",
@@ -57,10 +57,6 @@
     "rimraf": "^5.0.10",
     "rollup": "^4.24.0",
     "scripts": "0.12.0"
-  },
-  "jest": {
-    "prettierPath": null,
-    "testEnvironment": "jsdom"
   },
   "files": [
     "lib/*"


### PR DESCRIPTION
Help prevent regressions to code coverage for babel-plugin, eslint-plugin, style-value-parser, and stylex packages. The thresholds for packages with low coverage should be increased as coverage improves.