### PR TITLE
[style-value-parser] process disjoint, intersecting, and subset ranges in media queries

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -1832,7 +1832,7 @@ describe('@stylexjs/babel-plugin', () => {
               },
             });
           `,
-            { enableLastMediaQueryWins: true },
+            { enableMediaQueryOrder: true },
           );
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';

--- a/packages/@stylexjs/babel-plugin/src/shared/common-types.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/common-types.js
@@ -52,7 +52,7 @@ export type StyleXOptions = $ReadOnly<{
   enableDebugDataProp?: ?boolean,
   enableDevClassNames?: ?boolean,
   enableFontSizePxToRem?: ?boolean,
-  enableLastMediaQueryWins?: ?boolean,
+  enableMediaQueryOrder?: ?boolean,
   enableLegacyValueFlipping?: ?boolean,
   enableLogicalStylesPolyfill?: ?boolean,
   enableMinifiedKeys?: ?boolean,

--- a/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/flatten-raw-style-obj.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/flatten-raw-style-obj.js
@@ -24,7 +24,7 @@ export function flattenRawStyleObject(
   style: RawStyles,
   options: StyleXOptions,
 ): $ReadOnlyArray<$ReadOnly<[string, IPreRule]>> {
-  const processedStyle = options.enableLastMediaQueryWins
+  const processedStyle = options.enableMediaQueryOrder
     ? lastMediaQueryWinsTransform(style)
     : style;
   return _flattenRawStyleObject(processedStyle, [], options);

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/default-options.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/default-options.js
@@ -17,7 +17,7 @@ export const defaultOptions: StyleXOptions = {
   enableDevClassNames: false,
   enableDebugDataProp: true,
   enableFontSizePxToRem: false,
-  enableLastMediaQueryWins: false,
+  enableMediaQueryOrder: false,
   enableLegacyValueFlipping: false,
   enableLogicalStylesPolyfill: false,
   enableMinifiedKeys: true,

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -75,7 +75,7 @@ export type StyleXOptions = $ReadOnly<{
   enableDebugDataProp?: boolean,
   enableDevClassNames?: boolean,
   enableInlinedConditionalMerge?: boolean,
-  enableLastMediaQueryWins?: boolean,
+  enableMediaQueryOrder?: boolean,
   enableLegacyValueFlipping?: boolean,
   enableLogicalStylesPolyfill?: boolean,
   enableMinifiedKeys?: boolean,
@@ -222,12 +222,12 @@ export default class StateManager {
         'options.enableMinifiedKeys',
       );
 
-    const enableLastMediaQueryWins: StyleXStateOptions['enableLastMediaQueryWins'] =
+    const enableMediaQueryOrder: StyleXStateOptions['enableMediaQueryOrder'] =
       z.logAndDefault(
         z.boolean(),
-        options.enableLastMediaQueryWins ?? false,
+        options.enableMediaQueryOrder ?? false,
         false,
-        'options.enableLastMediaQueryWins',
+        'options.enableMediaQueryOrder',
       );
 
     const enableLegacyValueFlipping: StyleXStateOptions['enableLegacyValueFlipping'] =
@@ -355,7 +355,7 @@ export default class StateManager {
       enableFontSizePxToRem,
       enableInlinedConditionalMerge,
       enableMinifiedKeys,
-      enableLastMediaQueryWins,
+      enableMediaQueryOrder,
       enableLegacyValueFlipping,
       enableLogicalStylesPolyfill,
       importSources,

--- a/packages/style-value-parser/src/at-queries/__tests__/media-query-transform-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/media-query-transform-test.js
@@ -450,7 +450,7 @@ describe('Media Query Transformer', () => {
           default: '1 / 2',
           '@media (max-width: 1440px) and (min-width: 900px)': '1 / 4',
           '@media (max-width: 800px) and (min-width: 600px)': '1 / 3',
-          '@media (max-width: 500px)': '1 / 1',
+          '@media (max-width: 500px) and (min-width: 400px)': '1 / 1',
         },
       },
     };
@@ -461,7 +461,7 @@ describe('Media Query Transformer', () => {
           default: '1 / 2',
           '@media (min-width: 900px) and (max-width: 1440px)': '1 / 4',
           '@media (min-width: 600px) and (max-width: 800px)': '1 / 3',
-          '@media (max-width: 500px)': '1 / 1',
+          '@media (min-width: 400px) and (max-width: 500px)': '1 / 1',
         },
       },
     };
@@ -511,7 +511,7 @@ describe('Media Query Transformer', () => {
       foo: {
         gridColumn: {
           default: '1 / 2',
-          '@media (min-width: 900px) and (max-width: 999.99px) or (min-width: 1100.01px) and (max-width: 1440px)':
+          '@media ((min-width: 900px) and (max-width: 999.99px)) or ((min-width: 1100.01px) and (max-width: 1440px))':
             '1 / 4',
           '@media (min-width: 1000px) and (max-width: 1100px)': '1 / 3',
           '@media (min-width: 400px) and (max-width: 500px)': '1 / 1',
@@ -538,7 +538,7 @@ describe('Media Query Transformer', () => {
       foo: {
         gridColumn: {
           default: '1 / 2',
-          '@media (min-width: 900px) and (max-width: 999.99px) or (min-width: 1100.01px) and (max-width: 1440px)':
+          '@media ((min-width: 900px) and (max-width: 999.99px)) or ((min-width: 1100.01px) and (max-width: 1440px))':
             '1 / 4',
           '@media (min-width: 1000px) and (max-width: 1100px)': '1 / 3',
         },
@@ -565,9 +565,9 @@ describe('Media Query Transformer', () => {
       foo: {
         gridColumn: {
           default: '1 / 2',
-          '@media (min-width: 900px) and (max-width: 999.99px) or (min-width: 1100.01px) and (max-width: 1440px)':
+          '@media ((min-width: 900px) and (max-width: 999.99px)) or ((min-width: 1100.01px) and (max-width: 1440px))':
             '1 / 4',
-          '@media (min-width: 1000px) and (max-width: 1009.99px) or (min-width: 1050.01px) and (max-width: 1100px)':
+          '@media ((min-width: 1000px) and (max-width: 1009.99px)) or ((min-width: 1050.01px) and (max-width: 1100px))':
             '1 / 3',
           '@media (min-width: 1010px) and (max-width: 1050px)': '1 / -1',
         },

--- a/packages/style-value-parser/src/at-queries/__tests__/media-query-transform-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/media-query-transform-test.js
@@ -418,7 +418,59 @@ describe('Media Query Transformer', () => {
     expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
   });
 
-  test('mixed min/max width with ranges', () => {
+  test('mixed min/max width with disjoint ranges', () => {
+    const originalStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px) and (min-width: 900px)': '1 / 4',
+          '@media (max-width: 800px) and (min-width: 600px)': '1 / 3',
+        },
+      },
+    };
+
+    const expectedStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (min-width: 900px) and (max-width: 1440px)': '1 / 4',
+          '@media (min-width: 600px) and (max-width: 800px)': '1 / 3',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('mixed min/max width with many disjoint ranges', () => {
+    const originalStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px) and (min-width: 900px)': '1 / 4',
+          '@media (max-width: 800px) and (min-width: 600px)': '1 / 3',
+          '@media (max-width: 500px)': '1 / 1',
+        },
+      },
+    };
+
+    const expectedStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (min-width: 900px) and (max-width: 1440px)': '1 / 4',
+          '@media (min-width: 600px) and (max-width: 800px)': '1 / 3',
+          '@media (max-width: 500px)': '1 / 1',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('mixed min/max width with overlapping ranges', () => {
     const originalStyles = {
       foo: {
         gridColumn: {
@@ -433,9 +485,91 @@ describe('Media Query Transformer', () => {
       foo: {
         gridColumn: {
           default: '1 / 2',
-          '@media (min-width: 900px) and (max-width: 1440px) and (not ((min-width: 600px) and (max-width: 1040px)))':
-            '1 / 4',
+          '@media (min-width: 1040.01px) and (max-width: 1440px)': '1 / 4',
           '@media (min-width: 600px) and (max-width: 1040px)': '1 / 3',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('mixed min/max width with mixed ranges', () => {
+    const originalStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px) and (min-width: 900px)': '1 / 4',
+          '@media (max-width: 1100px) and (min-width: 1000px)': '1 / 3',
+          '@media (max-width: 500px) and (min-width: 400px)': '1 / 1',
+        },
+      },
+    };
+
+    const expectedStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (min-width: 900px) and (max-width: 999.99px) or (min-width: 1100.01px) and (max-width: 1440px)':
+            '1 / 4',
+          '@media (min-width: 1000px) and (max-width: 1100px)': '1 / 3',
+          '@media (min-width: 400px) and (max-width: 500px)': '1 / 1',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('mixed min/max width with intersecting ranges', () => {
+    const originalStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px) and (min-width: 900px)': '1 / 4',
+          '@media (max-width: 1100px) and (min-width: 1000px)': '1 / 3',
+        },
+      },
+    };
+
+    const expectedStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (min-width: 900px) and (max-width: 999.99px) or (min-width: 1100.01px) and (max-width: 1440px)':
+            '1 / 4',
+          '@media (min-width: 1000px) and (max-width: 1100px)': '1 / 3',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
+
+  test('mixed min/max width with many intersecting ranges', () => {
+    const originalStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (max-width: 1440px) and (min-width: 900px)': '1 / 4',
+          '@media (max-width: 1100px) and (min-width: 1000px)': '1 / 3',
+          '@media (max-width: 1050px) and (min-width: 1010px)': '1 / -1',
+        },
+      },
+    };
+
+    const expectedStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (min-width: 900px) and (max-width: 999.99px) or (min-width: 1100.01px) and (max-width: 1440px)':
+            '1 / 4',
+          '@media (min-width: 1000px) and (max-width: 1009.99px) or (min-width: 1050.01px) and (max-width: 1100px)':
+            '1 / 3',
+          '@media (min-width: 1010px) and (max-width: 1050px)': '1 / -1',
         },
       },
     };

--- a/packages/style-value-parser/src/at-queries/__tests__/parse-media-query-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/parse-media-query-test.js
@@ -2008,23 +2008,13 @@ describe('style-value-parser/at-queries', () => {
         expect(parsed).toMatchInlineSnapshot(`
           MediaQuery {
             "queries": {
-              "rule": {
-                "rules": [
-                  {
-                    "key": "all",
-                    "not": true,
-                    "type": "media-keyword",
-                  },
-                ],
-                "type": "and",
-              },
-              "type": "not",
+              "key": "all",
+              "not": false,
+              "type": "media-keyword",
             },
           }
         `);
-        expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (not (not all))"',
-        );
+        expect(parsed.toString()).toMatchInlineSnapshot('"@media all"');
       });
 
       test('@media not all and (monochrome) and (min-width: 600px)', () => {


### PR DESCRIPTION
Updated mergeIntervalsForAnd to properly merge and simplify ranges for min-width / max-width pairs:
- build numeric intervals for each dimension (width/height). it collects all the lower and upper bounds from the rules and determines the tightest range:
   - for min-width it takes the largest lower bound
   - for max-width it takes the smallest upper bound

Added handling for the special case of overlapping queries inside an outer range. If there's a gap in the valid intervals, the function now splits the outer range into valid disjoint intervals on either side of the hole.
 - if the hole fully overlaps the lower or upper side of the outer range, we drop the empty side
 - if both sides are valid, we return them as an or group so the final query represents both disjoint intervals
 - if only one side is valid, we just return that branch directly instead of wrapping it in or

Added tests for all combinations of ranges:
- disjoint ranges (completely separate, media query should be preserved)
- overlapping ranges (just decrease the bounds of the parent interval)
- subset ranges (split into two ranges, a, c becomes a, b and b, c)
