### PR TITLE
feat: allow inline keyframe expressions inside viewTransitionClass

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-viewTransitionClass-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-viewTransitionClass-test.js
@@ -65,6 +65,7 @@ describe('@stylexjs/babel-plugin', () => {
         }
       `);
     });
+
     test('local variables used in view transition class', () => {
       const { code, metadata } = transform(`
         import * as stylex from '@stylexjs/stylex';
@@ -96,6 +97,7 @@ describe('@stylexjs/babel-plugin', () => {
         }
       `);
     });
+
     test('using keyframes', () => {
       const { code, metadata } = transform(`
         import * as stylex from '@stylexjs/stylex';
@@ -118,7 +120,6 @@ describe('@stylexjs/babel-plugin', () => {
           },
         });
       `);
-
       expect(code).toMatchInlineSnapshot(`
         "import * as stylex from '@stylexjs/stylex';
         const fadeIn = "x18re5ia-B";
@@ -156,6 +157,63 @@ describe('@stylexjs/babel-plugin', () => {
         }
       `);
     });
+
+    test('using inline keyframes', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        const cls = stylex.viewTransitionClass({
+          old: {
+            animationName: stylex.keyframes({
+              from: {opacity: 1},
+              to: {opacity: 0},
+            }),
+            animationDuration: '1s',
+          },
+          new: {
+            animationName: stylex.keyframes({
+              from: {opacity: 0},
+              to: {opacity: 1},
+            }),
+            animationDuration: '1s',
+          },
+        });
+      `);
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        const cls = "xfh0f9i";"
+      `);
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1jn504y-B",
+              {
+                "ltr": "@keyframes x1jn504y-B{from{opacity:1;}to{opacity:0;}}",
+                "rtl": null,
+              },
+              1,
+            ],
+            [
+              "x18re5ia-B",
+              {
+                "ltr": "@keyframes x18re5ia-B{from{opacity:0;}to{opacity:1;}}",
+                "rtl": null,
+              },
+              1,
+            ],
+            [
+              "xfh0f9i",
+              {
+                "ltr": "::view-transition-old(*.xfh0f9i){animation-name:x1jn504y-B;animation-duration:1s;}::view-transition-new(*.xfh0f9i){animation-name:x18re5ia-B;animation-duration:1s;}",
+                "rtl": null,
+              },
+              1,
+            ],
+          ],
+        }
+      `);
+    });
+
     test.skip('using contextual styles', () => {
       const { code, metadata } = transform(`
         import * as stylex from 'stylex';

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-view-transition-class.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-view-transition-class.js
@@ -19,6 +19,7 @@ import {
   keyframes as stylexKeyframes,
 } from '../shared';
 import stylexViewTransitionClass from '../shared/stylex-view-transition-class';
+import type { InjectableStyle } from '../shared/common-types';
 
 /// This function looks for `stylex.viewTransitionClass` calls within variable declarations and transforms them.
 /// 1. It finds the first argument to `stylex.viewTransitionClass` and validates it.
@@ -68,20 +69,38 @@ export default function transformStyleXViewTransitionClass(
     const args: $ReadOnlyArray<NodePath<>> = init.get('arguments');
     const firstArgPath = args[0];
 
+    const otherInjectedCSSRules: { [propertyName: string]: InjectableStyle } =
+      {};
+
+    const keyframes = <
+      Obj: {
+        +[key: string]: { +[k: string]: string | number },
+      },
+    >(
+      animation: Obj,
+    ): string => {
+      const [animationName, injectedStyle] = stylexKeyframes(
+        animation,
+        state.options,
+      );
+      otherInjectedCSSRules[animationName] = injectedStyle;
+      return animationName;
+    };
+
     const identifiers: FunctionConfig['identifiers'] = {};
     const memberExpressions: FunctionConfig['memberExpressions'] = {};
     state.stylexFirstThatWorksImport.forEach((name) => {
       identifiers[name] = { fn: stylexFirstThatWorks };
     });
     state.stylexKeyframesImport.forEach((name) => {
-      identifiers[name] = { fn: stylexKeyframes };
+      identifiers[name] = { fn: keyframes };
     });
     state.stylexImport.forEach((name) => {
       if (memberExpressions[name] == null) {
         memberExpressions[name] = {};
       }
       memberExpressions[name].firstThatWorks = { fn: stylexFirstThatWorks };
-      memberExpressions[name].keyframes = { fn: stylexKeyframes };
+      memberExpressions[name].keyframes = { fn: keyframes };
     });
 
     const { confident, value } = evaluate(firstArgPath, state, {
@@ -105,10 +124,16 @@ export default function transformStyleXViewTransitionClass(
     // This should be a string
     init.replaceWith(t.stringLiteral(viewTransitionClassName));
 
-    state.registerStyles(
-      [[viewTransitionClassName, { ltr, rtl }, priority]],
-      path,
+    const injectedStyles = {
+      ...otherInjectedCSSRules,
+      [viewTransitionClassName]: { priority, ltr, rtl },
+    };
+
+    const listOfStyles = Object.entries(injectedStyles).map(
+      ([key, { priority, ...rest }]) => [key, rest, priority],
     );
+
+    state.registerStyles(listOfStyles, path);
   }
 }
 


### PR DESCRIPTION

## Overview

In https://github.com/facebook/stylex/pull/1078 I added an initial implementation of `viewTransitionClass` and when I was doing some additional manual exploration I noticed that using the `keyframes` API inline in the `viewTransitionClass` object wasn't working so this diff resolves that by adding support. This is a small thing but can really help keep the view transition configuration (relatively) consise.

## Test Plan

Added unit test covering the scenario and it is passing.
