### PR TITLE
[babel-plugin] Don't auto-enable runtimeInjection option for dev option

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-createTheme-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-createTheme-test.js
@@ -820,10 +820,54 @@ describe('@stylexjs/babel-plugin', () => {
     });
 
     describe('options `dev:true`', () => {
-      test('adds style injection', () => {
+      test('adds dev data', () => {
         const options = {
           dev: true,
           filename: '/html/js/components/Foo.react.js',
+        };
+        const fixture = createFixture(`
+          export const theme = stylex.createTheme(vars, {
+            color: 'orange'
+          });
+        `);
+        const { code, metadata } = transform(fixture, options);
+
+        expect(code).toMatchInlineSnapshot(`
+          "import * as stylex from '@stylexjs/stylex';
+          export const vars = {
+            color: "var(--xwx8imx)",
+            otherColor: "var(--xaaua2w)",
+            radius: "var(--xbbre8)",
+            __themeName__: "xop34xu"
+          };
+          export const theme = {
+            Foo__theme: "Foo__theme",
+            $$css: true,
+            xop34xu: "xowvtgn xop34xu"
+          };"
+        `);
+        expect(metadata).toMatchInlineSnapshot(`
+          {
+            "stylex": [
+              [
+                "xowvtgn",
+                {
+                  "ltr": ".xowvtgn, .xowvtgn:root{--xwx8imx:orange;}",
+                  "rtl": null,
+                },
+                0.5,
+              ],
+            ],
+          }
+        `);
+      });
+    });
+
+    describe('options `runtimeInjection:true`', () => {
+      test('adds style injection', () => {
+        const options = {
+          filename: '/html/js/components/Foo.react.js',
+          runtimeInjection: true,
         };
         const fixture = createFixture(`
           export const theme = stylex.createTheme(vars, {
@@ -844,7 +888,6 @@ describe('@stylexjs/babel-plugin', () => {
           };
           _inject2(".xowvtgn, .xowvtgn:root{--xwx8imx:orange;}", 0.5);
           export const theme = {
-            Foo__theme: "Foo__theme",
             $$css: true,
             xop34xu: "xowvtgn xop34xu"
           };"

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineVars-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineVars-test.js
@@ -743,10 +743,7 @@ describe('@stylexjs/babel-plugin', () => {
         );
 
         expect(code).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import * as stylex from '@stylexjs/stylex';
-          _inject2(":root, .xop34xu{--color-xwx8imx:red;--nextColor-xk6xtqk:green;--otherColor-xaaua2w:blue;}", 0);
+          "import * as stylex from '@stylexjs/stylex';
           export const vars = {
             color: "var(--color-xwx8imx)",
             nextColor: "var(--nextColor-xk6xtqk)",
@@ -772,10 +769,55 @@ describe('@stylexjs/babel-plugin', () => {
       });
     });
 
+    describe('options `runtimeInjection:true`', () => {
+      test('tokens object', () => {
+        const options = { runtimeInjection: true };
+        const { code, metadata } = transform(
+          `
+          import * as stylex from '@stylexjs/stylex';
+          export const vars = stylex.defineVars({
+            color: 'red',
+            nextColor: 'green',
+            otherColor: 'blue'
+          });
+        `,
+          options,
+        );
+
+        expect(code).toMatchInlineSnapshot(`
+          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+          var _inject2 = _inject;
+          import * as stylex from '@stylexjs/stylex';
+          _inject2(":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}", 0);
+          export const vars = {
+            color: "var(--xwx8imx)",
+            nextColor: "var(--xk6xtqk)",
+            otherColor: "var(--xaaua2w)",
+            __themeName__: "xop34xu"
+          };"
+        `);
+
+        expect(metadata).toMatchInlineSnapshot(`
+          {
+            "stylex": [
+              [
+                "xop34xu",
+                {
+                  "ltr": ":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}",
+                  "rtl": null,
+                },
+                0,
+              ],
+            ],
+          }
+        `);
+      });
+    });
+
     describe('options `themeFileExtension`', () => {
       test('processes tokens in files with configured extension', () => {
         const options = {
-          dev: true,
+          debug: true,
           filename: '/stylex/packages/src/vars/default.cssvars.js',
           unstable_moduleResolution: {
             rootDir: '/stylex/packages/',
@@ -794,10 +836,7 @@ describe('@stylexjs/babel-plugin', () => {
         );
 
         expect(code).toMatchInlineSnapshot(`
-          "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-          var _inject2 = _inject;
-          import * as stylex from '@stylexjs/stylex';
-          _inject2(":root, .x1bxutiz{--color-x1lzcbr1:red;}", 0);
+          "import * as stylex from '@stylexjs/stylex';
           export const vars = {
             color: "var(--color-x1lzcbr1)",
             __themeName__: "x1bxutiz"

--- a/packages/@stylexjs/babel-plugin/src/utils/__tests__/state-manager-test.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/__tests__/state-manager-test.js
@@ -130,10 +130,6 @@ describe('StateManager config parsing', () => {
       expect(stateManager.options.debug).toBe(true);
       // enableDevClassNames is disabled by default in 'dev'
       expect(stateManager.options.enableDevClassNames).toBe(false);
-      // runtimeInjection is enabled by default in 'dev'
-      expect(stateManager.options.runtimeInjection).toBe(
-        '@stylexjs/stylex/lib/stylex-inject',
-      );
       expect(warnings).toEqual([]);
     });
   });

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -228,8 +228,8 @@ export default class StateManager {
     const configRuntimeInjection: StyleXOptions['runtimeInjection'] =
       z.logAndDefault(
         checkRuntimeInjection,
-        options.runtimeInjection ?? dev,
-        dev,
+        options.runtimeInjection ?? false,
+        false,
         'options.runtimeInjection',
       );
 

--- a/packages/@stylexjs/rollup-plugin/__tests__/index-test.js
+++ b/packages/@stylexjs/rollup-plugin/__tests__/index-test.js
@@ -204,10 +204,11 @@ describe('rollup-plugin-stylex', () => {
     `);
   });
 
-  describe('when in dev mode', () => {
+  describe('runtimeInjection:true', () => {
     it('preserves stylex.inject calls and does not extract CSS', async () => {
       const { css, js } = await runStylex({
-        dev: true,
+        debug: true,
+        runtimeInjection: true,
       });
 
       expect(css).toBeUndefined();

--- a/packages/@stylexjs/rollup-plugin/src/index.js
+++ b/packages/@stylexjs/rollup-plugin/src/index.js
@@ -175,7 +175,7 @@ export default function stylexPlugin({
       }
 
       if (
-        !dev &&
+        !options.runtimeInjection &&
         (metadata as $FlowFixMe).stylex != null &&
         (metadata as $FlowFixMe).stylex.length > 0
       ) {

--- a/packages/docs/docs/api/configuration/babel-plugin.mdx
+++ b/packages/docs/docs/api/configuration/babel-plugin.mdx
@@ -66,7 +66,7 @@ Used for setting up custom module aliases.
 ### `runtimeInjection`
 
 ```ts
-runtimeInjection: boolean // Default: the value of `dev`
+runtimeInjection: boolean // Default: false
 ```
 
 Should StyleX generate code to inject styles at runtime?


### PR DESCRIPTION
We want to discourage use of runtimeInjection in all scenarios, and will no longer enable it by default when 'dev' is true.
