### PR TITLE
[eslint-plugin] Add `enforce-extension` to exported rules

### DIFF
--- a/packages/@stylexjs/eslint-plugin/src/index.js
+++ b/packages/@stylexjs/eslint-plugin/src/index.js
@@ -10,6 +10,7 @@
 import validStyles from './stylex-valid-styles';
 import sortKeys from './stylex-sort-keys';
 import validShorthands from './stylex-valid-shorthands';
+import enforceExtension from './stylex-enforce-extension';
 import noUnused from './stylex-no-unused';
 import noLegacyContextualStyles from './stylex-no-legacy-contextual-styles';
 
@@ -17,12 +18,14 @@ const rules: {
   'valid-styles': typeof validStyles,
   'sort-keys': typeof sortKeys,
   'valid-shorthands': typeof validShorthands,
+  'enforce-extension': typeof enforceExtension,
   'no-unused': typeof noUnused,
   'no-legacy-contextual-styles': typeof noLegacyContextualStyles,
 } = {
   'valid-styles': validStyles,
   'sort-keys': sortKeys,
   'valid-shorthands': validShorthands,
+  'enforce-extension': enforceExtension,
   'no-unused': noUnused,
   'no-legacy-contextual-styles': noLegacyContextualStyles,
 };

--- a/packages/docs/docs/api/configuration/eslint-plugin.mdx
+++ b/packages/docs/docs/api/configuration/eslint-plugin.mdx
@@ -130,7 +130,7 @@ type Options = {
 }
 ```
 
-### `@stylexjs/stylex-valid-shorthands` rule
+### `@stylexjs/valid-shorthands` rule
 
 ```ts
 type Options = {
@@ -151,7 +151,7 @@ type Options = {
 };
 ```
 
-### `@stylexjs/stylex-enforce-extension` rule
+### `@stylexjs/enforce-extension` rule
 
 ```ts
 type Options = {
@@ -167,7 +167,7 @@ type Options = {
 };
 ```
 
-### `@stylexjs/stylex-no-unused` rule
+### `@stylexjs/no-unused` rule
 
 ```ts
 type Options = {
@@ -178,7 +178,7 @@ type Options = {
 };
 ```
 
-### `@stylexjs/stylex-no-legacy-contextual-styles` rule
+### `@stylexjs/no-legacy-contextual-styles` rule
 
 ```ts
 type Options = {


### PR DESCRIPTION
## What changed / motivation ?

The `enforce-extension` rule is missing from the top level export, add it there.

Also fixed a few cases where we are referring to rule names with an extraneous `stylex-` prefix in packages/docs/docs/api/configuration/eslint-plugin.mdx.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code