### PR TITLE
[Docs] Explain how `--` can be used to define manual names for CSS vars

### DIFF
--- a/packages/docs/babel.config.js
+++ b/packages/docs/babel.config.js
@@ -12,6 +12,7 @@ const isProd = process.env.NODE_ENV === 'production';
 
 const options = {
   dev: !isProd,
+  runtimeInjection: !isProd,
   test: false,
   stylexSheetName: '<>',
   unstable_moduleResolution: {

--- a/packages/docs/blog/2025-06-30-Release-v0.14.0.mdx
+++ b/packages/docs/blog/2025-06-30-Release-v0.14.0.mdx
@@ -37,11 +37,19 @@ const transitionClass = stylex.viewTransitionClass({
   },
 });
 
-// in a component definition
+// In a <ViewTransition> component
 
 <ViewTransition default={transitionClass}>
   <Content />
 </ViewTransition>
+
+// Or in Styles
+
+const styles = stylex.create({
+  container: {
+    viewTransitionClass: transitionClass,
+  },
+});
 ```
 
 ### Linter: `validImports`
@@ -59,17 +67,23 @@ The `@stylexjs/eslint-plugin` package now supports the `validImports` option for
 
 ### Style resolution
 
-StyleX will now use `property-specificity` instead of `application-order` as the default value for the `styleResolution` option (the strategy used to merge styles). The difference between these 2 strategies is as follows:
+StyleX now defaults to the `property-specificity` strategy instead of `application-order` for the `styleResolution` option. The difference between these 2 strategies is as follows:
 
 * `application-order`
   * The last style wins, i.e., `margin` wins over `marginTop` if it appears last in the order of styles.
-  * Larger generated JavaScript objects.
+  * Matches the behavior of inline styles in the browser.
 * `property-specificity`
   * The more specific style wins, i.e., `marginTop` wins over `margin` irrespective of the order of styles.
-  * Disallows more shorthands, e.g., `background`, `border`.
-  * Smaller generated JavaScript objects.
+  * Matches the behavior of Styling in React Native.
 
-If you experience visual regressions, set `styleResolution` to `application-order`. However, the [performance metrics](https://github.com/facebook/stylex/pull/1064) we track are all significantly improved or neutral when using `property-specificity`, therefore, we strongly encourage migration.
+Set `styleResolution` to `application-order` in your configuration to maintain the previous default behaviour
+and avoid visual regressions.
+
+We're making this change now as `application-order` could lead to significantly larger generated JavaScript objects,
+and have a [performance impact](https://github.com/facebook/stylex/pull/1064).
+
+This is a trade-off as we've heard that `application-order` is usually more intuitive for developers. We are working
+on making `application-order` more performant so using it remains a viable option.
 
 ## Fixes
 

--- a/packages/docs/docs/api/javascript/defineVars.mdx
+++ b/packages/docs/docs/api/javascript/defineVars.mdx
@@ -47,3 +47,34 @@ const styles = stylex.create({
   },
 });
 ```
+
+### Manual Variable Names
+
+`defineVars` will result in uniquely named variables in the generated CSS file.
+Use object keys that start with `--` to manually specify the variable name.
+
+```tsx title="vars.stylex.js"
+import * as stylex from '@stylexjs/stylex';
+
+export const tokens = stylex.defineVars({
+  '--primaryText': 'black',
+  '--secondaryText': '#333',
+  '--accent': 'blue',
+});
+```
+
+Using it remains the same:
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+import { tokens } from './vars.stylex.js';
+
+const styles = stylex.create({
+  container: {
+    color: tokens['--primaryText'],
+    backgroundColor: tokens['--accent'],
+  },
+});
+```
+
+Variable name uniqueness will need to be ensured manually when using manual variable names.

--- a/packages/docs/docs/learn/05-theming/01-defining-variables.mdx
+++ b/packages/docs/docs/learn/05-theming/01-defining-variables.mdx
@@ -48,7 +48,7 @@ export const tokens = stylex.defineVars({
 });
 ```
 
-This function, too, is processed at compile-time and CSS variable names are
+This function, too, is processed at compile-time and unique CSS variable names are
 automatically generated.
 
 This defines the variables at `:root` of the HTML document. They can be imported
@@ -75,7 +75,40 @@ export const colors = stylex.defineVars({
 
 Similarly, `@supports` can be used as well.
 
-## Rules when defining variables
+### Manual Variable Names
+
+The `defineVars` function lets you use treat variables as typical javascript objects.
+Behind the scenes, StyleX will generate unique and deterministic variable names based
+on the file name, variable name bound to `defineVars` and the key within the object.
+
+However, there cases where you may want to manually specify the variable name.
+This done by using strings that start with `--` as the object keys within your `defineVars` call.
+
+```tsx title="tokens.stylex.js"
+import * as stylex from '@stylexjs/stylex';
+
+export const tokens = stylex.defineVars({
+  '--primaryText': 'black',
+  '--secondaryText': '#333',
+  '--accent': 'blue',
+});
+```
+
+This call will use the exact strings as variable names in the generated CSS:
+`--primaryText`, `--secondaryText`, `--accent`.
+
+:::warning Ensure Uniqueness
+
+When using manual variable names, StyleX can no longer ensure that your variable
+names are globally unique. You will have to ensure that no two variable declarations
+with `defineVars` define the same manual variable name.
+
+:::
+
+Other than the name of the CSS variable in the generated CSS, these variables work
+just like any other variables defined with `defineVars`.
+
+## Rules when defining variable names 
 
 Variables are the only type of non-local value that can be used within a
 `create` call. This is made possible by enforcing a few rules:


### PR DESCRIPTION
## What changed / motivation ?

Added new content to `learn` and `api` sections.

Also made a small tweak the latest release notes.