### PR TITLE
[postcss-plugin] Add @layer and polyfill support via @csstools/postcss-cascade-layers

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -128,15 +128,15 @@ describe('@stylexjs/babel-plugin', () => {
       expect(stylexPlugin.processStylexRules(metadata)).toMatchInlineSnapshot(`
         "@keyframes x4ssjuf-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange);}}
         @keyframes x4ssjuf-B{0%{box-shadow:-1px 2px 3px 4px red;color:yellow;}100%{box-shadow:-10px 20px 30px 40px green;color:var(--orange);}}
-        .x1bg2uv5:not(#\\#){border-color:green}
-        .xdmqw5o:not(#\\#):not(#\\#){animation-name:x4ssjuf-B}
-        .xrkmrrc:not(#\\#):not(#\\#){background-color:red}
-        html:not([dir='rtl']) .x1skrh0i:not(#\\#):not(#\\#){text-shadow:1px 2px 3px 4px red}
-        html[dir='rtl'] .x1skrh0i:not(#\\#):not(#\\#){text-shadow:-1px 2px 3px 4px red}
-        @media (min-width:320px){html:not([dir='rtl']) .x1cmij7u.x1cmij7u:not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}
-        @media (min-width:320px){html[dir='rtl'] .x1cmij7u.x1cmij7u:not(#\\#):not(#\\#){text-shadow:-10px 20px 30px 40px green}}
-        @media (max-width: 1000px){.x1l0eizu.x1l0eizu:not(#\\#):not(#\\#):not(#\\#){border-color:blue}}
-        @media (max-width: 500px){@media (max-width: 1000px){.x5i7zo.x5i7zo.x5i7zo:not(#\\#):not(#\\#):not(#\\#):not(#\\#){border-color:yellow}}}"
+        .x1bg2uv5{border-color:green}
+        .xdmqw5o{animation-name:x4ssjuf-B}
+        .xrkmrrc{background-color:red}
+        html:not([dir='rtl']) .x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        html[dir='rtl'] .x1skrh0i{text-shadow:-1px 2px 3px 4px red}
+        @media (min-width:320px){html:not([dir='rtl']) .x1cmij7u.x1cmij7u{text-shadow:10px 20px 30px 40px green}}
+        @media (min-width:320px){html[dir='rtl'] .x1cmij7u.x1cmij7u{text-shadow:-10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1l0eizu.x1l0eizu{border-color:blue}}
+        @media (max-width: 500px){@media (max-width: 1000px){.x5i7zo.x5i7zo.x5i7zo{border-color:yellow}}}"
       `);
     });
 

--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -460,13 +460,8 @@ function processStylexRules(
         new Map(group.map(([a, b]) => [a, b])).values(),
       )
         .flatMap(({ ltr, rtl }) => {
-          let ltrRule = ltr,
+          const ltrRule = ltr,
             rtlRule = rtl;
-
-          if (!useLayers) {
-            ltrRule = addSpecificityLevel(ltrRule, index);
-            rtlRule = rtlRule && addSpecificityLevel(rtlRule, index);
-          }
 
           return rtlRule
             ? [
@@ -514,22 +509,6 @@ function addAncestorSelector(
 /**
  * Adds :not(#\#) to bump up specificity. as a polyfill for @layer
  */
-function addSpecificityLevel(selector: string, index: number): string {
-  if (selector.startsWith('@keyframes')) {
-    return selector;
-  }
-  const pseudo = Array.from({ length: index })
-    .map(() => ':not(#\\#)')
-    .join('');
-
-  const lastOpenCurly = selector.includes('::')
-    ? selector.indexOf('::')
-    : selector.lastIndexOf('{');
-  const beforeCurly = selector.slice(0, lastOpenCurly);
-  const afterCurly = selector.slice(lastOpenCurly);
-
-  return `${beforeCurly}${pseudo}${afterCurly}`;
-}
 
 export type StyleXTransformObj = $ReadOnly<{
   (): PluginObj<>,

--- a/packages/@stylexjs/cli/src/config.js
+++ b/packages/@stylexjs/cli/src/config.js
@@ -23,7 +23,7 @@ export type CliConfig = {
   babelPluginsPre?: $ReadOnlyArray<any>,
   babelPluginsPost?: $ReadOnlyArray<any>,
   modules_EXPERIMENTAL: $ReadOnlyArray<ModuleType>,
-  useCSSLayers?: boolean,
+  useCSSLayers?: 'none' | 'native' | 'polyfill',
   styleXConfig?: StyleXOptions,
 };
 

--- a/packages/@stylexjs/cli/src/index.js
+++ b/packages/@stylexjs/cli/src/index.js
@@ -71,7 +71,7 @@ const modules_EXPERIMENTAL: $ReadOnlyArray<ModuleType> =
 const babelPresets: $ReadOnlyArray<any> = args.babelPresets;
 const babelPluginsPre: $ReadOnlyArray<any> = args.babelPluginsPre;
 const babelPluginsPost: $ReadOnlyArray<any> = args.babelPluginsPost;
-const useCSSLayers: boolean = args.useCSSLayers;
+const useCSSLayers: 'none' | 'native' | 'polyfill' = args.useCSSLayers;
 const styleXConfig: StyleXOptions = (config.styleXConfig as $FlowFixMe) ?? {};
 
 const cliArgsConfig: CliConfig = {

--- a/packages/@stylexjs/cli/src/options.js
+++ b/packages/@stylexjs/cli/src/options.js
@@ -35,8 +35,8 @@ const options = {
   useCSSLayers: {
     alias: 'l',
     describe: 'Use CSS layers to optimize CSS rendering',
-    type: 'boolean',
-    default: false,
+    type: 'string',
+    default: 'none',
   },
   babelPresets: {
     describe:

--- a/packages/@stylexjs/cli/src/transform.js
+++ b/packages/@stylexjs/cli/src/transform.js
@@ -81,7 +81,7 @@ export async function compileDirectory(
 
   const compiledCSS = await styleXPlugin.processStylexRules(
     Array.from(config.state.styleXRules.values()).flat(),
-    config.useCSSLayers,
+    config.useCSSLayers !== 'none',
   );
 
   const cssBundlePath = path.join(config.output, config.styleXBundleName);

--- a/packages/@stylexjs/postcss-plugin/README.md
+++ b/packages/@stylexjs/postcss-plugin/README.md
@@ -130,8 +130,13 @@ and specify desired options. Refer to
 ### useCSSLayers
 
 ```js
-useCSSLayers: boolean; // Default: false
+useCSSLayers: 'none' | 'native' | 'polyfill'; // Default: 'none'
 ```
 
-Enabling this option switches Stylex from using `:not(#\#)` to using `@layers`
-for handling CSS specificity.
+The `useCSSLayers` option controls how StyleX handles CSS specificity and layer
+management. It supports three strategies:
+
+- `'none'` (default): Uses `:not(#\#)` to handle CSS specificity without layers
+- `'native'`: Uses native CSS `@layer` for handling CSS specificity
+- `'polyfill'`: Uses `@csstools/postcss-cascade-layers` to polyfill CSS layers
+  for browsers that don't support them

--- a/packages/@stylexjs/postcss-plugin/__tests__/__fixtures__/constants.stylex.js
+++ b/packages/@stylexjs/postcss-plugin/__tests__/__fixtures__/constants.stylex.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import * as stylex from '@stylexjs/stylex';
+
+export const styles = stylex.create({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: '100vh',
+    paddingTop: '32px',
+    paddingBottom: '32px',
+  },
+  main: {
+    fontSize: '24px',
+    lineHeight: 1,
+    fontFamily: 'sans-serif',
+    fontWeight: 400,
+    textAlign: 'center',
+    display: 'flex',
+    gap: '16px',
+    whiteSpace: 'nowrap',
+    flexDirection: 'row',
+  },
+  h1: {
+    fontWeight: 700,
+    fontFamily: 'monospace',
+  },
+});

--- a/packages/@stylexjs/postcss-plugin/__tests__/transform-postcss-polyfill-test.js
+++ b/packages/@stylexjs/postcss-plugin/__tests__/transform-postcss-polyfill-test.js
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+jest.autoMockOff();
+
+const path = require('path');
+const postcss = require('postcss');
+const stylexPlugin = require('../src/index');
+
+describe('@stylexjs/postcss-plugin', () => {
+  test('should transform @stylex at-rule and apply cascadeLayers polyfill', async () => {
+    const inputCss = `
+      @stylex;
+    `;
+
+    const pluginOptions = {
+      cwd: path.resolve(__dirname, '__fixtures__'),
+      include: ['constants.stylex.js'],
+      useCSSLayers: 'polyfill',
+      babelConfig: {
+        presets: ['@babel/preset-env'],
+        plugins: ['@stylexjs/babel-plugin'],
+      },
+    };
+
+    const result = await postcss([stylexPlugin(pluginOptions)]).process(
+      inputCss,
+      { from: undefined },
+    );
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "
+      .xou54vl{gap:16px}
+      .x6s0dn4:not(#\\#){align-items:center}
+      .x78zum5:not(#\\#){display:flex}
+      .xdt5ytf:not(#\\#){flex-direction:column}
+      .x1q0g3np:not(#\\#){flex-direction:row}
+      .x1ey7xld:not(#\\#){font-family:monospace}
+      .x6icuqf:not(#\\#){font-family:sans-serif}
+      .x1pvqxga:not(#\\#){font-size:24px}
+      .xo1l8bm:not(#\\#){font-weight:400}
+      .x1xlr1w8:not(#\\#){font-weight:700}
+      .x1qughib:not(#\\#){justify-content:space-between}
+      .xo5v014:not(#\\#){line-height:1}
+      .x2b8uid:not(#\\#){text-align:center}
+      .xuxw1ft:not(#\\#){white-space:nowrap}
+      .xg6iff7:not(#\\#):not(#\\#){min-height:100vh}
+      .x1gan7if:not(#\\#):not(#\\#){padding-bottom:32px}
+      .x1miatn0:not(#\\#):not(#\\#){padding-top:32px}
+          "
+    `);
+  });
+  test('should handle useCSSLayers: none', async () => {
+    const inputCss = `
+      @stylex;
+    `;
+
+    const pluginOptions = {
+      cwd: path.resolve(__dirname, '__fixtures__'),
+      include: ['constants.stylex.js'],
+      useCSSLayers: 'none',
+      babelConfig: {
+        presets: ['@babel/preset-env'],
+        plugins: ['@stylexjs/babel-plugin'],
+      },
+    };
+
+    const result = await postcss([stylexPlugin(pluginOptions)]).process(
+      inputCss,
+      { from: undefined },
+    );
+
+    expect(result.css).toMatchInlineSnapshot(`
+      ".xou54vl{gap:16px}
+      .x6s0dn4{align-items:center}
+      .x78zum5{display:flex}
+      .xdt5ytf{flex-direction:column}
+      .x1q0g3np{flex-direction:row}
+      .x1ey7xld{font-family:monospace}
+      .x6icuqf{font-family:sans-serif}
+      .x1pvqxga{font-size:24px}
+      .xo1l8bm{font-weight:400}
+      .x1xlr1w8{font-weight:700}
+      .x1qughib{justify-content:space-between}
+      .xo5v014{line-height:1}
+      .x2b8uid{text-align:center}
+      .xuxw1ft{white-space:nowrap}
+      .xg6iff7{min-height:100vh}
+      .x1gan7if{padding-bottom:32px}
+      .x1miatn0{padding-top:32px}
+          "
+    `);
+  });
+  test('should handle useCSSLayers: none', async () => {
+    const inputCss = `
+      @stylex;
+    `;
+
+    const pluginOptions = {
+      cwd: path.resolve(__dirname, '__fixtures__'),
+      include: ['constants.stylex.js'],
+      useCSSLayers: 'native',
+      babelConfig: {
+        presets: ['@babel/preset-env'],
+        plugins: ['@stylexjs/babel-plugin'],
+      },
+    };
+
+    const result = await postcss([stylexPlugin(pluginOptions)]).process(
+      inputCss,
+      { from: undefined },
+    );
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "
+      @layer priority1, priority2, priority3;
+      @layer priority1{
+      .xou54vl{gap:16px}
+      }
+      @layer priority2{
+      .x6s0dn4{align-items:center}
+      .x78zum5{display:flex}
+      .xdt5ytf{flex-direction:column}
+      .x1q0g3np{flex-direction:row}
+      .x1ey7xld{font-family:monospace}
+      .x6icuqf{font-family:sans-serif}
+      .x1pvqxga{font-size:24px}
+      .xo1l8bm{font-weight:400}
+      .x1xlr1w8{font-weight:700}
+      .x1qughib{justify-content:space-between}
+      .xo5v014{line-height:1}
+      .x2b8uid{text-align:center}
+      .xuxw1ft{white-space:nowrap}
+      }
+      @layer priority3{
+      .xg6iff7{min-height:100vh}
+      .x1gan7if{padding-bottom:32px}
+      .x1miatn0{padding-top:32px}
+      }
+          "
+    `);
+  });
+});

--- a/packages/@stylexjs/postcss-plugin/jest.config.js
+++ b/packages/@stylexjs/postcss-plugin/jest.config.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+module.exports = {
+  collectCoverageFrom: ['<rootDir>/src/index.js'],
+  coverageThreshold: {
+    global: {
+      branches: 50,
+      functions: 60,
+      lines: 70,
+      statements: 70,
+    },
+  },
+  testPathIgnorePatterns: ['/__fixtures__/'],
+  verbose: true,
+};

--- a/packages/@stylexjs/postcss-plugin/package.json
+++ b/packages/@stylexjs/postcss-plugin/package.json
@@ -15,5 +15,8 @@
     "fast-glob": "^3.3.2",
     "glob-parent": "^6.0.2",
     "is-glob": "^4.0.3"
+  },
+  "devDependencies": {
+    "@csstools/postcss-cascade-layers": "^5.0.1"
   }
 }

--- a/packages/@stylexjs/postcss-plugin/package.json
+++ b/packages/@stylexjs/postcss-plugin/package.json
@@ -11,12 +11,10 @@
   "dependencies": {
     "@babel/core": "^7.26.8",
     "@stylexjs/babel-plugin": "0.12.0",
+    "@csstools/postcss-cascade-layers": "^5.0.1",
     "postcss": "^8.4.49",
     "fast-glob": "^3.3.2",
     "glob-parent": "^6.0.2",
     "is-glob": "^4.0.3"
-  },
-  "devDependencies": {
-    "@csstools/postcss-cascade-layers": "^5.0.1"
   }
 }

--- a/packages/@stylexjs/postcss-plugin/src/builder.js
+++ b/packages/@stylexjs/postcss-plugin/src/builder.js
@@ -150,7 +150,7 @@ function createBuilder() {
       }),
     );
 
-    const css = bundler.bundle({ useCSSLayers });
+    const css = bundler.bundle({ useCSSLayers: useCSSLayers !== 'none' });
     return css;
   }
 

--- a/packages/@stylexjs/rollup-plugin/README.md
+++ b/packages/@stylexjs/rollup-plugin/README.md
@@ -43,9 +43,16 @@ The name of the output css file.
 ---
 ### useCSSLayers
 ```js
-useCSSLayers: boolean // Default: false
+useCSSLayers: 'none' | 'native' | 'polyfill' // Default: 'none'
 ```
-Enabling this option switches Stylex from using `:not(#\#)` to using `@layers` for handling CSS specificity.
+
+The `useCSSLayers` option controls how StyleX handles CSS specificity and layer
+management. It supports three strategies:
+
+- `'none'` (default): Uses `:not(#\#)` to handle CSS specificity without layers
+- `'native'`: Uses native CSS `@layer` for handling CSS specificity
+- `'polyfill'`: Uses `@csstools/postcss-cascade-layers` to polyfill CSS layers
+  for browsers that don't support them
 
 ---
 ### babelConfig

--- a/packages/@stylexjs/rollup-plugin/__tests__/index-test.js
+++ b/packages/@stylexjs/rollup-plugin/__tests__/index-test.js
@@ -34,7 +34,7 @@ describe('rollup-plugin-stylex', () => {
           exclude: [/npmStyles\.js/],
         }),
         stylexPlugin({
-          useCSSLayers: true,
+          useCSSLayers: 'native',
           ...options,
           lightningcssOptions: { minify: false },
         }),

--- a/packages/@stylexjs/rollup-plugin/src/index.js
+++ b/packages/@stylexjs/rollup-plugin/src/index.js
@@ -37,7 +37,7 @@ export type PluginOptions = $ReadOnly<{
     plugins?: $ReadOnlyArray<PluginItem>,
     presets?: $ReadOnlyArray<PluginItem>,
   }>,
-  useCSSLayers?: boolean,
+  useCSSLayers?: 'none' | 'native' | 'polyfill',
   lightningcssOptions?: Omit<
     TransformOptions<{}>,
     'code' | 'filename' | 'visitor',
@@ -63,7 +63,7 @@ export default function stylexPlugin({
   fileName = 'stylex.css',
   babelConfig: { plugins = [], presets = [] } = {},
   importSources = ['stylex', '@stylexjs/stylex'],
-  useCSSLayers = false,
+  useCSSLayers = 'none',
   lightningcssOptions,
   ...options
 }: PluginOptions = {}): Plugin<> {
@@ -78,7 +78,7 @@ export default function stylexPlugin({
       if (rules.length > 0) {
         const collectedCSS = stylexBabelPlugin.processStylexRules(
           rules,
-          useCSSLayers,
+          useCSSLayers !== 'none',
         );
 
         // Process the CSS using lightningcss

--- a/packages/docs/components/playground-utils/files.js
+++ b/packages/docs/components/playground-utils/files.js
@@ -101,7 +101,7 @@ module.exports = {
   plugins: {
     '@stylexjs/postcss-plugin': {
       include: ['src/**/*.{js,jsx}'],
-      useCSSLayers: true,
+      useCSSLayers: 'native',
       babelConfig,
     },
   },

--- a/packages/docs/docs/api/configuration/postcss-plugin.mdx
+++ b/packages/docs/docs/api/configuration/postcss-plugin.mdx
@@ -54,7 +54,13 @@ Array of paths or glob patterns to compile.
 ### useCSSLayers
 
 ```js
-useCSSLayers: boolean; // Default: false
+useCSSLayers: 'none' | 'native' | 'polyfill'; // Default: 'none'
 ```
 
-Enabling this option switches Stylex from using `:not(#\#)` to using `@layers` for handling CSS specificity.
+The `useCSSLayers` option controls how StyleX handles CSS specificity and layer
+management. It supports three strategies:
+
+- `'none'` (default): Uses `:not(#\#)` to handle CSS specificity without layers
+- `'native'`: Uses native CSS `@layer` for handling CSS specificity
+- `'polyfill'`: Uses `@csstools/postcss-cascade-layers` to polyfill CSS layers
+  for browsers that don't support them

--- a/packages/docs/docs/learn/03-installation.mdx
+++ b/packages/docs/docs/learn/03-installation.mdx
@@ -74,7 +74,7 @@ module.exports = {
         // any other files that should be included
         // this should include NPM dependencies that use StyleX
       ],
-      useCSSLayers: true,
+      useCSSLayers: 'none',
     },
     autoprefixer: {},
   },


### PR DESCRIPTION
## What changed / motivation ?

Previously, useCSSLayers offered limited choices, and its polyfill implementation was handled internally. 
This update replaces the custom polyfill with a well-maintained solution: @csstools/postcss-cascade-layers.

This change allows us to effectively support the following CSS Layer generation scenarios:

Order CSS correctly without @layer or a polyfill
Use native @layer
Polyfill @layer

## Linked PR/Issues

Fixes https://github.com/facebook/stylex/issues/1062

## Additional Context

useCSSLayers Option Refactoring

'none' (default): Handles CSS specificity using :not(#\\#) without relying on @layer or a polyfill.
'native': Utilizes native CSS @layer for specificity control. (This previously corresponded to useCSSLayers: true).
'polyfill': Implements CSS layer polyfilling using @csstools/postcss-cascade-layers. (This previously corresponded to useCSSLayers: false for the custom polyfill).
Example configuration:
```jsx
//postcss.config.js
module.exports = {
  plugins: {
    "@stylexjs/postcss-plugin": {
      include: [
        "./**/*.{js,jsx,ts,tsx}",
        "app/**/*.{js,jsx,ts,tsx}",
        "components/**/*.{js,jsx,ts,tsx}",
      ],
      useCSSLayers: "none",  // "none" | "native" | "polyfill"
    },
    autoprefixer: {},
  },
};
```

Polyfill Implementation Details
The previously self-implemented polyfill logic has been removed:

```jsx
// babal-plugin/src/index.js
if (!useLayers) {
	ltrRule = addSpecificityLevel(ltrRule, index);
	rtlRule = rtlRule && addSpecificityLevel(rtlRule, index);
}
```
The polyfill functionality is now powered by @csstools/postcss-cascade-layers, ensuring a more robust and compliant solution:

```jsx
// postcss-plugin/src/index.js
let processedCss = css;
if (useCSSLayers === 'polyfill') {
  const result = await postcss([
    cascadeLayers({
      onRevertLayerKeyword: 'warn',
      onConditionalRulesChangingLayerOrder: 'warn',
      onImportLayerRule: 'warn',
    }),
  ]).process(css);
  processedCss = result.css;
}
```

Transfile Example
[Testcode](https://github.com/facebook/stylex/compare/main...jeongminsang:stylex:main?expand=1#diff-a80b7764f34f4913554600107b195c7b9dd11fcf9adf590ff7672eb9ccdace53)

This change introduces breaking changes due to the modification of the useCSSLayers option's type and expected values. If backward compatibility is a critical concern, alternative implementation approaches might need to be considered.
How about we rework this, considering the breaking changes?
