### PR TITLE
Update 03-descendant styles.mdx

### DIFF
--- a/packages/docs/docs/learn/06-recipes/03-descendant styles.mdx
+++ b/packages/docs/docs/learn/06-recipes/03-descendant styles.mdx
@@ -74,7 +74,7 @@ const styles = stylex.create({
   }
 });
 
-function ParentWithHover() {
+function Child() {
   return (
       <span {...stylex.props(styles.child)}><Icon />A Row</span>
   );


### PR DESCRIPTION
The component on line 77 is incorrectly titled `ParentWithHover`, the same as the component on line 54. It looks like this was probably a copy error. But the component on the 77 is actually the descendant of the parent component on line 54.

## What changed / motivation ?

This is meant to clarify the documentation. The mislabelling makes the example confusing

## Linked PR/Issues

Fixes # (issue)

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code