### PR TITLE
Remove legacy RTL flipping of boxShadow, cursor, textShadow values

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-logical-values-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-logical-values-test.js
@@ -134,11 +134,14 @@ describe('@stylexjs/babel-plugin', () => {
 
     test('[legacy] value "e-resize" for "cursor" property', () => {
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { cursor: 'e-resize' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -150,11 +153,14 @@ describe('@stylexjs/babel-plugin', () => {
 
     test('[legacy] value "w-resize" for "cursor" property', () => {
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { cursor: 'w-resize' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -166,11 +172,14 @@ describe('@stylexjs/babel-plugin', () => {
 
     test('[legacy] value "ne-resize" for "cursor" property', () => {
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { cursor: 'ne-resize' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -182,11 +191,14 @@ describe('@stylexjs/babel-plugin', () => {
 
     test('[legacy] value "nw-resize" for "cursor" property', () => {
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { cursor: 'nw-resize' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -198,11 +210,14 @@ describe('@stylexjs/babel-plugin', () => {
 
     test('[legacy] value "se-resize" for "cursor" property', () => {
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { cursor: 'se-resize' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -214,11 +229,14 @@ describe('@stylexjs/babel-plugin', () => {
 
     test('[legacy] value "sw-resize" for "cursor" property', () => {
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { cursor: 'sw-resize' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -280,11 +298,14 @@ describe('@stylexjs/babel-plugin', () => {
 
     test('[legacy] value of "boxShadow" property', () => {
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { boxShadow: 'none' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -293,11 +314,14 @@ describe('@stylexjs/babel-plugin', () => {
         const classnames = "x1gnnqk1";"
       `);
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { boxShadow: '1px 1px #000' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -306,11 +330,14 @@ describe('@stylexjs/babel-plugin', () => {
         const classnames = "xtgyqtp";"
       `);
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { boxShadow: '-1px -1px #000' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -319,11 +346,14 @@ describe('@stylexjs/babel-plugin', () => {
         const classnames = "x1d2r41h";"
       `);
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { boxShadow: 'inset 1px 1px #000' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -332,11 +362,14 @@ describe('@stylexjs/babel-plugin', () => {
         const classnames = "x1x0mpz7";"
       `);
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { boxShadow: '1px 1px 1px 1px #000' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -345,11 +378,14 @@ describe('@stylexjs/babel-plugin', () => {
         const classnames = "x1fumi7f";"
       `);
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { boxShadow: 'inset 1px 1px 1px 1px #000' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -358,11 +394,14 @@ describe('@stylexjs/babel-plugin', () => {
         const classnames = "x1fs23zf";"
       `);
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { boxShadow: '2px 2px 2px 2px red, inset 1px 1px 1px 1px #000' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -374,11 +413,14 @@ describe('@stylexjs/babel-plugin', () => {
 
     test('[legacy] value of "textShadow" property', () => {
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { textShadow: 'none' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -387,11 +429,14 @@ describe('@stylexjs/babel-plugin', () => {
         const classnames = "x19pm5ym";"
       `);
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { textShadow: '1px 1px #000' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -400,11 +445,14 @@ describe('@stylexjs/babel-plugin', () => {
         const classnames = "x12y90mb";"
       `);
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { textShadow: '-1px -1px #000' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
@@ -413,11 +461,14 @@ describe('@stylexjs/babel-plugin', () => {
         const classnames = "x1l3mtsg";"
       `);
       expect(
-        transform(`
+        transform(
+          `
           import stylex from 'stylex';
           const styles = stylex.create({ x: { textShadow: '1px 1px 1px #000' } });
           const classnames = stylex(styles.x);
-        `),
+        `,
+          { enableLegacyValueFlipping: true },
+        ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -201,7 +201,6 @@ describe('@stylexjs/babel-plugin', () => {
       expect(stylexPlugin.processStylexRules(metadata)).toMatchInlineSnapshot(`
         "@property --color { syntax: "*"; inherits: false;}
         @keyframes xi07kvp-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange);}}
-        @keyframes xi07kvp-B{0%{box-shadow:-1px 2px 3px 4px red;color:yellow;}100%{box-shadow:-10px 20px 30px 40px green;color:var(--orange);}}
         :root, .xsg933n{--blue-xpqh4lw:blue;}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         .x6xqkwy, .x6xqkwy:root{--blue-xpqh4lw:lightblue;}
@@ -213,10 +212,8 @@ describe('@stylexjs/babel-plugin', () => {
         .animationName-xckgs0v:not(#\\#):not(#\\#):not(#\\#){animation-name:xi07kvp-B}
         .backgroundColor-xrkmrrc:not(#\\#):not(#\\#):not(#\\#){background-color:red}
         .color-xfx01vb:not(#\\#):not(#\\#):not(#\\#){color:var(--color)}
-        html:not([dir='rtl']) .textShadow-x1skrh0i:not(#\\#):not(#\\#):not(#\\#){text-shadow:1px 2px 3px 4px red}
-        html[dir='rtl'] .textShadow-x1skrh0i:not(#\\#):not(#\\#):not(#\\#){text-shadow:-1px 2px 3px 4px red}
-        @media (min-width:320px){html:not([dir='rtl']) .textShadow-x1cmij7u.textShadow-x1cmij7u:not(#\\#):not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}
-        @media (min-width:320px){html[dir='rtl'] .textShadow-x1cmij7u.textShadow-x1cmij7u:not(#\\#):not(#\\#):not(#\\#){text-shadow:-10px 20px 30px 40px green}}"
+        .textShadow-x1skrh0i:not(#\\#):not(#\\#):not(#\\#){text-shadow:1px 2px 3px 4px red}
+        @media (min-width:320px){.textShadow-x1cmij7u.textShadow-x1cmij7u:not(#\\#):not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}"
       `);
     });
 
@@ -273,7 +270,6 @@ describe('@stylexjs/babel-plugin', () => {
         @layer priority1, priority2, priority3, priority4;
         @property --color { syntax: "*"; inherits: false;}
         @keyframes xi07kvp-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange);}}
-        @keyframes xi07kvp-B{0%{box-shadow:-1px 2px 3px 4px red;color:yellow;}100%{box-shadow:-10px 20px 30px 40px green;color:var(--orange);}}
         :root, .xsg933n{--blue-xpqh4lw:blue;}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         .x6xqkwy, .x6xqkwy:root{--blue-xpqh4lw:lightblue;}
@@ -290,10 +286,8 @@ describe('@stylexjs/babel-plugin', () => {
         .animationName-xckgs0v{animation-name:xi07kvp-B}
         .backgroundColor-xrkmrrc{background-color:red}
         .color-xfx01vb{color:var(--color)}
-        html:not([dir='rtl']) .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        html[dir='rtl'] .textShadow-x1skrh0i{text-shadow:-1px 2px 3px 4px red}
-        @media (min-width:320px){html:not([dir='rtl']) .textShadow-x1cmij7u.textShadow-x1cmij7u{text-shadow:10px 20px 30px 40px green}}
-        @media (min-width:320px){html[dir='rtl'] .textShadow-x1cmij7u.textShadow-x1cmij7u{text-shadow:-10px 20px 30px 40px green}}
+        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        @media (min-width:320px){.textShadow-x1cmij7u.textShadow-x1cmij7u{text-shadow:10px 20px 30px 40px green}}
         }"
       `);
     });

--- a/packages/@stylexjs/babel-plugin/src/shared/common-types.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/common-types.js
@@ -52,6 +52,7 @@ export type StyleXOptions = $ReadOnly<{
   enableDebugDataProp?: ?boolean,
   enableDevClassNames?: ?boolean,
   enableFontSizePxToRem?: ?boolean,
+  enableLegacyValueFlipping?: ?boolean,
   enableLogicalStylesPolyfill?: ?boolean,
   enableMinifiedKeys?: ?boolean,
   styleResolution:

--- a/packages/@stylexjs/babel-plugin/src/shared/physical-rtl/generate-rtl.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/physical-rtl/generate-rtl.js
@@ -76,24 +76,6 @@ function flipShadow(value: string) {
   }
 }
 
-// // Should we be flipping shadows at all?
-// // I think the better approach would be to let engineers use
-// // CSS-vars directly.
-// const shadowsFlip: $ReadOnly<{
-//   [key: string]: (
-//     $ReadOnly<[string, string]>,
-//   ) => $ReadOnly<[string, string]> | null,
-// }> = {
-//   'box-shadow': ([key, val]) => {
-//     const rtlVal = flipShadow(val);
-//     return rtlVal ? [key, rtlVal] : null;
-//   },
-//   'text-shadow': ([key, val]) => {
-//     const rtlVal = flipShadow(val);
-//     return rtlVal ? [key, rtlVal] : null;
-//   },
-// };
-
 const logicalToPhysical: $ReadOnly<{ [string]: string }> = {
   start: 'right',
   end: 'left',
@@ -187,6 +169,7 @@ const inlinePropertyToRTL: $ReadOnly<{
 const propertyToRTL: $ReadOnly<{
   [key: string]: (
     $ReadOnly<[string, string]>,
+    options: StyleXOptions,
   ) => $ReadOnly<[string, string]> | null,
 }> = {
   'margin-start': ([_key, val]: $ReadOnly<[string, string]>) => [
@@ -279,17 +262,25 @@ const propertyToRTL: $ReadOnly<{
         .join(' '),
     ];
   },
-  cursor: ([key, val]) =>
-    cursorFlip[val] != null ? [key, cursorFlip[val]] : null,
 
-  // Should we be flipping shadows at all?
-  // I think the better approach would be to let engineers use
-  // CSS-vars directly.
-  'box-shadow': ([key, val]) => {
+  // Legacy / Incorrect value flipping
+  cursor: ([key, val], options = defaultOptions) => {
+    if (!options.enableLegacyValueFlipping) {
+      return null;
+    }
+    return cursorFlip[val] != null ? [key, cursorFlip[val]] : null;
+  },
+  'box-shadow': ([key, val], options = defaultOptions) => {
+    if (!options.enableLegacyValueFlipping) {
+      return null;
+    }
     const rtlVal = flipShadow(val);
     return rtlVal ? [key, rtlVal] : null;
   },
-  'text-shadow': ([key, val]) => {
+  'text-shadow': ([key, val], options = defaultOptions) => {
+    if (!options.enableLegacyValueFlipping) {
+      return null;
+    }
     const rtlVal = flipShadow(val);
     return rtlVal ? [key, rtlVal] : null;
   },
@@ -319,5 +310,5 @@ export default function generateRTL(
     return null;
   }
 
-  return propertyToRTL[key]([key, value]);
+  return propertyToRTL[key]([key, value], options);
 }

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/default-options.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/default-options.js
@@ -17,6 +17,7 @@ export const defaultOptions: StyleXOptions = {
   enableDevClassNames: false,
   enableDebugDataProp: true,
   enableFontSizePxToRem: false,
+  enableLegacyValueFlipping: false,
   enableLogicalStylesPolyfill: false,
   enableMinifiedKeys: true,
   styleResolution: 'property-specificity',

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -75,6 +75,7 @@ export type StyleXOptions = $ReadOnly<{
   enableDebugDataProp?: boolean,
   enableDevClassNames?: boolean,
   enableInlinedConditionalMerge?: boolean,
+  enableLegacyValueFlipping?: boolean,
   enableLogicalStylesPolyfill?: boolean,
   enableMinifiedKeys?: boolean,
   importSources: $ReadOnlyArray<
@@ -220,6 +221,14 @@ export default class StateManager {
         'options.enableMinifiedKeys',
       );
 
+    const enableLegacyValueFlipping: StyleXStateOptions['enableLegacyValueFlipping'] =
+      z.logAndDefault(
+        z.boolean(),
+        options.enableLegacyValueFlipping ?? false,
+        false,
+        'options.enableLegacyValueFlipping',
+      );
+
     const enableLogicalStylesPolyfill: StyleXStateOptions['enableLogicalStylesPolyfill'] =
       z.logAndDefault(
         z.boolean(),
@@ -337,6 +346,7 @@ export default class StateManager {
       enableFontSizePxToRem,
       enableInlinedConditionalMerge,
       enableMinifiedKeys,
+      enableLegacyValueFlipping,
       enableLogicalStylesPolyfill,
       importSources,
       rewriteAliases:


### PR DESCRIPTION
Cartesian coordinates (x,y) and cardinal directions (N,E,S,W) should not be flipped for RTL writing directions. This behavior is neither part of the W3C standards nor common sense.

The behavior is preserved (but disabled by default) with a new feature flag - enableLegacyLogicalValues - while Meta migrates internal code off this behavior.

Fix #1120

