### PR TITLE
[babel-plugin] fix expansion for paddingLeft for legacy-expand-shorthands

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
@@ -299,6 +299,61 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
       `);
     });
 
+    test('padding: with longhand directional and logical property collisions', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            foo: {
+              padding: 5,
+              paddingInlineEnd: 10,
+            },
+
+            bar: {
+              padding: 2,
+              paddingInlineStart: 10,
+              paddingLeft: 22
+            },
+          });
+          stylex(styles.foo, styles.bar)
+          export const string = stylex(styles.foo, styles.bar, xstyle);
+        `,
+          { debug: true },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2(".paddingTop-x123j3cw{padding-top:5px}", 4000);
+        _inject2(".paddingBottom-xs9asl8{padding-bottom:5px}", 4000);
+        _inject2(".paddingInlineStart-xaso8d8{padding-left:5px}", 3000, ".paddingInlineStart-xaso8d8{padding-right:5px}");
+        _inject2(".paddingInlineEnd-x2vl965{padding-right:10px}", 3000, ".paddingInlineEnd-x2vl965{padding-left:10px}");
+        _inject2(".paddingTop-x1nn3v0j{padding-top:2px}", 4000);
+        _inject2(".paddingBottom-x1120s5i{padding-bottom:2px}", 4000);
+        _inject2(".paddingLeft-xnljgj5{padding-left:22px}", 4000);
+        const styles = {
+          foo: {
+            "paddingTop-kLKAdn": "paddingTop-x123j3cw",
+            "paddingBottom-kGO01o": "paddingBottom-xs9asl8",
+            "paddingInlineStart-kZCmMZ": "paddingInlineStart-xaso8d8",
+            "paddingInlineEnd-kwRFfy": "paddingInlineEnd-x2vl965",
+            $$css: true
+          },
+          bar: {
+            "paddingTop-kLKAdn": "paddingTop-x1nn3v0j",
+            "paddingBottom-kGO01o": "paddingBottom-x1120s5i",
+            "paddingLeft-kE3dHu": "paddingLeft-xnljgj5",
+            "paddingInlineStart-kZCmMZ": null,
+            "paddingInlineEnd-kwRFfy": null,
+            $$css: true
+          }
+        };
+        "paddingTop-x1nn3v0j paddingBottom-x1120s5i paddingLeft-xnljgj5";
+        export const string = stylex(styles.foo, styles.bar, xstyle);"
+      `);
+    });
+
     test('padding: with null longhand property collisions', () => {
       expect(
         transform(`

--- a/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/legacy-expand-shorthands.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/legacy-expand-shorthands.js
@@ -322,8 +322,8 @@ const shorthands: $ReadOnly<{ [key: string]: (TStyleValue) => TReturn }> = {
   ],
   paddingLeft: (val: TStyleValue): TReturn => [
     ['paddingLeft', val],
-    ['paddingStart', null],
-    ['paddingEnd', null],
+    ['paddingInlineStart', null],
+    ['paddingInlineEnd', null],
   ],
   paddingRight: (val: TStyleValue): TReturn => [
     ['paddingRight', val],


### PR DESCRIPTION
fixes https://github.com/facebook/stylex/issues/1149 

in https://github.com/facebook/stylex/pull/1083 i missed expanding paddingLeft into logical inline styles, so they never get mapped to paddingLeft/paddingRight in `generate-ltr` / `generate-rtl`