### PR TITLE
[babel-plugin] document fail cases for defineConsts

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
@@ -358,6 +358,43 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
+    test.skip('works with firstThatWorks', () => {
+      const { code } = transformWithInlineConsts(`
+        import * as stylex from '@stylexjs/stylex';
+        import { colors } from './constants.stylex';
+
+        export const styles = stylex.create({
+          nodeEnd: (animationDuration) => ({
+            foo: {
+              color: stylex.firstThatWorks(colors.background, 'transparent'),
+            },
+          }),
+        });
+      `);
+
+      expect(code).toMatchInlineSnapshot(`
+      `);
+    });
+
+    test.skip('works with dynamic styles', () => {
+      const { code } = transformWithInlineConsts(`
+        import * as stylex from '@stylexjs/stylex';
+        import { breakpoints } from './constants.stylex';
+
+        export const styles = stylex.create({
+          nodeEnd: (animationDuration) => ({
+            transition: {
+              [breakpoints.small]: 'none',
+              default: \`transform \${animationDuration}ms ease-in-out\`,
+            },
+          }),
+        });
+      `);
+
+      expect(code).toMatchInlineSnapshot(`
+      `);
+    });
+
     test('adds multiple media query placeholders from constants.stylex', () => {
       const { code, metadata } = transformWithInlineConsts(`
         import * as stylex from '@stylexjs/stylex';

--- a/packages/docs/docs/api/javascript/defineConsts.mdx
+++ b/packages/docs/docs/api/javascript/defineConsts.mdx
@@ -10,7 +10,7 @@ sidebar_position: 3
 
 Defines static style constants that can be used directly in `create` calls anywhere in the codebase. Unlike `defineVars`, these values are inlined at build time and do not generate actual CSS variables.
 
-*Note: `defineConsts` is an experimental feature and cannot currently be used with `firstThatWorks` or when `runtimeInjection` is enabled.*
+*Note: `defineConsts` is an experimental feature and cannot currently be used with `firstThatWorks`, dynamic styles, or when `runtimeInjection` is enabled.*
 
 Common use cases include:
 - Media queries


### PR DESCRIPTION
Let's add some documentation for known fail cases for `defineConsts` as I circle around to them

See https://github.com/facebook/stylex/issues/1154, https://github.com/facebook/stylex/issues/1162