### PR TITLE
[docs] remove errant import statement

### DIFF
--- a/packages/docs/docs/learn/07-ecosystem.mdx
+++ b/packages/docs/docs/learn/07-ecosystem.mdx
@@ -65,7 +65,7 @@ to use JSXAttribute to define StyleX.
 
 ### Prettier
 
-* [prettier-plugin-stylex-key-sort](https://github.com/nedjulius/prettier-plugin-stylex-key-sort) is a 
+* [prettier-plugin-stylex-key-sort](https://github.com/nedjulius/prettier-plugin-stylex-key-sort) is a
   Prettier plugin that automatically sorts StyleX keys.
 
 ## Bun
@@ -74,5 +74,4 @@ Bun is a JavaScript runtime, bundler, test runner and package manager. The follo
 plugins are available for Bun:
 
 * [bun-plugin-stylex](https://www.npmjs.com/package/bun-plugin-stylex)
-import { is } from "@babel/types"
 


### PR DESCRIPTION
## What changed / motivation ?

I was reading the docs and noticed the errant `import` statement that was introduced in https://github.com/facebook/stylex/pull/688

## Linked PR/Issues

N/A

## Additional Context

<img width="518" height="299" alt="Screenshot 2025-07-30 at 5 59 17 PM" src="https://github.com/user-attachments/assets/79fb1fcb-e98a-4d51-9884-126391ab4a38" />

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code