### PR TITLE
fix: allow stylex.types.* in StyleXStyles by resolving CSSType to underlying type

### DIFF
--- a/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.js
@@ -9,8 +9,6 @@
 
 'use strict';
 
-import type { CSSType } from './VarTypes';
-
 type CSSCursor =
   | 'auto'
   | 'default'
@@ -102,7 +100,7 @@ type alignSelf =
   | 'safe center'
   | 'unsafe center'
   | all;
-type all = null | 'initial' | 'inherit' | 'unset' | CSSType;
+type all = null | 'initial' | 'inherit' | 'unset';
 type animationDelay = time;
 type animationDirection = singleAnimationDirection;
 type animationDuration = time;

--- a/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+import type { CSSType } from './VarTypes';
+
 type CSSCursor =
   | 'auto'
   | 'default'
@@ -100,7 +102,7 @@ type alignSelf =
   | 'safe center'
   | 'unsafe center'
   | all;
-type all = null | 'initial' | 'inherit' | 'unset';
+type all = null | 'initial' | 'inherit' | 'unset' | CSSType;
 type animationDelay = time;
 type animationDirection = singleAnimationDirection;
 type animationDuration = time;

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
@@ -150,7 +150,9 @@ export type LegacyThemeStyles = Readonly<{ [constantName: string]: string }>;
 
 type ComplexStyleValueType<T> =
   T extends StyleXVar<infer U>
-    ? U
+    ? U extends CSSType<infer V>
+      ? V
+      : U
     : T extends string | number | null
       ? T
       : T extends ReadonlyArray<infer U>

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.js
@@ -122,7 +122,9 @@ export type LegacyThemeStyles = $ReadOnly<{
 
 type ComplexStyleValueType<+T> =
   T extends StyleXVar<infer U>
-    ? U
+    ? U extends CSSType<infer V>
+      ? V
+      : U
     : T extends string | number | null
       ? T
       : T extends $ReadOnlyArray<infer U>


### PR DESCRIPTION
## What changed / motivation ?

Currently at type level (at least in TypeScript, I'm not fully sure about Flow so if it impacts it in some way - I'm open for any feedback 😃) you can't use vars created by `styles.defineVars` inside of variable typed as `StyleXStyles`(which is useful for e.g. component props). 

Example (adjusted code from `examples/example-nextjs/typetests/theming`):

```ts
export const ButtonTokens = stylex.defineVars({
  bgColor: stylex.types.color('red'),
  color: 'currentcolor',
  height: 'var(--button-height-medium)',
  opacity: '1',
});
```

in other file:

```tax
const styles = stylex.create({
  test1: {
    padding: 4,
    color: ButtonTokens.bgColor,
    backgroundColor: `color-mix(in oklch, ${ButtonTokens.bgColor}, 'white')`,
  },
});

const test: stylex.StyleXStyles = styles.test1;
```

This causes TypeScript error:

![image](https://github.com/user-attachments/assets/8cdb2b5b-ed01-48d8-b665-41c1b5f96bc5)

This happens because through some generics it mostly accepts `CSSPropertiesWithExtras` which are defined for each CSS property inside of `StyleXCSSTypes.js`. All of them accept some union/subset of string/number/null.

WIth change from this PR:

![image](https://github.com/user-attachments/assets/a4b82456-97fe-4b7d-8ab9-002620ae4039)

(no error 😃)

~I'm not 100% sure about this approach but it seems to work and I'm fully open for any feedback. I thought that maybe ideally would be listing supported `CSSType` subset inside of each property - so e.g. `<angle>` defined by `stylex.types.angle` could only be accepted by properties that in reality accepts angles. But I have two thoughts here - 1. It'd work differently than just `styles.create` where you can pass any type created to `styles.types.*` to any property. 2. It'd be a huge effort so I wanted to get some feedback before trying to do so 😅 But I'm open to implementing it this way if it makes sense?~

Changed the approach from initial one - there's a type helper that resolves type of created styles to `StyleXClassNameFor` when using `stylex.create` and there's already some logic responsible for mapping them at a type level so they're normalized. Added logic for resolving `CSSType` inside of `StyleXVar` as well

## Linked PR/Issues

Fixes https://github.com/facebook/stylex/issues/1075

## Additional Context

Similarly to this PR - https://github.com/facebook/stylex/pull/1095 I saw there's some example which in theory has dir named `typetests` but they're already borked - I'd love to add some test cases for types if guided to do so 😃 

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code