### PR TITLE
[babel-plugin] minor refinement for media query error handling

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/flatten-raw-style-obj.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/flatten-raw-style-obj.js
@@ -25,14 +25,15 @@ export function flattenRawStyleObject(
   style: RawStyles,
   options: StyleXOptions,
 ): $ReadOnlyArray<$ReadOnly<[string, IPreRule]>> {
+  let processedStyle = style;
   try {
-    const processedStyle = options.enableMediaQueryOrder
+    processedStyle = options.enableMediaQueryOrder
       ? lastMediaQueryWinsTransform(style)
       : style;
-    return _flattenRawStyleObject(processedStyle, [], options);
   } catch (error) {
     throw new Error(messages.INVALID_MEDIA_QUERY_SYNTAX);
   }
+  return _flattenRawStyleObject(processedStyle, [], options);
 }
 
 export function _flattenRawStyleObject(


### PR DESCRIPTION
Let's narrow the error handling to just the `lastMediaQueryWinsTransform` call, so we can later add better compiler validation to `flattenRawStyleObject` down the road