### PR TITLE
[docs] rename `stylex.*` functions to `*` in docs and READMEs

### DIFF
--- a/packages/@stylexjs/babel-plugin/README.md
+++ b/packages/@stylexjs/babel-plugin/README.md
@@ -6,7 +6,7 @@ generated from all JS files within your project should be concatenated together 
 file using the `processStyles` function which is also exported from the same module.
 
 `@stylexjs/babel-plugin` is fairly lightweight. It pre-computes `stylex` related functions like
-`stylex.create` and `stylex.keyframes` by converting the argument AST to a JS object and transforming them
+`create` and `keyframes` by converting the argument AST to a JS object and transforming them
 by passing them to the functions of the corresponding names within `@stylex/shared`
 
 

--- a/packages/@stylexjs/babel-plugin/src/shared/README.md
+++ b/packages/@stylexjs/babel-plugin/src/shared/README.md
@@ -9,17 +9,17 @@ It exports two primary functions `create` and `keyframes`.
 
 #### ⭐️ `create`
 
-The `stylex.create` function is implemented here and can be found within `stylex-create.js` and is the default export of a function named `styleXCreateSet(...)`.
+The `create` function is implemented here and can be found within `stylex-create.js` and is the default export of a function named `styleXCreateSet(...)`.
 
 ##### `styleXCreateSet(...)`
 
-> The function is called `styleXCreateSet` because `stylex.create` transforms a "set" or collection of multiple style [namespaces](#namespace)
+> The function is called `styleXCreateSet` because `create` transforms a "set" or collection of multiple style [namespaces](#namespace)
 
 This function itself mostly just traverses over the objects to run each [namespaces](#namespace) through the `styleXCreateNamespace(...)` function. Other than that, it takes the styles to be injected from each namespace in a [Namespace Set](#namespace-set) and deduplicates them so the style isn't injected multiple times if it's used within multiple Namespaces in the same set.
 
 ##### `styleXCreateNamespace(...)`
 
-> This function has been kept separate in case we want to add a new function to the StyleX API in the future called `stylex.createOne` which transforms a single [namespace](#namespace) instead of a [Namespace Set](#namespace-set)
+> This function has been kept separate in case we want to add a new function to the StyleX API in the future called `createOne` which transforms a single [namespace](#namespace) instead of a [Namespace Set](#namespace-set)
 
 This function is responsible to transforming a [namespace](#namespace) to a [Compiled Namespace](#compiled-namespace) by hashing each key value pair and returning an object where the values have been replaced by classNames.
 
@@ -45,16 +45,16 @@ The `[resolvedNamespace, injectedStyles]` is returned.
 
 ### Back to `create` with the `@stylexjs/babel-plugin` package
 
-The `create` function within the babel plugin package takes the `stylex.create(...)` function call and replaces it with the `compiledNamespaceSet`.
+The `create` function within the babel plugin package takes the `create(...)` function call and replaces it with the `compiledNamespaceSet`.
 
 It also takes each of the `injectedStyles` and:
 
-1. Either injects it as a `stylex.inject` call (if in `dev` mode)
+1. Either injects it as a `inject` call (if in `dev` mode)
 2. Or, adds it to the array of injected styles on [`babel.state.metadata`](#babel-metadata)
 
 #### ⭐️ `keyframes`
 
-This is the function backing `stylex.keyframes`. It works similarly to `create` but it's more simplified since it only defines a single CSS `@keyframes` rule and returns a single string.
+This is the function backing `keyframes`. It works similarly to `create` but it's more simplified since it only defines a single CSS `@keyframes` rule and returns a single string.
 
 Here again, the source AST is converted to a JS object and passed to `stylex-keyframes.js` within the `shared` package.
 
@@ -62,9 +62,9 @@ There, first the shorthands are expanded and then the whole objects is hashed. T
 
 The "name" and the CSS `@keyframes` rules are returned as a tuple.
 
-The `stylex.keyframes` call is replaced with the final string.
+The `keyframes` call is replaced with the final string.
 
-The CSS `@keyframes` rule is either injected using `stylex.inject` in dev mode or set onto the `stylex` array on [`babel.state.metadata`](#babel-metadata).
+The CSS `@keyframes` rule is either injected using `inject` in dev mode or set onto the `stylex` array on [`babel.state.metadata`](#babel-metadata).
 
 #### `convert-to-className` (`shared` package)
 

--- a/packages/@stylexjs/eslint-plugin/README.md
+++ b/packages/@stylexjs/eslint-plugin/README.md
@@ -66,7 +66,7 @@ This rule helps to sort the StyleX property keys according to
 ### stylex/stylex-valid-shorthands
 
 This ESLint rule enforces the use of individual longhand CSS properties in place
-of multivalue shorthands when using `stylex.create` for reasons of consistency
+of multivalue shorthands when using `create` for reasons of consistency
 and performance. The rule provides an autofix to replace the shorthand with the
 equivalent longhand properties.
 
@@ -114,20 +114,20 @@ This rule has a few custom config options that can be set.
 ### @stylexjs/stylex-enforce-extension
 
 This rule ensures consistent naming for StyleX theme files that export variables
-using `stylex.defineVars()`.
+using `defineVars`.
 
 #### Not allowed
 
-- Exporting `stylex.defineVars()` in a file **not** ending in `.stylex.js` or
+- Exporting `defineVars` in a file **not** ending in `.stylex.js` or
   `.stylex.ts`
 - Using the `.stylex.js` / `.stylex.ts` extension without exporting
-  `stylex.defineVars()`
-- Mixing `stylex.defineVars()` with other exports in the same file
+  `defineVars`
+- Mixing `defineVars` with other exports in the same file
 
 #### Instead...
 
 - Use `.stylex.js` or `.stylex.ts` for files that only export
-  `stylex.defineVars()`
+  `defineVars`
 - Export **only** theme vars from these files
 
 #### Config options
@@ -141,7 +141,7 @@ using `stylex.defineVars()`.
 
 ### `stylex-no-unused`
 
-This rule flags unused styles created with `stylex.create(...)`. If a style key
+This rule flags unused styles created with `create(...)`. If a style key
 is defined but never used, the rule auto-strips them from the create call.
 
 #### Config options

--- a/packages/@stylexjs/stylex/README.md
+++ b/packages/@stylexjs/stylex/README.md
@@ -30,7 +30,7 @@ for
 
 ### stylex.create()
 
-Styles are defined as a map of CSS rules using `stylex.create()`. In the example
+Styles are defined as a map of CSS rules using `create`. In the example
 below, there are 2 different CSS rules. The names "root" and "highlighted" are
 arbitrary names given to the rules.
 
@@ -75,7 +75,7 @@ code with a "compiled style" object.
 
 ### stylex.props()
 
-Applying style rules to specific elements is done using `stylex.props`. Each
+Applying style rules to specific elements is done using `props`. Each
 argument to this function must be a reference to a compiled style object, or an
 array of compiled style objects. The function merges styles from left to right.
 
@@ -83,9 +83,9 @@ array of compiled style objects. The function merges styles from left to right.
 <div {...stylex.props(styles.root, styles.highlighted)} />
 ```
 
-The `stylex.props` function returns React props as required to render an
+The `props` function returns React props as required to render an
 element. StyleX styles can still be passed to other components via props, but
-only the components rendering host platform elements will use `stylex.props()`.
+only the components rendering host platform elements will use `props()`.
 For example:
 
 ```tsx
@@ -125,7 +125,7 @@ style property values passed in via props.
 
 ### stylex.firstThatWorks()
 
-Defining fallback styles is done with `stylex.firstThatWorks()`. This is useful
+Defining fallback styles is done with `firstThatWorks`. This is useful
 for engines that may not support a specific style property.
 
 ```tsx

--- a/packages/docs/blog/2023-12-29-Release-v0.4.1.md
+++ b/packages/docs/blog/2023-12-29-Release-v0.4.1.md
@@ -16,7 +16,7 @@ fixing bugs and making improvements. Here are some of the highlights:
 
 - The amount of JavaScript generated after compilation has been further reduced.
 - Added support for some previously missing CSS properties to the ESLint plugin.
-- Added support for using variables in `stylex.keyframes`.
+- Added support for using variables in `keyframes`.
 - Removed the code for style injection from the production runtime, reducing the
   size of the runtime by over 50%.
 - Added Flow and TypeScript types for the Rollup Plugin.

--- a/packages/docs/blog/2024-01-25-Release-v0.5.0.md
+++ b/packages/docs/blog/2024-01-25-Release-v0.5.0.md
@@ -11,14 +11,14 @@ tags: [release]
 
 We're excited to release Stylex v0.5.0 with some big improvements and fixes!
 
-## New `stylex.attrs` function
+## New `attrs` function
 
-The `stylex.props` function returns an object with a `className` string and a
+The `props` function returns an object with a `className` string and a
 `style` object. Some frameworks may expect `class` instead of `className` and a
 string value for `style`.
 
-We are introducing a new `stylex.attrs` function so StyleX works well in more
-places. `stylex.attrs` returns an object with a `class` string and a `style`
+We are introducing a new `attrs` function so StyleX works well in more
+places. `attrs` returns an object with a `class` string and a `style`
 string.
 
 ## New `sort-keys` rule for the Eslint plugin
@@ -56,7 +56,7 @@ Thanks [@nedjulius](https://github.com/nedjulius)!
 - Some CSS properties which previously caused type and lint errors will now be
   accepted.
 - Using variables for `opacity` will no longer cause type errors.
-- Using `stylex.keyframes` within `stylex.defineVars` will now work correctly
+- Using `keyframes` within `defineVars` will now work correctly
 - `runtimeInjection` will correctly be handled
 - Setting the value of variables from `defineVars` as dynamic styles will now
   work correctly.

--- a/packages/docs/blog/2024-04-16-Release-v0.6.1.mdx
+++ b/packages/docs/blog/2024-04-16-Release-v0.6.1.mdx
@@ -5,9 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 slug: v0.6.1
 title: Release 0.6.1
-authors: 
+authors:
   - nmn
-tags: 
+tags:
   - release
 ---
 
@@ -21,8 +21,8 @@ and themes in StyleX.
 
 ### Fallback values for variables
 
-You can now provide a fallback value for variables defined with the `stylex.defineVars` API.
-This new capability does not introduce any new API. Instead, the existing `stylex.firstThatWorks` API
+You can now provide a fallback value for variables defined with the `defineVars` API.
+This new capability does not introduce any new API. Instead, the existing `firstThatWorks` API
 now supports variables as arguments.
 
 ```tsx
@@ -44,7 +44,7 @@ StyleX introduces a brand new set of APIs for defining `<syntax>` types for CSS
 variables. This results in `@property` rules in the generated CSS output which
 can be used to animate CSS variables as well as other special use-cases.
 
-The new `stylex.types.*` functions can be used when defining variables to define
+The new `types.*` functions can be used when defining variables to define
 them with a particular type.
 
 ```tsx
@@ -66,7 +66,7 @@ const typedTokens = stylex.defineVars({
 ```
 
 Once variables have been defined with types, they can be animated
-with `stylex.keyframes` just like any other CSS property.
+with `keyframes` just like any other CSS property.
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';
@@ -99,7 +99,7 @@ This new capability is primarily about CSS types, but the new API
 also makes the TypeScript (or Flow) types for the variables more powerful.
 
 As can be seen in the example, generic type arguments can be used to constrain
-the values the variable can take when creating themes with `stylex.createTheme`.
+the values the variable can take when creating themes with `createTheme`.
 
 
 ## ESlint plugin
@@ -120,13 +120,11 @@ The `valid-styles` rule has been improved to allow more expressive
 ## Miscellaneous
 
 - ESlint `'valid-styles'` rule now allows using variables created with
-  `stylex.defineVars` as keys within dynamic styles.
-- Bug-fixes to the experimental `stylex.include` API
-- Fixed debug className generation for `stylex.createTheme`
+  `defineVars` as keys within dynamic styles.
+- Bug-fixes to the experimental `include` API
+- Fixed debug className generation for `createTheme`
 - Units are no longer removed from `0` values
 - Compilation bug-fixes
 
 Our [Ecosystem](/docs/learn/ecosystem/) page continues to grow with community projects. Including a
 [Prettier plugin](https://github.com/nedjulius/prettier-plugin-stylex-key-sort) for sorting StyleX styles.
-
-

--- a/packages/docs/blog/2024-06-25-Release-v0.7.0.mdx
+++ b/packages/docs/blog/2024-06-25-Release-v0.7.0.mdx
@@ -5,9 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 slug: v0.7.0
 title: Release 0.7.0
-authors: 
+authors:
   - nmn
-tags: 
+tags:
   - release
 ---
 
@@ -36,15 +36,15 @@ Special thanks to [Joel Austin](https://github.com/Jta26) for his work on the CL
 
 ## Literal names for CSS variables
 
-When using, `stylex.defineVars`, StyleX abstracts away the actual CSS variable name,
+When using, `defineVars`, StyleX abstracts away the actual CSS variable name,
 and lets you use it as a JavaScript reference. Behind the scenes, unique variable names
 are generated for each variable.
 
 However, there are scenarios where it is useful to know the exact variable name. For
 example, when you may want to use the variable in a standalone CSS file.
 
-To address such use-cases, we have updated the `stylex.defineVars` API to use literals
-that start with `--` as is. Other than the keys passed to `stylex.defineVars`, the 
+To address such use-cases, we have updated the `defineVars` API to use literals
+that start with `--` as is. Other than the keys passed to `defineVars`, the
 API is unchanged.
 
 ```ts

--- a/packages/docs/blog/2024-10-06-Release-v0.8.0.mdx
+++ b/packages/docs/blog/2024-10-06-Release-v0.8.0.mdx
@@ -5,9 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 slug: v0.8.0
 title: Release 0.8.0
-authors: 
+authors:
   - nmn
-tags: 
+tags:
   - release
 ---
 
@@ -62,7 +62,7 @@ This rule offers an autofix for all disallowed properties.
 ### New `enforce-extension` rule
 
 This new rule enforces the [rules when defining variables](https://stylexjs.com/docs/learn/theming/defining-variables/#rules-when-defining-variables)._createMdxContent
-It enforces that usages of `stylex.defineVars` are named exports within a file with a `.stylex.js` (or '.ts' or '.jsx' or '.tsx') extension,
+It enforces that usages of `defineVars` are named exports within a file with a `.stylex.js` (or '.ts' or '.jsx' or '.tsx') extension,
 and that such a file does not have any other exports.
 
 
@@ -79,7 +79,7 @@ Notably, the `valid-styles` rule should now understand:
 
 StyleX's compilation process is conceptually a three step process:
 
-1. Transform JavaScript source files to replace usages of `stylex.create` etc. 
+1. Transform JavaScript source files to replace usages of `create` etc.
    with the resulting classNames and collect the generated CSS.
 2. De-duplicate and sort all the collected CSS.
 3. Write the CSS to a file.
@@ -99,7 +99,7 @@ We've made two small but important improvements for theming in StyleX.
 
 ### Use `stylex.firstThatWorks` to define fallback values for CSS variables.
 
-StyleX has a `stylex.firstThatWorks` function that can be used to define fallback values for CSS property.
+StyleX has a `firstThatWorks` function that can be used to define fallback values for CSS property.
 This is akin to using the same property multiple times with different values in CSS.
 
 ```css
@@ -143,8 +143,8 @@ const styles = stylex.create({
 
 ### Themes have higher specificity than default var values
 
-The CSS rule created with `stylex.createTheme` now has higher specificity than the rule
-created with `stylex.defineVars`.
+The CSS rule created with `createTheme` now has higher specificity than the rule
+created with `defineVars`.
 
 This should not have been issue in the vast majority of cases already, as we always sorted
 the rules in the correct order. However, in extreme edge-cases where you may be loading multiple
@@ -170,7 +170,3 @@ projects to our [ecosystem page](https://stylexjs.com/docs/learn/ecosystem/).
 
 We've also updated the search on our website to be much more comprehensive and accurate.
 (Powered by Algolia)
-
-
-
-

--- a/packages/docs/blog/2024-11-01-Release-v0.9.3.mdx
+++ b/packages/docs/blog/2024-11-01-Release-v0.9.3.mdx
@@ -5,9 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 slug: v0.9.3
 title: Release 0.9.3
-authors: 
+authors:
   - nmn
-tags: 
+tags:
   - release
 ---
 
@@ -16,14 +16,14 @@ StyleX v0.9.3 is now available with some big improvements and bug-fixes.
 ## Improvements to Theming APIs
 
 There are some big improvements to the predictability and reliability of our
-theming APIs — `stylex.defineVars` and `stylex.createTheme`.
+theming APIs — `defineVars` and `createTheme`.
 
 ### Breaking Change: Themes are now exclusive
 
-When you create a `VarGroup` with `stylex.defineVars`, you are able to theme
-any subset of the variables within using the `stylex.createTheme` API. These
-themes can then be applied like any other StyleX styles using `stylex.props`
-(or `stylex.attrs`). If you try to apply multiple themes for the same `VarGroup`,
+When you create a `VarGroup` with `defineVars`, you are able to theme
+any subset of the variables within using the `createTheme` API. These
+themes can then be applied like any other StyleX styles using `props`
+(or `attrs`). If you try to apply multiple themes for the same `VarGroup`,
 on the same element, *the last applied theme wins*, just as you might expect.
 
 However, previously, if you instead applied one theme on a parent element,
@@ -118,7 +118,7 @@ We will be making further improvements to minimize any such edge-cases.
 
 The StyleX Babel plugin now uses the `esm-resolve` package to resolve ESM imports.
 This should fix most situations where the compiler would fail to resolve `VarGroup`
-imports in result in the compilation of `stylex.create` to fail.
+imports in result in the compilation of `create` to fail.
 
 Thanks [hipstersmoothie](https://github.com/hipstersmoothie)!
 
@@ -131,7 +131,7 @@ expected, ran into certain browser bugs and resulted in styles that were unneces
 bloated.
 
 In v0.9.3, `null` values for Dynamic styles work exactly the same as using `null`
-as a static value within `stylex.create`. This means any previously applied value
+as a static value within `create`. This means any previously applied value
 for the given property will be removed and no className will be applied for that
 property.
 
@@ -141,7 +141,7 @@ property.
 The `@stylexjs/dev-runtime` package is a development-only package that lets you use
 a *much slower* version of StyleX that runs entirely at runtime. Previously, it worked
 by patching the main `@stylexjs/stylex` package at runtime. However, this did not always
-work reliably. 
+work reliably.
 
 **Breaking Change**: The `@stylexjs/dev-runtime` package now *returns* the StyleX API.
 

--- a/packages/docs/blog/2025-02-27-Release-v0.11.0.mdx
+++ b/packages/docs/blog/2025-02-27-Release-v0.11.0.mdx
@@ -24,7 +24,7 @@ import Dial from '../components/Dial';
 ## Debugging Improvements
 
 ### Improved Runtime Debugging
-We've made some big improvements to the information available in debug mode. We now include sourceMap information to indicate the file and line of the `stylex.create` call responsible for providing styles on a given element. This information is contained in the `data-style-src` prop in the DOM. To use, set `debug` to `true` in the StyleX config. (Thanks [necolas](https://github.com/necolas))
+We've made some big improvements to the information available in debug mode. We now include sourceMap information to indicate the file and line of the `create` call responsible for providing styles on a given element. This information is contained in the `data-style-src` prop in the DOM. To use, set `debug` to `true` in the StyleX config. (Thanks [necolas](https://github.com/necolas))
 
 ## CLI Cache Improvements
 

--- a/packages/docs/docs/api/configuration/babel-plugin.mdx
+++ b/packages/docs/docs/api/configuration/babel-plugin.mdx
@@ -141,7 +141,7 @@ unstable_moduleResolution: // Default: undefined
     }
 ```
 
-Strategy to use for resolving variables defined with `stylex.defineVars()`.
+Strategy to use for resolving variables defined with `defineVars`.
 This is required if you plan to use StyleX's theming APIs.
 
 **NOTE**: While theming APIs are stable, the shape of this configuration option

--- a/packages/docs/docs/api/javascript/defineConsts.mdx
+++ b/packages/docs/docs/api/javascript/defineConsts.mdx
@@ -8,9 +8,9 @@ sidebar_position: 3
 
 # `stylex.defineConsts`
 
-Defines static style constants that can be used directly in `stylex.create` calls anywhere in the codebase. Unlike `stylex.defineVars`, these values are inlined at build time and do not generate actual CSS variables.
+Defines static style constants that can be used directly in `create` calls anywhere in the codebase. Unlike `defineVars`, these values are inlined at build time and do not generate actual CSS variables.
 
-*Note: `stylex.defineConsts` is an experimental feature and cannot currently be used with `stylex.firstThatWorks` or when `runtimeInjection` is enabled.*
+*Note: `defineConsts` is an experimental feature and cannot currently be used with `firstThatWorks` or when `runtimeInjection` is enabled.*
 
 Common use cases include:
 - Media queries
@@ -49,7 +49,7 @@ export const animations = stylex.defineConsts({
 });
 ```
 
-You can then import and use these constants in any `stylex.create` call:
+You can then import and use these constants in any `create` call:
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';

--- a/packages/docs/docs/api/javascript/defineVars.mdx
+++ b/packages/docs/docs/api/javascript/defineVars.mdx
@@ -9,7 +9,7 @@ sidebar_position: 4
 # `stylex.defineVars`
 
 Creates global CSS Custom Properties (Variables) that can be imported and used
-within `stylex.create` calls anywhere within a codebase.
+within `create` calls anywhere within a codebase.
 
 ```ts
 function defineVars<Styles extends {[key: string]: Value}>(
@@ -34,7 +34,7 @@ export const colors = stylex.defineVars({
 });
 ```
 
-You can then import and use these variables in any `stylex.create` call.
+You can then import and use these variables in any `create` call.
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';

--- a/packages/docs/docs/api/javascript/types.mdx
+++ b/packages/docs/docs/api/javascript/types.mdx
@@ -8,8 +8,8 @@ sidebar_position: 8
 
 # `stylex.types.*`
 
-A set of helper functions to be used within [`stylex.defineVars`](./defineVars.mdx)
-and [`stylex.createTheme`](./createTheme.mdx) to define CSS types for variables.
+A set of helper functions to be used within [`defineVars`](./defineVars.mdx)
+and [`createTheme`](./createTheme.mdx) to define CSS types for variables.
 
 These functions result in `@property` CSS rules for the variables with the appropriate
 `syntax` value.
@@ -17,7 +17,7 @@ These functions result in `@property` CSS rules for the variables with the appro
 ### Example use:
 
 The `types.*` functions are compatible with all patterns that are supported
-by `stylex.defineVars` and `stylex.createTheme` already.
+by `defineVars` and `createTheme` already.
 
 For example, consider the following set of variables:
 

--- a/packages/docs/docs/api/types/Theme.mdx
+++ b/packages/docs/docs/api/types/Theme.mdx
@@ -13,7 +13,7 @@ type Theme<T extends VarGroup<unknown, symbol>>
 ```
 
 A `Theme` is a type that represents a style that *themes* a set of variables in a given
-`VarGroup`. It's the result of calling [`stylex.createTheme`](../javascript/createTheme.mdx).
+`VarGroup`. It's the result of calling [`createTheme`](../javascript/createTheme.mdx).
 
 
 ```tsx
@@ -62,5 +62,5 @@ Now, `theme1` has a unique type identity and a different `Theme` for `vars`
 would not satisfy `typeof theme1`.
 
 This advanced use-case should be rarely needed, but it's available when it is.
-  
+
 </details>

--- a/packages/docs/docs/api/types/VarGroup.mdx
+++ b/packages/docs/docs/api/types/VarGroup.mdx
@@ -6,21 +6,21 @@
 sidebar_position: 4
 ---
 
-# `VarGroup<>` 
+# `VarGroup<>`
 
 ```tsx
 type VarGroup<Tokens extends {}>
 ```
 
 A `VarGroup` is the type of the object that is generated as a result of calling
-[`stylex.defineVars`](../javascript/defineVars.mdx). It maps keys to references 
+[`defineVars`](../javascript/defineVars.mdx). It maps keys to references
 to CSS custom properties.
 
-`VarGroup` is also the required type for the first argument to 
-[`stylex.createTheme`](../javascript/createTheme.mdx)
+`VarGroup` is also the required type for the first argument to
+[`createTheme`](../javascript/createTheme.mdx)
 
-Usually, `VarGroup` is not needed explicitly, as it can be 
-inferred from the argument to `stylex.defineVars`.
+Usually, `VarGroup` is not needed explicitly, as it can be
+inferred from the argument to `defineVars`.
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';
@@ -69,7 +69,7 @@ export const theme1 = stylex.createTheme(vars, {
 
 export const theme2 = stylex.createTheme(vars, {
   // Error: 'orange' is not assignable to 'red' | 'blue' | 'green' | 'yellow'
-  color: 'orange', 
+  color: 'orange',
 });
 ```
 
@@ -87,7 +87,7 @@ While, it's not needed in most cases, `VarGroup` also accepts an optional second
 </summary>
 
 TypeScript (and Flow) use structural typing, which means that two objects with the same
-shape are considered to be the same type. However, each usage of `stylex.defineVars` results
+shape are considered to be the same type. However, each usage of `defineVars` results
 in a new set of variables.
 
 It can be useful to have a unique type identity for each `VarGroup` created to be able to

--- a/packages/docs/docs/learn/02-thinking-in-stylex.mdx
+++ b/packages/docs/docs/learn/02-thinking-in-stylex.mdx
@@ -56,8 +56,8 @@ Here's how this plays out in practice:
 #### 1. Styles created and applied locally
 
 When authoring and consuming styles within the same file, the cost of StyleX is zero.
-This is because in addition to compiling away `stylex.create` calls, StyleX also
-compiles away `stylex.props` calls when possible.
+This is because in addition to compiling away `create` calls, StyleX also
+compiles away `props` calls when possible.
 
 So,
 
@@ -95,9 +95,9 @@ There is no runtime overhead here.
 #### 2. Using styles across files
 
 Passing styles across file boundaries incurs a small cost for the
-additional power and expressivity. The `stylex.create` call is not deleted
+additional power and expressivity. The `create` call is not deleted
 entirely and instead leaves behind an object mapping keys to
-class names. And the `stylex.props()` calls are executed at runtime.
+class names. And the `props` calls are executed at runtime.
 
 This code, for example:
 
@@ -156,7 +156,7 @@ function MyComponent({style}) {
 
 
 This is a little more code, but the runtime cost is still minimal
-because of how fast the `stylex.props()` function is.
+because of how fast the `props` function is.
 
 Most other styling solutions don't enable composition of styles across file
 boundaries. The state of the art is to combine lists of class names.
@@ -173,7 +173,7 @@ At its core, StyleX can be boiled down to two functions:
 1. `stylex.create`
 2. `stylex.props`
 
-`stylex.create` is used to create styles and `stylex.props` is used to apply
+`create` is used to create styles and `props` is used to apply
 those styles to an element.
 
 Within these two functions, we choose to rely on common JS patterns rather than
@@ -257,12 +257,12 @@ We want styles to be type-safe, so we've spent a lot of time coming up with
 APIs to replace these strings with references to JavaScript constants. So far this
 is reflected in the following APIs:
 
-1. `stylex.create` Abstracts away the generated class names entirely. You deal
+1. `create` Abstracts away the generated class names entirely. You deal
    with "opaque" JavaScript objects with strong types to indicate the styles
    they represent.
-2. `stylex.defineVars` Abstracts away the names of CSS variables generated.
+2. `defineVars` Abstracts away the names of CSS variables generated.
    They can be imported as constants and used within styles directly.
-3. `stylex.keyframes` Abstracts away the names of keyframe animations. Instead
+3. `keyframes` Abstracts away the names of keyframe animations. Instead
    they are declared as constants and used by reference.
 
 We're looking into ways to make other CSS identifiers such as
@@ -275,7 +275,7 @@ been tailored to work best with React today, it is designed to be used with any
 JavaScript framework that allows authoring markup in JavaScript. This includes frameworks
 that use JSX, template strings, etc.
 
-`stylex.props` returns an object with `className` and `style` properties. A wrapper
+`props` returns an object with `className` and `style` properties. A wrapper
 function may be needed to convert this to make it work with various frameworks.
 
 ### Encapsulation

--- a/packages/docs/docs/learn/04-styling-ui/01-defining-styles.mdx
+++ b/packages/docs/docs/learn/04-styling-ui/01-defining-styles.mdx
@@ -35,7 +35,7 @@ The following are **not** allowed:
 
 ## Creating styles
 
-Styles must be created with the `stylex.create` function. You can define one or
+Styles must be created with the `create` function. You can define one or
 more "namespaces", or objects of styles. In the example below, there are 2
 "namespaces" - one called `base` and the other `highlighted`. The names are
 arbitrary and represent the constant used to capture the result of the
@@ -205,7 +205,7 @@ const styles = stylex.create({
 
 ## Keyframe animations
 
-You can use the `stylex.keyframes()` function to define keyframe animations.
+You can use the `keyframes` function to define keyframe animations.
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';

--- a/packages/docs/docs/learn/04-styling-ui/02-using-styles.mdx
+++ b/packages/docs/docs/learn/04-styling-ui/02-using-styles.mdx
@@ -10,7 +10,7 @@ sidebar_position: 2
 
 Once styles have been defined, they must be converted to `className` and
 `styles` props that can be spread on HTML elements using the
-[`stylex.props`](../../api/javascript/props.mdx) function.
+[`props`](../../api/javascript/props.mdx) function.
 
 ```tsx
 <div {...stylex.props(styles.base)} />
@@ -21,12 +21,12 @@ use them conditionally, or even compose styles across module boundaries.
 
 ## Merging styles
 
-The `stylex.props` function can take a list of styles and merge them in a
+The `props` function can take a list of styles and merge them in a
 deterministic way, where the last style applied always wins. The order in which
 the styles are defined does not affect the resulting styles, only the order in
 which they are applied to the HTML element.
 
-Using `stylex.props` is only required when styles are set on React
+Using `props` is only required when styles are set on React
 DOM host elements like `<div>`.
 
 Consider styles that are defined as follows:
@@ -55,10 +55,10 @@ last. If instead the order of the styles were reversed, the text would be gray.
 <div {...stylex.props(styles.highlighted, styles.base)} />
 ```
 
-A simple way to think about the `stylex.props` function is that merges many
+A simple way to think about the `props` function is that merges many
 objects and the later objects have precedence over previous objects.
 
-Each individual style object can be passed to `stylex.props` as a separate
+Each individual style object can be passed to `props` as a separate
 argument, or passed in as an array of styles.
 
 ```tsx
@@ -68,7 +68,7 @@ argument, or passed in as an array of styles.
 ## Conditional styles
 
 Styles can be applied conditionally at runtime using common JavaScript
-patterns such as ternary expressions and the `&&` operator. `stylex.props`
+patterns such as ternary expressions and the `&&` operator. `props`
 ignores falsy values such as `null`, `undefined`, or `false`.
 
 ```tsx

--- a/packages/docs/docs/learn/05-theming/01-defining-variables.mdx
+++ b/packages/docs/docs/learn/05-theming/01-defining-variables.mdx
@@ -31,7 +31,7 @@ for these variables for UI sub-trees.
 
 ## Defining Variables
 
-A group of variables are defined using the `stylex.defineVars` function:
+A group of variables are defined using the `defineVars` function:
 
 ```tsx title="tokens.stylex.js"
 import * as stylex from '@stylexjs/stylex';
@@ -52,7 +52,7 @@ This function, too, is processed at compile-time and CSS variable names are
 automatically generated.
 
 This defines the variables at `:root` of the HTML document. They can be imported
-as constants and used within `stylex.create` calls.
+as constants and used within `create` calls.
 
 ### Using Media Queries
 
@@ -78,7 +78,7 @@ Similarly, `@supports` can be used as well.
 ## Rules when defining variables
 
 Variables are the only type of non-local value that can be used within a
-`stylex.create` call. This is made possible by enforcing a few rules:
+`create` call. This is made possible by enforcing a few rules:
 
 #### 1. Variables must be defined in `.stylex.js` files
 
@@ -93,7 +93,7 @@ Variables must be in a file with one of the following extensions:
 
 #### 2. Variables must be named exports
 
-Every `stylex.defineVars` call _must_ be a named export.
+Every `defineVars` call _must_ be a named export.
 
 ##### Allowed:
 

--- a/packages/docs/docs/learn/05-theming/02-using-variables.mdx
+++ b/packages/docs/docs/learn/05-theming/02-using-variables.mdx
@@ -19,7 +19,7 @@ option needs to be enabled in the StyleX Babel configuration to enable theming A
 :::
 
 Once [variables have been defined](./01-defining-variables.mdx), they can be imported
-and used to declare styles with `stylex.create`.
+and used to declare styles with `create`.
 
 Assume the following variables have been defined in a file called
 `tokens.stylex.js`:

--- a/packages/docs/docs/learn/05-theming/03-creating-themes.mdx
+++ b/packages/docs/docs/learn/05-theming/03-creating-themes.mdx
@@ -41,8 +41,8 @@ export const dracula = stylex.createTheme(colors, {
 
 ## Applying Themes
 
-A “theme” is a style object similar to the ones created with `stylex.create()`.
-They can be applied to an element using `stylex.props()` to override variables
+A “theme” is a style object similar to the ones created with `create()`.
+They can be applied to an element using `props()` to override variables
 for that element and all its descendants.
 
 ```tsx title="components/MyComponent.js"
@@ -66,7 +66,7 @@ theme. This choice has been to help catch accidental omissions. Even at the cost
 of occasional tedium.
 
 Unlike when defining and using variables, themes can be created with
-`stylex.createTheme()` anywhere in a codebase, and passed around across files or
+`createTheme` anywhere in a codebase, and passed around across files or
 components.
 
 :::info

--- a/packages/docs/docs/learn/05-theming/04-variable-types.mdx
+++ b/packages/docs/docs/learn/05-theming/04-variable-types.mdx
@@ -96,9 +96,9 @@ The primary utility of `stylex.types.*` functions is to enable functionality
 by declaring types for variables in the generated CSS. However, the StyleX API
 also enhances the type-safety within your own codebase.
 
-When a variable is declared with a certain type within `stylex.defineVars`, the
+When a variable is declared with a certain type within `defineVars`, the
 static types will enforce that the same type function is used when the variable
-is themed within a `stylex.createTheme` call.
+is themed within a `createTheme` call.
 
 
 ```tsx title="theme.js"
@@ -114,8 +114,8 @@ export const highContrast = stylex.createTheme(tokens, {
 });
 ```
 
-Since the types for the variables are already declared within the `stylex.defineVars`
-call, the usage type functions within `stylex.createTheme` is functionally a no-op, but
+Since the types for the variables are already declared within the `defineVars`
+call, the usage type functions within `createTheme` is functionally a no-op, but
 is required by the static types for type-safety.
 
 ## Example use-cases
@@ -123,7 +123,7 @@ is required by the static types for type-safety.
 ### Simulating [`round()`](https://developer.mozilla.org/en-US/docs/Web/CSS/round)
 
 Modern browsers are starting to support
-the [`round()`](https://developer.mozilla.org/en-US/docs/Web/CSS/round) function in CSS. 
+the [`round()`](https://developer.mozilla.org/en-US/docs/Web/CSS/round) function in CSS.
 However, the feature can be simulated with a variable with an `integer` type:
 
 ```tsx
@@ -150,7 +150,7 @@ It is usually not possible to animate gradients. However, by using a typed
 within it.
 
 Instead of animating a *normal* CSS property, the `angle` variable can be
-animated with `stylex.keyframes`:
+animated with `keyframes`:
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';

--- a/packages/docs/docs/learn/06-recipes/03-descendant styles.mdx
+++ b/packages/docs/docs/learn/06-recipes/03-descendant styles.mdx
@@ -23,7 +23,7 @@ Using CSS variables, you can style descendants based on a parent's state, such a
 
 ### Step 1
 
-Define one or more variables using `stylex.defineVars`:
+Define one or more variables using `defineVars`:
 
 ```tsx variables.stylex.ts
 // variables.stylex.ts

--- a/packages/docs/docs/learn/06-recipes/04-reset-themes.mdx
+++ b/packages/docs/docs/learn/06-recipes/04-reset-themes.mdx
@@ -8,8 +8,8 @@ sidebar_position: 4
 
 # Reset Theme
 
-The `stylex.defineVars` function is used to create a set of CSS variables,
-called `VarGroup`s. Further, the `stylex.createTheme` function can be used to create 
+The `defineVars` function is used to create a set of CSS variables,
+called `VarGroup`s. Further, the `createTheme` function can be used to create
 `Theme`s, that override the values of the variables defined within `VarGroup`s.
 
 Many `VarGroup`s can be defined which can then be independently overridden with `Theme`s.


### PR DESCRIPTION
Left a few instances in titles or headers where it seemed appropriate, but otherwise renaming across docs for consistency