### PR TITLE
[babel-plugin] rewrite dynamic styles construction 

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/evaluation-import-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/evaluation-import-test.js
@@ -372,7 +372,7 @@ describe('Evaluation of imported values works based on configuration', () => {
         _inject2("@property ----__hashed_var__1jqb1tb { syntax: \\"*\\"; inherits: false;}", 0);
         const styles = {
           color: color => [{
-            "--__hashed_var__1jqb1tb": color == null ? null : "__hashed_var__b69i2g",
+            "--__hashed_var__1jqb1tb": color != null ? "__hashed_var__b69i2g" : color,
             $$css: true
           }, {
             "----__hashed_var__1jqb1tb": color != null ? color : undefined

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -191,7 +191,7 @@ describe('@stylexjs/babel-plugin', () => {
             $$css: "app/main.js:31"
           },
           dynamic: color => [{
-            "color-kMwMTN": "color-xfx01vb",
+            "color-kMwMTN": color != null ? "color-xfx01vb" : color,
             $$css: "app/main.js:56"
           }, {
             "--color": color != null ? color : undefined
@@ -257,7 +257,7 @@ describe('@stylexjs/babel-plugin', () => {
             $$css: "app/main.js:31"
           },
           dynamic: color => [{
-            "color-kMwMTN": "color-xfx01vb",
+            "color-kMwMTN": color != null ? "color-xfx01vb" : color,
             $$css: "app/main.js:56"
           }, {
             "--color": color != null ? color : undefined

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -2044,7 +2044,7 @@ describe('@stylexjs/babel-plugin', () => {
           export const styles = {
             root: color => [{
               kWkggS: "xrkmrrc",
-              kMwMTN: "xfx01vb",
+              kMwMTN: color != null ? "xfx01vb" : color,
               $$css: true
             }, {
               "--color": color != null ? color : undefined
@@ -2099,7 +2099,7 @@ describe('@stylexjs/babel-plugin', () => {
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
             one: color => [{
-              kMwMTN: "xfx01vb",
+              kMwMTN: color != null ? "xfx01vb" : color,
               $$css: true
             }, {
               "--color": color != null ? color : undefined
@@ -2157,8 +2157,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
             root: (bgColor, otherColor) => [{
-              "--background-color": bgColor == null ? null : "x15mgraa",
-              "--otherColor": otherColor == null ? null : "x1qph05k",
+              "--background-color": bgColor != null ? "x15mgraa" : bgColor,
+              "--otherColor": otherColor != null ? "x1qph05k" : otherColor,
               $$css: true
             }, {
               "----background-color": bgColor != null ? bgColor : undefined,
@@ -2221,7 +2221,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: width => [{
-                kzqmXN: "x1bl4301",
+                kzqmXN: width != null ? "x1bl4301" : width,
                 $$css: true
               }, {
                 "--width": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
@@ -2243,6 +2243,80 @@ describe('@stylexjs/babel-plugin', () => {
                   "--width",
                   {
                     "ltr": "@property --width { syntax: "*"; inherits: false;}",
+                    "rtl": null,
+                  },
+                  0,
+                ],
+              ],
+            }
+          `);
+        });
+
+        test('set mixed values', () => {
+          const { code, metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: (width) => ({
+                width,
+                backgroundColor: 'red',
+                height: width + 100,
+              })
+            });
+          `);
+          // Check that dynamic number values get units where appropriate
+          expect(code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: width => [{
+                kzqmXN: width != null ? "x1bl4301" : width,
+                kWkggS: "xrkmrrc",
+                kZKoxP: width + 100 != null ? "x1f5funs" : width + 100,
+                $$css: true
+              }, {
+                "--width": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width),
+                "--height": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width + 100)
+              }]
+            };"
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x1bl4301",
+                  {
+                    "ltr": ".x1bl4301{width:var(--width)}",
+                    "rtl": null,
+                  },
+                  4000,
+                ],
+                [
+                  "xrkmrrc",
+                  {
+                    "ltr": ".xrkmrrc{background-color:red}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+                [
+                  "x1f5funs",
+                  {
+                    "ltr": ".x1f5funs{height:var(--height)}",
+                    "rtl": null,
+                  },
+                  4000,
+                ],
+                [
+                  "--width",
+                  {
+                    "ltr": "@property --width { syntax: "*"; inherits: false;}",
+                    "rtl": null,
+                  },
+                  0,
+                ],
+                [
+                  "--height",
+                  {
+                    "ltr": "@property --height { syntax: "*"; inherits: false;}",
                     "rtl": null,
                   },
                   0,
@@ -2275,7 +2349,7 @@ describe('@stylexjs/babel-plugin', () => {
             import { vars } from 'vars.stylex.js';
             export const styles = {
               root: width => [{
-                "--x1anmu0j": width == null ? null : "x14vhreu",
+                "--x1anmu0j": width != null ? "x14vhreu" : width,
                 $$css: true
               }, {
                 "----x1anmu0j": width != null ? width : undefined
@@ -2326,8 +2400,8 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: color => [{
-                kWkggS: "x1ttfofm",
-                kMwMTN: "x74ai9j",
+                kWkggS: color != null ? "x1ttfofm" : color,
+                kMwMTN: color != null ? "x74ai9j" : color,
                 $$css: true
               }, {
                 "--1e2mv7m": color != null ? color : undefined,
@@ -2393,7 +2467,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (hover, active, focus) => [{
-                kMwMTN: "x74ai9j x19c4yy1 x10peeyq x126ychx",
+                kMwMTN: (hover != null ? "x74ai9j" : hover) + (active != null ? "x19c4yy1" : active) + (focus != null ? "x10peeyq" : focus) + "x126ychx",
                 $$css: true
               }, {
                 "--1113oo7": hover != null ? hover : undefined,
@@ -2486,8 +2560,8 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               foo: (a, b) => [{
-                kxBb7d: "x6r7ojb",
-                kB1Fuz: "x5ga601",
+                kxBb7d: a != null ? "x6r7ojb" : a,
+                kB1Fuz: b != null ? "x5ga601" : b,
                 $$css: true
               }, {
                 "--1g451k2": a != null ? a : undefined,
@@ -2550,7 +2624,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               foo: color => [{
-                k8Qsv1: "xwdnmik",
+                k8Qsv1: color != null ? "xwdnmik" : color,
                 $$css: true
               }, {
                 "--163tekb": color != null ? color : undefined
@@ -2596,7 +2670,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               foo: width => [{
-                k8pbKx: "x3j4sww",
+                k8pbKx: width != null ? "x3j4sww" : width,
                 $$css: true
               }, {
                 "--msahdu": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
@@ -2645,7 +2719,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               foo: color => [{
-                kxBb7d: "x16oeupf x10u3axo",
+                kxBb7d: "x16oeupf" + "x10u3axo",
                 $$css: true
               }, {
                 "--6bge3v": color != null ? color : undefined
@@ -2703,7 +2777,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (a, b, c) => [{
-                kzqmXN: "x1svif2g x1a6pj3q xf0apgt",
+                kzqmXN: ('color-mix(' + color + ', blue)' != null ? "x1svif2g" : 'color-mix(' + color + ', blue)') + (b != null ? "x1a6pj3q" : b) + (c != null ? "xf0apgt" : c),
                 $$css: true
               }, {
                 "--1xmrurk": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)('color-mix(' + color + ', blue)'),
@@ -2785,7 +2859,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (a, b, c) => [{
-                kMwMTN: "x1n25116 x1oeo35w x10db8fb",
+                kMwMTN: (a != null ? "x1n25116" : a) + (b != null ? "x1oeo35w" : b) + (c != null ? "x10db8fb" : c),
                 $$css: true
               }, {
                 "--4xs81a": a != null ? a : undefined,
@@ -2869,7 +2943,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (a, b, c) => [{
-                kGuDYH: "x1cfcgx7 x956mei xarp7f8",
+                kGuDYH: (a != null ? "x1cfcgx7" : a) + (b != null ? "x956mei" : b) + (c != null ? "xarp7f8" : c),
                 $$css: true
               }, {
                 "--19zvkyr": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(a),
@@ -3550,10 +3624,10 @@ describe('@stylexjs/babel-plugin', () => {
           export const styles = {
             default: margin => [{
               kWkggS: "xrkmrrc",
-              k71WvV: "x1555q52 x1bi16m7",
-              k1K539: "x1hvr6ea x3skgmg",
-              keTefX: "x1feukp3 xgzim5p",
-              keoZOQ: "x17zef60",
+              k71WvV: (margin != null ? "x1555q52" : margin) + (margin + 4 != null ? "x1bi16m7" : margin + 4),
+              k1K539: (margin != null ? "x1hvr6ea" : margin) + (margin + 4 != null ? "x3skgmg" : margin + 4),
+              keTefX: (margin != null ? "x1feukp3" : margin) + (margin + 4 != null ? "xgzim5p" : margin + 4),
+              keoZOQ: margin - 4 != null ? "x17zef60" : margin - 4,
               $$css: true
             }, {
               "--14mfytm": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin),

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -2270,7 +2270,7 @@ describe('@stylexjs/babel-plugin', () => {
               root: width => [{
                 kzqmXN: width != null ? "x1bl4301" : width,
                 kWkggS: "xrkmrrc",
-                kZKoxP: width + 100 != null ? "x1f5funs" : width + 100,
+                kZKoxP: "x1f5funs",
                 $$css: true
               }, {
                 "--width": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width),
@@ -2777,7 +2777,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (a, b, c) => [{
-                kzqmXN: ('color-mix(' + color + ', blue)' != null ? "x1svif2g" : 'color-mix(' + color + ', blue)') + (b != null ? "x1a6pj3q" : b) + (c != null ? "xf0apgt" : c),
+                kzqmXN: "x1svif2g" + (b != null ? "x1a6pj3q" : b) + (c != null ? "xf0apgt" : c),
                 $$css: true
               }, {
                 "--1xmrurk": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)('color-mix(' + color + ', blue)'),
@@ -3624,10 +3624,10 @@ describe('@stylexjs/babel-plugin', () => {
           export const styles = {
             default: margin => [{
               kWkggS: "xrkmrrc",
-              k71WvV: (margin != null ? "x1555q52" : margin) + (margin + 4 != null ? "x1bi16m7" : margin + 4),
-              k1K539: (margin != null ? "x1hvr6ea" : margin) + (margin + 4 != null ? "x3skgmg" : margin + 4),
-              keTefX: (margin != null ? "x1feukp3" : margin) + (margin + 4 != null ? "xgzim5p" : margin + 4),
-              keoZOQ: margin - 4 != null ? "x17zef60" : margin - 4,
+              k71WvV: (margin != null ? "x1555q52" : margin) + "x1bi16m7",
+              k1K539: (margin != null ? "x1hvr6ea" : margin) + "x3skgmg",
+              keTefX: (margin != null ? "x1feukp3" : margin) + "xgzim5p",
+              keoZOQ: "x17zef60",
               $$css: true
             }, {
               "--14mfytm": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin),

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
@@ -32,6 +32,14 @@ import { messages } from '../shared';
 import { evaluateStyleXCreateArg } from './parse-stylex-create-arg';
 import flatMapExpandedShorthands from '../shared/preprocess-rules';
 
+function isSafeToSkipNullCheck(expr: t.Expression) {
+  return (
+    (t.isBinaryExpression(expr) &&
+      ['+', '-', '*', '/', '**'].includes(expr.operator)) ||
+    (t.isUnaryExpression(expr) && ['-', '+'].includes(expr.operator))
+  );
+}
+
 /// This function looks for `stylex.create` calls and transforms them.
 /// 1. It finds the first argument to `stylex.create` and validates it.
 /// 2. It pre-processes valid-dynamic parts of style object such as custom presets (spreads)
@@ -283,7 +291,7 @@ export default function transformStyleXCreate(
                     ({ path }) => origClassPaths[cls] === path,
                   )?.expression;
 
-                  if (expr) {
+                  if (expr && !isSafeToSkipNullCheck(expr)) {
                     exprList.push(
                       t.conditionalExpression(
                         t.binaryExpression('!=', expr, t.nullLiteral()),


### PR DESCRIPTION
Rewrite for dynamic styles handling that is sort of long overdue. previous approach is quite imprecise and brittle in the way strings are built up. this has a few changes to the existing behaviour:
- old version mapped classNames back to expressions via `origClassPaths` dict (kind of brittle reverse look up of stringified path arrays that were pretty broken - according to the tests, never fully worked) (causing issues like https://github.com/facebook/stylex/issues/1146)
- new version just inspects the metadata directly to build a list of style keys by determining which styles are expressions instead of static
- also rebuilds the string from scratch with conditional logic instead of mutating in place strangely

Testing:
- tested in `example-nextjs`
- confirmed
   - no width omitted
   - null check catches only undefined and null (meaning 0 and false still omits classname)
   - computed expressions like (width + 100) work as expected
         - undefined + 100 -> NaNpx
         - null + 100 → 100 -> 100px
   - multiple dynamic values
   - static values within a dynamic style are preserved
