### PR TITLE
[babel-plugin] add compiler error handling for media query validation

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-create-test.js
@@ -573,6 +573,22 @@ describe('@stylexjs/babel-plugin', () => {
         }).toThrow(messages.INVALID_PSEUDO_OR_AT_RULE);
 
         expect(() => {
+          transform(
+            `
+            import * as stylex from '@stylexjs/stylex';
+            const styles = stylex.create({
+              root: {
+                'color': {
+                  '@media not ((not (min-width: 400px))': 'blue'
+                },
+              },
+            });
+          `,
+            { enableMediaQueryOrder: true },
+          );
+        }).toThrow(messages.INVALID_MEDIA_QUERY_SYNTAX);
+
+        expect(() => {
           transform(`
             import * as stylex from '@stylexjs/stylex';
             const styles = stylex.create({

--- a/packages/@stylexjs/babel-plugin/src/shared/messages.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/messages.js
@@ -39,6 +39,7 @@ export const INVALID_CONST_KEY =
   'Keys in defineConsts() cannot start with "--".';
 export const INVALID_PSEUDO = 'Invalid pseudo selector, not on the whitelist.';
 export const INVALID_PSEUDO_OR_AT_RULE = 'Invalid pseudo or at-rule.';
+export const INVALID_MEDIA_QUERY_SYNTAX = 'Invalid media query syntax.';
 export const LINT_UNCLOSED_FUNCTION = 'Rule contains an unclosed function';
 export const LOCAL_ONLY =
   'The return value of create() should not be exported.';

--- a/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/flatten-raw-style-obj.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/flatten-raw-style-obj.js
@@ -11,6 +11,7 @@ import type { RawStyles, StyleXOptions, TStyleValue } from '../common-types';
 
 import flatMapExpandedShorthands from './index';
 import { lastMediaQueryWinsTransform } from 'style-value-parser';
+import * as messages from '../messages';
 
 import {
   NullPreRule,
@@ -24,10 +25,14 @@ export function flattenRawStyleObject(
   style: RawStyles,
   options: StyleXOptions,
 ): $ReadOnlyArray<$ReadOnly<[string, IPreRule]>> {
-  const processedStyle = options.enableMediaQueryOrder
-    ? lastMediaQueryWinsTransform(style)
-    : style;
-  return _flattenRawStyleObject(processedStyle, [], options);
+  try {
+    const processedStyle = options.enableMediaQueryOrder
+      ? lastMediaQueryWinsTransform(style)
+      : style;
+    return _flattenRawStyleObject(processedStyle, [], options);
+  } catch (error) {
+    throw new Error(messages.INVALID_MEDIA_QUERY_SYNTAX);
+  }
 }
 
 export function _flattenRawStyleObject(


### PR DESCRIPTION
https://github.com/facebook/stylex/pull/1147 also simplifies and validates the MQ. Let's add compiler messaging for invalid media query syntax.

Tested in example-nextjs
```
 ⨯ ./app/page.tsx
Error: /Users/mellyeliu/stylex/examples/example-nextjs/app/page.tsx: Invalid pseudo or at-rule.
    at transformFile.next (<anonymous>)
    at run.next (<anonymous>)
    at transform.next (<anonymous>)
Import trace for requested module:
./app/page.tsx
```