### PR TITLE
[babel-plugin] polyfill all nonstandard properties in 'legacy-expand-…

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
@@ -28,7 +28,7 @@ function transform(source, opts = {}) {
         {
           runtimeInjection: true,
           styleResolution: 'legacy-expand-shorthands',
-          enableLogicalStylesPolyfill: true,
+          enableLogicalStylesPolyfill: opts.enableLogicalStylesPolyfill ?? true,
           ...opts,
         },
       ],
@@ -36,63 +36,8 @@ function transform(source, opts = {}) {
   }).code;
 }
 
-describe('Legacy-shorthand-expansion resolution', () => {
-  describe('while using RN non-standard shorthands', () => {
-    test('padding: basic shorthand', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          export const styles = stylex.create({
-            foo: {
-              padding: 5
-            }
-          });
-          stylex(styles.foo);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x123j3cw{padding-top:5px}", 4000);
-        _inject2(".x1gabggj{padding-right:5px}", 3000, ".x1gabggj{padding-left:5px}");
-        _inject2(".xs9asl8{padding-bottom:5px}", 4000);
-        _inject2(".xaso8d8{padding-left:5px}", 3000, ".xaso8d8{padding-right:5px}");
-        export const styles = {
-          foo: {
-            kLKAdn: "x123j3cw",
-            kwRFfy: "x1gabggj",
-            kGO01o: "xs9asl8",
-            kZCmMZ: "xaso8d8",
-            $$css: true
-          }
-        };
-        "x123j3cw x1gabggj xs9asl8 xaso8d8";"
-      `);
-    });
-
-    test('margin: basic shorthand', () => {
-      expect(
-        transform(`
-          import stylex from 'stylex';
-          const styles = stylex.create({
-            foo: {
-              margin: '10px 20px 30px 40px'
-            }
-          });
-          stylex(styles.foo);
-        `),
-      ).toMatchInlineSnapshot(`
-        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
-        var _inject2 = _inject;
-        import stylex from 'stylex';
-        _inject2(".x1anpbxc{margin-top:10px}", 4000);
-        _inject2(".x3aesyq{margin-right:20px}", 3000, ".x3aesyq{margin-left:20px}");
-        _inject2(".x4n8cb0{margin-bottom:30px}", 4000);
-        _inject2(".x11hdunq{margin-left:40px}", 3000, ".x11hdunq{margin-right:40px}");
-        "x1anpbxc x3aesyq x4n8cb0 x11hdunq";"
-      `);
-    });
-
+describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfill: true)', () => {
+  describe('while using RN non-standard properties', () => {
     test('padding: with longhand property collisions', () => {
       expect(
         transform(`
@@ -206,6 +151,61 @@ describe('Legacy-shorthand-expansion resolution', () => {
   });
 
   describe('while using standard logical properties', () => {
+    test('padding: basic shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            foo: {
+              padding: 5
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x123j3cw{padding-top:5px}", 4000);
+        _inject2(".x1gabggj{padding-right:5px}", 3000, ".x1gabggj{padding-left:5px}");
+        _inject2(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject2(".xaso8d8{padding-left:5px}", 3000, ".xaso8d8{padding-right:5px}");
+        export const styles = {
+          foo: {
+            kLKAdn: "x123j3cw",
+            kwRFfy: "x1gabggj",
+            kGO01o: "xs9asl8",
+            kZCmMZ: "xaso8d8",
+            $$css: true
+          }
+        };
+        "x123j3cw x1gabggj xs9asl8 xaso8d8";"
+      `);
+    });
+
+    test('margin: basic shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              margin: '10px 20px 30px 40px'
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1anpbxc{margin-top:10px}", 4000);
+        _inject2(".x3aesyq{margin-right:20px}", 3000, ".x3aesyq{margin-left:20px}");
+        _inject2(".x4n8cb0{margin-bottom:30px}", 4000);
+        _inject2(".x11hdunq{margin-left:40px}", 3000, ".x11hdunq{margin-right:40px}");
+        "x1anpbxc x3aesyq x4n8cb0 x11hdunq";"
+      `);
+    });
+
     test('paddingInline: basic shorthand', () => {
       expect(
         transform(`
@@ -457,6 +457,478 @@ describe('Legacy-shorthand-expansion resolution', () => {
         import stylex from 'stylex';
         _inject2(".xpilrb4{border-left-width:1px}", 3000, ".xpilrb4{border-right-width:1px}");
         _inject2(".x1lun4ml{border-right-width:1px}", 3000, ".x1lun4ml{border-left-width:1px}");
+        "xpilrb4 x1lun4ml";"
+      `);
+    });
+  });
+});
+
+describe('legacy-shorthand-expansion resolution (enableLogicalStylesPolyfill: false)', () => {
+  describe('while using RN non-standard properties', () => {
+    test('padding: with longhand property collisions', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              padding: 5,
+              paddingEnd: 10,
+            },
+
+            bar: {
+              padding: 2,
+              paddingStart: 10,
+            },
+          });
+          stylex(styles.foo, styles.bar);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x123j3cw{padding-top:5px}", 4000);
+        _inject2(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject2(".xaso8d8{padding-inline-start:5px}", 3000);
+        _inject2(".x2vl965{padding-inline-end:10px}", 3000);
+        _inject2(".x1nn3v0j{padding-top:2px}", 4000);
+        _inject2(".x14vy60q{padding-inline-end:2px}", 3000);
+        _inject2(".x1120s5i{padding-bottom:2px}", 4000);
+        _inject2(".xe2zdcy{padding-inline-start:10px}", 3000);
+        "x1nn3v0j x14vy60q x1120s5i xe2zdcy";"
+      `);
+    });
+
+    test('padding: with null longhand property collisions', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              padding: 5,
+              paddingEnd: 10,
+            },
+
+            bar: {
+              padding: 2,
+              paddingStart: null,
+            },
+          });
+          stylex(styles.foo, styles.bar);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x123j3cw{padding-top:5px}", 4000);
+        _inject2(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject2(".xaso8d8{padding-inline-start:5px}", 3000);
+        _inject2(".x2vl965{padding-inline-end:10px}", 3000);
+        _inject2(".x1nn3v0j{padding-top:2px}", 4000);
+        _inject2(".x14vy60q{padding-inline-end:2px}", 3000);
+        _inject2(".x1120s5i{padding-bottom:2px}", 4000);
+        "x1nn3v0j x14vy60q x1120s5i";"
+      `);
+    });
+
+    test('borderColor: basic shorthand', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              borderColor: 'red blue green yellow'
+            }
+          });
+          stylex(styles.foo);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1uu1fcu{border-top-color:red}", 4000);
+        _inject2(".xcejqfc{border-inline-end-color:blue}", 3000);
+        _inject2(".x1hnil3p{border-bottom-color:green}", 4000);
+        _inject2(".xqzb60q{border-inline-start-color:yellow}", 3000);
+        "x1uu1fcu xcejqfc x1hnil3p xqzb60q";"
+      `);
+    });
+
+    test('borderWidth: basic shorthand', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              borderWidth: '1px 2px 3px 4px'
+            }
+          });
+          stylex(styles.foo);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x178xt8z{border-top-width:1px}", 4000);
+        _inject2(".x1alpsbp{border-inline-end-width:2px}", 3000);
+        _inject2(".x2x41l1{border-bottom-width:3px}", 4000);
+        _inject2(".x56jcm7{border-inline-start-width:4px}", 3000);
+        "x178xt8z x1alpsbp x2x41l1 x56jcm7";"
+      `);
+    });
+  });
+
+  describe('while using standard logical properties', () => {
+    test('padding: basic shorthand', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            foo: {
+              padding: 5
+            }
+          });
+          stylex(styles.foo);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x123j3cw{padding-top:5px}", 4000);
+        _inject2(".x1gabggj{padding-inline-end:5px}", 3000);
+        _inject2(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject2(".xaso8d8{padding-inline-start:5px}", 3000);
+        export const styles = {
+          foo: {
+            kLKAdn: "x123j3cw",
+            kwRFfy: "x1gabggj",
+            kGO01o: "xs9asl8",
+            kZCmMZ: "xaso8d8",
+            $$css: true
+          }
+        };
+        "x123j3cw x1gabggj xs9asl8 xaso8d8";"
+      `);
+    });
+
+    test('margin: basic shorthand', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              margin: '10px 20px 30px 40px'
+            }
+          });
+          stylex(styles.foo);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1anpbxc{margin-top:10px}", 4000);
+        _inject2(".x3aesyq{margin-inline-end:20px}", 3000);
+        _inject2(".x4n8cb0{margin-bottom:30px}", 4000);
+        _inject2(".x11hdunq{margin-inline-start:40px}", 3000);
+        "x1anpbxc x3aesyq x4n8cb0 x11hdunq";"
+      `);
+    });
+
+    test('paddingInline: basic shorthand', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            foo: {
+              paddingInline: 5
+            }
+          });
+          stylex(styles.foo);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xaso8d8{padding-inline-start:5px}", 3000);
+        _inject2(".x1gabggj{padding-inline-end:5px}", 3000);
+        export const styles = {
+          foo: {
+            kZCmMZ: "xaso8d8",
+            kwRFfy: "x1gabggj",
+            kE3dHu: null,
+            kpe85a: null,
+            $$css: true
+          }
+        };
+        "xaso8d8 x1gabggj";"
+      `);
+    });
+
+    test('padding: with longhand property collisions', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              padding: 5,
+              paddingInlineEnd: 10,
+            },
+
+            bar: {
+              padding: 2,
+              paddingInlineStart: 10,
+            },
+          });
+          stylex(styles.foo, styles.bar);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x123j3cw{padding-top:5px}", 4000);
+        _inject2(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject2(".xaso8d8{padding-inline-start:5px}", 3000);
+        _inject2(".x2vl965{padding-inline-end:10px}", 3000);
+        _inject2(".x1nn3v0j{padding-top:2px}", 4000);
+        _inject2(".x14vy60q{padding-inline-end:2px}", 3000);
+        _inject2(".x1120s5i{padding-bottom:2px}", 4000);
+        _inject2(".xe2zdcy{padding-inline-start:10px}", 3000);
+        "x1nn3v0j x14vy60q x1120s5i xe2zdcy";"
+      `);
+    });
+
+    test('padding: with null longhand property collisions', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              padding: 5,
+              paddingInlineEnd: 10,
+            },
+
+            bar: {
+              padding: 2,
+              paddingInlineStart: null,
+            },
+          });
+          stylex(styles.foo, styles.bar);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x123j3cw{padding-top:5px}", 4000);
+        _inject2(".xs9asl8{padding-bottom:5px}", 4000);
+        _inject2(".xaso8d8{padding-inline-start:5px}", 3000);
+        _inject2(".x2vl965{padding-inline-end:10px}", 3000);
+        _inject2(".x1nn3v0j{padding-top:2px}", 4000);
+        _inject2(".x14vy60q{padding-inline-end:2px}", 3000);
+        _inject2(".x1120s5i{padding-bottom:2px}", 4000);
+        "x1nn3v0j x14vy60q x1120s5i";"
+      `);
+    });
+
+    test('marginInline: basic shorthand', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            foo: {
+              marginInline: 5
+            }
+          });
+          stylex(styles.foo);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xpcyujq{margin-inline-start:5px}", 3000);
+        _inject2(".xf6vk7d{margin-inline-end:5px}", 3000);
+        export const styles = {
+          foo: {
+            keTefX: "xpcyujq",
+            k71WvV: "xf6vk7d",
+            koQZXg: null,
+            km5ZXQ: null,
+            $$css: true
+          }
+        };
+        "xpcyujq xf6vk7d";"
+      `);
+    });
+
+    test('margin: with longhand property collisions', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              margin: 5,
+              marginInlineEnd: 10,
+            },
+
+            bar: {
+              margin: 2,
+              marginInlineStart: 10,
+            },
+          });
+          stylex(styles.foo, styles.bar);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1ok221b{margin-top:5px}", 4000);
+        _inject2(".xu06os2{margin-bottom:5px}", 4000);
+        _inject2(".xpcyujq{margin-inline-start:5px}", 3000);
+        _inject2(".x1sa5p1d{margin-inline-end:10px}", 3000);
+        _inject2(".xr9ek0c{margin-top:2px}", 4000);
+        _inject2(".xnnr8r{margin-inline-end:2px}", 3000);
+        _inject2(".xjpr12u{margin-bottom:2px}", 4000);
+        _inject2(".x1hm9lzh{margin-inline-start:10px}", 3000);
+        "xr9ek0c xnnr8r xjpr12u x1hm9lzh";"
+      `);
+    });
+
+    test('margin: with null longhand property collisions', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              margin: 5,
+              marginInlineEnd: 10,
+            },
+
+            bar: {
+              margin: 2,
+              marginInlineStart: null,
+            },
+          });
+          stylex(styles.foo, styles.bar);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1ok221b{margin-top:5px}", 4000);
+        _inject2(".xu06os2{margin-bottom:5px}", 4000);
+        _inject2(".xpcyujq{margin-inline-start:5px}", 3000);
+        _inject2(".x1sa5p1d{margin-inline-end:10px}", 3000);
+        _inject2(".xr9ek0c{margin-top:2px}", 4000);
+        _inject2(".xnnr8r{margin-inline-end:2px}", 3000);
+        _inject2(".xjpr12u{margin-bottom:2px}", 4000);
+        "xr9ek0c xnnr8r xjpr12u";"
+      `);
+    });
+
+    test('border: basic shorthand', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              border: '1px solid red'
+            }
+          });
+          stylex(styles.foo);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x122jhqu{border-top:1px solid red}", 2000);
+        _inject2(".xcmqxwo{border-inline-end:1px solid red}", 2000);
+        _inject2(".xql0met{border-bottom:1px solid red}", 2000);
+        _inject2(".x1lsjq1p{border-inline-start:1px solid red}", 2000);
+        "x122jhqu xcmqxwo xql0met x1lsjq1p";"
+      `);
+    });
+
+    test('borderInlineColor: basic shorthand', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              borderInlineColor: 'red'
+            }
+          });
+          stylex(styles.foo);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1777cdg{border-inline-start-color:red}", 3000);
+        _inject2(".x9cubbk{border-inline-end-color:red}", 3000);
+        "x1777cdg x9cubbk";"
+      `);
+    });
+
+    test('borderInlineWidth: basic shorthand', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              borderInlineWidth: 1
+            }
+          });
+          stylex(styles.foo);
+        `,
+          { enableLogicalStylesPolyfill: false },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xpilrb4{border-inline-start-width:1px}", 3000);
+        _inject2(".x1lun4ml{border-inline-end-width:1px}", 3000);
         "xpilrb4 x1lun4ml";"
       `);
     });

--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-legacy-polyfills-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-legacy-polyfills-test.js
@@ -28,7 +28,7 @@ describe('@stylexjs/babel-plugin', () => {
    * Non-standard CSS polyfills
    * These are deprecated and should be removed once Meta has migrated off them.
    */
-  describe('[transform] CSS property polyfills', () => {
+  describe('[transform] CSS property polyfills (styleResolution: application-order)', () => {
     test('[non-standard] "end" (aka "insetInlineEnd")', () => {
       const { metadata } = transform(`
         import * as stylex from '@stylexjs/stylex';
@@ -240,7 +240,7 @@ describe('@stylexjs/babel-plugin', () => {
     });
   });
 
-  describe('[transform] CSS value polyfills', () => {
+  describe('[transform] CSS value polyfills (styleResolution: application-order)', () => {
     /**
      * Non-standard values
      * These are deprecated and should be removed once Meta has migrated off them.
@@ -322,6 +322,770 @@ describe('@stylexjs/babel-plugin', () => {
               {
                 "ltr": ".xrbpyxo{float:left}",
                 "rtl": ".xrbpyxo{float:right}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+  });
+
+  describe('[transform] CSS property polyfills (styleResolution: legacy-expand-shorthands and enableLogicalStylesPolyfill: true)', () => {
+    const legacyOpts = {
+      enableLogicalStylesPolyfill: true,
+      styleResolution: 'legacy-expand-shorthands',
+    };
+
+    test('[non-standard] "end" (aka "insetInlineEnd")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { end: 5 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xceh6e4",
+              {
+                "ltr": ".xceh6e4{right:5px}",
+                "rtl": ".xceh6e4{left:5px}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "marginEnd" (aka "marginInlineEnd")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { marginEnd: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x14z9mp",
+              {
+                "ltr": ".x14z9mp{margin-right:0}",
+                "rtl": ".x14z9mp{margin-left:0}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "marginHorizontal" (aka "marginInline")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { marginHorizontal: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1lziwak",
+              {
+                "ltr": ".x1lziwak{margin-left:0}",
+                "rtl": ".x1lziwak{margin-right:0}",
+              },
+              3000,
+            ],
+            [
+              "x14z9mp",
+              {
+                "ltr": ".x14z9mp{margin-right:0}",
+                "rtl": ".x14z9mp{margin-left:0}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "marginStart" (aka "marginInlineStart")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { marginStart: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1lziwak",
+              {
+                "ltr": ".x1lziwak{margin-left:0}",
+                "rtl": ".x1lziwak{margin-right:0}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "marginVertical" (aka "marginBlock")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { marginVertical: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xdj266r",
+              {
+                "ltr": ".xdj266r{margin-top:0}",
+                "rtl": null,
+              },
+              4000,
+            ],
+            [
+              "xat24cr",
+              {
+                "ltr": ".xat24cr{margin-bottom:0}",
+                "rtl": null,
+              },
+              4000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "paddingEnd" (aka "paddingInlineEnd")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { paddingEnd: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xyri2b",
+              {
+                "ltr": ".xyri2b{padding-right:0}",
+                "rtl": ".xyri2b{padding-left:0}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "paddingHorizontal" (aka "paddingInline")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { paddingHorizontal: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1c1uobl",
+              {
+                "ltr": ".x1c1uobl{padding-left:0}",
+                "rtl": ".x1c1uobl{padding-right:0}",
+              },
+              3000,
+            ],
+            [
+              "xyri2b",
+              {
+                "ltr": ".xyri2b{padding-right:0}",
+                "rtl": ".xyri2b{padding-left:0}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "paddingStart" (aka "paddingInlineStart")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { paddingStart: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1c1uobl",
+              {
+                "ltr": ".x1c1uobl{padding-left:0}",
+                "rtl": ".x1c1uobl{padding-right:0}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "paddingVertical" (aka "paddingBlock")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { paddingVertical: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xexx8yu",
+              {
+                "ltr": ".xexx8yu{padding-top:0}",
+                "rtl": null,
+              },
+              4000,
+            ],
+            [
+              "x18d9i69",
+              {
+                "ltr": ".x18d9i69{padding-bottom:0}",
+                "rtl": null,
+              },
+              4000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "start" (aka "insetInlineStart")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { start: 5 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1fb7gu6",
+              {
+                "ltr": ".x1fb7gu6{left:5px}",
+                "rtl": ".x1fb7gu6{right:5px}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+  });
+
+  describe('[transform] CSS value polyfills (styleResolution: legacy-expand-shorthands and enableLogicalStylesPolyfill: true)', () => {
+    const legacyOpts = {
+      enableLogicalStylesPolyfill: true,
+      styleResolution: 'legacy-expand-shorthands',
+    };
+
+    test('[non-standard] value "end" (aka "inlineEnd") for "clear" property', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { clear: 'end' } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xodj72a",
+              {
+                "ltr": ".xodj72a{clear:right}",
+                "rtl": ".xodj72a{clear:left}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] value "start" (aka "inlineStart") for "clear" property', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { clear: 'start' } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x390i0x",
+              {
+                "ltr": ".x390i0x{clear:left}",
+                "rtl": ".x390i0x{clear:right}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] value "end" (aka "inlineEnd") for "float" property', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { float: 'end' } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1guec7k",
+              {
+                "ltr": ".x1guec7k{float:right}",
+                "rtl": ".x1guec7k{float:left}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] value "start" (aka "inlineStart") for "float" property', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { float: 'start' } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xrbpyxo",
+              {
+                "ltr": ".xrbpyxo{float:left}",
+                "rtl": ".xrbpyxo{float:right}",
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+  });
+
+  describe('[transform] CSS property polyfills (styleResolution: legacy-expand-shorthands and enableLogicalStylesPolyfill: false)', () => {
+    const legacyOpts = {
+      enableLogicalStylesPolyfill: false,
+      styleResolution: 'legacy-expand-shorthands',
+    };
+
+    test('[non-standard] "end" (aka "insetInlineEnd")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { end: 5 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xceh6e4",
+              {
+                "ltr": ".xceh6e4{inset-inline-end:5px}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "marginEnd" (aka "marginInlineEnd")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { marginEnd: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x14z9mp",
+              {
+                "ltr": ".x14z9mp{margin-inline-end:0}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "marginHorizontal" (aka "marginInline")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { marginHorizontal: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1lziwak",
+              {
+                "ltr": ".x1lziwak{margin-inline-start:0}",
+                "rtl": null,
+              },
+              3000,
+            ],
+            [
+              "x14z9mp",
+              {
+                "ltr": ".x14z9mp{margin-inline-end:0}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "marginStart" (aka "marginInlineStart")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { marginStart: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1lziwak",
+              {
+                "ltr": ".x1lziwak{margin-inline-start:0}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "marginVertical" (aka "marginBlock")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { marginVertical: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xdj266r",
+              {
+                "ltr": ".xdj266r{margin-top:0}",
+                "rtl": null,
+              },
+              4000,
+            ],
+            [
+              "xat24cr",
+              {
+                "ltr": ".xat24cr{margin-bottom:0}",
+                "rtl": null,
+              },
+              4000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "paddingEnd" (aka "paddingInlineEnd")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { paddingEnd: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xyri2b",
+              {
+                "ltr": ".xyri2b{padding-inline-end:0}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "paddingHorizontal" (aka "paddingInline")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { paddingHorizontal: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1c1uobl",
+              {
+                "ltr": ".x1c1uobl{padding-inline-start:0}",
+                "rtl": null,
+              },
+              3000,
+            ],
+            [
+              "xyri2b",
+              {
+                "ltr": ".xyri2b{padding-inline-end:0}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "paddingStart" (aka "paddingInlineStart")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { paddingStart: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1c1uobl",
+              {
+                "ltr": ".x1c1uobl{padding-inline-start:0}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "paddingVertical" (aka "paddingBlock")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { paddingVertical: 0 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xexx8yu",
+              {
+                "ltr": ".xexx8yu{padding-top:0}",
+                "rtl": null,
+              },
+              4000,
+            ],
+            [
+              "x18d9i69",
+              {
+                "ltr": ".x18d9i69{padding-bottom:0}",
+                "rtl": null,
+              },
+              4000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] "start" (aka "insetInlineStart")', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { start: 5 } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1fb7gu6",
+              {
+                "ltr": ".x1fb7gu6{inset-inline-start:5px}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+  });
+
+  describe('[transform] CSS value polyfills (styleResolution: legacy-expand-shorthands and enableLogicalStylesPolyfill: false)', () => {
+    const legacyOpts = {
+      enableLogicalStylesPolyfill: false,
+      styleResolution: 'legacy-expand-shorthands',
+    };
+
+    test('[non-standard] value "end" (aka "inlineEnd") for "clear" property', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { clear: 'end' } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xodj72a",
+              {
+                "ltr": ".xodj72a{clear:inline-end}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] value "start" (aka "inlineStart") for "clear" property', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { clear: 'start' } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x390i0x",
+              {
+                "ltr": ".x390i0x{clear:inline-start}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] value "end" (aka "inlineEnd") for "float" property', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { float: 'end' } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1guec7k",
+              {
+                "ltr": ".x1guec7k{float:inline-end}",
+                "rtl": null,
+              },
+              3000,
+            ],
+          ],
+        }
+      `);
+    });
+
+    test('[non-standard] value "start" (aka "inlineStart") for "float" property', () => {
+      const { metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({ x: { float: 'start' } });
+      `,
+        legacyOpts,
+      );
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xrbpyxo",
+              {
+                "ltr": ".xrbpyxo{float:inline-start}",
+                "rtl": null,
               },
               3000,
             ],

--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-logical-properties-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-logical-properties-test.js
@@ -1087,9 +1087,9 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x17qophe{left:0}", 3000, ".x17qophe{right:0}");
-          _inject2(".xds687c{right:0}", 3000, ".xds687c{left:0}");
-          const classnames = "x17qophe xds687c";"
+          _inject2(".x1o0tod{left:0}", 3000, ".x1o0tod{right:0}");
+          _inject2(".xtijo5x{right:0}", 3000, ".xtijo5x{left:0}");
+          const classnames = "x1o0tod xtijo5x";"
         `);
       });
 
@@ -1110,8 +1110,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x17qophe{left:0}", 3000, ".x17qophe{right:0}");
-          const classnames = "x17qophe";"
+          _inject2(".x1o0tod{left:0}", 3000, ".x1o0tod{right:0}");
+          const classnames = "x1o0tod";"
         `);
       });
 
@@ -1132,8 +1132,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".xds687c{right:0}", 3000, ".xds687c{left:0}");
-          const classnames = "xds687c";"
+          _inject2(".xtijo5x{right:0}", 3000, ".xtijo5x{left:0}");
+          const classnames = "xtijo5x";"
         `);
       });
 
@@ -1154,8 +1154,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x8u2fvd{border-top-left-radius:5px}", 3000, ".x8u2fvd{border-top-right-radius:5px}");
-          const classnames = "x8u2fvd";"
+          _inject2(".x13t61ll{border-top-left-radius:5px}", 3000, ".x13t61ll{border-top-right-radius:5px}");
+          const classnames = "x13t61ll";"
         `);
       });
 
@@ -1176,8 +1176,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x5yzy4c{border-bottom-left-radius:5px}", 3000, ".x5yzy4c{border-bottom-right-radius:5px}");
-          const classnames = "x5yzy4c";"
+          _inject2(".xbxn0j6{border-bottom-left-radius:5px}", 3000, ".xbxn0j6{border-bottom-right-radius:5px}");
+          const classnames = "xbxn0j6";"
         `);
       });
 
@@ -1198,8 +1198,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x1ht7hnu{border-top-right-radius:5px}", 3000, ".x1ht7hnu{border-top-left-radius:5px}");
-          const classnames = "x1ht7hnu";"
+          _inject2(".x1kchd1x{border-top-right-radius:5px}", 3000, ".x1kchd1x{border-top-left-radius:5px}");
+          const classnames = "x1kchd1x";"
         `);
       });
 
@@ -1220,8 +1220,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x1quq95r{border-bottom-right-radius:5px}", 3000, ".x1quq95r{border-bottom-left-radius:5px}");
-          const classnames = "x1quq95r";"
+          _inject2(".x1u0fnx4{border-bottom-right-radius:5px}", 3000, ".x1u0fnx4{border-bottom-left-radius:5px}");
+          const classnames = "x1u0fnx4";"
         `);
       });
     });
@@ -1605,9 +1605,9 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x17qophe{start:0}", 3000);
-          _inject2(".xds687c{end:0}", 3000);
-          const classnames = "x17qophe xds687c";"
+          _inject2(".x1o0tod{inset-inline-start:0}", 3000);
+          _inject2(".xtijo5x{inset-inline-end:0}", 3000);
+          const classnames = "x1o0tod xtijo5x";"
         `);
       });
 
@@ -1628,8 +1628,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x17qophe{start:0}", 3000);
-          const classnames = "x17qophe";"
+          _inject2(".x1o0tod{inset-inline-start:0}", 3000);
+          const classnames = "x1o0tod";"
         `);
       });
 
@@ -1650,8 +1650,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".xds687c{end:0}", 3000);
-          const classnames = "xds687c";"
+          _inject2(".xtijo5x{inset-inline-end:0}", 3000);
+          const classnames = "xtijo5x";"
         `);
       });
 
@@ -1672,8 +1672,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x8u2fvd{border-top-start-radius:5px}", 3000);
-          const classnames = "x8u2fvd";"
+          _inject2(".x13t61ll{border-start-start-radius:5px}", 3000);
+          const classnames = "x13t61ll";"
         `);
       });
 
@@ -1694,8 +1694,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x5yzy4c{border-bottom-start-radius:5px}", 3000);
-          const classnames = "x5yzy4c";"
+          _inject2(".xbxn0j6{border-end-start-radius:5px}", 3000);
+          const classnames = "xbxn0j6";"
         `);
       });
 
@@ -1716,8 +1716,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x1ht7hnu{border-top-end-radius:5px}", 3000);
-          const classnames = "x1ht7hnu";"
+          _inject2(".x1kchd1x{border-start-end-radius:5px}", 3000);
+          const classnames = "x1kchd1x";"
         `);
       });
 
@@ -1738,8 +1738,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import stylex from 'stylex';
-          _inject2(".x1quq95r{border-bottom-end-radius:5px}", 3000);
-          const classnames = "x1quq95r";"
+          _inject2(".x1u0fnx4{border-end-end-radius:5px}", 3000);
+          const classnames = "x1u0fnx4";"
         `);
       });
     });

--- a/packages/@stylexjs/babel-plugin/src/shared/physical-rtl/generate-rtl.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/physical-rtl/generate-rtl.js
@@ -164,6 +164,14 @@ const inlinePropertyToRTL: $ReadOnly<{
     'border-bottom-left-radius',
     val,
   ],
+  'inset-inline-start': ([_key, val]: $ReadOnly<[string, string]>) => [
+    'right',
+    val,
+  ],
+  'inset-inline-end': ([_key, val]: $ReadOnly<[string, string]>) => [
+    'left',
+    val,
+  ],
 };
 
 const propertyToRTL: $ReadOnly<{
@@ -252,7 +260,11 @@ const propertyToRTL: $ReadOnly<{
       key,
       words
         .map((word) =>
-          word === 'start' ? 'right' : word === 'end' ? 'left' : word,
+          word === 'start' || word === 'insetInlineStart'
+            ? 'right'
+            : word === 'end' || word === 'insetInlineEnd'
+              ? 'left'
+              : word,
         )
         .join(' '),
     ];

--- a/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/legacy-expand-shorthands.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/legacy-expand-shorthands.js
@@ -105,8 +105,8 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
   },
   borderHorizontal: (rawValue: TStyleValue): TReturn => {
     return [
-      ['borderStart', rawValue],
-      ['borderEnd', rawValue],
+      ['borderInlineStart', rawValue],
+      ['borderInlineEnd', rawValue],
     ];
   },
   borderStyle: (rawValue: TStyleValue): TReturn => {
@@ -165,10 +165,10 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
     const [top, right = top, bottom = top, left = right] = splitValue(rawValue);
 
     return [
-      ['borderTopStartRadius', top],
-      ['borderTopEndRadius', right],
-      ['borderBottomEndRadius', bottom],
-      ['borderBottomStartRadius', left],
+      ['borderStartStartRadius', top],
+      ['borderStartEndRadius', right],
+      ['borderEndEndRadius', bottom],
+      ['borderEndStartRadius', left],
     ];
   },
 
@@ -199,9 +199,9 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
 
   inset: (rawValue: TStyleValue): TReturn => [
     ['top', rawValue],
-    ['end', rawValue],
+    ['insetInlineEnd', rawValue],
     ['bottom', rawValue],
-    ['start', rawValue],
+    ['insetInlineStart', rawValue],
   ],
   insetInline: (rawValue: TStyleValue): TReturn => [
     ...shorthands.start(rawValue),
@@ -212,24 +212,24 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
     ['bottom', rawValue],
   ],
   start: (rawValue: TStyleValue): TReturn => [
-    ['start', rawValue],
+    ['insetInlineStart', rawValue],
     ['left', null],
     ['right', null],
   ],
   end: (rawValue: TStyleValue): TReturn => [
-    ['end', rawValue],
+    ['insetInlineEnd', rawValue],
     ['left', null],
     ['right', null],
   ],
   left: (rawValue: TStyleValue): TReturn => [
     ['left', rawValue],
-    ['start', null],
-    ['end', null],
+    ['insetInlineStart', null],
+    ['insetInlineEnd', null],
   ],
   right: (rawValue: TStyleValue): TReturn => [
     ['right', rawValue],
-    ['start', null],
-    ['end', null],
+    ['insetInlineStart', null],
+    ['insetInlineEnd', null],
   ],
 
   gap: (rawValue: TStyleValue): TReturn => {
@@ -341,6 +341,9 @@ const aliases = {
   maxBlockSize: (val: TStyleValue): TReturn => [['maxHeight', val]],
   maxInlineSize: (val: TStyleValue): TReturn => [['maxWidth', val]],
 
+  borderStart: (val: TStyleValue): TReturn => [['borderInlineStart', val]],
+  borderEnd: (val: TStyleValue): TReturn => [['borderInlineEnd', val]],
+
   borderBlockWidth: shorthands.borderVerticalWidth,
   borderBlockStyle: shorthands.borderVerticalStyle,
   borderBlockColor: shorthands.borderVerticalColor,
@@ -365,17 +368,18 @@ const aliases = {
   borderInlineWidth: shorthands.borderHorizontalWidth,
   borderInlineStyle: shorthands.borderHorizontalStyle,
   borderInlineColor: shorthands.borderHorizontalColor,
-  borderStartStartRadius: (val: TStyleValue): TReturn => [
-    ['borderTopStartRadius', val],
+
+  borderTopStartRadius: (val: TStyleValue): TReturn => [
+    ['borderStartStartRadius', val],
   ],
-  borderStartEndRadius: (val: TStyleValue): TReturn => [
-    ['borderTopEndRadius', val],
+  borderTopEndRadius: (val: TStyleValue): TReturn => [
+    ['borderStartEndRadius', val],
   ],
-  borderEndStartRadius: (val: TStyleValue): TReturn => [
-    ['borderBottomStartRadius', val],
+  borderBottomStartRadius: (val: TStyleValue): TReturn => [
+    ['borderEndStartRadius', val],
   ],
-  borderEndEndRadius: (val: TStyleValue): TReturn => [
-    ['borderBottomEndRadius', val],
+  borderBottomEndRadius: (val: TStyleValue): TReturn => [
+    ['borderEndEndRadius', val],
   ],
 
   gridGap: shorthands.gap,


### PR DESCRIPTION
Adding some missing polyfills for some of the more obscure nonstandard properties we use internally. Previously these would get translated to LTR/RTL, but we need to add mappings to standard logical properties. 

- borderStart
- start, end -> insetInlineStart, insetInlineEnd
- float: start, end -> float: inline-start, inline-end
- borderTopStartRadius -> borderStartStartRadius

Synced with the flag turned on and off internally, all screenshot tests passing. Added some tests to to document the expected behaviour. These tests are a bit verbose and the structure hard to navigate, and I'm hoping we can clean them up and reorganize them soon after we ship logical styles.
- `transform-legacy-polyfills-test` contains tests for all nonstandard properties
   - added both variants of `legacy-expand-shorthands`
- `stylex-transform-legacy-shorthands-test.js` contains all expanded shorthands
   - added `enableLogicalStylesPolyfill: false` tests