### PR TITLE
[eslint-plugin] fix isNumber utils and isMathCall utils

### DIFF
--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -1117,7 +1117,7 @@ const pageBreakInside = makeUnionRule(
   makeLiteralRule('auto'),
   makeLiteralRule('avoid'),
 );
-const perspective = makeUnionRule(makeLiteralRule('none'), isNumber);
+const perspective = makeUnionRule(makeLiteralRule('none'), isNumber, isString);
 const perspectiveOrigin = isString;
 const pointerEvents = makeUnionRule(
   makeLiteralRule('auto'),
@@ -1938,7 +1938,7 @@ const CSSProperties = {
   insetInlineStart: isStringOrNumber,
   insetInlineEnd: isStringOrNumber,
 
-  height: isStringOrNumber,
+  height: width,
   width: width,
   blockSize: blockSize,
   inlineSize: inlineSize,


### PR DESCRIPTION
Fixes #1134

- `isNumber`  previously returned `undefined` due to an improper ternary check, causing them to always pass. rewrote using basic if/else for readability
- `isMathCall` logic was error prone and overly strict, required all Math.*() arguments to be recursively valid numbers, false negatives and circular dependencies
- Meaning every length css property (or any property with an `isNumber` check) was always valid as per the linter
- Fixed logic to correctly return a `RuleResponse` when a value is invalid.
- Also allowed `MemberExpression` and `CallExpression` nodes to broadly allow functions/vars as valid number values (we could make this stricter, but they're not reliably statically analyzable, and I suspect it'll add a ton of volume to the internal eslint errors, and it's still safer than before (checking nothing))
- This rule is in a pretty bad shape so this is one of many iterations
