### PR TITLE
[babel plugin] avoid mutating rules in processStylexRules

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -291,5 +291,33 @@ describe('@stylexjs/babel-plugin', () => {
         }"
       `);
     });
+
+    test('no mutation of rules', () => {
+      const { metadata } = transform(fixture);
+
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze#deep_freezing
+      function deepFreeze(object) {
+        const propNames = Reflect.ownKeys(object);
+
+        for (const name of propNames) {
+          const value = object[name];
+
+          if (
+            (value && typeof value === 'object') ||
+            typeof value === 'function'
+          ) {
+            deepFreeze(value);
+          }
+        }
+
+        return Object.freeze(object);
+      }
+
+      deepFreeze(metadata);
+
+      expect(() => {
+        stylexPlugin.processStylexRules(metadata);
+      }).not.toThrow();
+    });
   });
 });

--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -431,7 +431,7 @@ function processStylexRules(
 
   let lastKPri = -1;
   const grouped = sortedRules.reduce((acc: Array<Array<Rule>>, rule) => {
-    const [_key, styleObj, priority] = rule;
+    const [key, { ...styleObj }, priority] = rule;
     const priorityLevel = Math.floor(priority / 1000);
 
     Object.keys(styleObj).forEach((dir) => {
@@ -447,12 +447,12 @@ function processStylexRules(
     });
 
     if (priorityLevel === lastKPri) {
-      acc[acc.length - 1].push(rule);
+      acc[acc.length - 1].push([key, styleObj, priority]);
       return acc;
     }
 
     lastKPri = priorityLevel;
-    acc.push([rule]);
+    acc.push([[key, styleObj, priority]]);
     return acc;
   }, []);
 


### PR DESCRIPTION
## What changed / motivation ?

We are evaluating StyleX and I ran into a bug in our WIP bundler integration that was caused by `processStylexRules` mutating rule objects. We were caching rules and it caused broken behavior for incremental compilations.

My fix in this PR is to remove the mutation of the rules. I have considered that consumers could just clone the rules before they pass it to `processStylexRules()` but I think it is better to remove the mutation so others don't run into similar hard to track down bugs. 

My fix is fairly naive in that it always shallow clones the `styleObj`. I was favoring simplicity here but if we want to be more perf conscious I have a version that [only clones when necessary](https://github.com/henryqdineen/stylex/commit/4da3e7b280763d234cae7227d80080914c0007f2).

I don't love the unit test but it serves it's purpose. If you would prefer I could add a unit test that more closely recreates the issue I was seeing. 

Thanks!

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code