### PR TITLE
[babel-plugin][legacy] omit `enableLogicalStylesPolyfill` config in keyframes

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-logical-values-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-logical-values-test.js
@@ -296,6 +296,41 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
+    // TODO: Add support for logical styles config
+    test.skip('[legacy] value of "paddingInline" property', () => {
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            x: {
+              animationName: stylex.keyframes({
+                '0%': {
+                  paddingInline: '1px 2px'
+                },
+                '100%': {
+                  paddingInline: '10px 20px'
+                }
+              })
+            }
+          });
+          const classnames = stylex(styles.x);
+        `,
+          {
+            enableLogicalStylesPolyfill: true,
+            styleResolution: 'legacy-expand-shorthands',
+          },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2("@keyframes x4skwlr-B{0%{padding-left:1px;padding-right:2px;}100%{padding-left:10px;padding-right:20px;}}", 0);
+        _inject2(".xzebctn{animation-name:x4skwlr-B}", 3000);
+        const classnames = "xzebctn";"
+      `);
+    });
+
     test('[legacy] value of "boxShadow" property', () => {
       expect(
         transform(
@@ -305,11 +340,9 @@ describe('@stylexjs/babel-plugin', () => {
             x: {
               animationName: stylex.keyframes({
                 '0%': {
-                  borderInlineEnd: '1px solid red',
                   boxShadow: '1px 2px 3px 4px red'
                 },
                 '100%': {
-                  borderInlineEnd: '1px solid transparent',
                   boxShadow: '10px 20px 30px 40px green'
                 }
               })
@@ -319,7 +352,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           {
             enableLegacyValueFlipping: true,
-            enableLogicalStylesPolyfill: true,
             styleResolution: 'legacy-expand-shorthands',
           },
         ),
@@ -327,9 +359,9 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2("@keyframes xz8o398-B{0%{border-right:1px solid red;box-shadow:1px 2px 3px 4px red;}100%{border-right:1px solid transparent;box-shadow:10px 20px 30px 40px green;}}", 0, "@keyframes xz8o398-B{0%{border-left:1px solid red;box-shadow:-1px 2px 3px 4px red;}100%{border-left:1px solid transparent;box-shadow:-10px 20px 30px 40px green;}}");
-        _inject2(".x1zkcg6{animation-name:xz8o398-B}", 3000);
-        const classnames = "x1zkcg6";"
+        _inject2("@keyframes x19mpx8i-B{0%{box-shadow:1px 2px 3px 4px red;}100%{box-shadow:10px 20px 30px 40px green;}}", 0);
+        _inject2(".x14pamct{animation-name:x19mpx8i-B}", 3000);
+        const classnames = "x14pamct";"
       `);
 
       expect(

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-keyframes.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-keyframes.js
@@ -46,10 +46,10 @@ export default function styleXKeyframes(
   );
 
   const ltrStyles = objMap(expandedObject, (frame) =>
-    objMapEntry(frame, (entry) => generateLtr(entry, options)),
+    objMapEntry(frame, generateLtr),
   );
   const rtlStyles = objMap(expandedObject, (frame) =>
-    objMapEntry(frame, (entry) => generateRtl(entry, options) ?? entry),
+    objMapEntry(frame, (entry) => generateRtl(entry) ?? entry),
   );
 
   const ltrString = constructKeyframesObj(ltrStyles);


### PR DESCRIPTION
This is an temporary fix for keyframes based on our CSS/JS pipeline limitations for our logical styles experiment:
- We're running an experiment to ship logical styles behind `enableLogicalStylesPolyfill`  for legacy migration and to allow for flexible direction modes across a page
- In [dbc6c3](https://github.com/facebook/stylex/pull/1144/commits/dbc6c374f5577f7e070900e67c9d4995dafae4b5) we added logic to use logical styles in keyframes for consistency. Since keyframes classname generation depends on the property key after polyfill, this ends up generating different classnames across experiment modes, leading to JS/CSS mismatch
- For styles within `stylex.create` classnames are stable with and without `enableLogicalStylesPolyfill` turned on. The polyfill is applied after classname construction, so the same CSS rule simply has a different property: value pair inside
- We can't serve two different JS bundles because it would regress the Haste build

Follow up in https://github.com/facebook/stylex/pull/1223