### PR TITLE
[babel-plugin] support configurations within `processStylexRules`

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -150,10 +150,10 @@ describe('@stylexjs/babel-plugin', () => {
         };"
       `);
       expect(
-        stylexPlugin.processStylexRules(
-          metadata,
-          { useLayers: false, enableLTRRTLComments: false },
-        ),
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: false,
+          enableLTRRTLComments: false,
+        }),
       ).toMatchInlineSnapshot(`
         ":root, .xsg933n{--blue-xpqh4lw:blue;}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}"
@@ -207,13 +207,18 @@ describe('@stylexjs/babel-plugin', () => {
           }]
         };"
       `);
-      expect(stylexPlugin.processStylexRules(metadata, { useLayers: false, enableLTRRTLComments: false },)).toMatchInlineSnapshot(`
+      expect(
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: false,
+          enableLTRRTLComments: false,
+        }),
+      ).toMatchInlineSnapshot(`
         "@property --x-color { syntax: "*"; inherits: false;}
         @keyframes xi07kvp-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange);}}
         :root, .xsg933n{--blue-xpqh4lw:blue;}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        .x6xqkwy, .x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma, .x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
+        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
+        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
         .margin-xymmreb:not(#\\#){margin:10px 20px}
         .padding-xss17vw:not(#\\#){padding:var(--large-x1ec7iuc)}
         .borderColor-x1bg2uv5:not(#\\#):not(#\\#){border-color:green}
@@ -278,16 +283,20 @@ describe('@stylexjs/babel-plugin', () => {
           }]
         };"
       `);
-      expect(stylexPlugin.processStylexRules(metadata, { useLayers: true, enableLTRRTLComments: false },))
-        .toMatchInlineSnapshot(`
+      expect(
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: true,
+          enableLTRRTLComments: false,
+        }),
+      ).toMatchInlineSnapshot(`
         "
         @layer priority1, priority2, priority3, priority4;
         @property --x-color { syntax: "*"; inherits: false;}
         @keyframes xi07kvp-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange);}}
         :root, .xsg933n{--blue-xpqh4lw:blue;}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        .x6xqkwy, .x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma, .x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
+        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
+        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
         @layer priority2{
         .margin-xymmreb{margin:10px 20px}
         .padding-xss17vw{padding:var(--large-x1ec7iuc)}
@@ -362,10 +371,10 @@ describe('@stylexjs/babel-plugin', () => {
       `);
 
       expect(
-        stylexPlugin.processStylexRules(
-          metadata,
-          { useLayers: false, enableLTRRTLComments: true },
-        ),
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: false,
+          enableLTRRTLComments: true,
+        }),
       ).toMatchInlineSnapshot(`
         ":root, .xsg933n{--blue-xpqh4lw:blue;}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
@@ -383,6 +392,37 @@ describe('@stylexjs/babel-plugin', () => {
         .marginTop-x1anpbxc:not(#\\#):not(#\\#){margin-top:10px}
         .paddingBottom-xs9asl8:not(#\\#):not(#\\#){padding-bottom:5px}
         .paddingTop-x123j3cw:not(#\\#):not(#\\#){padding-top:5px}"
+      `);
+    });
+
+    test('legacy-expand-shorthands duplicates theme selectors for higher precedence', () => {
+      const { _code, metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const themeColor = stylex.createTheme(vars, {
+          blue: 'lightblue'
+        });
+        export const themeSpacing = stylex.createTheme(spacing, {
+          small: '5px',
+          medium: '10px',
+          large: '20px'
+        });
+      `,
+        {
+          styleResolution: 'legacy-expand-shorthands',
+        },
+      );
+
+      expect(
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: false,
+          enableLTRRTLComments: false,
+        }),
+      ).toMatchInlineSnapshot(`
+        ":root, .xsg933n{--blue-xpqh4lw:blue;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
+        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}"
       `);
     });
   });

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -118,7 +118,9 @@ export const styles = stylex.create({
       default: '1px 2px 3px 4px red',
       '@media (min-width:320px)': '10px 20px 30px 40px green'
     },
-    padding: spacing.large
+    padding: spacing.large,
+    margin: '10px 20px',
+    float: 'inline-start'
   },
   dynamic: (color) => ({ color })
 });
@@ -147,7 +149,12 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "xbiwvf9"
         };"
       `);
-      expect(stylexPlugin.processStylexRules(metadata)).toMatchInlineSnapshot(`
+      expect(
+        stylexPlugin.processStylexRules(
+          metadata,
+          { useLayers: false, enableLTRRTLComments: false },
+        ),
+      ).toMatchInlineSnapshot(`
         ":root, .xsg933n{--blue-xpqh4lw:blue;}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}"
       `);
@@ -188,23 +195,26 @@ describe('@stylexjs/babel-plugin', () => {
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
             "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-x1cmij7u",
             "padding-kmVPX3": "padding-xss17vw",
+            "margin-kogj98": "margin-xymmreb",
+            "float-kyUFMd": "float-x1kmio9f",
             $$css: "app/main.js:31"
           },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:56"
+            $$css: "app/main.js:58"
           }, {
             "--x-color": color != null ? color : undefined
           }]
         };"
       `);
-      expect(stylexPlugin.processStylexRules(metadata)).toMatchInlineSnapshot(`
+      expect(stylexPlugin.processStylexRules(metadata, { useLayers: false, enableLTRRTLComments: false },)).toMatchInlineSnapshot(`
         "@property --x-color { syntax: "*"; inherits: false;}
         @keyframes xi07kvp-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange);}}
         :root, .xsg933n{--blue-xpqh4lw:blue;}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         .x6xqkwy, .x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma, .x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
+        .margin-xymmreb:not(#\\#){margin:10px 20px}
         .padding-xss17vw:not(#\\#){padding:var(--large-x1ec7iuc)}
         .borderColor-x1bg2uv5:not(#\\#):not(#\\#){border-color:green}
         @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c:not(#\\#):not(#\\#){border-color:var(--blue-xpqh4lw)}}
@@ -212,6 +222,8 @@ describe('@stylexjs/babel-plugin', () => {
         .animationName-xckgs0v:not(#\\#):not(#\\#):not(#\\#){animation-name:xi07kvp-B}
         .backgroundColor-xrkmrrc:not(#\\#):not(#\\#):not(#\\#){background-color:red}
         .color-x14rh7hd:not(#\\#):not(#\\#):not(#\\#){color:var(--x-color)}
+        html:not([dir='rtl']) .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:left}
+        html[dir='rtl'] .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:right}
         .textShadow-x1skrh0i:not(#\\#):not(#\\#):not(#\\#){text-shadow:1px 2px 3px 4px red}
         @media (min-width:320px){.textShadow-x1cmij7u.textShadow-x1cmij7u:not(#\\#):not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}"
       `);
@@ -254,17 +266,19 @@ describe('@stylexjs/babel-plugin', () => {
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
             "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-x1cmij7u",
             "padding-kmVPX3": "padding-xss17vw",
+            "margin-kogj98": "margin-xymmreb",
+            "float-kyUFMd": "float-x1kmio9f",
             $$css: "app/main.js:31"
           },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:56"
+            $$css: "app/main.js:58"
           }, {
             "--x-color": color != null ? color : undefined
           }]
         };"
       `);
-      expect(stylexPlugin.processStylexRules(metadata, true))
+      expect(stylexPlugin.processStylexRules(metadata, { useLayers: true, enableLTRRTLComments: false },))
         .toMatchInlineSnapshot(`
         "
         @layer priority1, priority2, priority3, priority4;
@@ -275,6 +289,7 @@ describe('@stylexjs/babel-plugin', () => {
         .x6xqkwy, .x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma, .x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
         @layer priority2{
+        .margin-xymmreb{margin:10px 20px}
         .padding-xss17vw{padding:var(--large-x1ec7iuc)}
         }
         @layer priority3{
@@ -286,9 +301,88 @@ describe('@stylexjs/babel-plugin', () => {
         .animationName-xckgs0v{animation-name:xi07kvp-B}
         .backgroundColor-xrkmrrc{background-color:red}
         .color-x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .float-x1kmio9f{float:left}
+        html[dir='rtl'] .float-x1kmio9f{float:right}
         .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
         @media (min-width:320px){.textShadow-x1cmij7u.textShadow-x1cmij7u{text-shadow:10px 20px 30px 40px green}}
         }"
+      `);
+    });
+
+    test('legacy-expand-shorthands with logical styles polyfill', () => {
+      const { code, metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const styles = stylex.create({
+          container: {
+            margin: '10px 20px',
+            padding: '5px 15px',
+            float: 'inline-start'
+          }
+        });
+      `,
+        {
+          styleResolution: 'legacy-expand-shorthands',
+          enableLogicalStylesPolyfill: true,
+        },
+      );
+
+      expect(code).toMatchInlineSnapshot(`
+        "import * as stylex from '@stylexjs/stylex';
+        export const constants = {
+          YELLOW: "yellow",
+          ORANGE: "var(--orange)",
+          mediaBig: "@media (max-width: 1000px)",
+          mediaSmall: "@media (max-width: 500px)"
+        };
+        export const vars = {
+          blue: "var(--blue-xpqh4lw)",
+          __varGroupHash__: "xsg933n"
+        };
+        export const spacing = {
+          small: "var(--small-x19twipt)",
+          medium: "var(--medium-xypjos2)",
+          large: "var(--large-x1ec7iuc)",
+          __varGroupHash__: "xbiwvf9"
+        };
+        export const styles = {
+          container: {
+            "marginTop-keoZOQ": "marginTop-x1anpbxc",
+            "marginInlineEnd-k71WvV": "marginInlineEnd-x3aesyq",
+            "marginBottom-k1K539": "marginBottom-xyorhqc",
+            "marginInlineStart-keTefX": "marginInlineStart-xqsn43r",
+            "paddingTop-kLKAdn": "paddingTop-x123j3cw",
+            "paddingInlineEnd-kwRFfy": "paddingInlineEnd-x1q3ajuy",
+            "paddingBottom-kGO01o": "paddingBottom-xs9asl8",
+            "paddingInlineStart-kZCmMZ": "paddingInlineStart-x1gx403c",
+            "float-kyUFMd": "float-x1kmio9f",
+            $$css: "app/main.js:23"
+          }
+        };"
+      `);
+
+      expect(
+        stylexPlugin.processStylexRules(
+          metadata,
+          { useLayers: false, enableLTRRTLComments: true },
+        ),
+      ).toMatchInlineSnapshot(`
+        ":root, .xsg933n{--blue-xpqh4lw:blue;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        /* @ltr begin */.float-x1kmio9f:not(#\\#){float:left}/* @ltr end */
+        /* @rtl begin */.float-x1kmio9f:not(#\\#){float:right}/* @rtl end */
+        /* @ltr begin */.marginInlineStart-xqsn43r:not(#\\#){margin-left:20px}/* @ltr end */
+        /* @rtl begin */.marginInlineStart-xqsn43r:not(#\\#){margin-right:20px}/* @rtl end */
+        /* @ltr begin */.marginInlineEnd-x3aesyq:not(#\\#){margin-right:20px}/* @ltr end */
+        /* @rtl begin */.marginInlineEnd-x3aesyq:not(#\\#){margin-left:20px}/* @rtl end */
+        /* @ltr begin */.paddingInlineStart-x1gx403c:not(#\\#){padding-left:15px}/* @ltr end */
+        /* @rtl begin */.paddingInlineStart-x1gx403c:not(#\\#){padding-right:15px}/* @rtl end */
+        /* @ltr begin */.paddingInlineEnd-x1q3ajuy:not(#\\#){padding-right:15px}/* @ltr end */
+        /* @rtl begin */.paddingInlineEnd-x1q3ajuy:not(#\\#){padding-left:15px}/* @rtl end */
+        .marginBottom-xyorhqc:not(#\\#):not(#\\#){margin-bottom:10px}
+        .marginTop-x1anpbxc:not(#\\#):not(#\\#){margin-top:10px}
+        .paddingBottom-xs9asl8:not(#\\#):not(#\\#){padding-bottom:5px}
+        .paddingTop-x123j3cw:not(#\\#):not(#\\#){padding-top:5px}"
       `);
     });
   });

--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -358,8 +358,18 @@ export type Rule = [
 ];
 function processStylexRules(
   rules: Array<Rule>,
-  useLayers: boolean = false,
+  config?:
+    | boolean
+    | {
+        useLayers?: boolean,
+        enableLTRRTLComments?: boolean,
+        ...
+      },
 ): string {
+  const {
+    useLayers = false,
+    enableLTRRTLComments: _enableLTRRTLComments = false,
+  } = typeof config === 'boolean' ? { useLayers: config } : config ?? {};
   if (rules.length === 0) {
     return '';
   }

--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -368,7 +368,7 @@ function processStylexRules(
 ): string {
   const {
     useLayers = false,
-    enableLTRRTLComments: _enableLTRRTLComments = false,
+    enableLTRRTLComments = false,
   } = typeof config === 'boolean' ? { useLayers: config } : config ?? {};
   if (rules.length === 0) {
     return '';
@@ -489,10 +489,15 @@ function processStylexRules(
           }
 
           return rtlRule
-            ? [
-                addAncestorSelector(ltrRule, "html:not([dir='rtl'])"),
-                addAncestorSelector(rtlRule, "html[dir='rtl']"),
-              ]
+            ? enableLTRRTLComments
+              ? [
+                  `/* @ltr begin */${ltrRule}/* @ltr end */`,
+                  `/* @rtl begin */${rtlRule}/* @rtl end */`,
+                ]
+              : [
+                  addAncestorSelector(ltrRule, "html:not([dir='rtl'])"),
+                  addAncestorSelector(rtlRule, "html[dir='rtl']"),
+                ]
             : [ltrRule];
         })
         .join('\n');

--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -366,10 +366,8 @@ function processStylexRules(
         ...
       },
 ): string {
-  const {
-    useLayers = false,
-    enableLTRRTLComments = false,
-  } = typeof config === 'boolean' ? { useLayers: config } : config ?? {};
+  const { useLayers = false, enableLTRRTLComments = false } =
+    typeof config === 'boolean' ? { useLayers: config } : config ?? {};
   if (rules.length === 0) {
     return '';
   }
@@ -486,6 +484,21 @@ function processStylexRules(
           if (!useLayers) {
             ltrRule = addSpecificityLevel(ltrRule, index);
             rtlRule = rtlRule && addSpecificityLevel(rtlRule, index);
+          }
+
+          // check if the selector looks like .xtrlmmh, .xtrlmmh:root
+          // if so, turn it into .xtrlmmh.xtrlmmh, .xtrlmmh.xtrlmmh:root
+          // This is to ensure the themes always have precedence over the
+          // default variable values
+          ltrRule = ltrRule.replace(
+            /\.([a-zA-Z0-9]+), \.([a-zA-Z0-9]+):root/g,
+            '.$1.$1, .$1.$1:root',
+          );
+          if (rtlRule) {
+            rtlRule = rtlRule.replace(
+              /\.([a-zA-Z0-9]+), \.([a-zA-Z0-9]+):root/g,
+              '.$1.$1, .$1.$1:root',
+            );
           }
 
           return rtlRule

--- a/packages/@stylexjs/babel-plugin/src/shared/common-types.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/common-types.js
@@ -55,6 +55,7 @@ export type StyleXOptions = $ReadOnly<{
   enableMediaQueryOrder?: ?boolean,
   enableLegacyValueFlipping?: ?boolean,
   enableLogicalStylesPolyfill?: ?boolean,
+  enableLTRRTLComments?: ?boolean,
   enableMinifiedKeys?: ?boolean,
   styleResolution:
     | 'application-order' // The last style applied wins.

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/default-options.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/default-options.js
@@ -20,6 +20,7 @@ export const defaultOptions: StyleXOptions = {
   enableMediaQueryOrder: false,
   enableLegacyValueFlipping: false,
   enableLogicalStylesPolyfill: false,
+  enableLTRRTLComments: false,
   enableMinifiedKeys: true,
   styleResolution: 'property-specificity',
   test: false,

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -76,6 +76,7 @@ export type StyleXOptions = $ReadOnly<{
   enableMediaQueryOrder?: boolean,
   enableLegacyValueFlipping?: boolean,
   enableLogicalStylesPolyfill?: boolean,
+  enableLTRRTLComments?: boolean,
   enableMinifiedKeys?: boolean,
   importSources: $ReadOnlyArray<
     string | $ReadOnly<{ from: string, as: string }>,
@@ -244,6 +245,14 @@ export default class StateManager {
         'options.enableLogicalStylesPolyfill',
       );
 
+    const enableLTRRTLComments: StyleXStateOptions['enableLTRRTLComments'] =
+      z.logAndDefault(
+        z.boolean(),
+        options.enableLTRRTLComments ?? false,
+        false,
+        'options.enableLTRRTLComments',
+      );
+
     const test: StyleXStateOptions['test'] = z.logAndDefault(
       z.boolean(),
       options.test ?? false,
@@ -356,6 +365,7 @@ export default class StateManager {
       enableMediaQueryOrder,
       enableLegacyValueFlipping,
       enableLogicalStylesPolyfill,
+      enableLTRRTLComments,
       importSources,
       rewriteAliases:
         typeof options.rewriteAliases === 'boolean'

--- a/packages/@stylexjs/cli/src/transform.js
+++ b/packages/@stylexjs/cli/src/transform.js
@@ -81,7 +81,10 @@ export async function compileDirectory(
 
   const compiledCSS = await styleXPlugin.processStylexRules(
     Array.from(config.state.styleXRules.values()).flat(),
-    config.useCSSLayers,
+    {
+      useLayers: config.useCSSLayers,
+      enableLTRRTLComments: config.styleXConfig?.enableLTRRTLComments,
+    },
   );
 
   const cssBundlePath = path.join(config.output, config.styleXBundleName);

--- a/packages/@stylexjs/postcss-plugin/src/builder.js
+++ b/packages/@stylexjs/postcss-plugin/src/builder.js
@@ -104,8 +104,14 @@ function createBuilder() {
 
   // Transforms the included files, bundles the CSS, and returns the result.
   async function build({ shouldSkipTransformError }) {
-    const { cwd, babelConfig, useCSSLayers, importSources, isDev } =
-      getConfig();
+    const {
+      cwd,
+      babelConfig,
+      useCSSLayers,
+      enableLTRRTLComments,
+      importSources,
+      isDev,
+    } = getConfig();
 
     const files = getFiles();
     const filesToTransform = [];
@@ -151,7 +157,7 @@ function createBuilder() {
       }),
     );
 
-    const css = bundler.bundle({ useCSSLayers });
+    const css = bundler.bundle({ useCSSLayers, enableLTRRTLComments });
     return css;
   }
 

--- a/packages/@stylexjs/postcss-plugin/src/bundler.js
+++ b/packages/@stylexjs/postcss-plugin/src/bundler.js
@@ -62,10 +62,13 @@ module.exports = function createBundler() {
   }
 
   //  Bundles all collected StyleX rules into a single CSS string.
-  function bundle({ useCSSLayers }) {
+  function bundle({ useCSSLayers, enableLTRRTLComments }) {
     const rules = Array.from(styleXRulesMap.values()).flat();
 
-    const css = stylexBabelPlugin.processStylexRules(rules, useCSSLayers);
+    const css = stylexBabelPlugin.processStylexRules(rules, {
+      useLayers: useCSSLayers,
+      enableLTRRTLComments,
+    });
 
     return css;
   }

--- a/packages/@stylexjs/postcss-plugin/src/plugin.js
+++ b/packages/@stylexjs/postcss-plugin/src/plugin.js
@@ -22,6 +22,7 @@ module.exports = function createPlugin() {
     include,
     exclude,
     useCSSLayers = false,
+    styleResolution = 'property-specificity',
     importSources = ['@stylexjs/stylex', 'stylex'],
   }) => {
     exclude = [
@@ -50,6 +51,7 @@ module.exports = function createPlugin() {
             cwd,
             babelConfig,
             useCSSLayers,
+            styleResolution,
             importSources,
             isDev,
           });

--- a/packages/@stylexjs/rollup-plugin/src/index.js
+++ b/packages/@stylexjs/rollup-plugin/src/index.js
@@ -76,10 +76,10 @@ export default function stylexPlugin({
     generateBundle(this: PluginContext) {
       const rules: Array<Rule> = Object.values(stylexRules).flat();
       if (rules.length > 0) {
-        const collectedCSS = stylexBabelPlugin.processStylexRules(
-          rules,
-          useCSSLayers,
-        );
+        const collectedCSS = stylexBabelPlugin.processStylexRules(rules, {
+          useLayers: useCSSLayers,
+          enableLTRRTLComments: options?.enableLTRRTLComments,
+        });
 
         // Process the CSS using lightningcss
         const { code } = transform({

--- a/packages/docs/scripts/make-stylex-sheet.js
+++ b/packages/docs/scripts/make-stylex-sheet.js
@@ -77,11 +77,10 @@ async function genSheet() {
 
   const ruleSets = await Promise.all(allFiles.map(transformFile));
 
-  const generatedCSS = stylexBabelPlugin.processStylexRules(
-    ruleSets.flat(),
-    false,
-    'property-specificity',
-  );
+  const generatedCSS = stylexBabelPlugin.processStylexRules(ruleSets.flat(), {
+    useLayers: false,
+    enableLTRRTLComments: false,
+  });
 
   await mkdirp(path.join(__dirname, '../.stylex/'));
 

--- a/packages/docs/scripts/make-stylex-sheet.js
+++ b/packages/docs/scripts/make-stylex-sheet.js
@@ -77,7 +77,11 @@ async function genSheet() {
 
   const ruleSets = await Promise.all(allFiles.map(transformFile));
 
-  const generatedCSS = stylexBabelPlugin.processStylexRules(ruleSets.flat());
+  const generatedCSS = stylexBabelPlugin.processStylexRules(
+    ruleSets.flat(),
+    false,
+    'property-specificity',
+  );
 
   await mkdirp(path.join(__dirname, '../.stylex/'));
 


### PR DESCRIPTION
To enable us to use `processStylexRules` internally, let's port some of the special handling we do in Haste to the OSS implementation. We only need to apply this to the legacy style resolution, which is only used inside of Meta. It's more performant to move this logic here than to do additional post processing again after grabbing the outputted rules

This includes:
- Adding generalizable config to `processStylexRules` to replace the previous useLayers param (backwards compatible via boolean check) 
- Adding `/* @ltr begin */` comments
    - The logical style polyfills that generate these comments are being removed, but we need to keep inline `float` polyfills for a while longer, and for legacy browsers
- Adding `theme` specificity bumps globally. We do this to bump the specificity of `createTheme` above `defineVars` with multiple sheets, but we can also do it everywhere (see: https://www.internalfb.com/diff/D66392781) 

### Testing:

- We expect no changes to OSS `styleResolution`s. The use of `processStylexRules` will be gated.
- No visual regressions to themes and LTR/RTL rendering

<img width="1306" height="608" alt="image" src="https://github.com/user-attachments/assets/9b9f82d1-d3d5-442d-9ced-13f7f04293b9" />
