### PR TITLE
0.14 blog typo

### DIFF
--- a/packages/docs/blog/2025-06-30-Release-v0.14.0.mdx
+++ b/packages/docs/blog/2025-06-30-Release-v0.14.0.mdx
@@ -18,7 +18,7 @@ StyleX v0.14.0 introduces new APIs to the compiler and linter, as well as a coup
 
 ### Compiler: `viewTransitionClass`
 
-The [`viewTransitionClass`](https://stylexjs.com/docs/api/javascript/viewTransitionClass/) API allows you to use StyleX to customize your [CSS View Transitions](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API). This API works nicely with React’s new [<ViewTransition />](https://react.dev/reference/react/ViewTransition) component:
+The [`viewTransitionClass`](https://stylexjs.com/docs/api/javascript/viewTransitionClass/) API allows you to use StyleX to customize your [CSS View Transitions](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API). This API works nicely with React’s new [`<ViewTransition />`](https://react.dev/reference/react/ViewTransition) component:
 
 ```tsx
 import {unstable_ViewTransition as ViewTransition} from 'react';


### PR DESCRIPTION
Doesn't render as expected currently:
![CleanShot 2025-07-02 at 13 56 01](https://github.com/user-attachments/assets/98dc530b-5685-4280-895b-a158e54e3a5a)
