### PR TITLE
[babel-plugin] refactor defineVars and defineConsts var naming

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/evaluation-import-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/evaluation-import-test.js
@@ -88,13 +88,13 @@ describe('Evaluation of imported values works based on configuration', () => {
       `);
     });
 
-    test('Importing file with ".stylex" and reading __themeName__ returns a className', () => {
+    test('Importing file with ".stylex" and reading __varGroupHash__ returns a className', () => {
       const transformation = transform(`
         import stylex from 'stylex';
         import { MyTheme } from 'otherFile.stylex';
         const styles = stylex.create({
           red: {
-            color: MyTheme.__themeName__,
+            color: MyTheme.__varGroupHash__,
           }
         });
         stylex(styles.red);
@@ -422,7 +422,7 @@ describe('Evaluation of imported values works based on configuration', () => {
         import { MyTheme } from './otherFile.stylex.js';
         const styles = stylex.create({
           red: {
-            color: MyTheme.__themeName__,
+            color: MyTheme.__varGroupHash__,
           }
         });
         stylex(styles.red);

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-import-export-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-import-export-test.js
@@ -236,7 +236,7 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           bar: "var(--x1hi1hmf)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
@@ -371,7 +371,7 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           bar: "var(--x1hi1hmf)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
@@ -421,7 +421,7 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           bar: "var(--x1hi1hmf)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
@@ -480,7 +480,7 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           bar: "var(--x1hi1hmf)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
@@ -521,7 +521,7 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           bar: "var(--x1hi1hmf)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
@@ -575,7 +575,7 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           bar: "var(--x1hi1hmf)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";
@@ -616,7 +616,7 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           bar: "var(--x1hi1hmf)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
         const fallback1 = "--x5jppmd";

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -138,13 +138,13 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           blue: "var(--blue-xpqh4lw)",
-          __themeName__: "xsg933n"
+          __varGroupHash__: "xsg933n"
         };
         export const spacing = {
           small: "var(--small-x19twipt)",
           medium: "var(--medium-xypjos2)",
           large: "var(--large-x1ec7iuc)",
-          __themeName__: "xbiwvf9"
+          __varGroupHash__: "xbiwvf9"
         };"
       `);
       expect(stylexPlugin.processStylexRules(metadata)).toMatchInlineSnapshot(`
@@ -165,13 +165,13 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           blue: "var(--blue-xpqh4lw)",
-          __themeName__: "xsg933n"
+          __varGroupHash__: "xsg933n"
         };
         export const spacing = {
           small: "var(--small-x19twipt)",
           medium: "var(--medium-xypjos2)",
           large: "var(--large-x1ec7iuc)",
-          __themeName__: "xbiwvf9"
+          __varGroupHash__: "xbiwvf9"
         };
         export const themeColor = {
           xsg933n: "x6xqkwy xsg933n",
@@ -234,13 +234,13 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           blue: "var(--blue-xpqh4lw)",
-          __themeName__: "xsg933n"
+          __varGroupHash__: "xsg933n"
         };
         export const spacing = {
           small: "var(--small-x19twipt)",
           medium: "var(--medium-xypjos2)",
           large: "var(--large-x1ec7iuc)",
-          __themeName__: "xbiwvf9"
+          __varGroupHash__: "xbiwvf9"
         };
         export const themeColor = {
           xsg933n: "x6xqkwy xsg933n",

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-createTheme-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-createTheme-test.js
@@ -112,7 +112,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xwx8imx)",
           otherColor: "var(--xaaua2w)",
           radius: "var(--xbbre8)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         export const theme = {
           xop34xu: "x4aw18j xop34xu",
@@ -193,7 +193,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xwx8imx)",
           otherColor: "var(--xaaua2w)",
           radius: "var(--xbbre8)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         export const theme = {
           xop34xu: "x4aw18j xop34xu",
@@ -273,7 +273,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xt4ziaz)",
           otherColor: "var(--x1e3it8h)",
           radius: "var(--x1onrunl)",
-          __themeName__: "x1xohuxq"
+          __varGroupHash__: "x1xohuxq"
         };
         export const theme = {
           x1xohuxq: "xv0nx9o x1xohuxq",
@@ -356,7 +356,7 @@ describe('@stylexjs/babel-plugin', () => {
           "--color": "var(--color)",
           "--otherColor": "var(--otherColor)",
           "--radius": "var(--radius)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         export const theme = {
           xop34xu: "x1l2ihi1 xop34xu",
@@ -415,7 +415,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xwx8imx)",
           otherColor: "var(--xaaua2w)",
           radius: "var(--xbbre8)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         const themeObj = {
           color: {
@@ -504,7 +504,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xwx8imx)",
           otherColor: "var(--xaaua2w)",
           radius: "var(--xbbre8)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         const RADIUS = 10;
         export const theme = {
@@ -566,7 +566,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xwx8imx)",
           otherColor: "var(--xaaua2w)",
           radius: "var(--xbbre8)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         const name = 'light';
         export const theme = {
@@ -628,7 +628,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xwx8imx)",
           otherColor: "var(--xaaua2w)",
           radius: "var(--xbbre8)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         const RADIUS = 10;
         export const theme = {
@@ -699,7 +699,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xwx8imx)",
           otherColor: "var(--xaaua2w)",
           radius: "var(--xbbre8)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         const RADIUS = 10;
         export const theme = {
@@ -778,7 +778,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xwx8imx)",
           otherColor: "var(--xaaua2w)",
           radius: "var(--xbbre8)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         export const theme = {
           xop34xu: "x4aw18j xop34xu",
@@ -873,7 +873,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xwx8imx)",
           otherColor: "var(--xaaua2w)",
           radius: "var(--xbbre8)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         export const theme = {
           xop34xu: "x4aw18j xop34xu",
@@ -887,7 +887,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--x103gslp)",
           otherColor: "var(--x1e7put6)",
           radius: "var(--xm3n3tg)",
-          __themeName__: "x1ngxneg"
+          __varGroupHash__: "x1ngxneg"
         };
         export const theme = {
           x1ngxneg: "xgl5cw9 x1ngxneg",
@@ -1052,7 +1052,7 @@ describe('@stylexjs/babel-plugin', () => {
             color: "var(--xwx8imx)",
             otherColor: "var(--xaaua2w)",
             radius: "var(--xbbre8)",
-            __themeName__: "xop34xu"
+            __varGroupHash__: "xop34xu"
           };
           export const theme = {
             xop34xu: "xowvtgn xop34xu",
@@ -1120,7 +1120,7 @@ describe('@stylexjs/babel-plugin', () => {
             color: "var(--xwx8imx)",
             otherColor: "var(--xaaua2w)",
             radius: "var(--xbbre8)",
-            __themeName__: "xop34xu"
+            __varGroupHash__: "xop34xu"
           };
           export const theme = {
             xop34xu: "xowvtgn xop34xu",
@@ -1189,7 +1189,7 @@ describe('@stylexjs/babel-plugin', () => {
             color: "var(--xwx8imx)",
             otherColor: "var(--xaaua2w)",
             radius: "var(--xbbre8)",
-            __themeName__: "xop34xu"
+            __varGroupHash__: "xop34xu"
           };
           export const theme = {
             xop34xu: "xowvtgn xop34xu",
@@ -1258,7 +1258,7 @@ describe('@stylexjs/babel-plugin', () => {
             color: "var(--xwx8imx)",
             otherColor: "var(--xaaua2w)",
             radius: "var(--xbbre8)",
-            __themeName__: "xop34xu"
+            __varGroupHash__: "xop34xu"
           };
           export const theme = {
             xop34xu: "xowvtgn xop34xu",
@@ -1328,7 +1328,7 @@ describe('@stylexjs/babel-plugin', () => {
             color: "var(--xwx8imx)",
             otherColor: "var(--xaaua2w)",
             radius: "var(--xbbre8)",
-            __themeName__: "xop34xu"
+            __varGroupHash__: "xop34xu"
           };
           export const theme = {
             Foo__theme: "Foo__theme",
@@ -1401,7 +1401,7 @@ describe('@stylexjs/babel-plugin', () => {
             color: "var(--xwx8imx)",
             otherColor: "var(--xaaua2w)",
             radius: "var(--xbbre8)",
-            __themeName__: "xop34xu"
+            __varGroupHash__: "xop34xu"
           };
           _inject2(".xowvtgn, .xowvtgn:root{--xwx8imx:orange;}", 0.5);
           export const theme = {

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineVars-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineVars-test.js
@@ -59,7 +59,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xwx8imx)",
           nextColor: "var(--xk6xtqk)",
           otherColor: "var(--xaaua2w)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };"
       `);
 
@@ -92,7 +92,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xwx8imx)",
           nextColor: "var(--xk6xtqk)",
           otherColor: "var(--xaaua2w)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };"
       `);
 
@@ -157,7 +157,7 @@ describe('@stylexjs/babel-plugin', () => {
           color: "var(--xwx8imx)",
           nextColor: "var(--xk6xtqk)",
           otherColor: "var(--xaaua2w)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };"
       `);
 
@@ -211,7 +211,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         export const vars = {
           color: "var(--xt4ziaz)",
-          __themeName__: "x1xohuxq"
+          __varGroupHash__: "x1xohuxq"
         };"
       `);
 
@@ -249,7 +249,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         export const vars = {
           color: "var(--xwx8imx)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };"
       `);
 
@@ -302,7 +302,7 @@ describe('@stylexjs/babel-plugin', () => {
         export const vars = {
           "--color": "var(--color)",
           "--otherColor": "var(--otherColor)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };"
       `);
 
@@ -364,7 +364,7 @@ describe('@stylexjs/babel-plugin', () => {
           "--color": "var(--color)",
           "--nextColor": "var(--nextColor)",
           "--otherColor": "var(--otherColor)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };"
       `);
 
@@ -414,7 +414,7 @@ describe('@stylexjs/babel-plugin', () => {
         const COLOR = 'red';
         export const vars = {
           color: "var(--xwx8imx)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };"
       `);
 
@@ -448,7 +448,7 @@ describe('@stylexjs/babel-plugin', () => {
         const NUMBER = 10;
         export const vars = {
           size: "var(--xu6xznv)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };"
       `);
 
@@ -482,7 +482,7 @@ describe('@stylexjs/babel-plugin', () => {
         const NUMBER = 10;
         export const vars = {
           radius: "var(--xbbre8)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };"
       `);
 
@@ -518,7 +518,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         export const vars = {
           color: "var(--xwx8imx)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };"
       `);
 
@@ -577,11 +577,11 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         export const vars = {
           color: "var(--xwx8imx)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         export const otherVars = {
           otherColor: "var(--xnjepv0)",
-          __themeName__: "x1pfrffu"
+          __varGroupHash__: "x1pfrffu"
         };"
       `);
 
@@ -624,11 +624,11 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         export const vars = {
           color: "var(--xwx8imx)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };
         export const otherVars = {
           otherColor: "var(--xnjepv0)",
-          __themeName__: "x1pfrffu"
+          __varGroupHash__: "x1pfrffu"
         };"
       `);
 
@@ -675,14 +675,14 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         export const vars = {
           color: "var(--xwx8imx)",
-          __themeName__: "xop34xu"
+          __varGroupHash__: "xop34xu"
         };"
       `);
       expect(code2).toMatchInlineSnapshot(`
         "import * as stylex from '@stylexjs/stylex';
         export const otherVars = {
           otherColor: "var(--xnjepv0)",
-          __themeName__: "x1pfrffu"
+          __varGroupHash__: "x1pfrffu"
         };"
       `);
 
@@ -741,7 +741,7 @@ describe('@stylexjs/babel-plugin', () => {
           export const vars = {
             color: "var(--color-xwx8imx)",
             otherColor: "var(--otherColor-xaaua2w)",
-            __themeName__: "xop34xu"
+            __varGroupHash__: "xop34xu"
           };"
         `);
 
@@ -799,7 +799,7 @@ describe('@stylexjs/babel-plugin', () => {
             "1.5 pixels": "var(--_1_5_pixels-x15ahj5d)",
             "corner#radius": "var(--corner_radius-x2ajqv2)",
             "@@primary": "var(--__primary-x13tvx0f)",
-            __themeName__: "xop34xu"
+            __varGroupHash__: "xop34xu"
           };"
         `);
 
@@ -841,7 +841,7 @@ describe('@stylexjs/babel-plugin', () => {
             color: "var(--color-xwx8imx)",
             nextColor: "var(--nextColor-xk6xtqk)",
             otherColor: "var(--otherColor-xaaua2w)",
-            __themeName__: "xop34xu"
+            __varGroupHash__: "xop34xu"
           };"
         `);
 
@@ -886,7 +886,7 @@ describe('@stylexjs/babel-plugin', () => {
             color: "var(--xwx8imx)",
             nextColor: "var(--xk6xtqk)",
             otherColor: "var(--xaaua2w)",
-            __themeName__: "xop34xu"
+            __varGroupHash__: "xop34xu"
           };"
         `);
 
@@ -932,7 +932,7 @@ describe('@stylexjs/babel-plugin', () => {
           "import * as stylex from '@stylexjs/stylex';
           export const vars = {
             color: "var(--color-x1lzcbr1)",
-            __themeName__: "x1bxutiz"
+            __varGroupHash__: "x1bxutiz"
           };"
         `);
 

--- a/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-createTheme-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-createTheme-test.js
@@ -41,7 +41,7 @@ describe('@stylexjs/babel-plugin', () => {
       expect(() => {
         transform(`
           import stylex from 'stylex';
-          stylex.createTheme({__themeName__: 'x568ih9'}, {});
+          stylex.createTheme({__varGroupHash__: 'x568ih9'}, {});
         `);
       }).toThrow(messages.unboundCallValue('createTheme'));
     });
@@ -80,14 +80,14 @@ describe('@stylexjs/babel-plugin', () => {
       expect(() => {
         transform(`
           import stylex from 'stylex';
-          const variables = stylex.createTheme({__themeName__: 'x568ih9'}, genStyles());
+          const variables = stylex.createTheme({__varGroupHash__: 'x568ih9'}, genStyles());
         `);
       }).toThrow(messages.nonStaticValue('createTheme'));
 
       expect(() => {
         transform(`
           import stylex from 'stylex';
-          const variables = stylex.createTheme({__themeName__: 'x568ih9'}, {});
+          const variables = stylex.createTheme({__varGroupHash__: 'x568ih9'}, {});
         `);
       }).not.toThrow();
     });
@@ -99,7 +99,7 @@ describe('@stylexjs/babel-plugin', () => {
         transform(`
           import stylex from 'stylex';
           const variables = stylex.createTheme(
-            {__themeName__: 'x568ih9', labelColor: 'var(--labelColorHash)'},
+            {__varGroupHash__: 'x568ih9', labelColor: 'var(--labelColorHash)'},
             {[labelColor]: 'red',});
         `);
       }).toThrow(messages.nonStaticValue('createTheme'));
@@ -113,7 +113,7 @@ describe('@stylexjs/babel-plugin', () => {
         transform(`
           import stylex from 'stylex';
           const variables = stylex.createTheme(
-            {__themeName__: 'x568ih9', cornerRadius: 'var(--cornerRadiusHash)'},
+            {__varGroupHash__: 'x568ih9', cornerRadius: 'var(--cornerRadiusHash)'},
             {cornerRadius: 5,}
           );
         `);
@@ -124,7 +124,7 @@ describe('@stylexjs/babel-plugin', () => {
         transform(`
           import stylex from 'stylex';
           const variables = stylex.createTheme(
-            {__themeName__: 'x568ih9', labelColor: 'var(--labelColorHash)'},
+            {__varGroupHash__: 'x568ih9', labelColor: 'var(--labelColorHash)'},
             {labelColor: 'red',}
           );
         `);
@@ -135,7 +135,7 @@ describe('@stylexjs/babel-plugin', () => {
         transform(`
           import stylex from 'stylex';
           const variables = stylex.createTheme(
-            {__themeName__: 'x568ih9', labelColor: 'var(--labelColorHash)'},
+            {__varGroupHash__: 'x568ih9', labelColor: 'var(--labelColorHash)'},
             {labelColor: labelColor,}
           );
         `);
@@ -145,7 +145,7 @@ describe('@stylexjs/babel-plugin', () => {
         transform(`
           import stylex from 'stylex';
           const variables = stylex.createTheme(
-            {__themeName__: 'x568ih9', labelColor: 'var(--labelColorHash)'},
+            {__varGroupHash__: 'x568ih9', labelColor: 'var(--labelColorHash)'},
             {labelColor: labelColor(),}
           );
         `);

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-create-theme.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-create-theme.js
@@ -22,11 +22,11 @@ import { defaultOptions } from './utils/default-options';
 // and returns a hashed className with variables overrides.
 //
 export default function styleXCreateTheme(
-  themeVars: { +__themeName__: string, +[string]: string },
+  themeVars: { +__varGroupHash__: string, +[string]: string },
   variables: { +[string]: string | { default: string, +[string]: string } },
   options?: StyleXOptions,
 ): [{ $$css: true, +[string]: string }, { [string]: InjectableStyle }] {
-  if (typeof themeVars.__themeName__ !== 'string') {
+  if (typeof themeVars.__varGroupHash__ !== 'string') {
     throw new Error(
       'Can only override variables theme created with defineVars().',
     );
@@ -82,11 +82,11 @@ export default function styleXCreateTheme(
     }
   }
 
-  const themeClass = `${overrideClassName} ${themeVars.__themeName__}`;
+  const themeClass = `${overrideClassName} ${themeVars.__varGroupHash__}`;
 
   return [
     {
-      [themeVars.__themeName__]: themeClass,
+      [themeVars.__varGroupHash__]: themeClass,
       $$css: true,
     },
     stylesToInject,

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-define-consts.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-define-consts.js
@@ -17,12 +17,12 @@ import createHash from './hash';
 
 export default function styleXDefineConsts<Vars: ConstsConfig>(
   constants: Vars,
-  options: $ReadOnly<{ ...Partial<StyleXOptions>, themeName: string, ... }>,
+  options: $ReadOnly<{ ...Partial<StyleXOptions>, exportId: string, ... }>,
 ): [
   { [string]: string | number }, // jsOutput JS output
   { [string]: InjectableConstStyle }, // metadata for registerinjectableStyles
 ] {
-  const { classNamePrefix, themeName, debug, enableDebugClassNames } = {
+  const { classNamePrefix, exportId, debug, enableDebugClassNames } = {
     ...defaultOptions,
     ...options,
   };
@@ -39,14 +39,14 @@ export default function styleXDefineConsts<Vars: ConstsConfig>(
       key[0] >= '0' && key[0] <= '9' ? `_${key}` : key
     ).replace(/[^a-zA-Z0-9]/g, '_');
 
-    const nameHash =
+    const constKey =
       debug && enableDebugClassNames
-        ? `${varSafeKey}-${classNamePrefix}${createHash(`${themeName}.${key}`)}`
-        : `${classNamePrefix}${createHash(`${themeName}.${key}`)}`;
+        ? `${varSafeKey}-${classNamePrefix}${createHash(`${exportId}.${key}`)}`
+        : `${classNamePrefix}${createHash(`${exportId}.${key}`)}`;
 
     jsOutput[key] = value;
-    injectableStyles[nameHash] = {
-      constKey: nameHash,
+    injectableStyles[constKey] = {
+      constKey,
       constVal: value,
       priority: 0,
       ltr: '',

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
@@ -169,14 +169,14 @@ function evaluateThemeRef(
     }
 
     const strToHash =
-      key === '__themeName__'
+      key === '__varGroupHash__'
         ? utils.genFileBasedIdentifier({ fileName, exportName })
         : utils.genFileBasedIdentifier({ fileName, exportName, key });
 
     const { debug, enableDebugClassNames } = state.traversalState.options;
 
     const varSafeKey =
-      key === '__themeName__'
+      key === '__varGroupHash__'
         ? ''
         : (key[0] >= '0' && key[0] <= '9' ? `_${key}` : key).replace(
             /[^a-zA-Z0-9]/g,
@@ -190,7 +190,7 @@ function evaluateThemeRef(
           utils.hash(strToHash)
         : state.traversalState.options.classNamePrefix + utils.hash(strToHash);
 
-    if (key === '__themeName__') {
+    if (key === '__varGroupHash__') {
       return varName;
     }
     return `var(--${varName})`;

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-create-theme.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-create-theme.js
@@ -150,10 +150,10 @@ export default function transformStyleXCreateTheme(
       );
     }
 
-    // Check that first arg has __themeName__ set
+    // Check that first arg has __varGroupHash__ set
     if (
-      typeof variables.__themeName__ !== 'string' ||
-      variables.__themeName__ === ''
+      typeof variables.__varGroupHash__ !== 'string' ||
+      variables.__varGroupHash__ === ''
     ) {
       throw callExpressionPath.buildCodeFrameError(
         'Can only override variables theme created with defineVars().',

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-consts.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-consts.js
@@ -69,11 +69,11 @@ export default function transformStyleXDefineConsts(
     }
 
     const exportName = varId.name;
-    const themeName = utils.genFileBasedIdentifier({ fileName, exportName });
+    const exportId = utils.genFileBasedIdentifier({ fileName, exportName });
 
     const [transformedJsOutput, jsOutput] = styleXDefineConsts(value, {
       ...state.options,
-      themeName,
+      exportId,
     });
 
     callExpressionPath.replaceWith(convertObjectToAST(transformedJsOutput));

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-vars.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-vars.js
@@ -155,7 +155,7 @@ export default function transformStyleXDefineVars(
       value,
       {
         ...state.options,
-        themeName: utils.genFileBasedIdentifier({ fileName, exportName }),
+        exportId: utils.genFileBasedIdentifier({ fileName, exportName }),
       },
     );
 


### PR DESCRIPTION
`defineVars` and `defineConsts` make use of a variable called `themeName`, which is actually a unique identifier for a group of variables (referred to as a `VarGroup` in the docs). This identifier is a hash generated from the var/const exported name and the file path. 

Renamed `themeName` to `varGroupHash` and the filename/export reference to `exportId` across `defineVars` and `defineConsts`, to better reflect their actual roles, as the naming has been hard to follow