### PR TITLE
docs: replace vite-plugin-stylex-dev with stylex-extend

### DIFF
--- a/packages/docs/docs/learn/07-ecosystem.mdx
+++ b/packages/docs/docs/learn/07-ecosystem.mdx
@@ -23,7 +23,7 @@ sidebar_position: 6
 The following community-maintained plugins are available for Vite:
 
 * [vite-plugin-stylex](https://www.npmjs.com/package/vite-plugin-stylex)
-* [vite-plugin-stylex-dev](https://www.npmjs.com/package/vite-plugin-stylex-dev)
+* [stylex-extend](https://github.com/nonzzz/stylex-extend)
 
 ### Webpack
 


### PR DESCRIPTION
## What changed / motivation ?

This PR changes the documentation of third-party bundler integrations.

According to vite-plugin-stylex-dev's [document](https://github.com/nonzzz/vite-plugin-stylex), it is no longer maintained, and the author encourage us to use stylex-extend by the same author instead.

## Linked PR/Issues

## Additional Context

<img width="870" height="611" alt="图片" src="https://github.com/user-attachments/assets/e1507464-0a54-4410-b307-8995fc80d9d7" />

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code