### PR TITLE
[eslint-plugin] allow local resolved constants in valid-styles number checks

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -257,6 +257,15 @@ eslintTester.run('stylex-valid-styles', rule.default, {
          paddingInlineEnd: Math.round(5 / 2),
        },
      })`,
+    // test for locally declared constants
+    `import * as stylex from '@stylexjs/stylex';
+    const FOO = 5;
+     stylex.create({
+       default: {
+         scrollMarginTop: FOO + 5,
+         scrollMarginBottom: FOO * 5,
+       },
+     })`,
     `import * as stylex from '@stylexjs/stylex';
      const x = 5;
      stylex.create({
@@ -573,6 +582,50 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       errors: [
         {
           message: 'Styles must be represented as JavaScript objects',
+        },
+      ],
+    },
+    {
+      code: `import * as stylex from '@stylexjs/stylex';
+    import { FOO } from 'foo';
+     stylex.create({
+       default: {
+         scrollMarginTop: FOO + 5,
+       },
+     })`,
+      errors: [
+        {
+          message:
+            'scrollMarginTop value must be one of:\n' +
+            'a number literal or math expression\n' +
+            'a string literal\n' +
+            'null\n' +
+            'initial\n' +
+            'inherit\n' +
+            'unset\n' +
+            'revert',
+        },
+      ],
+    },
+    {
+      code: `import * as stylex from '@stylexjs/stylex';
+    const FOO = 'bad string';
+     stylex.create({
+       default: {
+         scrollMarginTop: FOO + 5,
+       },
+     })`,
+      errors: [
+        {
+          message:
+            'scrollMarginTop value must be one of:\n' +
+            'a number literal or math expression\n' +
+            'a string literal\n' +
+            'null\n' +
+            'initial\n' +
+            'inherit\n' +
+            'unset\n' +
+            'revert',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -55,6 +55,7 @@ export type RuleCheck = (
   node: $ReadOnly<Expression | Pattern>,
   variables?: Variables,
   prop?: $ReadOnly<Property>,
+  context?: Rule.RuleContext,
 ) => RuleResponse;
 export type RuleResponse = void | {
   message: string,
@@ -567,7 +568,12 @@ const stylexValidStyles = {
             } as Rule.ReportDescriptor);
           }
 
-          const check = ruleChecker(style.value, varsWithFnArgs, style);
+          const check = ruleChecker(
+            style.value,
+            varsWithFnArgs,
+            style,
+            context,
+          );
           if (check != null) {
             const { message, suggest } = check;
             return context.report({

--- a/packages/@stylexjs/eslint-plugin/src/utils/makeVariableCheckingRule.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/makeVariableCheckingRule.js
@@ -7,17 +7,20 @@
  * @flow strict
  */
 
-import type { Expression, Pattern } from 'estree';
+import type { Expression, Pattern, Property } from 'estree';
 import type {
   RuleCheck,
   RuleResponse,
   Variables,
 } from '../stylex-valid-styles';
+/*:: import { Rule } from 'eslint'; */
 
 export default function makeVariableCheckingRule(rule: RuleCheck): RuleCheck {
   const varCheckingRule = (
     node: Expression | Pattern,
     variables?: Variables,
+    prop?: $ReadOnly<Property>,
+    context?: Rule.RuleContext,
   ): RuleResponse => {
     if (
       // $FlowFixMe
@@ -25,7 +28,7 @@ export default function makeVariableCheckingRule(rule: RuleCheck): RuleCheck {
       // $FlowFixMe
       node.type === 'TSAsExpression'
     ) {
-      return varCheckingRule(node.expression, variables);
+      return varCheckingRule(node.expression, variables, prop, context);
     }
     if (node.type === 'Identifier' && variables != null) {
       const existingVar = variables.get(node.name);
@@ -33,10 +36,10 @@ export default function makeVariableCheckingRule(rule: RuleCheck): RuleCheck {
         return undefined;
       }
       if (existingVar != null) {
-        return varCheckingRule(existingVar, variables);
+        return varCheckingRule(existingVar, variables, prop, context);
       }
     }
-    return rule(node);
+    return rule(node, variables, prop, context);
   };
 
   return varCheckingRule;


### PR DESCRIPTION
The `isNumber` lint check was incorrectly flagging identifiers for constants declared in the same file. We generally allow them in place of number literals as Babel handles the static evaluation of these bindings.

The rule now resolves scope correctly so that same-file `const` identifiers initialized with numbers can be used within arithmetic expressions and pass without error.

Within the `isNumber` check
- resolve math expressions down to both sides as before
- use `getScope` to determine whether any identifiers are declared within the file