### PR TITLE
[babel-plugin] Fix theming in dev/debug mode

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-import-export-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-import-export-test.js
@@ -251,8 +251,8 @@ describe('@stylexjs/babel-plugin', () => {
           }
         };
         const theme = {
-          $$css: true,
-          xop34xu: "xfnndu4 xop34xu"
+          xop34xu: "xfnndu4 xop34xu",
+          $$css: true
         };
         stylex.props(styles.root, theme);"
       `);
@@ -386,8 +386,8 @@ describe('@stylexjs/babel-plugin', () => {
           }
         };
         const theme = {
-          $$css: true,
-          xop34xu: "xfnndu4 xop34xu"
+          xop34xu: "xfnndu4 xop34xu",
+          $$css: true
         };
         foo.props(styles.root, theme);"
       `);
@@ -436,8 +436,8 @@ describe('@stylexjs/babel-plugin', () => {
           }
         };
         const theme = {
-          $$css: true,
-          xop34xu: "xfnndu4 xop34xu"
+          xop34xu: "xfnndu4 xop34xu",
+          $$css: true
         };
         props(styles.root, theme);"
       `);
@@ -495,8 +495,8 @@ describe('@stylexjs/babel-plugin', () => {
           }
         };
         const theme = {
-          $$css: true,
-          xop34xu: "xfnndu4 xop34xu"
+          xop34xu: "xfnndu4 xop34xu",
+          $$css: true
         };
         _props(styles.root, theme);"
       `);
@@ -536,8 +536,8 @@ describe('@stylexjs/babel-plugin', () => {
           }
         };
         const theme = {
-          $$css: true,
-          xop34xu: "xfnndu4 xop34xu"
+          xop34xu: "xfnndu4 xop34xu",
+          $$css: true
         };
         stylex.props(styles.root, theme);"
       `);
@@ -590,8 +590,8 @@ describe('@stylexjs/babel-plugin', () => {
           }
         };
         const theme = {
-          $$css: true,
-          xop34xu: "xfnndu4 xop34xu"
+          xop34xu: "xfnndu4 xop34xu",
+          $$css: true
         };
         css.props(styles.root, theme);"
       `);
@@ -631,8 +631,8 @@ describe('@stylexjs/babel-plugin', () => {
           }
         };
         const theme = {
-          $$css: true,
-          xop34xu: "xfnndu4 xop34xu"
+          xop34xu: "xfnndu4 xop34xu",
+          $$css: true
         };
         stylex.props(styles.root, theme);"
       `);

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -174,12 +174,12 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "xbiwvf9"
         };
         export const themeColor = {
-          $$css: true,
-          xsg933n: "x6xqkwy xsg933n"
+          xsg933n: "x6xqkwy xsg933n",
+          $$css: true
         };
         export const themeSpacing = {
-          $$css: true,
-          xbiwvf9: "x57uvma xbiwvf9"
+          xbiwvf9: "x57uvma xbiwvf9",
+          $$css: true
         };
         export const styles = {
           root: {
@@ -243,12 +243,12 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "xbiwvf9"
         };
         export const themeColor = {
-          $$css: true,
-          xsg933n: "x6xqkwy xsg933n"
+          xsg933n: "x6xqkwy xsg933n",
+          $$css: true
         };
         export const themeSpacing = {
-          $$css: true,
-          xbiwvf9: "x57uvma xbiwvf9"
+          xbiwvf9: "x57uvma xbiwvf9",
+          $$css: true
         };
         export const styles = {
           root: {

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-createTheme-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-createTheme-test.js
@@ -115,8 +115,8 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "xop34xu"
         };
         export const theme = {
-          $$css: true,
-          xop34xu: "x4aw18j xop34xu"
+          xop34xu: "x4aw18j xop34xu",
+          $$css: true
         };"
       `);
       expect(metadata).toMatchInlineSnapshot(`
@@ -196,8 +196,8 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "xop34xu"
         };
         export const theme = {
-          $$css: true,
-          xop34xu: "x4aw18j xop34xu"
+          xop34xu: "x4aw18j xop34xu",
+          $$css: true
         };"
       `);
       expect(metadata).toMatchInlineSnapshot(`
@@ -276,8 +276,8 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x1xohuxq"
         };
         export const theme = {
-          $$css: true,
-          x1xohuxq: "xv0nx9o x1xohuxq"
+          x1xohuxq: "xv0nx9o x1xohuxq",
+          $$css: true
         };"
       `);
       expect(metadata).toMatchInlineSnapshot(`
@@ -359,8 +359,8 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "xop34xu"
         };
         export const theme = {
-          $$css: true,
-          xop34xu: "x1l2ihi1 xop34xu"
+          xop34xu: "x1l2ihi1 xop34xu",
+          $$css: true
         };"
       `);
       expect(metadata).toMatchInlineSnapshot(`
@@ -430,8 +430,8 @@ describe('@stylexjs/babel-plugin', () => {
           radius: '6px'
         };
         export const theme = {
-          $$css: true,
-          xop34xu: "x4aw18j xop34xu"
+          xop34xu: "x4aw18j xop34xu",
+          $$css: true
         };"
       `);
       expect(metadata).toMatchInlineSnapshot(`
@@ -508,8 +508,8 @@ describe('@stylexjs/babel-plugin', () => {
         };
         const RADIUS = 10;
         export const theme = {
-          $$css: true,
-          xop34xu: "x1s6ff5p xop34xu"
+          xop34xu: "x1s6ff5p xop34xu",
+          $$css: true
         };"
       `);
       expect(metadata).toMatchInlineSnapshot(`
@@ -570,8 +570,8 @@ describe('@stylexjs/babel-plugin', () => {
         };
         const name = 'light';
         export const theme = {
-          $$css: true,
-          xop34xu: "xp8mj21 xop34xu"
+          xop34xu: "xp8mj21 xop34xu",
+          $$css: true
         };"
       `);
       expect(metadata).toMatchInlineSnapshot(`
@@ -632,8 +632,8 @@ describe('@stylexjs/babel-plugin', () => {
         };
         const RADIUS = 10;
         export const theme = {
-          $$css: true,
-          xop34xu: "x1et03wi xop34xu"
+          xop34xu: "x1et03wi xop34xu",
+          $$css: true
         };"
       `);
       expect(metadata).toMatchInlineSnapshot(`
@@ -703,8 +703,8 @@ describe('@stylexjs/babel-plugin', () => {
         };
         const RADIUS = 10;
         export const theme = {
-          $$css: true,
-          xop34xu: "x5gq8ml xop34xu"
+          xop34xu: "x5gq8ml xop34xu",
+          $$css: true
         };"
       `);
       expect(metadata).toMatchInlineSnapshot(`
@@ -781,12 +781,12 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "xop34xu"
         };
         export const theme = {
-          $$css: true,
-          xop34xu: "x4aw18j xop34xu"
+          xop34xu: "x4aw18j xop34xu",
+          $$css: true
         };
         export const otherTheme = {
-          $$css: true,
-          xop34xu: "xw6msop xop34xu"
+          xop34xu: "xw6msop xop34xu",
+          $$css: true
         };"
       `);
       expect(metadata).toMatchInlineSnapshot(`
@@ -876,8 +876,8 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "xop34xu"
         };
         export const theme = {
-          $$css: true,
-          xop34xu: "x4aw18j xop34xu"
+          xop34xu: "x4aw18j xop34xu",
+          $$css: true
         };"
       `);
 
@@ -890,8 +890,8 @@ describe('@stylexjs/babel-plugin', () => {
           __themeName__: "x1ngxneg"
         };
         export const theme = {
-          $$css: true,
-          x1ngxneg: "xgl5cw9 x1ngxneg"
+          x1ngxneg: "xgl5cw9 x1ngxneg",
+          $$css: true
         };"
       `);
 
@@ -1055,8 +1055,8 @@ describe('@stylexjs/babel-plugin', () => {
             __themeName__: "xop34xu"
           };
           export const theme = {
-            $$css: true,
-            xop34xu: "xowvtgn xop34xu"
+            xop34xu: "xowvtgn xop34xu",
+            $$css: true
           };"
         `);
         expect(metadata).toMatchInlineSnapshot(`
@@ -1123,8 +1123,8 @@ describe('@stylexjs/babel-plugin', () => {
             __themeName__: "xop34xu"
           };
           export const theme = {
-            $$css: true,
-            xop34xu: "xowvtgn xop34xu"
+            xop34xu: "xowvtgn xop34xu",
+            $$css: true
           };"
         `);
         expect(metadata).toMatchInlineSnapshot(`
@@ -1192,8 +1192,8 @@ describe('@stylexjs/babel-plugin', () => {
             __themeName__: "xop34xu"
           };
           export const theme = {
-            $$css: true,
-            xop34xu: "xowvtgn xop34xu"
+            xop34xu: "xowvtgn xop34xu",
+            $$css: true
           };"
         `);
         expect(metadata).toMatchInlineSnapshot(`
@@ -1261,8 +1261,8 @@ describe('@stylexjs/babel-plugin', () => {
             __themeName__: "xop34xu"
           };
           export const theme = {
-            $$css: true,
-            xop34xu: "xowvtgn xop34xu"
+            xop34xu: "xowvtgn xop34xu",
+            $$css: true
           };"
         `);
         expect(metadata).toMatchInlineSnapshot(`
@@ -1332,8 +1332,8 @@ describe('@stylexjs/babel-plugin', () => {
           };
           export const theme = {
             Foo__theme: "Foo__theme",
-            $$css: true,
-            xop34xu: "xowvtgn xop34xu"
+            xop34xu: "xowvtgn xop34xu",
+            $$css: true
           };"
         `);
         expect(metadata).toMatchInlineSnapshot(`
@@ -1405,8 +1405,8 @@ describe('@stylexjs/babel-plugin', () => {
           };
           _inject2(".xowvtgn, .xowvtgn:root{--xwx8imx:orange;}", 0.5);
           export const theme = {
-            $$css: true,
-            xop34xu: "xowvtgn xop34xu"
+            xop34xu: "xowvtgn xop34xu",
+            $$css: true
           };"
         `);
         expect(metadata).toMatchInlineSnapshot(`

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineVars-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineVars-test.js
@@ -37,6 +37,39 @@ function transform(source, opts = {}) {
 
 describe('@stylexjs/babel-plugin', () => {
   describe('[transform] stylex.defineVars()', () => {
+    test('tokens as null', () => {
+      const { code, metadata } = transform(`
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.defineVars({
+          color: null,
+          nextColor: {
+            default: null
+          },
+          otherColor: {
+            default: null,
+            '@media (prefers-color-scheme: dark)': null,
+            '@media print': null,
+          },
+        });
+      `);
+
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        export const vars = {
+          color: "var(--xwx8imx)",
+          nextColor: "var(--xk6xtqk)",
+          otherColor: "var(--xaaua2w)",
+          __themeName__: "xop34xu"
+        };"
+      `);
+
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [],
+        }
+      `);
+    });
+
     test('tokens object', () => {
       const { code, metadata } = transform(`
         import * as stylex from '@stylexjs/stylex';

--- a/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-createTheme-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-createTheme-test.js
@@ -74,7 +74,7 @@ describe('@stylexjs/babel-plugin', () => {
           const variables = stylex.createTheme({}, {});
         `);
       }).toThrow(
-        'Can only override variables theme created with stylex.defineVars().',
+        'Can only override variables theme created with defineVars().',
       );
 
       expect(() => {

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-create-theme.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-create-theme.js
@@ -28,7 +28,7 @@ export default function styleXCreateTheme(
 ): [{ $$css: true, +[string]: string }, { [string]: InjectableStyle }] {
   if (typeof themeVars.__themeName__ !== 'string') {
     throw new Error(
-      'Can only override variables theme created with stylex.defineVars().',
+      'Can only override variables theme created with defineVars().',
     );
   }
 
@@ -85,8 +85,10 @@ export default function styleXCreateTheme(
   const themeClass = `${overrideClassName} ${themeVars.__themeName__}`;
 
   return [
-    // $FlowFixMe[invalid-computed-prop]
-    { $$css: true, [themeVars.__themeName__]: themeClass },
+    {
+      [themeVars.__themeName__]: themeClass,
+      $$css: true,
+    },
     stylesToInject,
   ];
 }

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-vars-utils.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-vars-utils.js
@@ -37,7 +37,7 @@ export function collectVarsByAtRule(
     return;
   }
   if (Array.isArray(value)) {
-    throw new Error('Array is not supported in stylex.defineVars');
+    throw new Error('Array is not supported in defineVars');
   }
   if (typeof value === 'object') {
     if (value.default === undefined) {
@@ -76,7 +76,7 @@ export function getDefaultValue(value: VarsConfigValue): ?string {
     return null;
   }
   if (Array.isArray(value)) {
-    throw new Error('Array is not supported in stylex.defineVars');
+    throw new Error('Array is not supported in defineVars');
   }
   if (typeof value === 'object') {
     if (value.default === undefined) {
@@ -84,5 +84,5 @@ export function getDefaultValue(value: VarsConfigValue): ?string {
     }
     return getDefaultValue(value.default);
   }
-  throw new Error('Invalid value in stylex.defineVars');
+  throw new Error('Invalid value in defineVars');
 }

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/property-priorities.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/property-priorities.js
@@ -658,20 +658,17 @@ export const PSEUDO_CLASS_PRIORITIES: $ReadOnly<{ [string]: number }> = {
   ':last-of-type': 55,
   ':only-child': 56,
   ':only-of-type': 57,
-
   ':nth-child': 60,
   ':nth-last-child': 61,
   ':nth-of-type': 62,
   ':nth-last-of-type': 63, // 'nth-last-of-type' is the same priority as 'nth-of-type
   ':empty': 70,
-
   ':link': 80,
   ':any-link': 81,
   ':local-link': 82,
   ':target-within': 83,
   ':target': 84,
   ':visited': 85,
-
   ':enabled': 91,
   ':disabled': 92,
   ':required': 93,
@@ -681,7 +678,6 @@ export const PSEUDO_CLASS_PRIORITIES: $ReadOnly<{ [string]: number }> = {
   ':placeholder-shown': 97,
   ':in-range': 98,
   ':out-of-range': 99,
-
   ':default': 100,
   ':checked': 101,
   ':indeterminate': 101,
@@ -689,9 +685,7 @@ export const PSEUDO_CLASS_PRIORITIES: $ReadOnly<{ [string]: number }> = {
   ':valid': 103,
   ':invalid': 104,
   ':user-invalid': 105,
-
   ':autofill': 110,
-
   ':picture-in-picture': 120,
   ':modal': 121,
   ':fullscreen': 122,
@@ -700,7 +694,6 @@ export const PSEUDO_CLASS_PRIORITIES: $ReadOnly<{ [string]: number }> = {
   ':current': 125,
   ':past': 126,
   ':future': 127,
-
   ':hover': 130,
   ':focusWithin': 140,
   ':focus': 150,
@@ -752,17 +745,17 @@ export default function getPriority(key: string): number {
     return PSEUDO_CLASS_PRIORITIES[prop] ?? 40;
   }
 
-  if (longHandPhysical.has(key)) {
-    return 4000;
-  }
-  if (longHandLogical.has(key)) {
-    return 3000;
+  if (shorthandsOfShorthands.has(key)) {
+    return 1000;
   }
   if (shorthandsOfLonghands.has(key)) {
     return 2000;
   }
-  if (shorthandsOfShorthands.has(key)) {
-    return 1000;
+  if (longHandLogical.has(key)) {
+    return 3000;
+  }
+  if (longHandPhysical.has(key)) {
+    return 4000;
   }
   return 3000;
 }

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
@@ -175,14 +175,17 @@ function evaluateThemeRef(
 
     const { debug, enableDebugClassNames } = state.traversalState.options;
 
-    const varSafeKey = (
-      key[0] >= '0' && key[0] <= '9' ? `_${key}` : key
-    ).replace(/[^a-zA-Z0-9]/g, '_');
+    const varSafeKey =
+      key === '__themeName__'
+        ? ''
+        : (key[0] >= '0' && key[0] <= '9' ? `_${key}` : key).replace(
+            /[^a-zA-Z0-9]/g,
+            '_',
+          ) + '-';
 
     const varName =
       debug && enableDebugClassNames
         ? varSafeKey +
-          '-' +
           state.traversalState.options.classNamePrefix +
           utils.hash(strToHash)
         : state.traversalState.options.classNamePrefix + utils.hash(strToHash);

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluation-errors.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluation-errors.js
@@ -20,7 +20,7 @@ export const DEFAULT_IMPORT = `Error: Cannot use default imports.
 
 Please define your styles without depending on values imported from other files.
 
-You *may* use named imports to use variables defined with \`stylex.defineVars\` in a file with \`.stylex.js\` or \`.stylex.ts\` file.
+You *may* use named imports to use variables defined with \`defineVars\` in a file with \`.stylex.js\` or \`.stylex.ts\` file.
 See: https://stylexjs.com/docs/learn/theming/defining-variables/#rules-when-defining-variables for more information.
 `;
 

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-create-theme.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-create-theme.js
@@ -156,7 +156,7 @@ export default function transformStyleXCreateTheme(
       variables.__themeName__ === ''
     ) {
       throw callExpressionPath.buildCodeFrameError(
-        'Can only override variables theme created with stylex.defineVars().',
+        'Can only override variables theme created with defineVars().',
         SyntaxError,
       );
     }

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-consts.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-consts.js
@@ -65,7 +65,9 @@ export default function transformStyleXDefineConsts(
 
     const fileName = state.fileNameForHashing;
     if (fileName == null) {
-      throw new Error('No filename found for generating theme name.');
+      throw new Error(
+        'No filename found for generating defineConsts key name.',
+      );
     }
 
     const exportName = varId.name;

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-vars.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-vars.js
@@ -146,7 +146,7 @@ export default function transformStyleXDefineVars(
 
     const fileName = state.fileNameForHashing;
     if (fileName == null) {
-      throw new Error('No filename found for generating theme name.');
+      throw new Error('No filename found for generating defineVars key name.');
     }
 
     const exportName = varId.name;

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -1001,7 +1001,7 @@ revert`,
         {
           message: `animationName value must be one of:
 none
-a \`stylex.keyframes(...)\` function call, a reference to it or a many such valid
+a \`keyframes(...)\` function call, a reference to it or a many such valid
 null
 initial
 inherit

--- a/packages/@stylexjs/eslint-plugin/src/rules/isAnimationName.js
+++ b/packages/@stylexjs/eslint-plugin/src/rules/isAnimationName.js
@@ -48,7 +48,7 @@ export default function isAnimationName(
       } else {
         return {
           message:
-            'All expressions in a template literal must be a `stylex.keyframes(...)` function call',
+            'All expressions in a template literal must be a `keyframes(...)` function call',
         };
       }
     }
@@ -60,7 +60,7 @@ export default function isAnimationName(
       ) {
         return {
           message:
-            'All expressions in a template literal must be a `stylex.keyframes(...)` function call',
+            'All expressions in a template literal must be a `keyframes(...)` function call',
         };
       }
       if (
@@ -79,7 +79,7 @@ export default function isAnimationName(
     }
     return {
       message:
-        'a `stylex.keyframes(...)` function call, a reference to it or a many such valid',
+        'a `keyframes(...)` function call, a reference to it or a many such valid',
     };
   };
 }


### PR DESCRIPTION
This fixes a bug in StyleX theming. Before, defineVars was creating a `:root` rule with a classname that is unique to a given defineVars call. However, when debug mode is enabled, calls to createTheme were generating bad debug class names and the unique classname for vars was not being applied. This bug isn't caught by the unit tests because they are using fixtures and not using the bad logic in evaluate-path.js