### PR TITLE
[fix] Fix media query parser for conditions with number values

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
       "prettier-plugin-hermes-parser"
     ],
     "proseWrap": "always",
+    "trailingComma": "all",
     "overrides": [
       {
         "files": [

--- a/packages/style-value-parser/src/at-queries/__tests__/parse-media-query-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/parse-media-query-test.js
@@ -2860,4 +2860,242 @@ describe('style-value-parser/at-queries', () => {
       );
     });
   });
+
+  describe('additional media query features', () => {
+    test('@media (-webkit-min-device-pixel-ratio: 2)', () => {
+      const input = '@media (-webkit-min-device-pixel-ratio: 2)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "-webkit-min-device-pixel-ratio",
+            "type": "pair",
+            "value": 2,
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (-webkit-min-device-pixel-ratio: 2)"',
+      );
+    });
+
+    test('@media (-webkit-max-device-pixel-ratio: 1.5)', () => {
+      const input = '@media (-webkit-max-device-pixel-ratio: 1.5)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "-webkit-max-device-pixel-ratio",
+            "type": "pair",
+            "value": 1.5,
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (-webkit-max-device-pixel-ratio: 1.5)"',
+      );
+    });
+
+    test('@media (color-index: 256)', () => {
+      const input = '@media (color-index: 256)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "color-index",
+            "type": "pair",
+            "value": 256,
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (color-index: 256)"',
+      );
+    });
+
+    test('@media (min-color-index: 256)', () => {
+      const input = '@media (min-color-index: 256)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "min-color-index",
+            "type": "pair",
+            "value": 256,
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (min-color-index: 256)"',
+      );
+    });
+
+    test('@media (max-color-index: 65536)', () => {
+      const input = '@media (max-color-index: 65536)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "max-color-index",
+            "type": "pair",
+            "value": 65536,
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (max-color-index: 65536)"',
+      );
+    });
+
+    test('@media (resolution: 300dpi)', () => {
+      const input = '@media (resolution: 300dpi)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "resolution",
+            "type": "pair",
+            "value": {
+              "signCharacter": undefined,
+              "type": "integer",
+              "unit": "dpi",
+              "value": 300,
+            },
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (resolution: 300dpi)"',
+      );
+    });
+
+    test('@media (resolution: 2dppx)', () => {
+      const input = '@media (resolution: 2dppx)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "resolution",
+            "type": "pair",
+            "value": {
+              "signCharacter": undefined,
+              "type": "integer",
+              "unit": "dppx",
+              "value": 2,
+            },
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (resolution: 2dppx)"',
+      );
+    });
+
+    test('@media (resolution: 1.5dpcm)', () => {
+      const input = '@media (resolution: 1.5dpcm)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "resolution",
+            "type": "pair",
+            "value": {
+              "signCharacter": undefined,
+              "type": "number",
+              "unit": "dpcm",
+              "value": 1.5,
+            },
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (resolution: 1.5dpcm)"',
+      );
+    });
+
+    test('@media (color-gamut: p3)', () => {
+      const input = '@media (color-gamut: p3)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "color-gamut",
+            "type": "pair",
+            "value": "p3",
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (color-gamut: p3)"',
+      );
+    });
+
+    test('@media (color-gamut: rec2020)', () => {
+      const input = '@media (color-gamut: rec2020)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "color-gamut",
+            "type": "pair",
+            "value": "rec2020",
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (color-gamut: rec2020)"',
+      );
+    });
+
+    test('@media (video-color-gamut: srgb)', () => {
+      const input = '@media (video-color-gamut: srgb)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "video-color-gamut",
+            "type": "pair",
+            "value": "srgb",
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (video-color-gamut: srgb)"',
+      );
+    });
+
+    test('@media (video-color-gamut: p3)', () => {
+      const input = '@media (video-color-gamut: p3)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "video-color-gamut",
+            "type": "pair",
+            "value": "p3",
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (video-color-gamut: p3)"',
+      );
+    });
+
+    test('@media (video-color-gamut: rec2020)', () => {
+      const input = '@media (video-color-gamut: rec2020)';
+      const parsed = MediaQuery.parser.parseToEnd(input);
+      expect(parsed).toMatchInlineSnapshot(`
+        MediaQuery {
+          "queries": {
+            "key": "video-color-gamut",
+            "type": "pair",
+            "value": "rec2020",
+          },
+        }
+      `);
+      expect(parsed.toString()).toMatchInlineSnapshot(
+        '"@media (video-color-gamut: rec2020)"',
+      );
+    });
+  });
 });

--- a/packages/style-value-parser/src/at-queries/media-query.js
+++ b/packages/style-value-parser/src/at-queries/media-query.js
@@ -17,7 +17,7 @@ type Fraction = [number, '/', number];
 type WordRule = 'color' | 'monochrome' | 'grid' | 'color-index';
 type Length = TokenDimension[4];
 
-type MediaRuleValue = Length | string | Fraction;
+type MediaRuleValue = number | Length | string | Fraction;
 
 type MediaKeyword = {
   type: 'media-keyword',
@@ -109,6 +109,7 @@ const mediaRuleValueParser: TokenParser<MediaRuleValue> = TokenParser.oneOf(
     ).map(() => '/'),
     TokenParser.tokens.Number.map((token) => token[4].value),
   ).separatedBy(TokenParser.tokens.Whitespace.optional),
+  TokenParser.tokens.Number.map((token) => token[4].value),
 );
 
 const simplePairParser: TokenParser<MediaRulePair> = TokenParser.sequence(


### PR DESCRIPTION
## What changed / motivation ?

There was a bug in the media query parser where it couldn't parse queries such as
- `@media (-webkit-min-device-pixel-ratio: 2)`

After some investigation, it turned out that this was because the parser did not support bare numbers as values in media query conditions. This has now been fixed.

## Additional Context

Additional unit tests have been added to ensure more media queries can now be parsed as expected.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code