### PR TITLE
[docs] Update outdated or misleading theming docs

### DIFF
--- a/packages/docs/babel.config.js
+++ b/packages/docs/babel.config.js
@@ -12,6 +12,7 @@ const isProd = process.env.NODE_ENV === 'production';
 
 const options = {
   dev: !isProd,
+  runtimeInjection: !isProd,
   test: false,
   stylexSheetName: '<>',
   unstable_moduleResolution: {

--- a/packages/docs/docs/api/javascript/defineVars.mdx
+++ b/packages/docs/docs/api/javascript/defineVars.mdx
@@ -18,7 +18,9 @@ function defineVars<Styles extends {[key: string]: Value}>(
 ```
 
 By default, `defineVars` will create unique, hashed variable names. To create
-variables with stable names use a key that starts with `--`.
+variables with custom names use a key that starts with `--`. These will generate
+CSS custom properties with the provided name instead of generating a globally
+unique name.
 
 ### Example use:
 

--- a/packages/docs/docs/learn/05-theming/01-defining-variables.mdx
+++ b/packages/docs/docs/learn/05-theming/01-defining-variables.mdx
@@ -48,9 +48,11 @@ export const tokens = stylex.defineVars({
 });
 ```
 
-This function, too, is processed at compile-time and unique CSS variable names are automatically generated. These values can then be imported and used within `create` calls.
+This function, too, is processed at compile-time and unique CSS variable names are automatically generated. 
+These values can then be imported and used within `create` calls.
 
-To create variables with stable names that match the exact strings provided, use a key that starts with `--`. Doing so will mean that those variables are not unique to a given `defineVars` call.
+To create variables with custom stable names that match the exact strings provided, use a key that starts with `--`.
+Doing so will mean that StyleX cannot guarantee that those variables names are unique to a given `defineVars` call.
 
 ### Using Media Queries
 

--- a/packages/docs/docs/learn/05-theming/03-creating-themes.mdx
+++ b/packages/docs/docs/learn/05-theming/03-creating-themes.mdx
@@ -61,9 +61,8 @@ const styles = stylex.create({
 <div {...stylex.props(dracula, styles.container)}>{children}</div>;
 ```
 
-**NOTE:** All variables in a variable group must be overridden when creating a
-theme. This choice has been to help catch accidental omissions. Even at the cost
-of occasional tedium.
+**NOTE:** Any variables that are not overridden will revert back to their 
+default value that was set in the `defineVars` declaration.
 
 Unlike when defining and using variables, themes can be created with
 `createTheme` anywhere in a codebase, and passed around across files or

--- a/packages/docs/docs/learn/05-theming/04-variable-types.mdx
+++ b/packages/docs/docs/learn/05-theming/04-variable-types.mdx
@@ -164,9 +164,11 @@ const rotate = stylex.keyframes({
   to: { [tokens.angle]: '360deg' },
 });
 
+const colors = ['#ffadad', '#ffd6a5', '#fdffb6', '#caffbf', '#9bf6ff', '#a0c4ff', '#bdb2ff', '#ffc6ff'].join(', ');
+
 const styles = stylex.create({
   gradient: {
-    backgroundImage: `conic-gradient(from ${tokens.angle}, ...colors)`,
+    backgroundImage: `conic-gradient(from ${tokens.angle}, ${colors})`,
     animationName: rotate,
     animationDuration: '10s',
     animationTimingFunction: 'linear',

--- a/packages/docs/docs/learn/05-theming/04-variable-types.mdx
+++ b/packages/docs/docs/learn/05-theming/04-variable-types.mdx
@@ -18,7 +18,7 @@ option needs to be enabled in the StyleX Babel configuration to enable theming A
 
 :::
 
-:::warning Advanced use-cases
+:::warning Advanced use-case
 
 Declaring types for variables is an advanced use-case. It is not necessary for
 the majority of use-cases.
@@ -130,10 +130,13 @@ However, the feature can be simulated with a variable with an `integer` type:
 const styles = stylex.create({
   gradient: {
     // Math.floor
-    [tokens.int]: `calc(16 / 9)`
+    [tokens.int]: `calc(16 / 9)`,
 
     // Math.round
-    [tokens.int]: `calc((16 / 9) + 0.5)`
+    [tokens.int]: `calc((16 / 9) + 0.5)`,
+
+    // Now, the "integer" value can be used for styling:
+    width: `calc(${tokens.int} * 1px)`,
   },
 })
 ```


### PR DESCRIPTION
## What changed / motivation ?

There were some docs about theming that were outdated and incorrect. Thanks to @BMCwebdev for bringing it to our attention in https://github.com/facebook/stylex/discussions/947

I updated that and clarified some sentences that could be misleading.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code