### PR TITLE
Update npm-release documentation

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -4,32 +4,45 @@ Tools used to manage monorepo tasks like pre-commit hooks and npm releases.
 
 ## How to create a release
 
-The release script (run from the monorepo root) must be used to create and publish releases.
+The release script (run from the monorepo root) must be used to create and publish releases. All releases must follow semver versioning standards, e.g., `0.20.1`.
+
+Checkout a release branch from latest `main`:
 
 ```shell
-npm run release
-  # package version (required)
-  --pkg-version 0.10.2
-  # creates git commit and tag
-  --commit
-  # publishes to npm using 2fa
-  --publish --otp 123456
+git checkout main
+git pull origin main
+git checkout -b release/<version>
 ```
 
 You can perform a dry run by only specifying the new version for a release:
 
 ```shell
-npm run release -- --pkg-version 0.10.2
+npm run release -- --pkg-version <version>
 ```
 
-To commit and tag the release:
+To commit the release:
 
 ```shell
-npm run release -- --pkg-version 0.10.2 --commit
+npm run release -- --pkg-version <version> --commit
+```
+
+Push the branch up for review:
+
+```shell
+git push origin release/<version>
+```
+
+Once the branch has been merged, update `main` and the git-tag.
+
+```shell
+git checkout main
+git pull origin main
+git tag -am <version> "<version>"
+git push --tags origin main
 ```
 
 To publish the release:
 
 ```shell
-npm run release -- --pkg-version 0.10.2 --publish
+npm run release -- --pkg-version <version> --publish --otp 123456
 ```

--- a/tools/npm/release.js
+++ b/tools/npm/release.js
@@ -109,7 +109,7 @@ if (commit) {
   // commit
   execSync(`git commit -m "${pkgVersion}" --no-verify`, { stdio: 'inherit' });
   // tag
-  execSync(`git tag -fam ${pkgVersion} "${pkgVersion}"`, { stdio: 'inherit' });
+  // execSync(`git tag -fam ${pkgVersion} "${pkgVersion}"`, { stdio: 'inherit' });
 }
 
 if (publish) {
@@ -134,5 +134,5 @@ if (publish) {
     }
   });
   // push changes
-  execSync('git push --tags origin main', { stdio: 'inherit' });
+  // execSync('git push --tags origin main', { stdio: 'inherit' });
 }


### PR DESCRIPTION
We can't do everything in one command because we can't push commits directly to `main`. And the GitHub PR UI creates a new commit on merge, which means tags have to be added to the post-merge commit on `main`.
