### PR TITLE
[babel-plugin] fix classname construction for dynamic contextual styles

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -4078,7 +4078,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (hover, active, focus) => [{
-                kMwMTN: (hover != null ? "x1qvlgnj" : hover) + (active != null ? "xx746rz" : active) + (focus != null ? "x152n5rj" : focus) + "x126ychx",
+                kMwMTN: (hover != null ? "x1qvlgnj " : hover) + (active != null ? "xx746rz " : active) + (focus != null ? "x152n5rj " : focus) + "x126ychx",
                 $$css: true
               }, {
                 "--x-1113oo7": hover != null ? hover : undefined,
@@ -4329,7 +4329,7 @@ describe('@stylexjs/babel-plugin', () => {
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             const _temp = {
-              kxBb7d: "x16oeupf" + "xndy4z1",
+              kxBb7d: "x16oeupf " + "xndy4z1",
               "$$css": true
             };
             export const styles = {
@@ -4389,7 +4389,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (a, b, c) => [{
-                kzqmXN: "x11ymkkh" + (b != null ? "x17gmrvw" : b) + (c != null ? "x1bai16n" : c),
+                kzqmXN: "x11ymkkh " + (b != null ? "x17gmrvw " : b) + (c != null ? "x1bai16n" : c),
                 $$css: true
               }, {
                 "--x-1xmrurk": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)('color-mix(' + color + ', blue)'),
@@ -4471,7 +4471,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (a, b, c) => [{
-                kMwMTN: (a != null ? "x3d248p" : a) + (b != null ? "x1iuwwch" : b) + (c != null ? "x5268pl" : c),
+                kMwMTN: (a != null ? "x3d248p " : a) + (b != null ? "x1iuwwch " : b) + (c != null ? "x5268pl" : c),
                 $$css: true
               }, {
                 "--x-4xs81a": a != null ? a : undefined,
@@ -4555,7 +4555,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (a, b, c) => [{
-                kGuDYH: (a != null ? "xww4jgc" : a) + (b != null ? "xfqys7t" : b) + (c != null ? "x13w7uki" : c),
+                kGuDYH: (a != null ? "xww4jgc " : a) + (b != null ? "xfqys7t " : b) + (c != null ? "x13w7uki" : c),
                 $$css: true
               }, {
                 "--x-19zvkyr": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(a),
@@ -5240,9 +5240,9 @@ describe('@stylexjs/babel-plugin', () => {
           _inject2("@property --x-marginTop { syntax: \\"*\\"; inherits: false;}", 0);
           export const styles = {
             default: margin => [_temp, {
-              k71WvV: (margin != null ? "x17e2bsb" : margin) + "xtcj1g9",
-              k1K539: (margin != null ? "xg6eqc8" : margin) + "xgrn1a3",
-              keTefX: (margin != null ? "x19ja4a5" : margin) + "x2tye95",
+              k71WvV: (margin != null ? "x17e2bsb " : margin) + "xtcj1g9",
+              k1K539: (margin != null ? "xg6eqc8 " : margin) + "xgrn1a3",
+              keTefX: (margin != null ? "x19ja4a5 " : margin) + "x2tye95",
               $$css: true
             }, {
               "--x-14mfytm": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin),

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
@@ -329,22 +329,25 @@ export default function transformStyleXCreate(
                 let isStatic = true;
                 const exprList: t.Expression[] = [];
 
-                classList.forEach((cls) => {
+                classList.forEach((cls, index) => {
                   const expr = dynamicStyles.find(
                     ({ path }) => origClassPaths[cls] === path,
                   )?.expression;
+
+                  const isLast = index === classList.length - 1;
+                  const clsWithSpace = isLast ? cls : cls + ' ';
 
                   if (expr && !isSafeToSkipNullCheck(expr)) {
                     isStatic = false;
                     exprList.push(
                       t.conditionalExpression(
                         t.binaryExpression('!=', expr, t.nullLiteral()),
-                        t.stringLiteral(cls),
+                        t.stringLiteral(clsWithSpace),
                         expr,
                       ),
                     );
                   } else {
-                    exprList.push(t.stringLiteral(cls));
+                    exprList.push(t.stringLiteral(clsWithSpace));
                   }
                 });
 


### PR DESCRIPTION
Bug introduced in https://github.com/facebook/stylex/pull/1153, missing space concat for contextual styles. When we are constructing a key with multiple classnames (contextual style) we need to add a space suffix to each classname except the last. Previous logic included this `const suffix = index === classList.length - 1 ? '' : ' ';` but was not ported over.

Fixes https://github.com/facebook/stylex/issues/1191