### PR TITLE
[release] v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.15.1 (Aug 1, 2025)
+
+### Fixes
+
+- Hoist stylex.create and static className objects to the top level for support inside functions
+- Publish `style-value-parser`
+
 ## 0.15.0 (Jul 31, 2025)
 
 ### New features

--- a/examples/example-cli/package.json
+++ b/examples/example-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-cli",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "scripts": {
     "example:build": "stylex --config .stylex.json5"
   },
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.25.7",
     "@babel/preset-typescript": "^7.25.7",
-    "@stylexjs/cli": "0.15.0",
+    "@stylexjs/cli": "0.15.1",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5"

--- a/examples/example-esbuild/package.json
+++ b/examples/example-esbuild/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-esbuild",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Simple esbuild example for @stylexjs/esbuild-plugin",
   "main": "src/App.jsx",
   "scripts": {
@@ -11,13 +11,13 @@
   "license": "MIT",
   "dependencies": {
     "@stylexjs/open-props": "0.11.1",
-    "@stylexjs/stylex": "0.15.0",
+    "@stylexjs/stylex": "0.15.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },
   "devDependencies": {
     "@stylexjs/esbuild-plugin": "0.11.1",
-    "@stylexjs/eslint-plugin": "0.15.0",
+    "@stylexjs/eslint-plugin": "0.15.1",
     "esbuild": "^0.25.0",
     "eslint": "^8.57.1"
   }

--- a/examples/example-nextjs/package.json
+++ b/examples/example-nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-nextjs",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "scripts": {
     "clean": "rimraf .next",
     "example:build": "next build",
@@ -11,15 +11,15 @@
   },
   "dependencies": {
     "@stylexjs/open-props": "0.11.1",
-    "@stylexjs/stylex": "0.15.0",
+    "@stylexjs/stylex": "0.15.1",
     "next": "14.2.21",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "styled-jsx": "^5.1.1"
   },
   "devDependencies": {
-    "@stylexjs/eslint-plugin": "0.15.0",
-    "@stylexjs/postcss-plugin": "0.15.0",
+    "@stylexjs/eslint-plugin": "0.15.1",
+    "@stylexjs/postcss-plugin": "0.15.1",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^22.7.6",
     "@types/react": "^18.3.0",

--- a/examples/example-rollup/package.json
+++ b/examples/example-rollup/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-rollup",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A simple rollup example to test stylexjs/rollup-plugin",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.15.0",
+    "@stylexjs/stylex": "0.15.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -23,7 +23,7 @@
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.7",
-    "@stylexjs/rollup-plugin": "0.15.0",
+    "@stylexjs/rollup-plugin": "0.15.1",
     "rollup": "^4.24.0",
     "serve": "^14.2.4"
   }

--- a/examples/example-webpack/package.json
+++ b/examples/example-webpack/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-webpack",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A simple webpack example to test stylexjs/webpack-plugin",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.15.0"
+    "@stylexjs/stylex": "0.15.1"
   },
   "devDependencies": {
     "@stylexjs/webpack-plugin": "0.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       }
     },
     "examples/example-cli": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@stylexjs/open-props": "0.11.1",
         "react": "^18.3.0",
@@ -49,7 +49,7 @@
       "devDependencies": {
         "@babel/preset-react": "^7.25.7",
         "@babel/preset-typescript": "^7.25.7",
-        "@stylexjs/cli": "0.15.0",
+        "@stylexjs/cli": "0.15.1",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "typescript": "^5"
@@ -84,17 +84,17 @@
       }
     },
     "examples/example-esbuild": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@stylexjs/open-props": "0.11.1",
-        "@stylexjs/stylex": "0.15.0",
+        "@stylexjs/stylex": "0.15.1",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
       },
       "devDependencies": {
         "@stylexjs/esbuild-plugin": "0.11.1",
-        "@stylexjs/eslint-plugin": "0.15.0",
+        "@stylexjs/eslint-plugin": "0.15.1",
         "esbuild": "^0.25.0",
         "eslint": "^8.57.1"
       }
@@ -128,18 +128,18 @@
       }
     },
     "examples/example-nextjs": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@stylexjs/open-props": "0.11.1",
-        "@stylexjs/stylex": "0.15.0",
+        "@stylexjs/stylex": "0.15.1",
         "next": "14.2.21",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "styled-jsx": "^5.1.1"
       },
       "devDependencies": {
-        "@stylexjs/eslint-plugin": "0.15.0",
-        "@stylexjs/postcss-plugin": "0.15.0",
+        "@stylexjs/eslint-plugin": "0.15.1",
+        "@stylexjs/postcss-plugin": "0.15.1",
         "@types/json-schema": "^7.0.15",
         "@types/node": "^22.7.6",
         "@types/react": "^18.3.0",
@@ -302,10 +302,10 @@
       "license": "MIT"
     },
     "examples/example-rollup": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.15.0",
+        "@stylexjs/stylex": "0.15.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -317,7 +317,7 @@
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-replace": "^5.0.7",
-        "@stylexjs/rollup-plugin": "0.15.0",
+        "@stylexjs/rollup-plugin": "0.15.1",
         "rollup": "^4.24.0",
         "serve": "^14.2.4"
       }
@@ -344,10 +344,10 @@
       "license": "MIT"
     },
     "examples/example-webpack": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.15.0"
+        "@stylexjs/stylex": "0.15.1"
       },
       "devDependencies": {
         "@stylexjs/webpack-plugin": "0.11.1",
@@ -27021,7 +27021,7 @@
       }
     },
     "packages/@stylexjs/babel-plugin": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
@@ -27029,9 +27029,9 @@
         "@babel/traverse": "^7.26.8",
         "@babel/types": "^7.26.8",
         "@dual-bundle/import-meta-resolve": "^4.1.0",
-        "@stylexjs/stylex": "0.15.0",
+        "@stylexjs/stylex": "0.15.1",
         "postcss-value-parser": "^4.1.0",
-        "style-value-parser": "0.15.0"
+        "style-value-parser": "0.15.1"
       },
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.1",
@@ -27042,7 +27042,7 @@
         "@rollup/plugin-replace": "^6.0.1",
         "babel-plugin-syntax-hermes-parser": "^0.26.0",
         "rollup": "^4.24.0",
-        "scripts": "0.15.0"
+        "scripts": "0.15.1"
       }
     },
     "packages/@stylexjs/babel-plugin/node_modules/@rollup/plugin-commonjs": {
@@ -27115,14 +27115,14 @@
       }
     },
     "packages/@stylexjs/cli": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.26.8",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
         "@babel/types": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.15.0",
+        "@stylexjs/babel-plugin": "0.15.1",
         "ansis": "^3.3.2",
         "fb-watchman": "^2.0.2",
         "json5": "^2.2.3",
@@ -27133,7 +27133,7 @@
         "stylex": "lib/index.js"
       },
       "devDependencies": {
-        "scripts": "0.15.0"
+        "scripts": "0.15.1"
       }
     },
     "packages/@stylexjs/cli/node_modules/@babel/core": {
@@ -27166,7 +27166,7 @@
       }
     },
     "packages/@stylexjs/eslint-plugin": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "css-shorthand-expand": "^1.2.0",
@@ -27174,11 +27174,11 @@
       }
     },
     "packages/@stylexjs/postcss-plugin": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.15.0",
+        "@stylexjs/babel-plugin": "0.15.1",
         "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
@@ -27186,14 +27186,14 @@
       }
     },
     "packages/@stylexjs/rollup-plugin": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
         "@babel/plugin-syntax-flow": "^7.26.0",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
-        "@stylexjs/babel-plugin": "0.15.0",
+        "@stylexjs/babel-plugin": "0.15.1",
         "lightningcss": "^1.29.1"
       },
       "devDependencies": {
@@ -27253,7 +27253,7 @@
       }
     },
     "packages/@stylexjs/stylex": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "css-mediaquery": "^0.1.2",
@@ -27280,7 +27280,7 @@
         "cross-env": "^7.0.3",
         "rimraf": "^5.0.10",
         "rollup": "^4.24.0",
-        "scripts": "0.15.0"
+        "scripts": "0.15.1"
       }
     },
     "packages/@stylexjs/stylex/node_modules/@rollup/plugin-commonjs": {
@@ -27353,11 +27353,11 @@
       }
     },
     "packages/benchmarks": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/babel-plugin": "0.15.0",
-        "@stylexjs/rollup-plugin": "0.15.0",
+        "@stylexjs/babel-plugin": "0.15.1",
+        "@stylexjs/rollup-plugin": "0.15.1",
         "benchmark": "^2.1.4",
         "brotli-size": "^4.0.0",
         "clean-css": "^5.3.3",
@@ -27370,7 +27370,7 @@
       }
     },
     "packages/docs": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@docusaurus/core": "2.4.1",
         "@docusaurus/preset-classic": "2.4.1",
@@ -27379,7 +27379,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.1",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@mdx-js/react": "^1.6.22",
-        "@stylexjs/stylex": "0.15.0",
+        "@stylexjs/stylex": "0.15.1",
         "@webcontainer/api": "^1.3.0",
         "clsx": "^1.2.1",
         "codemirror": "^5.65.16",
@@ -27390,8 +27390,8 @@
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.15.0",
-        "@stylexjs/eslint-plugin": "0.15.0",
+        "@stylexjs/babel-plugin": "0.15.1",
+        "@stylexjs/eslint-plugin": "0.15.1",
         "clean-css": "^5.3.2",
         "eslint": "^8.57.1",
         "eslint-config-airbnb": "^19.0.4",
@@ -27415,7 +27415,7 @@
       }
     },
     "packages/scripts": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "flow-api-translator": "0.26.0",
@@ -27427,7 +27427,7 @@
       }
     },
     "packages/style-value-parser": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@csstools/css-tokenizer": "^3.0.3"
@@ -27455,10 +27455,10 @@
       }
     },
     "packages/typescript-tests": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.15.0",
+        "@stylexjs/stylex": "0.15.1",
         "typescript": "^5.8.3"
       },
       "engines": {

--- a/packages/@stylexjs/babel-plugin/package.json
+++ b/packages/@stylexjs/babel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/babel-plugin",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "StyleX babel plugin.",
   "main": "lib/index.js",
   "repository": {
@@ -21,9 +21,9 @@
     "@babel/traverse": "^7.26.8",
     "@babel/types": "^7.26.8",
     "@dual-bundle/import-meta-resolve": "^4.1.0",
-    "@stylexjs/stylex": "0.15.0",
+    "@stylexjs/stylex": "0.15.1",
     "postcss-value-parser": "^4.1.0",
-    "style-value-parser": "0.15.0"
+    "style-value-parser": "0.15.1"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "^5.1.1",
@@ -34,7 +34,7 @@
     "@rollup/plugin-replace": "^6.0.1",
     "babel-plugin-syntax-hermes-parser": "^0.26.0",
     "rollup": "^4.24.0",
-    "scripts": "0.15.0"
+    "scripts": "0.15.1"
   },
   "files": [
     "flow_modules/*",

--- a/packages/@stylexjs/cli/package.json
+++ b/packages/@stylexjs/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/cli",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A cli to compile a folder with StyleX",
   "main": "./lib/transform.js",
   "repository": "https://www.github.com/facebook/stylex",
@@ -19,7 +19,7 @@
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
     "@babel/types": "^7.26.8",
-    "@stylexjs/babel-plugin": "0.15.0",
+    "@stylexjs/babel-plugin": "0.15.1",
     "ansis": "^3.3.2",
     "fb-watchman": "^2.0.2",
     "json5": "^2.2.3",
@@ -27,7 +27,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "scripts": "0.15.0"
+    "scripts": "0.15.1"
   },
   "bin": {
     "stylex": "./lib/index.js"

--- a/packages/@stylexjs/eslint-plugin/package.json
+++ b/packages/@stylexjs/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/eslint-plugin",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "StyleX eslint plugin.",
   "main": "lib/index.js",
   "repository": {

--- a/packages/@stylexjs/postcss-plugin/package.json
+++ b/packages/@stylexjs/postcss-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/postcss-plugin",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "PostCSS plugin for StyleX",
   "main": "src/index.js",
   "repository": {
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.26.8",
-    "@stylexjs/babel-plugin": "0.15.0",
+    "@stylexjs/babel-plugin": "0.15.1",
     "postcss": "^8.4.49",
     "fast-glob": "^3.3.2",
     "glob-parent": "^6.0.2",

--- a/packages/@stylexjs/rollup-plugin/package.json
+++ b/packages/@stylexjs/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/rollup-plugin",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Rollup plugin for StyleX",
   "main": "./lib/index.js",
   "module": "./lib/es/index.mjs",
@@ -35,7 +35,7 @@
     "@babel/plugin-syntax-flow": "^7.26.0",
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
-    "@stylexjs/babel-plugin": "0.15.0",
+    "@stylexjs/babel-plugin": "0.15.1",
     "lightningcss": "^1.29.1"
   },
   "devDependencies": {

--- a/packages/@stylexjs/stylex/package.json
+++ b/packages/@stylexjs/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/stylex",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A library for defining styles for optimized user interfaces.",
   "main": "./lib/cjs/stylex.js",
   "module": "./lib/es/stylex.mjs",
@@ -61,7 +61,7 @@
     "cross-env": "^7.0.3",
     "rimraf": "^5.0.10",
     "rollup": "^4.24.0",
-    "scripts": "0.15.0"
+    "scripts": "0.15.1"
   },
   "files": [
     "lib/*"

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "benchmarks",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "scripts": {
     "perf": "node ./perf/run.js",
     "size": "NODE_ENV=production rollup --config ./size/rollup.config.mjs && node ./size/run.js",
@@ -9,8 +9,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/babel-plugin": "0.15.0",
-    "@stylexjs/rollup-plugin": "0.15.0",
+    "@stylexjs/babel-plugin": "0.15.1",
+    "@stylexjs/rollup-plugin": "0.15.1",
     "benchmark": "^2.1.4",
     "brotli-size": "^4.0.0",
     "clean-css": "^5.3.3",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "docs",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "scripts": {
     "build": "rimraf ./build ./docusaurus && cross-env NODE_ENV=production docusaurus build && node ./scripts/make-stylex-sheet.js",
     "clear": "docusaurus clear",
@@ -17,7 +17,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.1",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mdx-js/react": "^1.6.22",
-    "@stylexjs/stylex": "0.15.0",
+    "@stylexjs/stylex": "0.15.1",
     "@webcontainer/api": "^1.3.0",
     "clsx": "^1.2.1",
     "codemirror": "^5.65.16",
@@ -28,8 +28,8 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.26.8",
-    "@stylexjs/eslint-plugin": "0.15.0",
-    "@stylexjs/babel-plugin": "0.15.0",
+    "@stylexjs/eslint-plugin": "0.15.1",
+    "@stylexjs/babel-plugin": "0.15.1",
     "clean-css": "^5.3.2",
     "eslint": "^8.57.1",
     "eslint-config-airbnb": "^19.0.4",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "scripts",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Helper scripts for stylex monorepo.",
   "license": "MIT",
   "bin": {

--- a/packages/style-value-parser/package.json
+++ b/packages/style-value-parser/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "style-value-parser",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "main": "lib/index.js",
   "license": "MIT",

--- a/packages/typescript-tests/package.json
+++ b/packages/typescript-tests/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "typescript-tests",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "scripts": {
     "test": "tsc"
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.15.0",
+    "@stylexjs/stylex": "0.15.1",
     "typescript": "^5.8.3"
   },
   "engines": {


### PR DESCRIPTION
- Hoist stylex.create and static className objects to the top level for support inside functions
- Mark `style-value-parser` as public

Will be easier/more maintainable than inlining across packages 