### PR TITLE
[babel-plugin] create new `.transformed` file extension for pre-resolved variables and constants

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -507,15 +507,22 @@ export default class StateManager {
       return false;
     }
 
+    const themeFileExtension =
+      this.options.unstable_moduleResolution?.themeFileExtension ?? '.stylex';
+    const transformedVarsFileExtension = '.transformed';
+
+    const isValidStylexFile = matchesFileSuffix(themeFileExtension)(importPath);
+    const isValidTransformedVarsFile = matchesFileSuffix(
+      transformedVarsFileExtension,
+    )(importPath);
+
+    if (!isValidStylexFile && !isValidTransformedVarsFile) {
+      return false;
+    }
+
     switch (this.options.unstable_moduleResolution?.type) {
       case 'commonJS': {
         const aliases = this.options.aliases;
-        const themeFileExtension =
-          this.options.unstable_moduleResolution?.themeFileExtension ??
-          '.stylex';
-        if (!matchesFileSuffix(themeFileExtension)(importPath)) {
-          return false;
-        }
         const resolvedFilePath = filePathResolver(
           importPath,
           sourceFilePath,
@@ -526,22 +533,10 @@ export default class StateManager {
           : false;
       }
       case 'haste': {
-        const themeFileExtension =
-          this.options.unstable_moduleResolution.themeFileExtension ??
-          '.stylex';
-        if (!matchesFileSuffix(themeFileExtension)(importPath)) {
-          return false;
-        }
         return ['themeNameRef', addFileExtension(importPath, sourceFilePath)];
       }
       case 'experimental_crossFileParsing': {
         const aliases = this.options.aliases;
-        const themeFileExtension =
-          this.options.unstable_moduleResolution.themeFileExtension ??
-          '.stylex';
-        if (!matchesFileSuffix(themeFileExtension)(importPath)) {
-          return false;
-        }
         const resolvedFilePath = filePathResolver(
           importPath,
           sourceFilePath,

--- a/packages/@stylexjs/eslint-plugin/src/rules/isStylexResolvedVarsToken.js
+++ b/packages/@stylexjs/eslint-plugin/src/rules/isStylexResolvedVarsToken.js
@@ -12,14 +12,14 @@ import type { Expression, Pattern } from 'estree';
 
 export default function isStylexDefineVarsToken(
   node: Expression | Pattern,
-  stylexDefineVarsTokenImports: Set<string>,
+  stylexResolvedVarsTokenImports: Set<string>,
 ): boolean {
   if (node != null) {
     if (node.type === 'MemberExpression' && node.object.type === 'Identifier') {
-      return stylexDefineVarsTokenImports.has(node.object.name);
+      return stylexResolvedVarsTokenImports.has(node.object.name);
     }
     if (node.type === 'Identifier') {
-      return stylexDefineVarsTokenImports.has(node.name);
+      return stylexResolvedVarsTokenImports.has(node.name);
     }
     if (node.type === 'TemplateLiteral' && node.expressions.length > 0) {
       return (
@@ -29,7 +29,7 @@ export default function isStylexDefineVarsToken(
               expression.type === 'MemberExpression' &&
               expression.object.type === 'Identifier'
             ) {
-              return stylexDefineVarsTokenImports.has(expression.object.name)
+              return stylexResolvedVarsTokenImports.has(expression.object.name)
                 ? invalidTokenCounter
                 : invalidTokenCounter + 1;
             }


### PR DESCRIPTION
It's a common case for users to write their own transforms that do special processing to inline, modify, or pre-resolve constants. Because the StyleX linter and compiler run on pre-transformed JS, the linter will flag these imports and cause unnecessary noise for developers.

- This is a quick patch to unblock an internal launch and the specific approach can be revisited as needed.
- Adds a new file extension `.transformed` (for files with exports that are pre-resolved before StyleX runs) with similar handling to `.stylex` (for files with `defineConsts` and `defineVars` exports) allowing them to be used in `stylex.create` calls
- Some naming cleanup as `.stylex` marks both `defineConsts` and `defineVars` anyway
- Compiler behavior is unchanged: variables unresolved at build time will still trigger errors for unresolved constants or invalid pseudo or at-rules.

Future thinking:
- We could introduce a constants config that allows users to specify a suite of key: value pairs and handle them globally within stylex
