### PR TITLE
[babel-plugin] fix border shorthand expansion in `legacy-expand-short…

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
@@ -38,7 +38,7 @@ function transform(source, opts = {}) {
 
 describe('Legacy-shorthand-expansion resolution', () => {
   describe('while using RN non-standard shorthands', () => {
-    test('stylex call with exported short-form properties', () => {
+    test('padding: basic shorthand', () => {
       expect(
         transform(`
           import stylex from 'stylex';
@@ -69,7 +69,31 @@ describe('Legacy-shorthand-expansion resolution', () => {
         "x123j3cw x1gabggj xs9asl8 xaso8d8";"
       `);
     });
-    test('stylex call with short-form property collisions', () => {
+
+    test('margin: basic shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              margin: '10px 20px 30px 40px'
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1anpbxc{margin-top:10px}", 4000);
+        _inject2(".x3aesyq{margin-right:20px}", 3000, ".x3aesyq{margin-left:20px}");
+        _inject2(".x4n8cb0{margin-bottom:30px}", 4000);
+        _inject2(".x11hdunq{margin-left:40px}", 3000, ".x11hdunq{margin-right:40px}");
+        "x1anpbxc x3aesyq x4n8cb0 x11hdunq";"
+      `);
+    });
+
+    test('padding: with longhand property collisions', () => {
       expect(
         transform(`
           import stylex from 'stylex';
@@ -101,7 +125,8 @@ describe('Legacy-shorthand-expansion resolution', () => {
         "x1nn3v0j x14vy60q x1120s5i xe2zdcy";"
       `);
     });
-    test('stylex call with short-form property collisions with null', () => {
+
+    test('padding: with null longhand property collisions', () => {
       expect(
         transform(`
           import stylex from 'stylex';
@@ -132,9 +157,56 @@ describe('Legacy-shorthand-expansion resolution', () => {
         "x1nn3v0j x14vy60q x1120s5i";"
       `);
     });
+
+    test('borderColor: basic shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              borderColor: 'red blue green yellow'
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1uu1fcu{border-top-color:red}", 4000);
+        _inject2(".xcejqfc{border-right-color:blue}", 3000, ".xcejqfc{border-left-color:blue}");
+        _inject2(".x1hnil3p{border-bottom-color:green}", 4000);
+        _inject2(".xqzb60q{border-left-color:yellow}", 3000, ".xqzb60q{border-right-color:yellow}");
+        "x1uu1fcu xcejqfc x1hnil3p xqzb60q";"
+      `);
+    });
+
+    test('borderWidth: basic shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              borderWidth: '1px 2px 3px 4px'
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x178xt8z{border-top-width:1px}", 4000);
+        _inject2(".x1alpsbp{border-right-width:2px}", 3000, ".x1alpsbp{border-left-width:2px}");
+        _inject2(".x2x41l1{border-bottom-width:3px}", 4000);
+        _inject2(".x56jcm7{border-left-width:4px}", 3000, ".x56jcm7{border-right-width:4px}");
+        "x178xt8z x1alpsbp x2x41l1 x56jcm7";"
+      `);
+    });
   });
+
   describe('while using standard logical properties', () => {
-    test('stylex call with exported short-form properties', () => {
+    test('paddingInline: basic shorthand', () => {
       expect(
         transform(`
           import stylex from 'stylex';
@@ -163,7 +235,8 @@ describe('Legacy-shorthand-expansion resolution', () => {
         "xaso8d8 x1gabggj";"
       `);
     });
-    test('stylex call with short-form property collisions', () => {
+
+    test('padding: with longhand property collisions', () => {
       expect(
         transform(`
           import stylex from 'stylex';
@@ -195,7 +268,8 @@ describe('Legacy-shorthand-expansion resolution', () => {
         "x1nn3v0j x14vy60q x1120s5i xe2zdcy";"
       `);
     });
-    test('stylex call with short-form property collisions with null', () => {
+
+    test('padding: with null longhand property collisions', () => {
       expect(
         transform(`
           import stylex from 'stylex';
@@ -224,6 +298,166 @@ describe('Legacy-shorthand-expansion resolution', () => {
         _inject2(".x14vy60q{padding-right:2px}", 3000, ".x14vy60q{padding-left:2px}");
         _inject2(".x1120s5i{padding-bottom:2px}", 4000);
         "x1nn3v0j x14vy60q x1120s5i";"
+      `);
+    });
+
+    test('marginInline: basic shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            foo: {
+              marginInline: 5
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xpcyujq{margin-left:5px}", 3000, ".xpcyujq{margin-right:5px}");
+        _inject2(".xf6vk7d{margin-right:5px}", 3000, ".xf6vk7d{margin-left:5px}");
+        export const styles = {
+          foo: {
+            keTefX: "xpcyujq",
+            k71WvV: "xf6vk7d",
+            koQZXg: null,
+            km5ZXQ: null,
+            $$css: true
+          }
+        };
+        "xpcyujq xf6vk7d";"
+      `);
+    });
+
+    test('margin: with longhand property collisions', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              margin: 5,
+              marginInlineEnd: 10,
+            },
+
+            bar: {
+              margin: 2,
+              marginInlineStart: 10,
+            },
+          });
+          stylex(styles.foo, styles.bar);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1ok221b{margin-top:5px}", 4000);
+        _inject2(".xu06os2{margin-bottom:5px}", 4000);
+        _inject2(".xpcyujq{margin-left:5px}", 3000, ".xpcyujq{margin-right:5px}");
+        _inject2(".x1sa5p1d{margin-right:10px}", 3000, ".x1sa5p1d{margin-left:10px}");
+        _inject2(".xr9ek0c{margin-top:2px}", 4000);
+        _inject2(".xnnr8r{margin-right:2px}", 3000, ".xnnr8r{margin-left:2px}");
+        _inject2(".xjpr12u{margin-bottom:2px}", 4000);
+        _inject2(".x1hm9lzh{margin-left:10px}", 3000, ".x1hm9lzh{margin-right:10px}");
+        "xr9ek0c xnnr8r xjpr12u x1hm9lzh";"
+      `);
+    });
+
+    test('margin: with null longhand property collisions', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              margin: 5,
+              marginInlineEnd: 10,
+            },
+
+            bar: {
+              margin: 2,
+              marginInlineStart: null,
+            },
+          });
+          stylex(styles.foo, styles.bar);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1ok221b{margin-top:5px}", 4000);
+        _inject2(".xu06os2{margin-bottom:5px}", 4000);
+        _inject2(".xpcyujq{margin-left:5px}", 3000, ".xpcyujq{margin-right:5px}");
+        _inject2(".x1sa5p1d{margin-right:10px}", 3000, ".x1sa5p1d{margin-left:10px}");
+        _inject2(".xr9ek0c{margin-top:2px}", 4000);
+        _inject2(".xnnr8r{margin-right:2px}", 3000, ".xnnr8r{margin-left:2px}");
+        _inject2(".xjpr12u{margin-bottom:2px}", 4000);
+        "xr9ek0c xnnr8r xjpr12u";"
+      `);
+    });
+
+    test('border: basic shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              border: '1px solid red'
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x122jhqu{border-top:1px solid red}", 2000);
+        _inject2(".xcmqxwo{border-right:1px solid red}", 2000, ".xcmqxwo{border-left:1px solid red}");
+        _inject2(".xql0met{border-bottom:1px solid red}", 2000);
+        _inject2(".x1lsjq1p{border-left:1px solid red}", 2000, ".x1lsjq1p{border-right:1px solid red}");
+        "x122jhqu xcmqxwo xql0met x1lsjq1p";"
+      `);
+    });
+
+    test('borderInlineColor: basic shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              borderInlineColor: 'red'
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1777cdg{border-left-color:red}", 3000, ".x1777cdg{border-right-color:red}");
+        _inject2(".x9cubbk{border-right-color:red}", 3000, ".x9cubbk{border-left-color:red}");
+        "x1777cdg x9cubbk";"
+      `);
+    });
+
+    test('borderInlineWidth: basic shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              borderInlineWidth: 1
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xpilrb4{border-left-width:1px}", 3000, ".xpilrb4{border-right-width:1px}");
+        _inject2(".x1lun4ml{border-right-width:1px}", 3000, ".x1lun4ml{border-left-width:1px}");
+        "xpilrb4 x1lun4ml";"
       `);
     });
   });

--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-logical-properties-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-logical-properties-test.js
@@ -860,9 +860,9 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x73b8pu{border-left-color:0}", 3000, ".x73b8pu{border-right-color:0}");
-          _inject2(".x75gl4q{border-right-color:0}", 3000, ".x75gl4q{border-left-color:0}");
-          const classnames = "x73b8pu x75gl4q";"
+          _inject2(".x1t19a1o{border-left-color:0}", 3000, ".x1t19a1o{border-right-color:0}");
+          _inject2(".x14mj1wy{border-right-color:0}", 3000, ".x14mj1wy{border-left-color:0}");
+          const classnames = "x1t19a1o x14mj1wy";"
         `);
       });
 
@@ -905,9 +905,9 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x1lq8e90{border-left-style:0}", 3000, ".x1lq8e90{border-right-style:0}");
-          _inject2(".x1s5wcua{border-right-style:0}", 3000, ".x1s5wcua{border-left-style:0}");
-          const classnames = "x1lq8e90 x1s5wcua";"
+          _inject2(".xl8mozw{border-left-style:0}", 3000, ".xl8mozw{border-right-style:0}");
+          _inject2(".x10o505a{border-right-style:0}", 3000, ".x10o505a{border-left-style:0}");
+          const classnames = "xl8mozw x10o505a";"
         `);
       });
 
@@ -928,9 +928,9 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".xm0m39n{border-left-width:0}", 3000, ".xm0m39n{border-right-width:0}");
-          _inject2(".xcfux6l{border-right-width:0}", 3000, ".xcfux6l{border-left-width:0}");
-          const classnames = "xm0m39n xcfux6l";"
+          _inject2(".x14e42zd{border-left-width:0}", 3000, ".x14e42zd{border-right-width:0}");
+          _inject2(".x10w94by{border-right-width:0}", 3000, ".x10w94by{border-left-width:0}");
+          const classnames = "x14e42zd x10w94by";"
         `);
       });
 
@@ -1378,9 +1378,9 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x73b8pu{border-start-color:0}", 3000);
-          _inject2(".x75gl4q{border-end-color:0}", 3000);
-          const classnames = "x73b8pu x75gl4q";"
+          _inject2(".x1t19a1o{border-inline-start-color:0}", 3000);
+          _inject2(".x14mj1wy{border-inline-end-color:0}", 3000);
+          const classnames = "x1t19a1o x14mj1wy";"
         `);
       });
 
@@ -1423,9 +1423,9 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x1lq8e90{border-start-style:0}", 3000);
-          _inject2(".x1s5wcua{border-end-style:0}", 3000);
-          const classnames = "x1lq8e90 x1s5wcua";"
+          _inject2(".xl8mozw{border-inline-start-style:0}", 3000);
+          _inject2(".x10o505a{border-inline-end-style:0}", 3000);
+          const classnames = "xl8mozw x10o505a";"
         `);
       });
 
@@ -1446,9 +1446,9 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".xm0m39n{border-start-width:0}", 3000);
-          _inject2(".xcfux6l{border-end-width:0}", 3000);
-          const classnames = "xm0m39n xcfux6l";"
+          _inject2(".x14e42zd{border-inline-start-width:0}", 3000);
+          _inject2(".x10w94by{border-inline-end-width:0}", 3000);
+          const classnames = "x14e42zd x10w94by";"
         `);
       });
 

--- a/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/__tests__/flatten-raw-style-obj-test.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/__tests__/flatten-raw-style-obj-test.js
@@ -128,16 +128,18 @@ describe('Flatten Style Object with legacy shorthand expansion', () => {
           new PreRule('borderTopColor', 'red', ['borderTopColor']),
         ],
         [
-          'borderEndColor',
-          new PreRule('borderEndColor', 'red', ['borderEndColor']),
+          'borderInlineEndColor',
+          new PreRule('borderInlineEndColor', 'red', ['borderInlineEndColor']),
         ],
         [
           'borderBottomColor',
           new PreRule('borderBottomColor', 'red', ['borderBottomColor']),
         ],
         [
-          'borderStartColor',
-          new PreRule('borderStartColor', 'red', ['borderStartColor']),
+          'borderInlineStartColor',
+          new PreRule('borderInlineStartColor', 'red', [
+            'borderInlineStartColor',
+          ]),
         ],
       ]);
     });

--- a/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/legacy-expand-shorthands.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/legacy-expand-shorthands.js
@@ -87,9 +87,9 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
   border: (rawValue: TStyleValue): TReturn => {
     return [
       ['borderTop', rawValue],
-      ['borderEnd', rawValue],
+      ['borderInlineEnd', rawValue],
       ['borderBottom', rawValue],
-      ['borderStart', rawValue],
+      ['borderInlineStart', rawValue],
     ];
   },
 
@@ -98,9 +98,9 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
 
     return [
       ['borderTopColor', top],
-      ['borderEndColor', right],
+      ['borderInlineEndColor', right],
       ['borderBottomColor', bottom],
-      ['borderStartColor', left],
+      ['borderInlineStartColor', left],
     ];
   },
   borderHorizontal: (rawValue: TStyleValue): TReturn => {
@@ -114,9 +114,9 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
 
     return [
       ['borderTopStyle', top],
-      ['borderEndStyle', right],
+      ['borderInlineEndStyle', right],
       ['borderBottomStyle', bottom],
-      ['borderStartStyle', left],
+      ['borderInlineStartStyle', left],
     ];
   },
   borderVertical: (rawValue: TStyleValue): TReturn => {
@@ -130,23 +130,23 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
 
     return [
       ['borderTopWidth', top],
-      ['borderEndWidth', right],
+      ['borderInlineEndWidth', right],
       ['borderBottomWidth', bottom],
-      ['borderStartWidth', left],
+      ['borderInlineStartWidth', left],
     ];
   },
 
   borderHorizontalColor: (rawValue: TStyleValue): TReturn => [
-    ['borderStartColor', rawValue],
-    ['borderEndColor', rawValue],
+    ['borderInlineStartColor', rawValue],
+    ['borderInlineEndColor', rawValue],
   ],
   borderHorizontalStyle: (rawValue: TStyleValue): TReturn => [
-    ['borderStartStyle', rawValue],
-    ['borderEndStyle', rawValue],
+    ['borderInlineStartStyle', rawValue],
+    ['borderInlineEndStyle', rawValue],
   ],
   borderHorizontalWidth: (rawValue: TStyleValue): TReturn => [
-    ['borderStartWidth', rawValue],
-    ['borderEndWidth', rawValue],
+    ['borderInlineStartWidth', rawValue],
+    ['borderInlineEndWidth', rawValue],
   ],
   borderVerticalColor: (rawValue: TStyleValue): TReturn => [
     ['borderTopColor', rawValue],


### PR DESCRIPTION
In https://github.com/facebook/stylex/pull/1083 we migrated margin/padding shorthand expansion to standard logical properties as an intermediary step before they are rewritten as physical direction ones. We need to do the same for border properties.

- Added tests to cover margin and border in `stylex-transform-legacy-shorthands-test` 

Synced internally and screenshots in WWW are passing