### PR TITLE
[babel-plugin] fix `defineConsts` at-rules for dynamic styles

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
@@ -373,25 +373,128 @@ describe('@stylexjs/babel-plugin', () => {
       `);
 
       expect(code).toMatchInlineSnapshot(`
+            `);
+    });
+
+    test('works with dynamic styles constants', () => {
+      const { code, metadata } = transformWithInlineConsts(`
+        import * as stylex from '@stylexjs/stylex';
+        import { colors } from './constants.stylex';
+
+        export const styles = stylex.create({
+          node: (padding) => ({
+            padding: padding,
+            color: colors.background,
+          }),
+        });
+      `);
+
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        import { colors } from './constants.stylex';
+        const _temp = {
+          kMwMTN: "xy1iwrb",
+          "$$css": true
+        };
+        export const styles = {
+          node: padding => [_temp, {
+            kmVPX3: padding != null ? "x1fozly0" : padding,
+            $$css: true
+          }, {
+            "--x-padding": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(padding)
+          }]
+        };"
+      `);
+
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "x1fozly0",
+              {
+                "ltr": ".x1fozly0{padding:var(--x-padding)}",
+                "rtl": null,
+              },
+              1000,
+            ],
+            [
+              "xy1iwrb",
+              {
+                "ltr": ".xy1iwrb{color:var(--x180gk19)}",
+                "rtl": null,
+              },
+              3000,
+            ],
+            [
+              "--x-padding",
+              {
+                "ltr": "@property --x-padding { syntax: "*"; inherits: false;}",
+                "rtl": null,
+              },
+              0,
+            ],
+          ],
+        }
       `);
     });
 
-    test.skip('works with dynamic styles', () => {
-      const { code } = transformWithInlineConsts(`
+    test('works with dynamic styles at-rules', () => {
+      const { code, metadata } = transformWithInlineConsts(`
         import * as stylex from '@stylexjs/stylex';
         import { breakpoints } from './constants.stylex';
 
         export const styles = stylex.create({
-          nodeEnd: (animationDuration) => ({
-            transition: {
-              [breakpoints.small]: 'none',
-              default: \`transform \${animationDuration}ms ease-in-out\`,
+          node: (color) => ({
+            color: {
+              [breakpoints.small]: 'blue',
+              default: color,
             },
           }),
         });
       `);
 
       expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        import { breakpoints } from './constants.stylex';
+        export const styles = {
+          node: color => [{
+            kMwMTN: "xbs0o1n " + (color != null ? "x3d248p" : color),
+            $$css: true
+          }, {
+            "--x-4xs81a": color != null ? color : undefined
+          }]
+        };"
+      `);
+
+      expect(metadata).toMatchInlineSnapshot(`
+        {
+          "stylex": [
+            [
+              "xbs0o1n",
+              {
+                "ltr": "var(--x1r2wpmh){.xbs0o1n.xbs0o1n{color:blue}}",
+                "rtl": null,
+              },
+              6000,
+            ],
+            [
+              "x3d248p",
+              {
+                "ltr": ".x3d248p{color:var(--x-4xs81a)}",
+                "rtl": null,
+              },
+              3000,
+            ],
+            [
+              "--x-4xs81a",
+              {
+                "ltr": "@property --x-4xs81a { syntax: "*"; inherits: false;}",
+                "rtl": null,
+              },
+              0,
+            ],
+          ],
+        }
       `);
     });
 

--- a/packages/@stylexjs/babel-plugin/src/visitors/parse-stylex-create-arg.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/parse-stylex-create-arg.js
@@ -150,12 +150,17 @@ function evaluatePartialObjectRecursively(
         return { confident: false, deopt: keyResult.deopt, value: null };
       }
       let key = keyResult.value;
-      if (key.startsWith('var(') && key.endsWith(')')) {
-        key = key.slice(4, -1);
-      }
 
       const valuePath: NodePath<t.Expression | t.PatternLike> =
         prop.get('value');
+
+      if (key.startsWith('var(') && key.endsWith(')')) {
+        const inner = key.slice(4, -1);
+        // When the `keyPath` is not empty, the var(--hash) is a `defineConsts` at-rule placeholder and must be kept intact.
+        if (keyPath.length === 0) {
+          key = inner;
+        }
+      }
 
       if (valuePath.isObjectExpression()) {
         const result = evaluatePartialObjectRecursively(


### PR DESCRIPTION
In https://github.com/facebook/stylex/pull/376 (ancient history) we added some special handling for `defineVars` variables within dynamic styles. This worked fine up until we implemented `defineConsts` support for at-rules, where the processing logic breaks the placeholder wrapping around CSS rules needed for at-rule support for `defineConsts`.

The simplest solution is to check the `keyPath` for the key we're processing. 
- If the `keyPath` is empty, it belongs to a `defineVars` call, as CSS custom properties can't be used within at-rules. 
- If the `keyPath` exists, we can be sure that it's wrapping another property, and thus must be a `defineConsts` placeholder

I also spent a while attempting to create clearer placeholders for `defineConsts` instead of the ambiguous `var(--hash)` placeholders we use, but that requires decoupling much of the logic shared between `defineVars` and `defineConsts` in `evaluate-path`. So this will be something we can revisit longer term.

Tested on example-nextjs:
- `defineConsts` values work as expected (same before and after this PR)
- `defineConsts` MQs work as expected now 
  - tested when set to `defineConsts` values and string literals
- dynamic styles work as expected

```tsx
export const colors = stylex.defineConsts({
  red: 'red',
  blue: 'darkblue',
  yellow: 'yellow',
});

export const breakpoints = stylex.defineConsts({
  sm: '@media (max-width: 640px)',
  md: '@media (min-width: 641px)',
});
```

```tsx
const style = stylex.create({
  main: (height) => ({
    color: {
      default: colors.red,
      [breakpoints.sm]: colors.blue,
      [breakpoints.md]: colors.yellow,
    },
    paddingTop: spacing.xxl,
  }),
```

https://github.com/user-attachments/assets/04deacdc-85fc-4634-97af-7d6a0524f0d8






 