### PR TITLE
[eslint-plugin] support validImports options for all rules

### DIFF
--- a/packages/@stylexjs/eslint-plugin/README.md
+++ b/packages/@stylexjs/eslint-plugin/README.md
@@ -55,6 +55,14 @@ their **suggested replacements**.
 This rule helps to sort the StyleX property keys according to
 [property priorities](https://github.com/facebook/stylex/blob/main/packages/shared/src/utils/property-priorities.js).
 
+#### Config options
+
+```json
+{
+  "validImports": ["stylex", "@stylexjs/stylex"]
+}
+```
+
 ### stylex/stylex-valid-shorthands
 
 This ESLint rule enforces the use of individual longhand CSS properties in place
@@ -98,7 +106,8 @@ This rule has a few custom config options that can be set.
 ```js
 {
   allowImportant: false,                       // Whether `!important` is allowed
-  preferInline: false                          // Whether the expansion uses logical direction properties over physical
+  preferInline: false,                         // Whether the expansion uses logical direction properties over physical
+  validImports: ['stylex', '@stylexjs/stylex']
 }
 ```
 
@@ -125,7 +134,8 @@ using `stylex.defineVars()`.
 
 ```json
 {
-  "themeFileExtension": ".stylex.js" // default, can be customized
+  "themeFileExtension": ".stylex.js", // default, can be customized
+  "validImports": ["stylex", "@stylexjs/stylex"]
 }
 ```
 
@@ -134,10 +144,26 @@ using `stylex.defineVars()`.
 This rule flags unused styles created with `stylex.create(...)`. If a style key
 is defined but never used, the rule auto-strips them from the create call.
 
+#### Config options
+
+```json
+{
+  "validImports": ["stylex", "@stylexjs/stylex"]
+}
+```
+
 ### `stylex-no-legacy-contextual-styles`
 
 This rule flags usages of the original media query/pseudo class syntax that
 wraps multiple property values within a single @-rule or pseudo class like this:
+
+#### Config options
+
+```json
+{
+  "validImports": ["stylex", "@stylexjs/stylex"]
+}
+```
 
 ```js
 const styles = stylex.create({

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-enforce-extension-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-enforce-extension-test.js
@@ -15,20 +15,26 @@ const ruleTester = new RuleTester({
 });
 
 const invalidFilenameWithDefineVars =
-  'Files that export StyleX variables defined with `stylex.defineVars()` must end with the `.stylex.jsx` or `.stylex.tsx` extension.';
+  'Files that export StyleX variables defined with `defineVars()` must end with the `.stylex.jsx` or `.stylex.tsx` extension.';
 const invalidFilenameWithoutDefineVars =
-  'Only StyleX variables defined with `stylex.defineVars()` can be exported from a file with the `.stylex.jsx` or `.stylex.tsx` extension.';
+  'Only StyleX variables defined with `defineVars()` can be exported from a file with the `.stylex.jsx` or `.stylex.tsx` extension.';
 const invalidExportWithDefineVars =
-  'Files that export `stylex.defineVars()` must not export anything else.';
+  'Files that export `defineVars()` must not export anything else.';
 
 ruleTester.run('stylex-enforce-extension', rule.default, {
   valid: [
     {
-      code: 'export const vars = stylex.defineVars({});',
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.defineVars({});
+      `,
       filename: 'testComponent.stylex.jsx',
     },
     {
-      code: 'export const vars = stylex.defineVars({});',
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.defineVars({});
+      `,
       filename: 'testComponent.stylex.tsx',
     },
     {
@@ -40,12 +46,18 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
       filename: 'testComponent.tsx',
     },
     {
-      code: 'export const vars = stylex.defineVars({});',
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.defineVars({});
+      `,
       filename: 'testComponent.custom.jsx',
       options: [{ themeFileExtension: '.custom.jsx' }],
     },
     {
-      code: 'export const vars = stylex.defineVars({});',
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.defineVars({});
+      `,
       filename: 'testComponent.custom.tsx',
       options: [{ themeFileExtension: '.custom.jsx' }],
     },
@@ -56,21 +68,42 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
     },
     {
       code: `
+        import * as stylex from '@stylexjs/stylex';
         export const vars = stylex.defineVars({ color: 'red' });
         export default stylex.defineVars({ background: 'blue' });
       `,
       filename: 'myComponent.stylex.jsx',
     },
+    {
+      options: [{ validImports: ['custom-stylex'] }],
+      code: `
+        import * as stylex from 'custom-stylex';
+        export const vars = stylex.defineVars({});
+      `,
+      filename: 'testComponent.stylex.jsx',
+    },
+    {
+      options: [{ validImports: [{ from: 'a', as: 'css' }] }],
+      code: `
+        import { css } from 'a';
+        export const vars = css.defineVars({});
+      `,
+      filename: 'testComponent.stylex.jsx',
+    },
   ],
 
   invalid: [
     {
-      code: 'export const vars = stylex.defineVars({});',
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.defineVars({});
+      `,
       filename: 'testComponent.jsx',
       errors: [{ message: invalidFilenameWithDefineVars }],
     },
     {
       code: `
+        import * as stylex from '@stylexjs/stylex';
         export const vars = stylex.defineVars({ color: 'red' });
         export const somethingElse = someFunction();
         export default stylex.defineVars({ background: 'blue' });
@@ -83,6 +116,7 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
     },
     {
       code: `
+        import * as stylex from '@stylexjs/stylex';
         export const vars = someFunction();
         export const somethingElse = someFunction();
         export default stylex.defineVars({ background: 'blue' });
@@ -96,6 +130,7 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
     },
     {
       code: `
+        import * as stylex from '@stylexjs/stylex';
         export const vars = stylex.defineVars({
           color: 'blue',
         });
@@ -106,6 +141,7 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
     },
     {
       code: `
+        import * as stylex from '@stylexjs/stylex';
         export const vars = stylex.defineVars({
           color: 'red',
         });
@@ -115,7 +151,10 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
       errors: [{ message: invalidExportWithDefineVars }],
     },
     {
-      code: 'export const vars = stylex.defineVars({});',
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.defineVars({});
+      `,
       filename: 'testComponent.tsx',
       errors: [{ message: invalidFilenameWithDefineVars }],
     },
@@ -130,13 +169,16 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
       errors: [{ message: invalidFilenameWithoutDefineVars }],
     },
     {
-      code: 'export const vars = stylex.defineVars({});',
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.defineVars({});
+      `,
       filename: 'testComponent.jsx',
       options: [{ themeFileExtension: '.custom.jsx' }],
       errors: [
         {
           message:
-            'Files that export StyleX variables defined with `stylex.defineVars()` must end with the `.custom.jsx` or `.custom.tsx` extension.',
+            'Files that export StyleX variables defined with `defineVars()` must end with the `.custom.jsx` or `.custom.tsx` extension.',
         },
       ],
     },
@@ -147,7 +189,57 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
       errors: [
         {
           message:
-            'Only StyleX variables defined with `stylex.defineVars()` can be exported from a file with the `.custom.jsx` or `.custom.tsx` extension.',
+            'Only StyleX variables defined with `defineVars()` can be exported from a file with the `.custom.jsx` or `.custom.tsx` extension.',
+        },
+      ],
+    },
+    {
+      options: [{ validImports: ['custom-stylex'] }],
+      code: `
+        import * as stylex from 'custom-stylex';
+        export const vars = stylex.defineVars({});
+      `,
+      filename: 'testComponent.jsx',
+      errors: [
+        {
+          message:
+            'Files that export StyleX variables defined with `defineVars()` must end with the `.stylex.jsx` or `.stylex.tsx` extension.',
+        },
+      ],
+    },
+    {
+      options: [{ validImports: [{ from: 'a', as: 'css' }] }],
+      code: `
+        import { css } from 'a';
+        export const vars = css.defineVars({});
+      `,
+      filename: 'testComponent.jsx',
+      errors: [
+        {
+          message:
+            'Files that export StyleX variables defined with `defineVars()` must end with the `.stylex.jsx` or `.stylex.tsx` extension.',
+        },
+      ],
+    },
+    {
+      options: [{ validImports: ['custom-stylex'] }],
+      code: 'export const somethingElse = {};',
+      filename: 'testComponent.stylex.jsx',
+      errors: [
+        {
+          message:
+            'Only StyleX variables defined with `defineVars()` can be exported from a file with the `.stylex.jsx` or `.stylex.tsx` extension.',
+        },
+      ],
+    },
+    {
+      options: [{ validImports: [{ from: 'a', as: 'css' }] }],
+      code: 'export const somethingElse = {};',
+      filename: 'testComponent.stylex.jsx',
+      errors: [
+        {
+          message:
+            'Only StyleX variables defined with `defineVars()` can be exported from a file with the `.stylex.jsx` or `.stylex.tsx` extension.',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-no-legacy-contextual-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-no-legacy-contextual-styles-test.js
@@ -24,7 +24,7 @@ eslintTester.run('stylex-no-legacy-contextual-styles', rule.default, {
   valid: [
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           '::placeholder': {
@@ -44,11 +44,44 @@ eslintTester.run('stylex-no-legacy-contextual-styles', rule.default, {
       });
     `,
     },
+    {
+      options: [{ validImports: ['custom-stylex'] }],
+      code: `
+        import * as stylex from 'custom-stylex';
+        const styles = stylex.create({
+          main: {
+            '::placeholder': {
+              color: '#999',
+            },
+            width: {
+              default: '100%',
+              '@media (min-width: 600px)': {
+                default: '50%',
+                '@media screen': '40%'
+              },
+            }
+          },
+        });
+      `,
+    },
+    {
+      options: [{ validImports: [{ from: 'a', as: 'css' }] }],
+      code: `
+        import { css } from 'a';
+        const styles = css.create({
+          main: {
+            '::placeholder': {
+              color: '#999',
+            },
+          },
+        });
+      `,
+    },
   ],
   invalid: [
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           width: '100%',
@@ -81,6 +114,46 @@ eslintTester.run('stylex-no-legacy-contextual-styles', rule.default, {
         {
           message:
             'This pseudo class syntax is deprecated. Use the new syntax specified here: https://stylexjs.com/docs/learn/styling-ui/defining-styles/#pseudo-classes',
+        },
+      ],
+    },
+    {
+      options: [{ validImports: ['custom-stylex'] }],
+      code: `
+        import * as stylex from 'custom-stylex';
+        const styles = stylex.create({
+          main: {
+            width: '100%',
+            ':hover': {
+              width: '50%',
+            }
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            'This pseudo class syntax is deprecated. Use the new syntax specified here: https://stylexjs.com/docs/learn/styling-ui/defining-styles/#pseudo-classes',
+        },
+      ],
+    },
+    {
+      options: [{ validImports: [{ from: 'a', as: 'css' }] }],
+      code: `
+        import { css } from 'a';
+        const styles = css.create({
+          main: {
+            width: '100%',
+            '@media (max-width: 600px)': {
+              width: '50%',
+            }
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            'This media query syntax is deprecated. Use the new syntax specified here: https://stylexjs.com/docs/learn/styling-ui/defining-styles/#media-queries-and-other--rules',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-no-unused-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-no-unused-test.js
@@ -25,7 +25,7 @@ eslintTester.run('stylex-no-unused', rule.default, {
     {
       // all style used; identifier and literal
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             borderColor: {
@@ -65,7 +65,7 @@ eslintTester.run('stylex-no-unused', rule.default, {
     {
       // stylex not default export
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             borderColor: {
@@ -105,7 +105,7 @@ eslintTester.run('stylex-no-unused', rule.default, {
     {
       // indirect usage of style
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             display: 'flex',
@@ -154,7 +154,7 @@ eslintTester.run('stylex-no-unused', rule.default, {
     {
       // styles default export
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           borderColor: {
@@ -175,7 +175,7 @@ eslintTester.run('stylex-no-unused', rule.default, {
     {
       // styles named default inline export
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       export default styles = stylex.create({
         maxDimensionsModal: {
           maxWidth: '90%',
@@ -190,7 +190,7 @@ eslintTester.run('stylex-no-unused', rule.default, {
     {
       // styles anonymous default inline export
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       export default stylex.create({
         maxDimensionsModal: {
           maxWidth: '90%',
@@ -202,11 +202,52 @@ eslintTester.run('stylex-no-unused', rule.default, {
       })
     `,
     },
+    {
+      // Meta-only use of default import
+      code: `
+      import stylex from 'stylex';
+      export default stylex.create({
+        maxDimensionsModal: {
+          maxWidth: '90%',
+          maxHeight: '90%',
+        }
+      })
+    `,
+    },
+    {
+      // importSources with custom import
+      options: [{ validImports: ['custom-stylex'] }],
+      code: `
+        import * as stylex from 'custom-stylex';
+        const styles = stylex.create({
+          main: {
+            color: 'red',
+          },
+        });
+        export default function Component() {
+          return <div {...stylex.props(styles.main)} />;
+        }
+      `,
+    },
+    {
+      options: [{ validImports: [{ from: 'a', as: 'css' }] }],
+      code: `
+        import { css } from 'a';
+        const styles = css.create({
+          main: {
+            color: 'red',
+          },
+        });
+        export default function Component() {
+          return <div {...css.props(styles.main)} />;
+        }
+      `,
+    },
   ],
   invalid: [
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             borderColor: {
@@ -229,7 +270,7 @@ eslintTester.run('stylex-no-unused', rule.default, {
         }
       `,
       output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           dynamic: (color) => ({
             backgroundColor: color,
@@ -319,6 +360,72 @@ eslintTester.run('stylex-no-unused', rule.default, {
       errors: [
         {
           message: 'Unused style detected: styles.main',
+        },
+      ],
+    },
+    {
+      options: [{ validImports: ['custom-stylex'] }],
+      code: `
+        import * as stylex from 'custom-stylex';
+        const styles = stylex.create({
+          main: {
+            color: 'red',
+          },
+          unused: {
+            fontSize: '16px',
+          },
+        });
+        export default function Component() {
+          return <div {...stylex.props(styles.main)} />;
+        }
+      `,
+      output: `
+        import * as stylex from 'custom-stylex';
+        const styles = stylex.create({
+          main: {
+            color: 'red',
+          },
+        });
+        export default function Component() {
+          return <div {...stylex.props(styles.main)} />;
+        }
+      `,
+      errors: [
+        {
+          message: 'Unused style detected: styles.unused',
+        },
+      ],
+    },
+    {
+      options: [{ validImports: [{ from: 'a', as: 'css' }] }],
+      code: `
+        import { css } from 'a';
+        const styles = css.create({
+          main: {
+            color: 'red',
+          },
+          unused: {
+            fontSize: '16px',
+          },
+        });
+        export default function Component() {
+          return <div {...css.props(styles.main)} />;
+        }
+      `,
+      output: `
+        import { css } from 'a';
+        const styles = css.create({
+          main: {
+            color: 'red',
+          },
+        });
+        export default function Component() {
+          return <div {...css.props(styles.main)} />;
+        }
+      `,
+      errors: [
+        {
+          message: 'Unused style detected: styles.unused',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -24,7 +24,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
   valid: [
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           borderColor: {
@@ -43,7 +43,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: {
           width: {
@@ -144,7 +144,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const someAnimation = stylex.keyframes({
           '0%': {
             borderColor: 'red',
@@ -159,7 +159,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         nav: {
           maxWidth: {
@@ -174,7 +174,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
   invalid: [
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             padding: 10,
@@ -184,7 +184,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         });
       `,
       output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             animationDuration: '100ms',
@@ -202,7 +202,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const obj = { fontSize: '12px' };
         const styles = stylex.create({
           button: {
@@ -215,7 +215,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         });
       `,
       output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const obj = { fontSize: '12px' };
         const styles = stylex.create({
           button: {
@@ -264,7 +264,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const someAnimation = stylex.keyframes({
           '0%': {
             borderColor: 'red',
@@ -277,7 +277,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         });
       `,
       output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const someAnimation = stylex.keyframes({
           '0%': {
             borderColor: 'red',
@@ -439,7 +439,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: {
           // zee
@@ -450,7 +450,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
       })
       `,
       output: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: {
           // bar
@@ -469,13 +469,13 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: { backgroundColor: 'red', alignItems: 'center', }
       })
       `,
       output: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: { alignItems: 'center', backgroundColor: 'red', }
       })
@@ -489,7 +489,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: { // foo
           // foo
@@ -501,7 +501,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
       })
       `,
       output: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: { // foo
           // bar
@@ -521,7 +521,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: {
           /*
@@ -537,7 +537,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
       })
       `,
       output: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: {
           alignItems: 'center',
@@ -561,7 +561,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: {
           backgroundColor: 'red',             //       foo
@@ -570,7 +570,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
       })
       `,
       output: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: {
           alignItems: 'center',       // baz
@@ -587,7 +587,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: {
           /*
@@ -598,7 +598,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
       })
       `,
       output: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: {
           alignItems: 'center',
@@ -617,7 +617,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: {
           // foo
@@ -628,7 +628,7 @@ eslintTester.run('stylex-sort-keys', rule.default, {
       })
       `,
       output: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         foo: {
           // foo

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -24,7 +24,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
   valid: [
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           marginInlineEnd: '14px',
@@ -35,7 +35,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           borderRadius: 5,
@@ -45,7 +45,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           margin: 10,
@@ -55,7 +55,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           marginInline: 0,
@@ -65,7 +65,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           paddingInline: 0,
@@ -75,7 +75,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           marginBlock: 10,
@@ -85,7 +85,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           paddingBlock: 10,
@@ -95,7 +95,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           padding: 'calc(0.5 * 100px)',
@@ -105,7 +105,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           marginTop: '10em',
@@ -118,7 +118,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           borderWidth: '1px',
@@ -131,7 +131,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           borderColor: 'rgb(0, 0, 0)',
@@ -140,11 +140,34 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       })
     `,
     },
+    {
+      options: [{ validImports: ['custom-stylex'] }],
+      code: `
+        import * as stylex from 'custom-stylex';
+        const styles = stylex.create({
+          main: {
+            marginInlineEnd: '14px',
+            marginInlineStart: '14px',
+          },
+        })
+      `,
+    },
+    {
+      options: [{ validImports: [{ from: 'a', as: 'css' }] }],
+      code: `
+        import { css } from 'a';
+        const styles = css.create({
+          main: {
+            borderRadius: 5,
+          },
+        })
+      `,
+    },
   ],
   invalid: [
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             margin: '10px 12px 13px 14px',
@@ -152,7 +175,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         });
       `,
       output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             marginTop: '10px',
@@ -171,7 +194,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           borderRight: '4px solid var(--fds-gray-10)'
@@ -188,7 +211,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     {
       options: [{ preferInline: true }],
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             borderRadius: '10px 15px 20px 25px',
@@ -196,7 +219,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         });
       `,
       output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             borderStartStartRadius: '10px',
@@ -215,7 +238,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             borderRadius: '10px 15px 20px 25px',
@@ -223,7 +246,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         });
       `,
       output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             borderTopLeftRadius: '10px',
@@ -242,7 +265,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             marginHorizontal: '10px',
@@ -253,7 +276,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         });
       `,
       output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             marginInline: '10px',
@@ -284,7 +307,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             margin: '10px 10px 10px',
@@ -294,7 +317,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         });
       `,
       output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             margin: '10px',
@@ -320,7 +343,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               borderColor: 'rgb(0, 0, 0), rgb(5, 5, 5)',
@@ -329,7 +352,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           })
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               borderTopColor: 'rgb(0, 0, 0),',
@@ -356,7 +379,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           borderWidth: 'calc(100% - 20px) calc(90% - 20px)',
@@ -383,7 +406,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
 
     {
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               borderWidth: '1px 2px 3px 4px',
@@ -398,7 +421,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               borderTopWidth: '1px',
@@ -469,7 +492,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             outline: '2px dashed red',
@@ -477,7 +500,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         });
       `,
       output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
             outlineWidth: '2px',
@@ -495,7 +518,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               background: '#ff0 url("image.jpg") no-repeat fixed center / cover !important',
@@ -503,7 +526,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               backgroundColor: '#ff0',
@@ -525,7 +548,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     {
       options: [{ allowImportant: true }],
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               background: '#ff0 url("image.jpg") no-repeat fixed center / cover !important',
@@ -533,7 +556,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               backgroundColor: '#ff0 !important',
@@ -554,7 +577,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               margin: '0px',
@@ -564,7 +587,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               margin: '0px',
@@ -588,7 +611,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     {
       options: [{ allowImportant: true }],
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               margin: '10px 12px 13px 14px !important',
@@ -596,7 +619,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               marginTop: '10px !important',
@@ -615,7 +638,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               margin: '10px 12px 13px 14px !important',
@@ -623,7 +646,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               marginTop: '10px',
@@ -643,7 +666,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     {
       options: [{ preferInline: true }],
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               margin: '10em 1em 5em 2em',
@@ -651,7 +674,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               marginTop: '10em',
@@ -670,7 +693,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               margin: '10em 1em',
@@ -678,7 +701,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               marginBlock: '10em',
@@ -695,7 +718,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               marginInline: '10em 1em',
@@ -703,7 +726,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               marginInlineStart: '10em',
@@ -720,7 +743,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               marginBlock: '10em 1em',
@@ -728,7 +751,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               marginBlockStart: '10em',
@@ -745,7 +768,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               paddingBlock: '10em 1em',
@@ -753,7 +776,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               paddingBlockStart: '10em',
@@ -770,7 +793,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           borderWidth: '4px 5px 6px 7px',
@@ -794,7 +817,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         },
       ],
       output: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           borderTopWidth: '4px',
@@ -816,7 +839,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     {
       options: [{ preferInline: true }],
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           borderWidth: '4px 5px 6px 7px',
@@ -840,7 +863,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         },
       ],
       output: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         main: {
           borderTopWidth: '4px',
@@ -861,7 +884,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               paddingTop: '10em',
@@ -874,7 +897,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               paddingTop: '10em',
@@ -907,7 +930,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
     {
       code: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               padding: '10em 1em',
@@ -915,7 +938,7 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
           });
         `,
       output: `
-          import stylex from 'stylex';
+          import * as stylex from '@stylexjs/stylex';
           const styles = stylex.create({
             main: {
               paddingBlock: '10em',
@@ -927,6 +950,58 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         {
           message:
             'Property shorthands using multiple values like "padding: 10em 1em" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      options: [{ validImports: ['custom-stylex'] }],
+      code: `
+        import * as stylex from 'custom-stylex';
+        const styles = stylex.create({
+          main: {
+            margin: '10px 12px',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from 'custom-stylex';
+        const styles = stylex.create({
+          main: {
+            marginBlock: '10px',
+            marginInline: '12px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "margin: 10px 12px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      options: [{ validImports: [{ from: 'a', as: 'css' }] }],
+      code: `
+        import { css } from 'a';
+        const styles = css.create({
+          main: {
+            padding: '5px 10px',
+          },
+        });
+      `,
+      output: `
+        import { css } from 'a';
+        const styles = css.create({
+          main: {
+            paddingBlock: '5px',
+            paddingInline: '10px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "padding: 5px 10px" are not supported in StyleX. Separate into individual properties.',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -24,7 +24,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
   valid: [
     // test for local static variables
     `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const start = 'start';
       const styles = stylex.create({
         default: {
@@ -38,7 +38,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       });
     `,
     `
-      import stylex from "stylex";
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         validStyle: {
           marginInlineStart: "10px",
@@ -53,7 +53,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       });
     `,
     `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const start = 'start';
       const grayscale = 'grayscale';
       const styles = stylex.create({
@@ -68,7 +68,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       });
     `,
     `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const bounce = stylex.keyframes({
         '0%': {
           transform: 'translateY(0)',
@@ -89,7 +89,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       });
     `,
     `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         default: {
           animationName: stylex.keyframes({
@@ -109,7 +109,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       });
     `,
     `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const bounce = stylex.keyframes({
         '0%': {
           transform: 'translateY(0)',
@@ -140,7 +140,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     // test for nested styles
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const TRANSPARENT = 0;
         const OPAQUE = 1;
         const styles = stylex.create({
@@ -197,7 +197,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             width: '50%',
@@ -211,7 +211,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           base: {
             width: {
@@ -226,26 +226,26 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       options: [{ allowOuterPseudoAndMedia: true }],
     },
     // test for positive numbers
-    'import stylex from "stylex"; stylex.create({default: {marginInlineStart: 5}});',
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {marginInlineStart: 5}});",
     // test for literals as namespaces
-    'import stylex from "stylex"; stylex.create({"default-1": {marginInlineStart: 5}});',
-    'import stylex from "stylex"; stylex.create({["default-1"]: {marginInlineStart: 5}});',
+    'import * as stylex from \'@stylexjs/stylex\'; stylex.create({"default-1": {marginInlineStart: 5}});',
+    'import * as stylex from \'@stylexjs/stylex\'; stylex.create({["default-1"]: {marginInlineStart: 5}});',
     // test for numbers as namespaces
-    'import stylex from "stylex"; stylex.create({0: {marginInlineStart: 5}});',
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({0: {marginInlineStart: 5}});",
     // test for computed numbers as namespaces
-    'import stylex from "stylex"; stylex.create({[0]: {marginInlineStart: 5}});',
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({[0]: {marginInlineStart: 5}});",
     // test for negative values.
-    'import stylex from "stylex"; stylex.create({default: {marginInlineStart: -5}});',
-    "import stylex from 'stylex'; stylex.create({default: {textAlign: 'start'}});",
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {marginInlineStart: -5}});",
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {textAlign: 'start'}});",
     // test for presets
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          textAlign: 'start',
        }
      });`,
     // test for Math
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          marginInlineStart: Math.abs(-1),
@@ -254,7 +254,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
          paddingInlineEnd: Math.round(5 / 2),
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      const x = 5;
      stylex.create({
        default: {
@@ -265,7 +265,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
        },
      })`,
     // test for Search
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'WebkitAppearance': 'textfield',
@@ -284,7 +284,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
        },
      })`,
     // test for input ranges
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'WebkitAppearance': 'textfield',
@@ -306,86 +306,86 @@ eslintTester.run('stylex-valid-styles', rule.default, {
        },
      })`,
     // test for color
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'color': 'red',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'color': '#fff',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'color': '#fafbfc',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'color': '#fafbfcfc',
        },
      })`,
     // test for relative width
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '30rem',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '30em',
        },
       })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '30ch',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '30ex',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '30vh',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '30vw',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'contain': '300px',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'containIntrinsicSize': '300px',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'containIntrinsicSize': 'auto 300px',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        a: {
          interpolateSize: 'numeric-only',
@@ -394,28 +394,28 @@ eslintTester.run('stylex-valid-styles', rule.default, {
          interpolateSize: 'allow-keywords',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'containIntrinsicInlineSize': '300px',
          'containIntrinsicBlockSize': '200px',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'containIntrinsicInlineSize': 'auto 300px',
          'containIntrinsicBlockSize': 'auto 200px',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'containIntrinsicWidth': '300px',
          'containIntrinsicHeight': '200px',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'containIntrinsicWidth': 'auto 300px',
@@ -424,63 +424,63 @@ eslintTester.run('stylex-valid-styles', rule.default, {
      })`,
 
     // test for absolute width
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '30px',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '30cm',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '30mm',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '30in',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '30pc',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '30pt',
        },
      })`,
     // test for percentage
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          'width': '50%',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
        default: {
          fontWeight: 'var(--weight)',
        },
      })`,
-    `import stylex from "stylex";
+    `import * as stylex from '@stylexjs/stylex';
      stylex.create({
       default: {
         fontWeight: 'var(--🔴)',
       },
     })`,
     `
-    import stylex from "stylex";
+    import * as stylex from '@stylexjs/stylex';
     const red = 'var(--🔴)';
     stylex.create({
       default: {
@@ -489,7 +489,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     })`,
     // test for field-sizing
     `
-    import stylex from "stylex";
+    import * as stylex from '@stylexjs/stylex';
     const red = 'var(--🔴)';
     stylex.create({
       default: {
@@ -497,7 +497,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       },
     })`,
     `
-    import stylex from "stylex";
+    import * as stylex from '@stylexjs/stylex';
     const red = 'var(--🔴)';
     stylex.create({
       default: {
@@ -506,7 +506,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     })`,
     // test for stylex create vars tokens
     `
-    import stylex from 'stylex';
+    import * as stylex from '@stylexjs/stylex';
     import {TextTypeTokens as TextType, ColorTokens} from 'DspSharedTextTokens.stylex';
     stylex.create({
       root: {
@@ -519,7 +519,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     `,
     // test using vars as keys
     `
-    import stylex from 'stylex';
+    import * as stylex from '@stylexjs/stylex';
     import { componentVars } from './bug.stylex';
     stylex.create({
       host: {
@@ -529,7 +529,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     `,
     // test using vars as keys in dynamic styles
     `
-    import stylex from'stylex';
+    import * as stylex from'stylex';
     import { tokens } from 'tokens.stylex';
     stylex.create({
       root: (position) => ({
@@ -539,7 +539,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     `,
     // test importing vars from paths including code file extension
     `
-    import stylex from 'stylex';
+    import * as stylex from '@stylexjs/stylex';
     import { vars } from './vars.stylex';
     import { varsJs } from './vars.stylex.js';
     import { varsTs } from './vars.stylex.ts';
@@ -563,7 +563,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
   invalid: [
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = {default: {width: '30pt'}};
         stylex.create(styles);
       `,
@@ -574,7 +574,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       ],
     },
     {
-      code: "import stylex from 'stylex'; stylex.create({default: {textAlin: 'left'}});",
+      code: "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {textAlin: 'left'}});",
       errors: [
         {
           message: 'This is not a key that is allowed by stylex',
@@ -582,14 +582,14 @@ eslintTester.run('stylex-valid-styles', rule.default, {
             {
               desc: 'Did you mean "textAlign"?',
               output:
-                "import stylex from 'stylex'; stylex.create({default: {textAlign: 'left'}});",
+                "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {textAlign: 'left'}});",
             },
           ],
         },
       ],
     },
     {
-      code: "import stylex from 'stylex'; stylex.create({default: {textAlin: 'left'}});",
+      code: "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {textAlin: 'left'}});",
       errors: [
         {
           message: 'This is not a key that is allowed by stylex',
@@ -597,14 +597,14 @@ eslintTester.run('stylex-valid-styles', rule.default, {
             {
               desc: 'Did you mean "textAlign"?',
               output:
-                "import stylex from 'stylex'; stylex.create({default: {textAlign: 'left'}});",
+                "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {textAlign: 'left'}});",
             },
           ],
         },
       ],
     },
     {
-      code: 'import stylex from "stylex"; stylex.create({default: {["textAlin"]: \'left\'}});',
+      code: "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {[\"textAlin\"]: 'left'}});",
       errors: [
         {
           message: 'This is not a key that is allowed by stylex',
@@ -612,7 +612,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
             {
               desc: 'Did you mean "textAlign"?',
               output:
-                'import stylex from "stylex"; stylex.create({default: {["textAlign"]: \'left\'}});',
+                "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {[\"textAlign\"]: 'left'}});",
             },
           ],
         },
@@ -620,7 +620,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           invalidStyle: {
             marginStart: '10px',
@@ -669,7 +669,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
         },
       ],
       output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           invalidStyle: {
             marginInlineStart: '10px',
@@ -686,7 +686,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           invalidStyle: {
             borderStartWidth: '2px',
@@ -725,7 +725,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
         },
       ],
       output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           invalidStyle: {
             borderInlineStartWidth: '2px',
@@ -739,7 +739,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       `,
     },
     {
-      code: "import stylex from 'stylex'; stylex.create({default: {textAlign: 'lfet'}});",
+      code: "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {textAlign: 'lfet'}});",
       errors: [
         {
           message: `textAlign value must be one of:
@@ -759,7 +759,7 @@ revert`,
       ],
     },
     {
-      code: 'import stylex from "stylex"; stylex.create({default: {fontWeight: 10001}});',
+      code: "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {fontWeight: 10001}});",
       errors: [
         {
           message: `fontWeight value must be one of:
@@ -778,7 +778,7 @@ revert`,
       ],
     },
     {
-      code: 'import stylex from "stylex"; stylex.create({default: {content: 100 + 100}});',
+      code: "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {content: 100 + 100}});",
       errors: [
         {
           message: `content value must be one of:
@@ -792,7 +792,7 @@ revert`,
       ],
     },
     {
-      code: "import stylex from 'stylex'; stylex.create({default: {':hover': {textAlin: 'left'}}});",
+      code: "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {':hover': {textAlin: 'left'}}});",
       options: [{ allowOuterPseudoAndMedia: true }],
       errors: [
         {
@@ -801,7 +801,7 @@ revert`,
       ],
     },
     {
-      code: "import stylex from 'stylex'; stylex.create({default: {':focus': {textAlign: 'lfet'}}});",
+      code: "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {':focus': {textAlign: 'lfet'}}});",
       options: [{ allowOuterPseudoAndMedia: true }],
       errors: [
         {
@@ -822,7 +822,7 @@ revert`,
             {
               desc: 'Did you mean "left"? Replace "lfet" with "left"',
               output:
-                "import stylex from 'stylex'; stylex.create({default: {':focus': {textAlign: 'left'}}});",
+                "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {':focus': {textAlign: 'left'}}});",
             },
           ],
         },
@@ -830,7 +830,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         stylex.create({
           default: {
             ':focs': {
@@ -849,7 +849,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         stylex.create({
           default: {
             ':focus': {
@@ -869,7 +869,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const bounce = stylex.keyframes({
           '0%': {
             transform: 'translateY(0)',
@@ -905,7 +905,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             border: "1px solid blue",
@@ -920,7 +920,7 @@ revert`,
             {
               desc: "Replace 'border' with 'borderWidth', 'borderStyle' and 'borderColor' instead?",
               output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
@@ -936,7 +936,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             border: '1px solid rgba(var(--black), 0.0975)',
@@ -951,7 +951,7 @@ revert`,
             {
               desc: "Replace 'border' with 'borderWidth', 'borderStyle' and 'borderColor' instead?",
               output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
@@ -967,7 +967,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             border: "solid blue 1px",
@@ -982,7 +982,7 @@ revert`,
             {
               desc: "Replace 'border' with 'borderWidth', 'borderStyle' and 'borderColor' instead?",
               output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
@@ -998,7 +998,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             border: "blue 1px solid",
@@ -1013,7 +1013,7 @@ revert`,
             {
               desc: "Replace 'border' with 'borderWidth', 'borderStyle' and 'borderColor' instead?",
               output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
@@ -1029,7 +1029,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             border: "1px blue solid",
@@ -1044,7 +1044,7 @@ revert`,
             {
               desc: "Replace 'border' with 'borderWidth', 'borderStyle' and 'borderColor' instead?",
               output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
@@ -1060,7 +1060,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             border: "1px solid",
@@ -1075,7 +1075,7 @@ revert`,
             {
               desc: "Replace 'border' with 'borderWidth', 'borderStyle' and 'borderColor' instead?",
               output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
@@ -1090,7 +1090,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             border: "1px var(--foo)",
@@ -1105,7 +1105,7 @@ revert`,
             {
               desc: "Replace 'border' with 'borderWidth', 'borderStyle' and 'borderColor' instead?",
               output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
@@ -1120,7 +1120,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             border: "1px",
@@ -1135,7 +1135,7 @@ revert`,
             {
               desc: "Replace 'border' with 'borderWidth', 'borderStyle' and 'borderColor' instead?",
               output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
@@ -1149,7 +1149,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             border: "none",
@@ -1164,7 +1164,7 @@ revert`,
             {
               desc: "Replace 'border' with 'borderWidth', 'borderStyle' and 'borderColor' instead?",
               output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             borderStyle: 'none',
@@ -1178,7 +1178,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             border: 0,
@@ -1193,7 +1193,7 @@ revert`,
             {
               desc: "Replace 'border' set to a number with 'borderWidth' instead?",
               output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             borderWidth: 0,
@@ -1207,7 +1207,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             border: 4,
@@ -1222,7 +1222,7 @@ revert`,
             {
               desc: "Replace 'border' set to a number with 'borderWidth' instead?",
               output: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             borderWidth: 4,
@@ -1236,7 +1236,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'custom-import';
+        import * as stylex from 'custom-import';
         const styles = stylex.create({
           default: {
             border: 4,
@@ -1252,7 +1252,7 @@ revert`,
             {
               desc: "Replace 'border' set to a number with 'borderWidth' instead?",
               output: `
-        import stylex from 'custom-import';
+        import * as stylex from 'custom-import';
         const styles = stylex.create({
           default: {
             borderWidth: 4,
@@ -1266,7 +1266,7 @@ revert`,
     },
     {
       code: `
-      import stylex from'stylex';
+      import * as stylex from'stylex';
       import {TextTypeTokens as TextType, ColorTokens} from 'DspSharedTextTokens';
       stylex.create({
         root: {
@@ -1445,7 +1445,7 @@ revert`,
 eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
   valid: [
     `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         default: {
           display: 'grid',
@@ -1457,7 +1457,7 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
     `,
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             display: 'grid',
@@ -1478,7 +1478,7 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             display: 'grid',
@@ -1498,7 +1498,7 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
     },
     {
       code: `
-        import stylex from'stylex';
+        import * as stylex from'stylex';
         const styles = stylex.create({
           default: {
             textUnderlineOffset: 'auto',
@@ -1508,7 +1508,7 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
     },
     {
       code: `
-        import stylex from'stylex';
+        import * as stylex from'stylex';
         const styles = stylex.create({
           default: {
             textUnderlineOffset: '1px',
@@ -1518,7 +1518,7 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
     },
     {
       code: `
-        import stylex from'stylex';
+        import * as stylex from'stylex';
         const styles = stylex.create({
           default: {
             textUnderlineOffset: '100%',
@@ -1528,7 +1528,7 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
     },
     {
       code: `
-        import stylex from'stylex';
+        import * as stylex from'stylex';
         const styles = stylex.create({
           base: {
             backgroundColor: {
@@ -1542,7 +1542,7 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
   invalid: [
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             display: 'grid',
@@ -1574,7 +1574,7 @@ revert`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             display: 'grid',
@@ -1601,7 +1601,7 @@ grid properties disallowed for testing`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             display: 'grid',
@@ -1628,7 +1628,7 @@ grid properties disallowed for testing`,
     },
     {
       code: `
-        import stylex from 'stylex';
+        import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           default: {
             display: 'grid',
@@ -1650,7 +1650,7 @@ This property is not supported in legacy StyleX resolution.`,
     },
     {
       code: `
-      import stylex from 'stylex';
+      import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({
         base:{
           background: ''
@@ -1665,7 +1665,7 @@ This property is not supported in legacy StyleX resolution.`,
     },
     {
       code: `
-        import stylex from'stylex';
+        import * as stylex from'stylex';
         const styles = stylex.create({
           b:{
             textUnderlineOffset: '',

--- a/packages/@stylexjs/eslint-plugin/src/utils/createImportTracker.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/createImportTracker.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+import type { ImportDeclaration } from 'estree';
+
+export type ValidImportSource =
+  | string
+  | {
+      from: string,
+      as: string,
+    };
+
+type ImportTracker = {
+  ImportDeclaration: (node: ImportDeclaration) => void,
+  isStylexDefaultImport: (name: string) => boolean,
+  isStylexNamedImport: (importName: string, name: string) => boolean,
+  clear: () => void,
+};
+
+export default function createImportTracker(
+  importsToLookFor: Array<ValidImportSource>,
+): ImportTracker {
+  const styleXDefaultImports = new Set<string>();
+  const styleXNamedImports = new Map<string, Set<string>>();
+
+  function handleImportDeclaration(node: ImportDeclaration) {
+    if (
+      node.source.type !== 'Literal' ||
+      typeof node.source.value !== 'string'
+    ) {
+      return;
+    }
+
+    const foundImportSource = importsToLookFor.find((importSource) => {
+      if (typeof importSource === 'string') {
+        return importSource === node.source?.value;
+      }
+      return importSource.from === node.source?.value;
+    });
+
+    if (!foundImportSource) {
+      return;
+    }
+
+    if (typeof foundImportSource === 'string') {
+      node.specifiers.forEach((specifier) => {
+        if (
+          specifier.type === 'ImportDefaultSpecifier' ||
+          specifier.type === 'ImportNamespaceSpecifier'
+        ) {
+          styleXDefaultImports.add(specifier.local.name);
+        }
+
+        if (specifier.type === 'ImportSpecifier') {
+          const importName = specifier.imported.name;
+          if (!styleXNamedImports.has(importName)) {
+            styleXNamedImports.set(importName, new Set());
+          }
+          styleXNamedImports.get(importName)?.add(specifier.local.name);
+        }
+      });
+    }
+
+    if (typeof foundImportSource === 'object') {
+      node.specifiers.forEach((specifier) => {
+        if (specifier.type === 'ImportSpecifier') {
+          if (specifier.imported.name === foundImportSource.as) {
+            styleXDefaultImports.add(specifier.local.name);
+          }
+        }
+      });
+    }
+  }
+
+  function isStylexDefaultImport(name: string): boolean {
+    return styleXDefaultImports.has(name);
+  }
+
+  function isStylexNamedImport(importName: string, name: string): boolean {
+    return styleXNamedImports.get(importName)?.has(name) ?? false;
+  }
+
+  function clear() {
+    styleXDefaultImports.clear();
+    styleXNamedImports.clear();
+  }
+
+  return {
+    ImportDeclaration: handleImportDeclaration,
+    isStylexDefaultImport,
+    isStylexNamedImport,
+    clear,
+  };
+}

--- a/packages/docs/docs/api/configuration/eslint-plugin.mdx
+++ b/packages/docs/docs/api/configuration/eslint-plugin.mdx
@@ -16,7 +16,7 @@ sidebar_position: 2
 type Options = {
   // Possible strings where you can import stylex from
   //
-  // Default: ['@stylexjs/stylex']
+  // Default: ['stylex', '@stylexjs/stylex']
   validImports: Array<string | { from: string, as: string }>,
 
   // Custom limits for values of various properties
@@ -98,7 +98,7 @@ type PropLimits = {
 type Options = {
   // Possible string where you can import stylex from
   //
-  // Default: ['@stylexjs/stylex']
+  // Default: ['stylex', '@stylexjs/stylex']
   validImports: Array<string | { from: string, as: string }>,
 
   // Minimum number of keys required after which the rule is enforced
@@ -128,4 +128,63 @@ type Options = {
     ]
   }
 }
+```
+
+### `@stylexjs/stylex-valid-shorthands` rule
+
+```ts
+type Options = {
+  // Possible string where you can import stylex from
+  //
+  // Default: ['stylex', '@stylexjs/stylex']
+  validImports: Array<string | { from: string, as: string }>,
+
+  // Whether `!important` is allowed
+  //
+  // Default: false
+  allowImportant: boolean,
+
+  // Whether the expansion uses logical direction properties over physical
+  //
+  // Default: false
+  preferInline: boolean,
+};
+```
+
+### `@stylexjs/stylex-enforce-extension` rule
+
+```ts
+type Options = {
+  // Possible string where you can import stylex from
+  //
+  // Default: ['stylex', '@stylexjs/stylex']
+  validImports: Array<string | { from: string, as: string }>,
+
+  // The file extension to enforce for theme files
+  //
+  // Default: '.stylex.js'
+  themeFileExtension: string,
+};
+```
+
+### `@stylexjs/stylex-no-unused` rule
+
+```ts
+type Options = {
+  // Possible string where you can import stylex from
+  //
+  // Default: ['stylex', '@stylexjs/stylex']
+  validImports: Array<string | { from: string, as: string }>,
+};
+```
+
+### `@stylexjs/stylex-no-legacy-contextual-styles` rule
+
+```ts
+type Options = {
+  // Possible string where you can import stylex from
+  //
+  // Default: ['stylex', '@stylexjs/stylex']
+  validImports: Array<string | { from: string, as: string }>,
+};
 ```


### PR DESCRIPTION
## What changed / motivation ?

Continuing on https://github.com/facebook/stylex/pull/1039, this PR adds `validImports` option to all eslint rules with support for both the string and object syntax uniformly, for RSD compatibility and other custom aliases.

I've also updated API docs and the README to document the options. I expect documentation rework to be made in another PR (pending https://github.com/facebook/stylex/issues/1057) so made the change minimal.

Main changes:
- added `validImports` option to all rules
- refactored the import name tracking logic to `src/utils/createImportTracker.js` to reduce duplication
- added unit tests to test for custom aliases
- documented changes

## Linked PR/Issues

Fixes https://github.com/facebook/stylex/issues/1056

## Additional Context

I ran the following tests locally and confirmed existing and new tests are passing:
```bash
npm run test
```

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code