### PR TITLE
[babel-plugin][legacy] fix expansion for marginInline, paddingInline, etc

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
@@ -236,6 +236,36 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
       `);
     });
 
+    test('paddingInline: basic multivalue shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            foo: {
+              paddingInline: "5px 10px"
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xaso8d8{padding-left:5px}", 3000, ".xaso8d8{padding-right:5px}");
+        _inject2(".x2vl965{padding-right:10px}", 3000, ".x2vl965{padding-left:10px}");
+        export const styles = {
+          foo: {
+            kZCmMZ: "xaso8d8",
+            kwRFfy: "x2vl965",
+            kE3dHu: null,
+            kpe85a: null,
+            $$css: true
+          }
+        };
+        "xaso8d8 x2vl965";"
+      `);
+    });
+
     test('padding: with longhand property collisions', () => {
       expect(
         transform(`
@@ -328,6 +358,64 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
           }
         };
         "xpcyujq xf6vk7d";"
+      `);
+    });
+
+    test('marginInline: basic multivalue shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            foo: {
+              marginInline: "5px 10px"
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".xpcyujq{margin-left:5px}", 3000, ".xpcyujq{margin-right:5px}");
+        _inject2(".x1sa5p1d{margin-right:10px}", 3000, ".x1sa5p1d{margin-left:10px}");
+        export const styles = {
+          foo: {
+            keTefX: "xpcyujq",
+            k71WvV: "x1sa5p1d",
+            koQZXg: null,
+            km5ZXQ: null,
+            $$css: true
+          }
+        };
+        "xpcyujq x1sa5p1d";"
+      `);
+    });
+
+    test('marginBlock: basic multivalue shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            foo: {
+              marginBlock: "5px 10px"
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x1ok221b{margin-top:5px}", 4000);
+        _inject2(".xyorhqc{margin-bottom:10px}", 4000);
+        export const styles = {
+          foo: {
+            keoZOQ: "x1ok221b",
+            k1K539: "xyorhqc",
+            $$css: true
+          }
+        };
+        "x1ok221b xyorhqc";"
       `);
     });
 
@@ -717,6 +805,34 @@ describe('legacy-shorthand-expansion resolution (enableLogicalStylesPolyfill: fa
         _inject2(".x1120s5i{padding-bottom:2px}", 4000);
         _inject2(".xe2zdcy{padding-inline-start:10px}", 3000);
         "x1nn3v0j x14vy60q x1120s5i xe2zdcy";"
+      `);
+    });
+
+    test('paddingBlock: basic multivalue shorthand', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          export const styles = stylex.create({
+            foo: {
+              paddingBlock: "5px 10px"
+            }
+          });
+          stylex(styles.foo);
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".x123j3cw{padding-top:5px}", 4000);
+        _inject2(".x1a8lsjc{padding-bottom:10px}", 4000);
+        export const styles = {
+          foo: {
+            kLKAdn: "x123j3cw",
+            kGO01o: "x1a8lsjc",
+            $$css: true
+          }
+        };
+        "x123j3cw x1a8lsjc";"
       `);
     });
 

--- a/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/legacy-expand-shorthands.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/legacy-expand-shorthands.js
@@ -250,10 +250,10 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
       ['marginInlineStart', left],
     ];
   },
-  marginHorizontal: (rawValue: TStyleValue): TReturn => [
-    ...shorthands.marginStart(rawValue),
-    ...shorthands.marginEnd(rawValue),
-  ],
+  marginHorizontal: (rawValue: TStyleValue): TReturn => {
+    const [start, end = start] = splitValue(rawValue);
+    return [...shorthands.marginStart(start), ...shorthands.marginEnd(end)];
+  },
   marginStart: (rawValue: TStyleValue): TReturn => [
     ['marginInlineStart', rawValue],
     ['marginLeft', null],
@@ -275,9 +275,10 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
     ['marginInlineEnd', null],
   ],
   marginVertical: (rawValue: TStyleValue): TReturn => {
+    const [top, bottom = top] = splitValue(rawValue);
     return [
-      ['marginTop', rawValue],
-      ['marginBottom', rawValue],
+      ['marginTop', top],
+      ['marginBottom', bottom],
     ];
   },
 
@@ -298,10 +299,10 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
       ['paddingInlineStart', left],
     ];
   },
-  paddingHorizontal: (val: TStyleValue): TReturn => [
-    ...shorthands.paddingStart(val),
-    ...shorthands.paddingEnd(val),
-  ],
+  paddingHorizontal: (val: TStyleValue): TReturn => {
+    const [start, end = start] = splitValue(val);
+    return [...shorthands.paddingStart(start), ...shorthands.paddingEnd(end)];
+  },
   paddingStart: (val: TStyleValue): TReturn => [
     ['paddingInlineStart', val],
     ['paddingLeft', null],
@@ -322,10 +323,13 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
     ['paddingInlineStart', null],
     ['paddingInlineEnd', null],
   ],
-  paddingVertical: (val: TStyleValue): TReturn => [
-    ['paddingTop', val],
-    ['paddingBottom', val],
-  ],
+  paddingVertical: (val: TStyleValue): TReturn => {
+    const [top, bottom = top] = splitValue(val);
+    return [
+      ['paddingTop', top],
+      ['paddingBottom', bottom],
+    ];
+  },
 };
 
 const aliases = {


### PR DESCRIPTION
This is a longstanding bug for `marginInline`, `marginBlock`, `paddingInline`, `paddingBlock` (https://github.com/facebook/stylex/issues/1091). I'm guessing it's an oversight because the rest of the shorthands (`margin`, `padding`, `gap`, etc.) are handled with `splitValue`. 

Currently, we don't split or handle the values passed to any of these properties. The `valid-shorthands` linter discourages them anyway, but internally it's not enabled everywhere and not strictly enforced.

```
paddingBlock: "5px 10px" ->

_inject2(".x4tyy86{padding-top:5px 10px}", 4000);
_inject2(".xr7q0qe{padding-bottom:5px 10px}", 4000);
```

This PR handles these values appropriately:


```
paddingBlock: "5px 10px" ->

_inject2(".x4tyy86{padding-top:5px}", 4000);
_inject2(".xr7q0qe{padding-bottom:10px}", 4000);
```