### PR TITLE
[postcss-plugin] Implement custom importSources for React Strict DOM compatibility

### DIFF
--- a/packages/@stylexjs/postcss-plugin/README.md
+++ b/packages/@stylexjs/postcss-plugin/README.md
@@ -135,3 +135,14 @@ useCSSLayers: boolean; // Default: false
 
 Enabling this option switches Stylex from using `:not(#\#)` to using `@layers`
 for handling CSS specificity.
+
+---
+
+### importSources
+
+```js
+importSources: Array<string | { from: string, as: string }>; // Default: ['@stylexjs/stylex', 'stylex']
+```
+
+Possible strings where you can import stylex from. Files that do not match the
+import sources may be skipped from being processed to speed up compilation.

--- a/packages/@stylexjs/postcss-plugin/src/builder.js
+++ b/packages/@stylexjs/postcss-plugin/src/builder.js
@@ -104,7 +104,8 @@ function createBuilder() {
 
   // Transforms the included files, bundles the CSS, and returns the result.
   async function build({ shouldSkipTransformError }) {
-    const { cwd, babelConfig, useCSSLayers, isDev } = getConfig();
+    const { cwd, babelConfig, useCSSLayers, importSources, isDev } =
+      getConfig();
 
     const files = getFiles();
     const filesToTransform = [];
@@ -140,7 +141,7 @@ function createBuilder() {
       filesToTransform.map((file) => {
         const filePath = path.resolve(cwd, file);
         const contents = fs.readFileSync(filePath, 'utf-8');
-        if (!bundler.shouldTransform(contents)) {
+        if (!bundler.shouldTransform(contents, { importSources })) {
           return;
         }
         return bundler.transform(filePath, contents, babelConfig, {

--- a/packages/@stylexjs/postcss-plugin/src/bundler.js
+++ b/packages/@stylexjs/postcss-plugin/src/bundler.js
@@ -13,8 +13,15 @@ module.exports = function createBundler() {
   const styleXRulesMap = new Map();
 
   // Determines if the source code should be transformed based on the presence of StyleX imports.
-  function shouldTransform(sourceCode) {
-    return sourceCode.includes('stylex');
+  function shouldTransform(sourceCode, options) {
+    const { importSources } = options;
+
+    return importSources.some((importSource) => {
+      if (typeof importSource === 'string') {
+        return sourceCode.includes(importSource);
+      }
+      return importSource.includes(sourceCode.from);
+    });
   }
 
   // Transforms the source code using Babel, extracting StyleX rules and storing them.
@@ -25,6 +32,7 @@ module.exports = function createBundler() {
         filename: id,
         caller: {
           name: '@stylexjs/postcss-plugin',
+          platform: 'web',
           isDev,
         },
         ...babelConfig,

--- a/packages/@stylexjs/postcss-plugin/src/index.js
+++ b/packages/@stylexjs/postcss-plugin/src/index.js
@@ -22,6 +22,7 @@ const plugin = ({
   include,
   exclude,
   useCSSLayers = false,
+  importSources = ['@stylexjs/stylex', 'stylex'],
 }) => {
   exclude = [
     // Exclude type declaration files by default because it never contains any CSS rules.
@@ -49,6 +50,7 @@ const plugin = ({
           cwd,
           babelConfig,
           useCSSLayers,
+          importSources,
           isDev,
         });
 

--- a/packages/docs/docs/api/configuration/postcss-plugin.mdx
+++ b/packages/docs/docs/api/configuration/postcss-plugin.mdx
@@ -41,6 +41,17 @@ Array of paths or glob patterns to exclude from compilation. Paths in `exclude` 
 
 ---
 
+## importSources
+
+```js
+importSources: Array<string | { from: string, as: string }>; // Default: ['@stylexjs/stylex', 'stylex']
+```
+
+Possible strings where you can import stylex from. Files that do not match the
+import sources may be skipped from being processed to speed up compilation.
+
+---
+
 ### include
 
 ```js


### PR DESCRIPTION
## What changed / motivation ?

This PR adds `importSources` option to be configurable in order to allow reusing the plugin for react-strict-dom, and sets `platform: "web"` as babel.caller as required by RSD babel preset.

react-strict-dom currently relies on a community-maintained package [postcss-react-strict-dom](https://github.com/javascripter/postcss-react-strict-dom) that I maintain to extract styles statically.

I'm intending to upstream the PostCSS plugin to RSD but [the initial attempt](https://github.com/facebook/react-strict-dom/pull/282) required forking the plugin instead of simply re-exporting the plugin with pre-defined config because `shouldTransform()` function currently  skips files that do not match `stylex`. This leads to additional maintenance burden and is not ideal.

By allowing `importSources` to be configurable, RSD users can now use this plugin with the following config:

```js
module.exports = {
  plugins: {
    '@stylexjs/postcss-plugin': {
      include: [
        require.resolve('react-strict-dom'),
        // Include source files to watch for style changes
        'src/**/*.{js,jsx,mjs,ts,tsx}',
      ],
      importSources: ['stylex', 'react-strict-dom']
  }
}
```

After this PR gets merged, on RSD side we can create `react-strict-dom/postcss-plugin` that re-exports `@stylexjs/postcss-plugin` so that additional config remains implementation detail for the user.

This strategy seems to be aligned with [the strategy necolas is considering for RSD's eslint plugin](https://github.com/facebook/react-strict-dom/discussions/304#discussioncomment-13093083) as well.

## Linked PR/Issues

https://github.com/facebook/react-strict-dom/issues/281#issuecomment-2712591645
https://github.com/facebook/react-strict-dom/pull/282

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->
I checked this PR makes the plugin compatible with RSD by:

1. Install the plugin from this branch to the examples:
```bash
cd react-strict-dom/apps/examples
npm add "file:///PATH_TO_REPO/stylex/packages/@stylexjs/postcss-plugin"
```

Then, modify `postcss.config.js` to use this plugin:
```js
module.exports = {
  plugins: {
    '@stylexjs/postcss-plugin': {
      include: [
        require.resolve('react-strict-dom'),
        'src/**/*.{js,jsx,mjs,ts,tsx}'
      ],
      impotSources: ['stylex', 'react-strict-dom']
    },
    autoprefixer: {}
  }
};
```

The example now renders correctly using the official `@stylexjs/postcss-plugin`:
```bash
npm run dev:web
```

<img width="1213" alt="Screenshot 2025-05-17 at 1 20 17" src="https://github.com/user-attachments/assets/0ad9621f-b46d-48b0-b906-a8bbbcaa435b" />


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code