### PR TITLE
[babel-plugin] support `defineConsts` var() overrides

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -28,7 +28,7 @@ function transform(source, opts = {}) {
     import * as stylex from '@stylexjs/stylex';
     export const constants = stylex.defineConsts({
       YELLOW: 'yellow',
-      ORANGE: 'var(--orange)',
+      ORANGE: 'var(--orange-theme-color)',
       mediaBig: '@media (max-width: 1000px)',
       mediaSmall: '@media (max-width: 500px)'
     });
@@ -122,6 +122,9 @@ export const styles = stylex.create({
     margin: '10px 20px',
     float: 'inline-start'
   },
+  overrideColor: {
+    [constants.ORANGE]: 'red'
+  },
   dynamic: (color) => ({ color })
 });
 `;
@@ -134,7 +137,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         export const constants = {
           YELLOW: "yellow",
-          ORANGE: "var(--orange)",
+          ORANGE: "var(--orange-theme-color)",
           mediaBig: "@media (max-width: 1000px)",
           mediaSmall: "@media (max-width: 500px)"
         };
@@ -166,7 +169,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         export const constants = {
           YELLOW: "yellow",
-          ORANGE: "var(--orange)",
+          ORANGE: "var(--orange-theme-color)",
           mediaBig: "@media (max-width: 1000px)",
           mediaSmall: "@media (max-width: 500px)"
         };
@@ -190,7 +193,7 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const styles = {
           root: {
-            "animationName-kKVMdj": "animationName-xckgs0v",
+            "animationName-kKVMdj": "animationName-x13ah0pd",
             "backgroundColor-kWkggS": "backgroundColor-xrkmrrc",
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
             "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-x1cmij7u",
@@ -199,9 +202,13 @@ describe('@stylexjs/babel-plugin', () => {
             "float-kyUFMd": "float-x1kmio9f",
             $$css: "app/main.js:31"
           },
+          overrideColor: {
+            "--orange-theme-color": "--orange-theme-color-xufgesz",
+            $$css: "app/main.js:58"
+          },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:58"
+            $$css: "app/main.js:61"
           }, {
             "--x-color": color != null ? color : undefined
           }]
@@ -214,17 +221,18 @@ describe('@stylexjs/babel-plugin', () => {
         }),
       ).toMatchInlineSnapshot(`
         "@property --x-color { syntax: "*"; inherits: false;}
-        @keyframes xi07kvp-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange);}}
+        @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
         :root, .xsg933n{--blue-xpqh4lw:blue;}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
+        .--orange-theme-color-xufgesz{--orange-theme-color:red}
         .margin-xymmreb:not(#\\#){margin:10px 20px}
         .padding-xss17vw:not(#\\#){padding:var(--large-x1ec7iuc)}
         .borderColor-x1bg2uv5:not(#\\#):not(#\\#){border-color:green}
         @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c:not(#\\#):not(#\\#){border-color:var(--blue-xpqh4lw)}}
         @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys:not(#\\#):not(#\\#){border-color:yellow}}}
-        .animationName-xckgs0v:not(#\\#):not(#\\#):not(#\\#){animation-name:xi07kvp-B}
+        .animationName-x13ah0pd:not(#\\#):not(#\\#):not(#\\#){animation-name:x35atj5-B}
         .backgroundColor-xrkmrrc:not(#\\#):not(#\\#):not(#\\#){background-color:red}
         .color-x14rh7hd:not(#\\#):not(#\\#):not(#\\#){color:var(--x-color)}
         html:not([dir='rtl']) .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:left}
@@ -242,7 +250,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         export const constants = {
           YELLOW: "yellow",
-          ORANGE: "var(--orange)",
+          ORANGE: "var(--orange-theme-color)",
           mediaBig: "@media (max-width: 1000px)",
           mediaSmall: "@media (max-width: 500px)"
         };
@@ -266,7 +274,7 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const styles = {
           root: {
-            "animationName-kKVMdj": "animationName-xckgs0v",
+            "animationName-kKVMdj": "animationName-x13ah0pd",
             "backgroundColor-kWkggS": "backgroundColor-xrkmrrc",
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
             "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-x1cmij7u",
@@ -275,9 +283,13 @@ describe('@stylexjs/babel-plugin', () => {
             "float-kyUFMd": "float-x1kmio9f",
             $$css: "app/main.js:31"
           },
+          overrideColor: {
+            "--orange-theme-color": "--orange-theme-color-xufgesz",
+            $$css: "app/main.js:58"
+          },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:58"
+            $$css: "app/main.js:61"
           }, {
             "--x-color": color != null ? color : undefined
           }]
@@ -292,11 +304,12 @@ describe('@stylexjs/babel-plugin', () => {
         "
         @layer priority1, priority2, priority3, priority4;
         @property --x-color { syntax: "*"; inherits: false;}
-        @keyframes xi07kvp-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange);}}
+        @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
         :root, .xsg933n{--blue-xpqh4lw:blue;}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
+        .--orange-theme-color-xufgesz{--orange-theme-color:red}
         @layer priority2{
         .margin-xymmreb{margin:10px 20px}
         .padding-xss17vw{padding:var(--large-x1ec7iuc)}
@@ -307,7 +320,7 @@ describe('@stylexjs/babel-plugin', () => {
         @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
         }
         @layer priority4{
-        .animationName-xckgs0v{animation-name:xi07kvp-B}
+        .animationName-x13ah0pd{animation-name:x35atj5-B}
         .backgroundColor-xrkmrrc{background-color:red}
         .color-x14rh7hd{color:var(--x-color)}
         html:not([dir='rtl']) .float-x1kmio9f{float:left}
@@ -340,7 +353,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         export const constants = {
           YELLOW: "yellow",
-          ORANGE: "var(--orange)",
+          ORANGE: "var(--orange-theme-color)",
           mediaBig: "@media (max-width: 1000px)",
           mediaSmall: "@media (max-width: 500px)"
         };


### PR DESCRIPTION
Adds support for overriding `defineConsts` variables that are set to `var(--*)` references when used in `stylex.create` to support Figma migration to StyleX.

- Previously, constants defined as CSS variable indirections could not be overridden in component create calls because the key reference was not changed. 
- We now map the `--consthash` value to the CSS variable name (`--background-color` in the example)
   - We replace `var(--hash)` with the `constValue` as always
   - We replace `--hash:` with the extracted `--varName:` for both simple variables `var(--varName)` and fallback variables `var(--varName, fallback)`. The `:` is to ensure we're replacing keys and not other edge cases that interfere with debug classnames 
- Constants now behave more like passthroughs: if the referenced CSS variable has an override, the override will be applied

We generally discourage this level of abstraction for maintenance reasons but want to provide optionality for users

```tsx
const colors = stylex.defineConsts({
  bg: "var(--background-color)",
  accent: "var(--accent, lightblue)"
});
```

Can now be used like so, similar to `defineVars`

```tsx
const styles = stylex.create({
  root: {
    [colors.bg]: "red",
    [colors.accent]: "darkblue"
  }
});
```

Tested on NextJS app for the following cases:
- Handling of regular values
- Handling of simple variables like `var(--background-color)`
- Handling of fallback vars `var(--background-color, fallback)`, testing with dynamic variables, etc

As a follow up,`transform-process` tests should to be rewritten to properly `defineConsts` transforms