### PR TITLE
[docs] introduce 'contextual styles' term

### DIFF
--- a/examples/example-nextjs/typetests/typetests.ts
+++ b/examples/example-nextjs/typetests/typetests.ts
@@ -110,7 +110,7 @@ styles3.foo satisfies StyleXStylesWithout<{ width: unknown }>;
 stylex.props(styles3.foo);
 
 /**
- * CONDITIONAL STYLES
+ * CONTEXTUAL STYLES
  */
 const styles4: Readonly<{
   foo: Readonly<{
@@ -139,7 +139,7 @@ styles4.foo satisfies StyleXStyles<{ width?: unknown }>;
 stylex.props(styles4.foo);
 
 /**
- * NESTED CONDITIONAL STYLES
+ * NESTED CONTEXTUAL STYLES
  */
 const styles5: Readonly<{
   foo: Readonly<{
@@ -171,7 +171,7 @@ styles5.foo satisfies StyleXStyles<{ width?: unknown }>;
 stylex.props(styles5.foo);
 
 /**
- * DYNAMIC NESTED CONDITIONAL STYLES
+ * DYNAMIC CONTEXTUAL STYLES
  */
 const styles6: Readonly<{
   foo: (mobile: number) => Readonly<

--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-call-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-call-test.js
@@ -664,7 +664,7 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
-    describe('with conditional styles and collisions', () => {
+    describe('with contextual styles and collisions', () => {
       test('stylex call with conditions', () => {
         expect(
           transform(

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
@@ -539,7 +539,7 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
-    describe('with conditional styles and collisions', () => {
+    describe('with contextual styles and collisions', () => {
       test('stylex call with conditions', () => {
         expect(
           transform(

--- a/packages/@stylexjs/eslint-plugin/README.md
+++ b/packages/@stylexjs/eslint-plugin/README.md
@@ -134,7 +134,7 @@ using `stylex.defineVars()`.
 This rule flags unused styles created with `stylex.create(...)`. If a style key
 is defined but never used, the rule auto-strips them from the create call.
 
-### `stylex-no-legacy-media-queries`
+### `stylex-no-legacy-conditional-styles`
 
 This rule flags usages of the original media query/pseudo class syntax that
 wraps multiple property values within a single @-rule or pseudo class like this:

--- a/packages/@stylexjs/eslint-plugin/README.md
+++ b/packages/@stylexjs/eslint-plugin/README.md
@@ -134,7 +134,7 @@ using `stylex.defineVars()`.
 This rule flags unused styles created with `stylex.create(...)`. If a style key
 is defined but never used, the rule auto-strips them from the create call.
 
-### `stylex-no-legacy-conditional-styles`
+### `stylex-no-legacy-contextual-styles`
 
 This rule flags usages of the original media query/pseudo class syntax that
 wraps multiple property values within a single @-rule or pseudo class like this:

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-no-legacy-contextual-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-no-legacy-contextual-styles-test.js
@@ -10,7 +10,7 @@
 jest.disableAutomock();
 
 const { RuleTester: ESLintTester } = require('eslint');
-const rule = require('../src/stylex-no-legacy-media-queries');
+const rule = require('../src/stylex-no-legacy-contextual-styles');
 
 const eslintTester = new ESLintTester({
   parser: require.resolve('hermes-eslint'),
@@ -20,7 +20,7 @@ const eslintTester = new ESLintTester({
   },
 });
 
-eslintTester.run('stylex-no-legacy-media-queries', rule.default, {
+eslintTester.run('stylex-no-legacy-contextual-styles', rule.default, {
   valid: [
     {
       code: `

--- a/packages/@stylexjs/eslint-plugin/src/index.js
+++ b/packages/@stylexjs/eslint-plugin/src/index.js
@@ -18,13 +18,13 @@ const rules: {
   'sort-keys': typeof sortKeys,
   'valid-shorthands': typeof validShorthands,
   'no-unused': typeof noUnused,
-  'no-legacy-Contextual-styles': typeof noLegacyContextualStyles,
+  'no-legacy-contextual-styles': typeof noLegacyContextualStyles,
 } = {
   'valid-styles': validStyles,
   'sort-keys': sortKeys,
   'valid-shorthands': validShorthands,
   'no-unused': noUnused,
-  'no-legacy-Contextual-styles': noLegacyContextualStyles,
+  'no-legacy-contextual-styles': noLegacyContextualStyles,
 };
 
 export { rules };

--- a/packages/@stylexjs/eslint-plugin/src/index.js
+++ b/packages/@stylexjs/eslint-plugin/src/index.js
@@ -11,20 +11,20 @@ import validStyles from './stylex-valid-styles';
 import sortKeys from './stylex-sort-keys';
 import validShorthands from './stylex-valid-shorthands';
 import noUnused from './stylex-no-unused';
-import noLegacyMediaQueries from './stylex-no-legacy-media-queries';
+import noLegacyContextualStyles from './stylex-no-legacy-contextual-styles';
 
 const rules: {
   'valid-styles': typeof validStyles,
   'sort-keys': typeof sortKeys,
   'valid-shorthands': typeof validShorthands,
   'no-unused': typeof noUnused,
-  'no-legacy-media-queries': typeof noLegacyMediaQueries,
+  'no-legacy-Contextual-styles': typeof noLegacyContextualStyles,
 } = {
   'valid-styles': validStyles,
   'sort-keys': sortKeys,
   'valid-shorthands': validShorthands,
   'no-unused': noUnused,
-  'no-legacy-media-queries': noLegacyMediaQueries,
+  'no-legacy-Contextual-styles': noLegacyContextualStyles,
 };
 
 export { rules };

--- a/packages/@stylexjs/eslint-plugin/src/stylex-no-legacy-contextual-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-no-legacy-contextual-styles.js
@@ -18,7 +18,7 @@ type Schema = {
   allowLineSeparatedGroups: boolean,
 };
 
-const stylexNoLegacyMediaQueries = {
+const stylexNoLegacyContextualStyles = {
   meta: {
     type: 'suggestion',
     docs: {
@@ -159,4 +159,4 @@ const stylexNoLegacyMediaQueries = {
   },
 };
 
-export default stylexNoLegacyMediaQueries as typeof stylexNoLegacyMediaQueries;
+export default stylexNoLegacyContextualStyles as typeof stylexNoLegacyContextualStyles;

--- a/packages/@stylexjs/stylex/flow-tests/stylex-create.js.flow
+++ b/packages/@stylexjs/stylex/flow-tests/stylex-create.js.flow
@@ -114,7 +114,7 @@ legacyMerge(styles3.foo);
 stylex.props([styles3.foo]);
 
 /**
- * CONDITIONAL STYLES
+ * CONTEXTUAL STYLES
  */
 const styles4: $ReadOnly<{
   foo: $ReadOnly<{
@@ -141,7 +141,7 @@ legacyMerge(styles4.foo);
 stylex.props([styles4.foo]);
 
 /**
- * NESTED CONDITIONAL STYLES
+ * NESTED CONTEXTUAL STYLES
  */
 const styles5: $ReadOnly<{
   foo: $ReadOnly<{
@@ -171,7 +171,7 @@ legacyMerge(styles5.foo);
 stylex.props([styles5.foo]);
 
 /**
- * DYNAMIC NESTED CONDITIONAL STYLES
+ * DYNAMIC CONTEXTUAL STYLES
  */
 const styles6: $ReadOnly<{
   foo: (number) => $ReadOnly<

--- a/packages/docs/blog/2025-04-10-Release-v0.12.0.mdx
+++ b/packages/docs/blog/2025-04-10-Release-v0.12.0.mdx
@@ -26,7 +26,7 @@ Compiling `createTheme` calls is now several orders of magnitude faster. This wa
 
 ## ESLint improvements
 
-### New `no-legacy-media-queries` rule
+### New `no-legacy-contextual-styles` rule
 
 A new rule has been added to the StyleX ESLint plugin to flag uses of the deprecated media query and pseudo-class syntax. This rule flags usage of the legacy media query and pseudo-class syntax that wraps multiple property values inside a single `@`-rule or pseudo-class block. This pattern is deprecated and should be replaced with the updated syntax [here](https://stylexjs.com/docs/learn/styling-ui/defining-styles/#media-queries-and-other--rules). (Thanks [vincentriemer](https://github.com/vincentriemer)!)
 

--- a/packages/docs/docs/learn/04-styling-ui/01-defining-styles.mdx
+++ b/packages/docs/docs/learn/04-styling-ui/01-defining-styles.mdx
@@ -166,7 +166,7 @@ const styles = stylex.create({
 
 :::info
 
-The `default` case is required when authoring conditional styles. If you don't
+The `default` case is required when authoring contextual styles. If you don't
 want any style to be applied in the default case, you can use `null` as the
 value.
 

--- a/packages/docs/docs/learn/06-recipes/03-descendant styles.mdx
+++ b/packages/docs/docs/learn/06-recipes/03-descendant styles.mdx
@@ -8,7 +8,7 @@ sidebar_position: 3
 
 # Variables for descendant styles
 
-It is not uncommon to define styles on an element that are dependent on a parent element's state, 
+It is not uncommon to define styles on an element that are dependent on a parent element's state,
 such as applying some styles conditionally when the parent element is hovered.
 
 StyleX doesn't allow arbitrary selectors or "styling at a distance". However, variables can be
@@ -16,7 +16,7 @@ used to achieve the same results in a safe and composable way.
 
 ## Example: Sidebar
 
-Consider the case where the content within a sidebar needs to have conditional styles applied
+Consider the case where the content within a sidebar needs to have contextual styles applied
 when the sidebar as whole is hovered.
 
 Using CSS variables, you can style descendants based on a parent's state, such as `:hover`.
@@ -36,7 +36,7 @@ export const vars = stylex.defineVars({
 
 ### Step 2
 
-Define conditional styles setting the value for the variable in the ancestor component.
+Define contextual styles setting the value for the variable in the ancestor component.
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';


### PR DESCRIPTION
Defining new term 'contextual styles' for nested conditions like pseudoclasses and at-rules

```
import * as stylex from '@stylexjs/stylex';

const styles = stylex.create({
  base: {
    width: {
      default: 800,
      '@media (max-width: 800px)': '100%',
      '@media (min-width: 1540px)': 1366,
    },
  },
});
```

and a small naming tweak to `no-legacy-media-queries` linter since this rule captures both media queries and pseudo classes