### PR TITLE
Remove addSpecificityLevel

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -463,10 +463,12 @@ function processStylexRules(
           let ltrRule = ltr,
             rtlRule = rtl;
 
+          /*
           if (!useLayers) {
             ltrRule = addSpecificityLevel(ltrRule, index);
             rtlRule = rtlRule && addSpecificityLevel(rtlRule, index);
           }
+          */
 
           return rtlRule
             ? [


### PR DESCRIPTION
Test impact on CSS bundle size of the addSpecificityLevel hack. Before adds the selectors. After removes them