### PR TITLE
[docs] fix variants usage examples

### DIFF
--- a/packages/docs/docs/learn/06-recipes/02-variants.mdx
+++ b/packages/docs/docs/learn/06-recipes/02-variants.mdx
@@ -153,8 +153,8 @@ function Button({
 }
 
 // Usage
-<Button color="primary" size="medium">Primary</Button>
-<Button color="secondary">Secondary</Button>
+<Button color="primary" size="medium" disabled>Primary</Button>
+<Button color="secondary" disabled={true}>Secondary</Button>
 ```
 
 There may be other scenarios where you need to be more explicit about the styles
@@ -228,6 +228,6 @@ function Button({
 }
 
 // Usage
-<Button color="primary" size="medium">Primary</Button>
-<Button color="secondary">Secondary</Button>
+<Button color="primary" size="medium" disabled>Primary</Button>
+<Button color="secondary" disabled={true}>Secondary</Button>
 ```


### PR DESCRIPTION
## What changed / motivation ?

The usage examples of the variants do not represent the exact code; we just need to add a missing prop

## Linked PR/Issues

No linked PR/issues

## Additional Context

check the usage section of these examples:
https://stylexjs.com/docs/learn/recipes/variants/#example-a-disabled-prop
https://stylexjs.com/docs/learn/recipes/variants/#example-two-definitions-for-color-variant-styles

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code