### PR TITLE
docs: Fix ESLint rule severity syntax in installation guide

### DIFF
--- a/packages/docs/docs/learn/03-installation.mdx
+++ b/packages/docs/docs/learn/03-installation.mdx
@@ -104,8 +104,8 @@ module.exports = {
   rules: {
     "@stylexjs/valid-styles": "error",
     "@stylexjs/no-unused": "error",
-    "@stylexjs/valid-shorthands": "warning",
-    "@stylexjs/sort-keys": "warning"
+    "@stylexjs/valid-shorthands": "warn",
+    "@stylexjs/sort-keys": "warn"
   },
 };
 ```


### PR DESCRIPTION
## What changed / motivation ?

Fixed incorrect ESLint rule severity syntax in the installation documentation (`packages/docs/docs/learn/03-installation.mdx`).

**Changes:**
- Changed `"warning"` to `"warn"` for `@stylexjs/sort-keys` rule
- Changed `"warning"` to `"warn"` for `@stylexjs/valid-shorthands` rule

**Motivation:**
The current documentation uses `"warning"` as ESLint rule severity, but this is not a valid ESLint rule level. According to [ESLint's official documentation](https://eslint.org/docs/latest/use/configure/rules#rule-severities), the only valid rule severity levels are:
- `"off"` or `0` - turn the rule off
- `"warn"` or `1` - turn the rule on as a warning (doesn't affect exit code)
- `"error"` or `2` - turn the rule on as an error (exit code is 1 when triggered)

This causes ESLint configuration validation errors when users follow the installation guide, resulting in build failures.

## Linked PR/Issues

Fixes #1131 

## Additional Context

**Before:**
```javascript
module.exports = {
  plugins: ["@stylexjs"],
  rules: {
    "@stylexjs/valid-styles": "error",
    "@stylexjs/no-unused": "error",
    "@stylexjs/valid-shorthands": "warning", // ❌ Invalid
    "@stylexjs/sort-keys": "warning"         // ❌ Invalid
  },
};
```

**After:**
```javascript
module.exports = {
  plugins: ["@stylexjs"],
  rules: {
    "@stylexjs/valid-styles": "error",
    "@stylexjs/no-unused": "error",
    "@stylexjs/valid-shorthands": "warn",    // ✅ Valid
    "@stylexjs/sort-keys": "warn"            // ✅ Valid
  },
};
```

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code