### PR TITLE
[babel-plugin] support at-rules in defineConsts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -144,6 +144,141 @@
         "typescript": "^5.3.3"
       }
     },
+    "examples/example-nextjs/node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.21.tgz",
+      "integrity": "sha512-HwEjcKsXtvszXz5q5Z7wCtrHeTTDSTgAbocz45PHMUjU3fBYInfvhR+ZhavDRUYLonm53aHZbB09QtJVJj8T7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.21.tgz",
+      "integrity": "sha512-TSAA2ROgNzm4FhKbTbyJOBrsREOMVdDIltZ6aZiKvCi/v0UwFmwigBGeqXDA97TFMpR3LNNpw52CbVelkoQBxA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.21.tgz",
+      "integrity": "sha512-0Dqjn0pEUz3JG+AImpnMMW/m8hRtl1GQCNbO66V1yp6RswSTiKmnHf3pTX6xMdJYSemf3O4Q9ykiL0jymu0TuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.21.tgz",
+      "integrity": "sha512-Ggfw5qnMXldscVntwnjfaQs5GbBbjioV4B4loP+bjqNEb42fzZlAaK+ldL0jm2CTJga9LynBMhekNfV8W4+HBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.21.tgz",
+      "integrity": "sha512-uokj0lubN1WoSa5KKdThVPRffGyiWlm/vCc/cMkWOQHw69Qt0X1o3b2PyLLx8ANqlefILZh1EdfLRz9gVpG6tg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.21.tgz",
+      "integrity": "sha512-iAEBPzWNbciah4+0yI4s7Pce6BIoxTQ0AGCkxn/UBuzJFkYyJt71MadYQkjPqCQCJAFQ26sYh7MOKdU+VQFgPg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.21.tgz",
+      "integrity": "sha512-plykgB3vL2hB4Z32W3ktsfqyuyGAPxqwiyrAi2Mr8LlEUhNn9VgkiAl5hODSBpzIfWweX3er1f5uNpGDygfQVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.21.tgz",
+      "integrity": "sha512-w5bacz4Vxqrh06BjWgua3Yf7EMDb8iMcVhNrNx8KnJXt8t+Uu0Zg4JHLDL/T7DkTCEEfKXO/Er1fcfWxn2xfPA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.21.tgz",
+      "integrity": "sha512-sT6+llIkzpsexGYZq8cjjthRyRGe5cJVhqh12FmlbxHqna6zsDDK8UNaV7g41T6atFHCJUPeLb3uyAwrBwy0NA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "examples/example-nextjs/node_modules/next": {
       "version": "14.2.21",
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.21.tgz",
@@ -5548,150 +5683,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.21",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.21.tgz",
-      "integrity": "sha512-HwEjcKsXtvszXz5q5Z7wCtrHeTTDSTgAbocz45PHMUjU3fBYInfvhR+ZhavDRUYLonm53aHZbB09QtJVJj8T7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.21",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.21.tgz",
-      "integrity": "sha512-TSAA2ROgNzm4FhKbTbyJOBrsREOMVdDIltZ6aZiKvCi/v0UwFmwigBGeqXDA97TFMpR3LNNpw52CbVelkoQBxA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.21",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.21.tgz",
-      "integrity": "sha512-0Dqjn0pEUz3JG+AImpnMMW/m8hRtl1GQCNbO66V1yp6RswSTiKmnHf3pTX6xMdJYSemf3O4Q9ykiL0jymu0TuA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.21",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.21.tgz",
-      "integrity": "sha512-Ggfw5qnMXldscVntwnjfaQs5GbBbjioV4B4loP+bjqNEb42fzZlAaK+ldL0jm2CTJga9LynBMhekNfV8W4+HBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.21",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.21.tgz",
-      "integrity": "sha512-uokj0lubN1WoSa5KKdThVPRffGyiWlm/vCc/cMkWOQHw69Qt0X1o3b2PyLLx8ANqlefILZh1EdfLRz9gVpG6tg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.21",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.21.tgz",
-      "integrity": "sha512-iAEBPzWNbciah4+0yI4s7Pce6BIoxTQ0AGCkxn/UBuzJFkYyJt71MadYQkjPqCQCJAFQ26sYh7MOKdU+VQFgPg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.21",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.21.tgz",
-      "integrity": "sha512-plykgB3vL2hB4Z32W3ktsfqyuyGAPxqwiyrAi2Mr8LlEUhNn9VgkiAl5hODSBpzIfWweX3er1f5uNpGDygfQVQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.21",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.21.tgz",
-      "integrity": "sha512-w5bacz4Vxqrh06BjWgua3Yf7EMDb8iMcVhNrNx8KnJXt8t+Uu0Zg4JHLDL/T7DkTCEEfKXO/Er1fcfWxn2xfPA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.21",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.21.tgz",
-      "integrity": "sha512-sT6+llIkzpsexGYZq8cjjthRyRGe5cJVhqh12FmlbxHqna6zsDDK8UNaV7g41T6atFHCJUPeLb3uyAwrBwy0NA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {

--- a/packages/@stylexjs/babel-plugin/__tests__/__fixtures__/constants.stylex.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/__fixtures__/constants.stylex.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+// constants.stylex.js
+import * as stylex from '@stylexjs/stylex';
+
+export const breakpoints = stylex.defineConsts({
+  small: '@media (max-width: 600px)',
+  medium: '@media (min-width: 601px) and (max-width: 1024px)',
+  large: '@media (max-width: 1025px)',
+});
+
+export const colors = stylex.defineConsts({
+  accent: 'hotpink',
+  background: 'white',
+  foreground: 'black',
+});

--- a/packages/@stylexjs/babel-plugin/jest.config.js
+++ b/packages/@stylexjs/babel-plugin/jest.config.js
@@ -26,5 +26,6 @@ module.exports = {
   snapshotFormat: {
     printBasicPrototype: false,
   },
+  testPathIgnorePatterns: ['/__fixtures__/'],
   verbose: true,
 };

--- a/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/PreRule.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/PreRule.js
@@ -68,6 +68,11 @@ export class PreRule implements IPreRule {
     return sortAtRules(unsortedAtRules);
   }
 
+  get constRules(): $ReadOnlyArray<string> {
+    // This is a placeholder for `defineConsts` values that are later inlined
+    return this.keyPath.filter((key) => key.startsWith('var(--'));
+  }
+
   compiled(
     options: StyleXOptions,
   ): $ReadOnlyArray<[string, InjectableStyle, ClassesToOriginalPaths]> {
@@ -75,8 +80,10 @@ export class PreRule implements IPreRule {
       [this.property, this.value],
       this.pseudos ?? [],
       this.atRules ?? [],
+      this.constRules ?? [],
       options,
     );
+
     return [[className, rule, { [className]: this.keyPath }]];
   }
 

--- a/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/basic-validation.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/basic-validation.js
@@ -58,7 +58,15 @@ function validateConditionalStyles(
 ): void {
   for (const key in val) {
     const v = val[key];
-    if (!(key.startsWith('@') || key.startsWith(':') || key === 'default')) {
+    if (
+      !(
+        key.startsWith('@') ||
+        key.startsWith(':') ||
+        // This is a placeholder for `defineConsts` values that are later inlined
+        key.startsWith('var(--') ||
+        key === 'default'
+      )
+    ) {
       throw new Error(messages.INVALID_PSEUDO_OR_AT_RULE);
     }
     if (conditions.includes(key)) {

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/__tests__/convert-to-className-test.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/__tests__/convert-to-className-test.js
@@ -12,7 +12,7 @@ import { convertStyleToClassName } from '../convert-to-className';
 const extractBody = (str: string) => str.slice(str.indexOf('{') + 1, -1);
 
 const convert = (styles: Parameters<typeof convertStyleToClassName>[0]) =>
-  extractBody(convertStyleToClassName(styles, [], [])[2].ltr);
+  extractBody(convertStyleToClassName(styles, [], [], [])[2].ltr);
 
 describe('convert-to-className test', () => {
   test('converts style to className', () => {
@@ -26,7 +26,7 @@ describe('convert-to-className test', () => {
       styleResolution: 'application-order',
       test: false,
     };
-    const result = convertStyleToClassName(['margin', 10], [], [], options);
+    const result = convertStyleToClassName(['margin', 10], [], [], [], options);
     const className = result[1];
     expect(className.startsWith('margin-x')).toBe(true);
   });
@@ -39,7 +39,7 @@ describe('convert-to-className test', () => {
       styleResolution: 'application-order',
       test: false,
     };
-    const result = convertStyleToClassName(['margin', 10], [], [], options);
+    const result = convertStyleToClassName(['margin', 10], [], [], [], options);
     const className = result[1];
     expect(className.startsWith('x')).toBe(true);
     expect(className.startsWith('margin-x')).toBe(false);
@@ -52,7 +52,7 @@ describe('convert-to-className test', () => {
       styleResolution: 'application-order',
       test: false,
     };
-    const result = convertStyleToClassName(['margin', 10], [], [], options);
+    const result = convertStyleToClassName(['margin', 10], [], [], [], options);
     const className = result[1];
     expect(className.startsWith('x')).toBe(true);
     expect(className.startsWith('margin-x')).toBe(false);

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/convert-to-className.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/convert-to-className.js
@@ -28,6 +28,7 @@ export function convertStyleToClassName(
   objEntry: $ReadOnly<[string, TRawValue]>,
   pseudos: $ReadOnlyArray<string>,
   atRules: $ReadOnlyArray<string>,
+  constRules: $ReadOnlyArray<string>,
   options: StyleXOptions = defaultOptions,
 ): StyleRule {
   const {
@@ -50,7 +51,7 @@ export function convertStyleToClassName(
   }
 
   const sortedPseudos = sortPseudos(pseudos ?? []);
-  const sortedAtRules = sortAtRules(atRules ?? []);
+  const sortedAtRules = sortAtRules([...atRules, ...constRules]);
 
   const pseudoHashString = sortedPseudos.join('');
   const atRuleHashString = sortedAtRules.join('');
@@ -74,6 +75,7 @@ export function convertStyleToClassName(
     value,
     pseudos,
     atRules,
+    constRules,
   );
 
   return [key, className, cssRules];


### PR DESCRIPTION
https://github.com/facebook/stylex/pull/944 only supports inlining values. Need to properly wrap css rules with media queries, @supports, @container etc

1. We were replacing var(--hash) in the final css ltr strings inside our main babel transform (in `processStylexRules`), but that only touches the output css and doesn’t affect how `stylex-create` wraps declarations
2. `stylex-create` walks the raw style object and builds the ltr strings by wrapping rules in @media {...} based on object keys, but we never looked for var(...) keys there—so any media constants were ignored
4. this diff patches the part that builds the `PreRule`s to detect key segments matching var(--hash) and emits them as literal var(--hash){...} wrappers as a placeholder. once `processStylexRules` runs (where we have the full consts map of { hash: '@media(...)' }), we replace those var(--hash) wrappers with their real queries as usual.
5. We can't inline within `PreRule` itself because we don't know all the constants until we scan all the defineConsts calls. It'd require a major reordering of visitors to capture them before stylex-create. (originally tried this)

TODO:
1. ~Add unit tests for defineConsts that include nested contextual styles with constants.~
2. ~Verify rule sorting precedence in nested contextual styles with pseudo-selectors, regular at-rules, and at-rule constants (eg. ensure :hover inside @media sorts correctly).~
3. ~Investigate why processRules tests appear to wrap media queries unexpectedly even before this patch when using defineConsts, as tested [here](https://github.com/facebook/stylex/commit/c9710b141805970736bc330fb7451441bf920f97)~
    a. This is because we need to simulate running stylex.create calls first instead of inlining the fixture above

Follow up:
- Add type validation for constants, either via a style.types.media registry or a basic allowlist (eg. only accept @media, @supports, @container for now).

## testing
tested on example-nextjs
```
    color: {
      default: 'black',
      [breakpoints.small: {
        default: 'red',
        [breakpoints.big]: {
          default: 'orange',
          '@media (max-width: 1200px)': 'CadetBlue'
        },
      },
   }
```
https://github.com/user-attachments/assets/93c6ea9c-8085-422c-b117-31b14578bd2a



