### PR TITLE
Adding position try to valid styles

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -562,6 +562,34 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       },
     })
     `,
+    // test for positionTryFallbacks with 'none'
+    `
+    import * as stylex from '@stylexjs/stylex';
+    stylex.create({
+      default: {
+        positionTryFallbacks: 'none',
+      },
+    });
+    `,
+    // test for positionTryFallbacks with string variable
+    `
+    import * as stylex from '@stylexjs/stylex';
+    const fallbackName = '--my-fallback';
+    stylex.create({
+      default: {
+        positionTryFallbacks: fallbackName,
+      },
+    });
+    `,
+    // test for positionTryFallbacks with multiple fallbacks
+    `
+    import * as stylex from '@stylexjs/stylex';
+    stylex.create({
+      default: {
+        positionTryFallbacks: '--fallback1, --fallback2, --fallback3',
+      },
+    });
+    `,
   ],
   invalid: [
     {
@@ -1943,6 +1971,28 @@ revert`,
         });
       `,
       errors: Array(31).fill({}),
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        stylex.create({
+          default: {
+            positionTryFallbacks: 42,
+          },
+        });
+      `,
+      errors: [
+        {
+          message: `positionTryFallbacks value must be one of:
+none
+a string literal
+null
+initial
+inherit
+unset
+revert`,
+        },
+      ],
     },
   ],
 });

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -587,6 +587,29 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       },
     });
     `,
+    // test for positionTryFallbacks with multiple stylex variables
+    `
+    import * as stylex from '@stylexjs/stylex';
+    const fallback1 = stylex.positionTry({
+      positionAnchor: '--anchor',
+      top: '0',
+      left: '0',
+      width: '100px',
+      height: '100px'
+    });
+    const fallback2 = stylex.positionTry({
+      positionAnchor: '--anchor',
+      bottom: '0',
+      right: '0',
+      width: '100px',
+      height: '100px'
+    });
+    stylex.create({
+      anchor: {
+        positionTryFallbacks: \`\${fallback1}, \${fallback2}\`,
+      },
+    });
+    `,
   ],
   invalid: [
     {

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -571,22 +571,19 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       },
     });
     `,
-    // test for positionTryFallbacks with string variable
+    // test for positionTryFallbacks with stylex variable
     `
     import * as stylex from '@stylexjs/stylex';
-    const fallbackName = '--my-fallback';
-    stylex.create({
-      default: {
-        positionTryFallbacks: fallbackName,
-      },
+    const fallback = stylex.positionTry({
+      positionAnchor: '--anchor',
+      top: '0',
+      left: '0',
+      width: '100px',
+      height: '100px'
     });
-    `,
-    // test for positionTryFallbacks with multiple fallbacks
-    `
-    import * as stylex from '@stylexjs/stylex';
     stylex.create({
-      default: {
-        positionTryFallbacks: '--fallback1, --fallback2, --fallback3',
+      anchor: {
+        positionTryFallbacks: fallback,
       },
     });
     `,
@@ -1985,7 +1982,8 @@ revert`,
         {
           message: `positionTryFallbacks value must be one of:
 none
-a string literal
+a CSS Variable
+a \`positionTry(...)\` function call, a reference to it or a many such valid
 null
 initial
 inherit

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -1994,10 +1994,6 @@ const CSSProperties = {
   pointerEvents: pointerEvents,
   position: position,
 
-  positionTryFallbacks: makeUnionRule(
-    makeLiteralRule('none'),
-    isString,
-  ) as RuleCheck,
 
   // Shorthand not yet supported
   placeContent: isString,

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -1994,7 +1994,6 @@ const CSSProperties = {
   pointerEvents: pointerEvents,
   position: position,
 
-
   // Shorthand not yet supported
   placeContent: isString,
   placeItems: isString,

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -1994,6 +1994,11 @@ const CSSProperties = {
   pointerEvents: pointerEvents,
   position: position,
 
+  positionTryFallbacks: makeUnionRule(
+    makeLiteralRule('none'),
+    isString,
+  ) as RuleCheck,
+
   // Shorthand not yet supported
   placeContent: isString,
   placeItems: isString,

--- a/packages/@stylexjs/eslint-plugin/src/rules/isPositionTryFallbacks.js
+++ b/packages/@stylexjs/eslint-plugin/src/rules/isPositionTryFallbacks.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+import type { RuleResponse, Variables } from '../stylex-valid-styles';
+import type { Node } from 'estree';
+
+export default function isPositionTryFallbacks(
+  styleXDefaultImports: Set<string>,
+  styleXPositionTryImports: Set<string>,
+): (node: Node, variables?: Variables) => RuleResponse {
+  return function isPositionTryFallbacksRec(
+    node: Node,
+    variables?: Variables,
+  ): RuleResponse {
+    if (
+      node.type === 'CallExpression' &&
+      node.callee.type === 'MemberExpression' &&
+      node.callee.object.type === 'Identifier' &&
+      node.callee.property.type === 'Identifier' &&
+      node.callee.property.name === 'positionTry' &&
+      (node.callee.object.name === 'stylex' ||
+        styleXDefaultImports.has(node.callee.object.name))
+    ) {
+      return undefined;
+    }
+    if (
+      node.type === 'CallExpression' &&
+      node.callee.type === 'Identifier' &&
+      (node.callee.name === 'positionTry' ||
+        styleXPositionTryImports.has(node.callee.name))
+    ) {
+      return undefined;
+    }
+    if (node.type === 'Identifier' && variables && variables.has(node.name)) {
+      const variable = variables.get(node.name);
+      if (variable === 'ARG') {
+        return undefined;
+      }
+      if (variable != null) {
+        return isPositionTryFallbacksRec(variable, variables);
+      } else {
+        return {
+          message:
+            'All expressions in a template literal must be a `positionTry(...)` function call',
+        };
+      }
+    }
+    if (node.type === 'TemplateLiteral') {
+      if (
+        !node.expressions.every(
+          (expr) => isPositionTryFallbacksRec(expr, variables) === undefined,
+        )
+      ) {
+        return {
+          message:
+            'All expressions in a template literal must be a `positionTry(...)` function call',
+        };
+      }
+      if (
+        !node.quasis.every((quasi, index, { length }) =>
+          index === 0 || index === length - 1
+            ? quasi.value.raw === ''
+            : quasi.value.raw === ', ',
+        )
+      ) {
+        return {
+          message:
+            'position try fallbacks must be separated by a comma and a space (", ")',
+        };
+      }
+      return undefined;
+    }
+    return {
+      message:
+        'a `positionTry(...)` function call, a reference to it or a many such valid',
+    };
+  };
+}

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -36,7 +36,9 @@ import isString from './rules/isString';
 import makeUnionRule from './rules/makeUnionRule';
 import isNumber from './rules/isNumber';
 import isAnimationName from './rules/isAnimationName';
+import isPositionTryFallbacks from './rules/isPositionTryFallbacks';
 import isStylexResolvedVarsToken from './rules/isStylexResolvedVarsToken';
+import isCSSVariable from './rules/isCSSVariable';
 import evaluate from './utils/evaluate';
 import resolveKey from './utils/resolveKey';
 import {
@@ -204,6 +206,7 @@ const stylexValidStyles = {
     const styleXDefaultImports = new Set<string>();
     const styleXCreateImports = new Set<string>();
     const styleXKeyframesImports = new Set<string>();
+    const styleXPositionTryImports = new Set<string>();
 
     const overrides: PropLimits = {
       ...(banPropsForLegacy ? legacyProps : {}),
@@ -216,6 +219,12 @@ const stylexValidStyles = {
       animationName: makeUnionRule(
         makeLiteralRule('none'),
         isAnimationName(styleXDefaultImports, styleXKeyframesImports),
+        all,
+      ),
+      positionTryFallbacks: makeUnionRule(
+        makeLiteralRule('none'),
+        isCSSVariable,
+        isPositionTryFallbacks(styleXDefaultImports, styleXPositionTryImports),
         all,
       ),
     };
@@ -734,6 +743,12 @@ const stylexValidStyles = {
                 specifier.imported.name === 'keyframes'
               ) {
                 styleXKeyframesImports.add(specifier.local.name);
+              }
+              if (
+                specifier.type === 'ImportSpecifier' &&
+                specifier.imported.name === 'positionTry'
+              ) {
+                styleXPositionTryImports.add(specifier.local.name);
               }
             });
           }


### PR DESCRIPTION
## What changed / motivation ?

Please include relevant motivation and context

The use of positionTryFallbacks causes a lint error:  This is not a key that is allowed by stylexESLint[stylex/valid-styles](https://www.internalfb.com/intern/bunny?q=eslint+stylex/valid-styles)

<img width="623" height="431" alt="image" src="https://github.com/user-attachments/assets/3d401695-c3b3-4082-a3ae-50081673a1e3" />


## Linked PR/Issues

N/A

## Additional Context

@mellyeliu allowed me to work on the change, so just tagging her here :)

Screenshots, Tests, Anything Else

I ran my tests using this command after moving to the eslint-plugin directory:
npx jest __tests__/stylex-valid-styles-test.js

made sure to check that 'npm run test' passes

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code