### PR TITLE
feat: add initial implementation for stylex.viewTransitionClass API

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-import-export-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-import-export-test.js
@@ -54,6 +54,7 @@ const defaultImportMap = {
   keyframes: 'stylex.keyframes',
   positionTry: 'stylex.positionTry',
   props: 'stylex.props',
+  viewTransitionClass: 'stylex.viewTransitionClass',
 };
 
 function createStylesFixture({
@@ -77,6 +78,7 @@ function createStylesFixture({
     keyframes,
     positionTry,
     props,
+    viewTransitionClass,
   } = importMap;
 
   const from = importSource?.from || importSource;
@@ -101,6 +103,20 @@ function createStylesFixture({
 
   return `
     ${defineConstsAndVarsOutput}
+    const viewTransition1 = ${viewTransitionClass}({
+      group: {
+        transitionProperty: 'none',
+      },
+      imagePair: {
+        borderRadius: 16,
+      },
+      old: {
+        animationDuration: '0.5s',
+      },
+      new: {
+        animationTimingFunction: 'ease-out',
+      },
+    });
     const fallback1 = ${positionTry}({
       anchorName: '--myAnchor',
       positionArea: 'top left',
@@ -222,6 +238,7 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
         const fallback2 = "--x17pzx6";
         const styles = {
@@ -243,6 +260,14 @@ describe('@stylexjs/babel-plugin', () => {
       expect(expectedImportTestMetadata).toMatchInlineSnapshot(`
         {
           "stylex": [
+            [
+              "xchu1hv",
+              {
+                "ltr": "::view-transition-group(*.xchu1hv){transition-property:none;}::view-transition-image-pair(*.xchu1hv){border-radius:16px;}::view-transition-old(*.xchu1hv){animation-duration:.5s;}::view-transition-new(*.xchu1hv){animation-timing-function:ease-out;}",
+                "rtl": null,
+              },
+              1,
+            ],
             [
               "--x5jppmd",
               {
@@ -333,6 +358,7 @@ describe('@stylexjs/babel-plugin', () => {
           keyframes: 'foo.keyframes',
           positionTry: 'foo.positionTry',
           props: 'foo.props',
+          viewTransitionClass: 'foo.viewTransitionClass',
         },
       });
 
@@ -347,6 +373,7 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
         const fallback2 = "--x17pzx6";
         const styles = {
@@ -371,7 +398,7 @@ describe('@stylexjs/babel-plugin', () => {
     test('import: named', () => {
       const fixture = createStylesFixture({
         importText:
-          '{create, createTheme, defineConsts, defineVars, firstThatWorks, keyframes, positionTry, props}',
+          '{create, createTheme, defineConsts, defineVars, firstThatWorks, keyframes, positionTry, props, viewTransitionClass}',
         importMap: {
           create: 'create',
           createTheme: 'createTheme',
@@ -381,13 +408,14 @@ describe('@stylexjs/babel-plugin', () => {
           keyframes: 'keyframes',
           positionTry: 'positionTry',
           props: 'props',
+          viewTransitionClass: 'viewTransitionClass',
         },
       });
 
       const { code, metadata } = transform(fixture);
 
       expect(code).toMatchInlineSnapshot(`
-        "import { create, createTheme, defineConsts, defineVars, firstThatWorks, keyframes, positionTry, props } from '@stylexjs/stylex';
+        "import { create, createTheme, defineConsts, defineVars, firstThatWorks, keyframes, positionTry, props, viewTransitionClass } from '@stylexjs/stylex';
         export const constants = {
           mediaQuery: "@media (min-width: 768px)"
         };
@@ -395,6 +423,7 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
         const fallback2 = "--x17pzx6";
         const styles = {
@@ -426,7 +455,8 @@ describe('@stylexjs/babel-plugin', () => {
           firstThatWorks as _firstThatWorks,
           keyframes as _keyframes,
           positionTry as _positionTry,
-          props as _props
+          props as _props,
+          viewTransitionClass as _viewTransitionClass
         }`,
         importMap: {
           create: '_create',
@@ -437,13 +467,14 @@ describe('@stylexjs/babel-plugin', () => {
           keyframes: '_keyframes',
           positionTry: '_positionTry',
           props: '_props',
+          viewTransitionClass: '_viewTransitionClass',
         },
       });
 
       const { code, metadata } = transform(fixture);
 
       expect(code).toMatchInlineSnapshot(`
-        "import { create as _create, createTheme as _createTheme, defineConsts as _defineConsts, defineVars as _defineVars, firstThatWorks as _firstThatWorks, keyframes as _keyframes, positionTry as _positionTry, props as _props } from '@stylexjs/stylex';
+        "import { create as _create, createTheme as _createTheme, defineConsts as _defineConsts, defineVars as _defineVars, firstThatWorks as _firstThatWorks, keyframes as _keyframes, positionTry as _positionTry, props as _props, viewTransitionClass as _viewTransitionClass } from '@stylexjs/stylex';
         export const constants = {
           mediaQuery: "@media (min-width: 768px)"
         };
@@ -451,6 +482,7 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
         const fallback2 = "--x17pzx6";
         const styles = {
@@ -491,6 +523,7 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
         const fallback2 = "--x17pzx6";
         const styles = {
@@ -526,6 +559,7 @@ describe('@stylexjs/babel-plugin', () => {
           keyframes: 'css.keyframes',
           positionTry: 'css.positionTry',
           props: 'css.props',
+          viewTransitionClass: 'css.viewTransitionClass',
         },
       });
 
@@ -543,6 +577,7 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
         const fallback2 = "--x17pzx6";
         const styles = {
@@ -583,6 +618,7 @@ describe('@stylexjs/babel-plugin', () => {
           bar: "var(--x1hi1hmf)",
           __themeName__: "xop34xu"
         };
+        const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
         const fallback2 = "--x17pzx6";
         const styles = {

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-viewTransitionClass-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-viewTransitionClass-test.js
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+jest.autoMockOff();
+
+const stylexPlugin = require('../src/index');
+const { transformSync } = require('@babel/core');
+
+function transform(source, opts = {}) {
+  const { code, metadata } = transformSync(source, {
+    filename: opts.filename,
+    parserOpts: {
+      flow: 'all',
+    },
+    plugins: [[stylexPlugin, { ...opts }]],
+  });
+
+  return { code, metadata };
+}
+
+describe('@stylexjs/babel-plugin', () => {
+  describe('[transform] stylex.viewTransitionClass', () => {
+    test('basic object', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const cls = stylex.viewTransitionClass({
+          group: {
+            transitionProperty: 'none',
+          },
+          imagePair: {
+            borderRadius: 16,
+          },
+          old: {
+            animationDuration: '0.5s',
+          },
+          new: {
+            animationTimingFunction: 'ease-out',
+          },
+        });
+      `);
+
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        export const cls = "xchu1hv";"
+      `);
+
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xchu1hv",
+              {
+                "ltr": "::view-transition-group(*.xchu1hv){transition-property:none;}::view-transition-image-pair(*.xchu1hv){border-radius:16px;}::view-transition-old(*.xchu1hv){animation-duration:.5s;}::view-transition-new(*.xchu1hv){animation-timing-function:ease-out;}",
+                "rtl": null,
+              },
+              1,
+            ],
+          ],
+        }
+      `);
+    });
+    test('local variables used in view transition class', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        const animationDuration = '1s';
+        const cls = stylex.viewTransitionClass({
+          old: { animationDuration },
+          new: { animationDuration },
+          group: { animationDuration },
+          imagePair: { animationDuration },
+        });
+      `);
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        const animationDuration = '1s';
+        const cls = "xtngzpi";"
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xtngzpi",
+              {
+                "ltr": "::view-transition-old(*.xtngzpi){animation-duration:1s;}::view-transition-new(*.xtngzpi){animation-duration:1s;}::view-transition-group(*.xtngzpi){animation-duration:1s;}::view-transition-image-pair(*.xtngzpi){animation-duration:1s;}",
+                "rtl": null,
+              },
+              1,
+            ],
+          ],
+        }
+      `);
+    });
+    test('using keyframes', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        const fadeIn = stylex.keyframes({
+          from: {opacity: 0},
+          to: {opacity: 1},
+        });
+        const fadeOut = stylex.keyframes({
+          from: {opacity: 1},
+          to: {opacity: 0},
+        });
+        const cls = stylex.viewTransitionClass({
+          old: {
+            animationName: fadeOut,
+            animationDuration: '1s',
+          },
+          new: {
+            animationName: fadeIn,
+            animationDuration: '1s',
+          },
+        });
+      `);
+
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        const fadeIn = "x18re5ia-B";
+        const fadeOut = "x1jn504y-B";
+        const cls = "xfh0f9i";"
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x18re5ia-B",
+              {
+                "ltr": "@keyframes x18re5ia-B{from{opacity:0;}to{opacity:1;}}",
+                "rtl": null,
+              },
+              1,
+            ],
+            [
+              "x1jn504y-B",
+              {
+                "ltr": "@keyframes x1jn504y-B{from{opacity:1;}to{opacity:0;}}",
+                "rtl": null,
+              },
+              1,
+            ],
+            [
+              "xfh0f9i",
+              {
+                "ltr": "::view-transition-old(*.xfh0f9i){animation-name:x1jn504y-B;animation-duration:1s;}::view-transition-new(*.xfh0f9i){animation-name:x18re5ia-B;animation-duration:1s;}",
+                "rtl": null,
+              },
+              1,
+            ],
+          ],
+        }
+      `);
+    });
+    test.skip('using contextual styles', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from 'stylex';
+        const cls = stylex.viewTransitionClass({
+          group: {
+            animationDuration: {
+              default: '1s',
+              '@media (min-width: 800px)': '2s'
+            }
+          },
+        });
+      `);
+      expect(code).toMatchInlineSnapshot();
+      expect(metadata).toMatchInlineSnapshot();
+    });
+  });
+});

--- a/packages/@stylexjs/babel-plugin/__tests__/validation-import-export-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/validation-import-export-test.js
@@ -70,5 +70,23 @@ describe('@stylexjs/babel-plugin', () => {
         `);
       }).not.toThrow();
     });
+
+    test('valid import: viewTransitionClass named import', () => {
+      expect(() => {
+        transform(`
+          import { viewTransitionClass } from '@stylexjs/stylex';
+          const transitionCls = viewTransitionClass({});
+        `);
+      }).not.toThrow();
+    });
+
+    test('valid import: viewTransitionClass from namespace import', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          const transitionCls = stylex.viewTransitionClass({});
+        `);
+      }).not.toThrow();
+    });
   });
 });

--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -31,6 +31,7 @@ import transformStylexCall, {
 } from './visitors/stylex-merge';
 import transformStylexProps from './visitors/stylex-props';
 import { skipStylexPropsChildren } from './visitors/stylex-props';
+import transformStyleXViewTransitionClass from './visitors/stylex-view-transition-class';
 
 const NAME = 'stylex';
 
@@ -285,6 +286,13 @@ function styleXTransform(): PluginObj<> {
             // Needs to be handled *before* `stylex.create` as the `create` call
             // may use the generated animation name.
             transformStyleXKeyframes(
+              parentPath as NodePath<t.VariableDeclarator>,
+              state,
+            );
+            // Look for `stylex.viewTransitionClass` calls
+            // Needs to be handled *after* `stylex.keyframes` since the `viewTransitionClass`
+            // call may use the generated animation name.
+            transformStyleXViewTransitionClass(
               parentPath as NodePath<t.VariableDeclarator>,
               state,
             );

--- a/packages/@stylexjs/babel-plugin/src/shared/messages.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/messages.js
@@ -54,3 +54,6 @@ export const UNKNOWN_PROP_KEY = 'Unknown property key';
 
 export const POSITION_TRY_INVALID_PROPERTY =
   'Invalid property in `positionTry()` call. It may only contain, positionAnchor, positionArea, inset properties (top, left, insetInline etc.), margin properties, size properties (height, inlineSize, etc.), and self-alignment properties (alignSelf, justifySelf, placeSelf)';
+
+export const VIEW_TRANSITION_CLASS_INVALID_PROPERTY =
+  'Invalid property in `viewTransitionClass()` call. It may only contain group, imagePair, old, and new properties';

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-view-transition-class.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-view-transition-class.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type { InjectableStyle, StyleXOptions } from './common-types';
+
+import createHash from './hash';
+import flatMapProperties from './preprocess-rules/index';
+import {
+  objFromEntries,
+  objEntries,
+  objMapKeys,
+  objMap,
+  Pipe,
+} from './utils/object-utils';
+import { defaultOptions } from './utils/default-options';
+import transformValue from './utils/transform-value';
+import dashify from './utils/dashify';
+
+type StyleValue = { +[string]: string | number };
+type StyleObj = {
+  group?: StyleValue,
+  imagePair?: StyleValue,
+  old?: StyleValue,
+  new?: StyleValue,
+};
+
+export default function styleXViewTransitionClass(
+  styles: StyleObj,
+  options: StyleXOptions = defaultOptions,
+): [string, InjectableStyle] {
+  const { classNamePrefix = 'x' } = options;
+  const preprocessedObject = objMap(styles, (style) =>
+    Pipe.create(style)
+      .pipe((style) => preprocessProperties(style, options))
+      .pipe((x) => objMapKeys(x, dashify))
+      .pipe((x) =>
+        objMap(x, (value, key) => transformValue(key, value, options)),
+      )
+      .done(),
+  );
+
+  const expandedObject = objMapKeys(
+    preprocessedObject,
+    (k) => `::view-transition-${dashify(k)}`,
+  );
+
+  const styleStrings = objMap(
+    expandedObject,
+    constructViewTransitionClassStyleStr,
+  );
+
+  const viewTransitionClassName =
+    classNamePrefix +
+    createHash(constructViewTransitionClassStyleStr(styleStrings));
+
+  const style = constructFinalViewTransitionCSSStr(
+    styleStrings,
+    viewTransitionClassName,
+  );
+
+  return [viewTransitionClassName, { ltr: style, rtl: null, priority: 1 }];
+}
+
+function preprocessProperties(
+  styles: { +[key: string]: string | number },
+  options: StyleXOptions,
+): {
+  +[key: string]: string | number,
+} {
+  return objFromEntries(
+    objEntries(styles)
+      .flatMap((pair): $ReadOnlyArray<[string, string | number]> =>
+        flatMapProperties(pair, options)
+          .map(([key, value]) => {
+            if (typeof value === 'string' || typeof value === 'number') {
+              return [key, value];
+            }
+            return null;
+          })
+          .filter(Boolean),
+      )
+      .filter(([_key, value]) => value != null),
+  );
+}
+
+function constructViewTransitionClassStyleStr(style: {
+  +[string]: string,
+}): string {
+  return objEntries(style)
+    .map(([k, v]) => `${k}:${v};`)
+    .join('');
+}
+
+function constructFinalViewTransitionCSSStr(
+  styles: { +[string]: string },
+  className: string,
+): string {
+  return objEntries(styles)
+    .map(([k, v]) => `${k}(*.${className}){${v}}`)
+    .join('');
+}

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -133,6 +133,7 @@ export default class StateManager {
   +stylexDefineConstsImport: Set<string> = new Set();
   +stylexCreateThemeImport: Set<string> = new Set();
   +stylexTypesImport: Set<string> = new Set();
+  +stylexViewTransitionClassImport: Set<string> = new Set();
 
   injectImportInserted: ?t.Identifier = null;
 

--- a/packages/@stylexjs/babel-plugin/src/visitors/imports.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/imports.js
@@ -67,6 +67,9 @@ export function readImportDeclarations(
             if (importedName === 'positionTry') {
               state.stylexPositionTryImport.add(localName);
             }
+            if (importedName === 'viewTransitionClass') {
+              state.stylexViewTransitionClassImport.add(localName);
+            }
             if (importedName === 'include') {
               state.stylexIncludeImport.add(localName);
             }
@@ -136,6 +139,9 @@ export function readRequires(
           }
           if (prop.key.name === 'positionTry') {
             state.stylexPositionTryImport.add(value.name);
+          }
+          if (prop.key.name === 'viewTransitionClass') {
+            state.stylexViewTransitionClassImport.add(value.name);
           }
           if (prop.key.name === 'include') {
             state.stylexIncludeImport.add(value.name);

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-view-transition-class.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-view-transition-class.js
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type { NodePath } from '@babel/traverse';
+import type { FunctionConfig } from '../utils/evaluate-path';
+
+import * as t from '@babel/types';
+import StateManager from '../utils/state-manager';
+import * as messages from '../shared/messages';
+import { evaluate } from '../utils/evaluate-path';
+import {
+  firstThatWorks as stylexFirstThatWorks,
+  keyframes as stylexKeyframes,
+} from '../shared';
+import stylexViewTransitionClass from '../shared/stylex-view-transition-class';
+
+/// This function looks for `stylex.viewTransitionClass` calls within variable declarations and transforms them.
+/// 1. It finds the first argument to `stylex.viewTransitionClass` and validates it.
+/// 2. It evaluates the style object to get a JS object. This also handles local constants automatically.
+/// 3. The actual transform is done by `stylexViewTransitionClass` from `../shared`
+/// 4. The results are replaced, and generated CSS rules are injected as needed.
+
+export default function transformStyleXViewTransitionClass(
+  path: NodePath<t.VariableDeclarator>,
+  state: StateManager,
+) {
+  const initPath = path.get('init');
+  if (!initPath.isCallExpression()) {
+    return;
+  }
+
+  const callExpressionPath: NodePath<t.CallExpression> = initPath;
+  const idPath = path.get('id');
+  if (!idPath.isIdentifier()) {
+    return;
+  }
+
+  const nodeInit: t.CallExpression = callExpressionPath.node;
+
+  if (
+    (nodeInit.callee.type === 'Identifier' &&
+      state.stylexViewTransitionClassImport.has(nodeInit.callee.name)) ||
+    (nodeInit.callee.type === 'MemberExpression' &&
+      nodeInit.callee.object.type === 'Identifier' &&
+      nodeInit.callee.property.name === 'viewTransitionClass' &&
+      nodeInit.callee.property.type === 'Identifier' &&
+      state.stylexImport.has(nodeInit.callee.object.name))
+  ) {
+    const init: ?NodePath<t.Expression> = path.get('init');
+    if (init == null || !init.isCallExpression()) {
+      throw path.buildCodeFrameError(
+        messages.nonStaticValue('viewTransitionClass'),
+        SyntaxError,
+      );
+    }
+    if (nodeInit.arguments.length !== 1) {
+      throw path.buildCodeFrameError(
+        messages.illegalArgumentLength('viewTransitionClass', 1),
+        SyntaxError,
+      );
+    }
+    const args: $ReadOnlyArray<NodePath<>> = init.get('arguments');
+    const firstArgPath = args[0];
+
+    const identifiers: FunctionConfig['identifiers'] = {};
+    const memberExpressions: FunctionConfig['memberExpressions'] = {};
+    state.stylexFirstThatWorksImport.forEach((name) => {
+      identifiers[name] = { fn: stylexFirstThatWorks };
+    });
+    state.stylexKeyframesImport.forEach((name) => {
+      identifiers[name] = { fn: stylexKeyframes };
+    });
+    state.stylexImport.forEach((name) => {
+      if (memberExpressions[name] == null) {
+        memberExpressions[name] = {};
+      }
+      memberExpressions[name].firstThatWorks = { fn: stylexFirstThatWorks };
+      memberExpressions[name].keyframes = { fn: stylexKeyframes };
+    });
+
+    const { confident, value } = evaluate(firstArgPath, state, {
+      identifiers,
+      memberExpressions,
+    });
+    if (!confident) {
+      throw callExpressionPath.buildCodeFrameError(
+        messages.nonStaticValue('viewTransitionClass'),
+        SyntaxError,
+      );
+    }
+
+    const plainObject = value;
+    assertValidViewTransitionClass(firstArgPath, plainObject);
+    assertValidProperties(firstArgPath, plainObject);
+
+    const [viewTransitionClassName, { ltr, priority, rtl }] =
+      stylexViewTransitionClass(plainObject, state.options);
+
+    // This should be a string
+    init.replaceWith(t.stringLiteral(viewTransitionClassName));
+
+    state.registerStyles(
+      [[viewTransitionClassName, { ltr, rtl }, priority]],
+      path,
+    );
+  }
+}
+
+// Validation of `stylex.viewTransitionClass` function call
+function assertValidViewTransitionClass(path: NodePath<>, obj: mixed) {
+  if (typeof obj !== 'object' || Array.isArray(obj) || obj == null) {
+    throw path.buildCodeFrameError(
+      messages.nonStyleObject('viewTransitionClass'),
+      SyntaxError,
+    );
+  }
+}
+
+const VALID_VIEW_TRANSITION_CLASS_PROPERTIES = [
+  'group',
+  'imagePair',
+  'old',
+  'new',
+];
+
+function assertValidProperties(path: NodePath<>, obj: Object) {
+  const keys = Object.keys(obj);
+  if (
+    keys.some((key) => !VALID_VIEW_TRANSITION_CLASS_PROPERTIES.includes(key))
+  ) {
+    throw path.buildCodeFrameError(
+      messages.VIEW_TRANSITION_CLASS_INVALID_PROPERTY,
+      SyntaxError,
+    );
+  }
+}

--- a/packages/@stylexjs/stylex/__tests__/inject-test.js
+++ b/packages/@stylexjs/stylex/__tests__/inject-test.js
@@ -24,6 +24,14 @@ describe('inject', () => {
     );
   });
 
+  test('::view-transition', () => {
+    const cssText =
+      '::view-transition-group(*.name){transition-property:none;}::view-transition-image-pair(*.name){border-radius:16px;}::view-transition-old(*.name){animation-duration:.5s;}::view-transition-new(*.name){animation-timing-function:ease-out;}';
+    expect(inject(cssText, 10)).toMatchInlineSnapshot(
+      '"::view-transition-group(*.name){transition-property:none;}::view-transition-image-pair(*.name){border-radius:16px;}::view-transition-old(*.name){animation-duration:.5s;}::view-transition-new(*.name){animation-timing-function:ease-out;}"',
+    );
+  });
+
   test('@media', () => {
     const cssText = '@media (min-width: 320px) { .color { color: red } }';
     expect(inject(cssText, 200)).toMatchInlineSnapshot(

--- a/packages/@stylexjs/stylex/__tests__/stylex-test.js
+++ b/packages/@stylexjs/stylex/__tests__/stylex-test.js
@@ -21,6 +21,7 @@ describe('stylex', () => {
       'firstThatWorks',
       'keyframes',
       'positionTry',
+      'viewTransitionClass',
     ].forEach((api) => {
       test(`stylex.${api}`, () => {
         expect(() => stylex[api]()).toThrow();

--- a/packages/@stylexjs/stylex/src/stylex.js
+++ b/packages/@stylexjs/stylex/src/stylex.js
@@ -26,6 +26,7 @@ import type {
   Theme,
   VarGroup,
   PositionTry,
+  ViewTransitionClass,
 } from './types/StyleXTypes';
 import type { ValueWithDefault } from './types/StyleXUtils';
 import * as Types from './types/VarTypes';
@@ -120,6 +121,12 @@ export function props(
   return result;
 }
 
+export const viewTransitionClass = (
+  _viewTransitionClass: ViewTransitionClass,
+): string => {
+  throw errorForFn('viewTransitionClass');
+};
+
 export const types = {
   angle: <T: string | 0 = string | 0>(
     _v: ValueWithDefault<T>,
@@ -208,6 +215,7 @@ type IStyleX = {
     'data-style-src'?: string,
     style?: $ReadOnly<{ [string]: string | number }>,
   }>,
+  viewTransitionClass: (viewTransitionClass: ViewTransitionClass) => string,
   types: typeof types,
   __customProperties?: { [string]: mixed },
   ...
@@ -228,5 +236,6 @@ _legacyMerge.keyframes = keyframes;
 _legacyMerge.positionTry = positionTry;
 _legacyMerge.props = props;
 _legacyMerge.types = types;
+_legacyMerge.viewTransitionClass = viewTransitionClass;
 
 export const legacyMerge: IStyleX = _legacyMerge;

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
@@ -139,6 +139,13 @@ export type PositionTry = Readonly<{
   placeSelf?: CSSProperties['placeSelf'],
 }>;
 
+export type ViewTransitionClass = Readonly<{
+  group?: CSSProperties,
+  imagePair?: CSSProperties,
+  old?: CSSProperties,
+  new?: CSSProperties,
+}>;
+
 export type LegacyThemeStyles = Readonly<{ [constantName: string]: string }>;
 
 type ComplexStyleValueType<T> =

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.js
@@ -108,6 +108,13 @@ export type PositionTry = $ReadOnly<{
   placeSelf?: CSSProperties['placeSelf'],
 }>;
 
+export type ViewTransitionClass = $ReadOnly<{
+  group?: CSSProperties,
+  imagePair?: CSSProperties,
+  old?: CSSProperties,
+  new?: CSSProperties,
+}>;
+
 export type LegacyThemeStyles = $ReadOnly<{
   [constantName: string]: string,
   ...

--- a/packages/docs/docs/api/index.mdx
+++ b/packages/docs/docs/api/index.mdx
@@ -25,6 +25,7 @@ sidebar_position: 1
 - [`stylex.positionTry()`](./javascript/positionTry.mdx)
 - [`stylex.props()`](./javascript/props.mdx)
 - [`stylex.types.*()`](./javascript/types.mdx)
+- [`stylex.viewTransitionClass()`](./javascript/viewTransitionClass.mdx)
 
 ## Static types
 

--- a/packages/docs/docs/api/javascript/viewTransitionClass.mdx
+++ b/packages/docs/docs/api/javascript/viewTransitionClass.mdx
@@ -1,0 +1,79 @@
+---
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+sidebar_position: 10
+---
+
+# `stylex.viewTransitionClass`
+
+Creates a set of `::view-transition` pseudo-element rules tied to a single class name which can be utilized for customizing the animations in a [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API).
+
+:::note
+
+The styles that `viewTransitionClass` accepts don't currently support media queries but adding support for them is a planned enhancement.
+
+:::
+
+```ts
+type ViewTransitionClassOptions = Readonly<{
+  group?: RawStyles,
+  imagePair?: RawStyles,
+  old?: RawStyles,
+  new?: RawStyles,
+}>;
+function viewTransitionClass(options: ViewTransitionClassOptions): string;
+```
+
+The options object the `viewTransitionClass` function takes in accepts the following keys which map to a corresponding View Transition pseudo-element:
+
+* `group` -> `::view-transition-group(*.theGeneratedClass)`
+* `imagePair` -> `::view-transition-image-pair(*.theGeneratedClass)`
+* `old` -> `::view-transition-old(*.theGeneratedClass)`
+* `new` -> `::view-transition-new(*.theGeneratedClass)`
+
+This method returns the generated class name as a string which can be added manually to the elements you want animations customized for, or if you're using React can be passed into the experimental [`<ViewTransition />`](https://react.dev/reference/react/ViewTransition) component.
+
+### Example use:
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+import { unstable_ViewTransition as ViewTransition } from 'react';
+
+const lingeringOldView = stylex.viewTransitionClass({
+  new: {
+    animationDuration: '1s',
+  },
+  old: {
+    animationDuration: '2s',
+  },
+});
+
+<ViewTransition default={lingeringOldView}>
+  {/* ... */}
+</ViewTransition>
+```
+
+`viewTransitionClass` calls can also accept [`keyframes`](keyframes.mdx) output to customize the animations even further:
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+
+const fadeInUp = stylex.keyframes({
+  from: {
+    opacity: 0,
+    transform: 'translateY(-30px)'
+  },
+  to: {
+    opacity: 1,
+    transform: 'translateY(0px)'
+  },
+});
+
+const transitionCls = stylex.viewTransitionClass({
+  new: {
+    animationName: fadeInUp,
+  },
+});
+```


### PR DESCRIPTION

## Overview

This PR adds an initial implementation of the `stylex.viewTransitionClass` API as described in https://github.com/facebook/stylex/discussions/1011. This implementation is not feature complete, most notably missing the ability to integrate media queries. It does however include the integrations necessary for accepting `stylex.keyframes` animations and accepting constants.

Adding things like media query integration in a scalable way (i.e. not duplicating the implementation that already exists for `stylex.create`) would likely require a non-trivial refactor of `stylex.create`'s transform so I'm putting this change up as an initial step and people can start experimenting with it.

## Test Plan:

### Unit Tests

Added new unit tests which are passing

### Manual Testing

Locally modified the NextJS example project & `Counter.tsx` file to utilize view transitions and verified that it is rendering correctly. I did not include these changes in this PR as it requires an experimental NextJS configuration.

Here's what the new source of `Counter.tsx` looks like:

```ts
/**
 * Copyright (c) Meta Platforms, Inc. and affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 *
 *
 */

'use client';

import * as stylex from '@stylexjs/stylex';
import { spacing, text, globalTokens as $ } from './globalTokens.stylex';
import { colors } from '@stylexjs/open-props/lib/colors.stylex';
import {
  startTransition,
  useState,
  unstable_ViewTransition as ViewTransition,
  unstable_addTransitionType as addAnimationType,
} from 'react';

const animationDuration = '300ms';
const animationTimingFunction = 'cubic-bezier(0.25, 1, 0.5, 1)'; // ease-out-quart

const fadeInFromLeft = stylex.keyframes({
  from: {
    opacity: 0,
    transform: 'translateX(30px)',
  },
  to: {
    opacity: 1,
    transform: 'translateX(0px)',
  },
});

const fadeInFromRight = stylex.keyframes({
  from: {
    opacity: 0,
    transform: 'translateX(-30px)',
  },
  to: {
    opacity: 1,
    transform: 'translateX(0px)',
  },
});

const fadeOutToRight = stylex.keyframes({
  from: {
    opacity: 1,
    transform: 'translateX(0px)',
  },
  to: {
    opacity: 0,
    transform: 'translateX(-30px)',
  },
});

const fadeOutToLeft = stylex.keyframes({
  from: {
    opacity: 1,
    transform: 'translateX(0px)',
  },
  to: {
    opacity: 0,
    transform: 'translateX(30px)',
  },
});

const incrementViewTransition = stylex.viewTransitionClass({
  new: {
    animationName: fadeInFromLeft,
    animationTimingFunction,
    animationDuration,
  },
  old: {
    animationName: fadeOutToRight,
    animationTimingFunction,
    animationDuration,
  },
});

const decrementViewTransition = stylex.viewTransitionClass({
  new: {
    animationName: fadeInFromRight,
    animationTimingFunction,
    animationDuration,
  },
  old: {
    animationName: fadeOutToLeft,
    animationTimingFunction,
    animationDuration,
  },
});

export default function Counter() {
  const [count, setCount] = useState(0);

  const increment = () =>
    startTransition(() => {
      addAnimationType('counter-increment');
      setCount((c) => c + 1);
    });
  const decrement = () =>
    startTransition(() => {
      addAnimationType('counter-decrement');
      setCount((c) => c - 1);
    });

  return (
    <div {...stylex.props(styles.container)}>
      <button {...stylex.props(styles.button)} onClick={decrement}>
        -
      </button>
      <ViewTransition
        update={{
          'counter-increment': incrementViewTransition,
          'counter-decrement': decrementViewTransition,
        }}
      >
        <div
          {...stylex.props(
            styles.count,
            Math.abs(count) > 99 && styles.largeNumber,
          )}
        >
          {count}
        </div>
      </ViewTransition>
      <button {...stylex.props(styles.button)} onClick={increment}>
        +
      </button>
    </div>
  );
}

const DARK = '@media (prefers-color-scheme: dark)' as const;

const styles = stylex.create({
  container: {
    display: 'flex',
    alignItems: 'center',
    justifyContent: 'center',
    flexDirection: 'row',
    borderRadius: spacing.md,
    borderWidth: 1,
    borderStyle: 'solid',
    borderColor: colors.blue7,
    padding: spacing.xxxs,
    fontFamily: $.fontSans,
    gap: spacing.xs,
  },
  button: {
    display: 'flex',
    alignItems: 'center',
    justifyContent: 'center',
    height: '6rem',
    aspectRatio: 1,
    color: colors.blue7,
    backgroundColor: {
      default: colors.gray3,
      ':hover': colors.gray4,
      [DARK]: {
        default: colors.gray9,
        ':hover': colors.gray8,
      },
    },
    borderWidth: 0,
    borderStyle: 'none',
    borderRadius: spacing.xs,
    padding: spacing.xs,
    margin: spacing.xs,
    cursor: 'pointer',
    fontSize: text.h2,
    transform: {
      default: null,
      ':hover': 'scale(1.025)',
      ':active': 'scale(0.975)',
    },
  },
  count: {
    fontSize: text.h2,
    fontWeight: 100,
    color: colors.lime7,
    minWidth: '6rem',
    textAlign: 'center',
    fontFamily: $.fontMono,
  },
  largeNumber: {
    fontSize: text.h3,
  },
});
```

And here is what the transition looks like:

https://github.com/user-attachments/assets/7574cacf-bad8-44be-9fd9-eb2957584649
