### PR TITLE
[stylex] Add types to exports

### DIFF
--- a/packages/@stylexjs/stylex/src/stylex.js
+++ b/packages/@stylexjs/stylex/src/stylex.js
@@ -31,13 +31,19 @@ import type { ValueWithDefault } from './types/StyleXUtils';
 import * as Types from './types/VarTypes';
 
 export type {
+  CompiledStyles,
+  InlineStyles,
+  Keyframes,
+  MapNamespaces,
   StaticStyles,
   StaticStylesWithout,
+  StyleXArray,
   StyleXStyles,
   StyleXStylesWithout,
   Theme,
   Types,
   VarGroup,
+  PositionTry,
 };
 
 import { styleq } from 'styleq';


### PR DESCRIPTION
These types are currently used by React Strict DOM

Needed for https://github.com/facebook/react-strict-dom/pull/311