### PR TITLE
[eslint-plugin] allow '0' values for length properties

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -236,6 +236,9 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     "import * as stylex from '@stylexjs/stylex'; stylex.create({[0]: {marginInlineStart: 5}});",
     // test for negative values.
     "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {marginInlineStart: -5}});",
+    // test for unitless length value 0
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {margin: 0}});",
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {padding: '0'}});",
     "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {textAlign: 'start'}});",
     // test for presets
     `import * as stylex from '@stylexjs/stylex';

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -55,6 +55,10 @@ const isLength: RuleCheck = makeUnionRule(isAbsoluteLength, isRelativeLength);
 const isNonNumericString: RuleCheck = (node: Node): RuleResponse => {
   if (node.type === 'Literal' && typeof node.value === 'string') {
     if (/^[-+]?(?:\d+|\d*\.\d+)$/.test(node.value)) {
+      if (node.value === '0') {
+        return undefined;
+      }
+
       return {
         message: 'a non-numeric string',
       };


### PR DESCRIPTION
Small patch for unitless '0' strings to allow `margin: '0'` syntax

https://developer.mozilla.org/en-US/docs/Web/CSS/length#syntax