### PR TITLE
[babel-plugin] polyfill float/clear logical values for legacy browser…

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-legacy-polyfills-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-legacy-polyfills-test.js
@@ -1012,8 +1012,8 @@ describe('@stylexjs/babel-plugin', () => {
             [
               "xodj72a",
               {
-                "ltr": ".xodj72a{clear:inline-end}",
-                "rtl": null,
+                "ltr": ".xodj72a{clear:right}",
+                "rtl": ".xodj72a{clear:left}",
               },
               3000,
             ],
@@ -1036,8 +1036,8 @@ describe('@stylexjs/babel-plugin', () => {
             [
               "x390i0x",
               {
-                "ltr": ".x390i0x{clear:inline-start}",
-                "rtl": null,
+                "ltr": ".x390i0x{clear:left}",
+                "rtl": ".x390i0x{clear:right}",
               },
               3000,
             ],
@@ -1060,8 +1060,8 @@ describe('@stylexjs/babel-plugin', () => {
             [
               "x1guec7k",
               {
-                "ltr": ".x1guec7k{float:inline-end}",
-                "rtl": null,
+                "ltr": ".x1guec7k{float:right}",
+                "rtl": ".x1guec7k{float:left}",
               },
               3000,
             ],
@@ -1084,8 +1084,8 @@ describe('@stylexjs/babel-plugin', () => {
             [
               "xrbpyxo",
               {
-                "ltr": ".xrbpyxo{float:inline-start}",
-                "rtl": null,
+                "ltr": ".xrbpyxo{float:left}",
+                "rtl": ".xrbpyxo{float:right}",
               },
               3000,
             ],

--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-logical-values-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-logical-values-test.js
@@ -43,7 +43,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".xof8tvn{clear:inline-end}", 3000);
+        _inject2(".xof8tvn{clear:right}", 3000, ".xof8tvn{clear:left}");
         const classnames = "xof8tvn";"
       `);
     });
@@ -59,7 +59,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x18lmvvi{clear:inline-start}", 3000);
+        _inject2(".x18lmvvi{clear:left}", 3000, ".x18lmvvi{clear:right}");
         const classnames = "x18lmvvi";"
       `);
     });
@@ -75,7 +75,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1h0q493{float:inline-end}", 3000);
+        _inject2(".x1h0q493{float:right}", 3000, ".x1h0q493{float:left}");
         const classnames = "x1h0q493";"
       `);
     });
@@ -91,7 +91,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2(".x1kmio9f{float:inline-start}", 3000);
+        _inject2(".x1kmio9f{float:left}", 3000, ".x1kmio9f{float:right}");
         const classnames = "x1kmio9f";"
       `);
     });

--- a/packages/@stylexjs/babel-plugin/src/shared/physical-rtl/generate-ltr.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/physical-rtl/generate-ltr.js
@@ -13,18 +13,16 @@ import { defaultOptions } from '../utils/default-options';
 const logicalToPhysical: $ReadOnly<{ [string]: string }> = {
   start: 'left',
   end: 'right',
+  'inline-start': 'left',
+  'inline-end': 'right',
 };
 
-const logicalToStandard: $ReadOnly<{ [string]: string }> = {
-  start: 'inline-start',
-  end: 'inline-end',
-};
-
-const convertToStandardProperties: $ReadOnly<{
+// These values are polyfilled to LTR/RTL equivalents due to incomplete browser support, regardless of `enableLogicalStylesPolyfill`
+const legacyValuesPolyfill: $ReadOnly<{
   [key: string]: ($ReadOnly<[string, string]>) => $ReadOnly<[string, string]>,
 }> = {
-  float: ([key, val]) => [key, logicalToStandard[val] ?? val],
-  clear: ([key, val]) => [key, logicalToStandard[val] ?? val],
+  float: ([key, val]) => [key, logicalToPhysical[val] ?? val],
+  clear: ([key, val]) => [key, logicalToPhysical[val] ?? val],
 };
 
 // These properties are kept for a polyfill that is only used with `legacy-expand-shorthands`
@@ -205,8 +203,8 @@ export default function generateLTR(
 
   if (styleResolution === 'legacy-expand-shorthands') {
     if (!enableLogicalStylesPolyfill) {
-      if (convertToStandardProperties[key]) {
-        return convertToStandardProperties[key](pair);
+      if (legacyValuesPolyfill[key]) {
+        return legacyValuesPolyfill[key](pair);
       }
       return pair;
     }

--- a/packages/@stylexjs/babel-plugin/src/shared/physical-rtl/generate-rtl.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/physical-rtl/generate-rtl.js
@@ -97,6 +97,16 @@ function flipShadow(value: string) {
 const logicalToPhysical: $ReadOnly<{ [string]: string }> = {
   start: 'right',
   end: 'left',
+  'inline-start': 'right',
+  'inline-end': 'left',
+};
+
+// These values are polyfilled to LTR/RTL equivalents due to incomplete browser support, regardless of `enableLogicalStylesPolyfill`
+const legacyValuesPolyfill: $ReadOnly<{
+  [key: string]: ($ReadOnly<[string, string]>) => $ReadOnly<[string, string]>,
+}> = {
+  float: ([key, val]) => [key, logicalToPhysical[val] ?? val],
+  clear: ([key, val]) => [key, logicalToPhysical[val] ?? val],
 };
 
 // These properties are kept for a polyfill that is only used with `legacy-expand-shorthands`
@@ -293,6 +303,10 @@ export default function generateRTL(
 
   if (styleResolution === 'legacy-expand-shorthands') {
     if (!enableLogicalStylesPolyfill) {
+      if (legacyValuesPolyfill[key]) {
+        return legacyValuesPolyfill[key]([key, value]);
+      }
+
       return null;
     }
 


### PR DESCRIPTION
Let's always polyfill `float` and `clear` logical values to directional values regardless of `enableLogicalStylesPolyfill` due to browser support limitations. 

See browser compatibility chart:

<img width="725" alt="image" src="https://github.com/user-attachments/assets/48b29807-c403-4472-a028-a4e2eafe95a6" />


