### PR TITLE
[babel-plugin] Remove duplicate className for nested pseudo-classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24056,30 +24056,6 @@
       "resolved": "packages/style-value-parser",
       "link": true
     },
-    "node_modules/styled-jsx": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.7.tgz",
-      "integrity": "sha512-HPLmEIYprxCeWDMLYiaaAhsV3yGfIlCqzuVOybE6fjF3SUJmH67nCoMDO+nAvHNHo46OfvpCNu4Rcue82dMNFg==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "client-only": "0.0.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/stylehacks": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -1567,7 +1567,7 @@ describe('@stylexjs/babel-plugin', () => {
           `);
         });
 
-        test('pseudo-class generated order (nested)', () => {
+        test('pseudo-class generated order (nested, same value)', () => {
           const { code, metadata } = transform(`
             import * as stylex from '@stylexjs/stylex';
             export const styles = stylex.create({
@@ -1583,12 +1583,11 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `);
-          // TODO: Fix duplicate class name - https://github.com/facebook/stylex/issues/1001
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: {
-                kMwMTN: "xa2ikkt xa2ikkt",
+                kMwMTN: "xa2ikkt",
                 $$css: true
               }
             };"
@@ -1600,6 +1599,55 @@ describe('@stylexjs/babel-plugin', () => {
                   "xa2ikkt",
                   {
                     "ltr": ".xa2ikkt:active:hover{color:red}",
+                    "rtl": null,
+                  },
+                  3300,
+                ],
+              ],
+            }
+          `);
+        });
+
+        test('pseudo-class generated order (nested, different value)', () => {
+          const { code, metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                color: {
+                  ':hover': {
+                    ':active':'red',
+                  },
+                  ':active': {
+                    ':hover':'green',
+                  },
+                },
+              },
+            });
+          `);
+          expect(code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: {
+                kMwMTN: "xa2ikkt x13pwkn",
+                $$css: true
+              }
+            };"
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "xa2ikkt",
+                  {
+                    "ltr": ".xa2ikkt:active:hover{color:red}",
+                    "rtl": null,
+                  },
+                  3300,
+                ],
+                [
+                  "x13pwkn",
+                  {
+                    "ltr": ".x13pwkn:active:hover{color:green}",
                     "rtl": null,
                   },
                   3300,

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-create.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-create.js
@@ -99,9 +99,10 @@ export default function styleXCreateSet(
         Object.assign(classPathsInNamespace, classesToOriginalPath);
       });
 
-      const className =
-        classNameTuples.map(([className]) => className).join(' ') || null;
-      namespaceObj[key] = className;
+      const classNames = classNameTuples.map(([className]) => className);
+      const uniqueClassNames = new Set(classNames);
+      const className = Array.from(uniqueClassNames).join(' ');
+      namespaceObj[key] = className !== '' ? className : null;
 
       for (const [className, injectable] of classNameTuples) {
         if (injectedStyles[className] == null) {


### PR DESCRIPTION
Nested pseudo-classes have a pre-determined order, which means 2 different ways of authoring a style were producing the same CSS. But the compiler was adding a duplicate class name into the compiled style object.

Co-authored-by: jeongminsang <jong0364@gmail.com>

Fix #1001