### PR TITLE
[babel-plugin][legacy] make stable hashes for keyframes

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-logical-values-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/transform-logical-values-test.js
@@ -296,8 +296,7 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
-    // TODO: Add support for logical styles config
-    test.skip('[legacy] value of "paddingInline" property', () => {
+    test('[legacy] value of "paddingInline" property', () => {
       expect(
         transform(
           `
@@ -325,7 +324,39 @@ describe('@stylexjs/babel-plugin', () => {
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
-        _inject2("@keyframes x4skwlr-B{0%{padding-left:1px;padding-right:2px;}100%{padding-left:10px;padding-right:20px;}}", 0);
+        _inject2("@keyframes x4skwlr-B{0%{padding-left:1px;padding-right:2px;}100%{padding-left:10px;padding-right:20px;}}", 0, "@keyframes x4skwlr-B{0%{padding-right:1px;padding-left:2px;}100%{padding-right:10px;padding-left:20px;}}");
+        _inject2(".xzebctn{animation-name:x4skwlr-B}", 3000);
+        const classnames = "xzebctn";"
+      `);
+
+      expect(
+        transform(
+          `
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            x: {
+              animationName: stylex.keyframes({
+                '0%': {
+                  paddingInline: '1px 2px'
+                },
+                '100%': {
+                  paddingInline: '10px 20px'
+                }
+              })
+            }
+          });
+          const classnames = stylex(styles.x);
+        `,
+          {
+            enableLogicalStylesPolyfill: false,
+            styleResolution: 'legacy-expand-shorthands',
+          },
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2("@keyframes x4skwlr-B{0%{padding-inline-start:1px;padding-inline-end:2px;}100%{padding-inline-start:10px;padding-inline-end:20px;}}", 0);
         _inject2(".xzebctn{animation-name:x4skwlr-B}", 3000);
         const classnames = "xzebctn";"
       `);

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-keyframes.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-keyframes.js
@@ -46,18 +46,24 @@ export default function styleXKeyframes(
   );
 
   const ltrStyles = objMap(expandedObject, (frame) =>
-    objMapEntry(frame, generateLtr),
+    objMapEntry(frame, (entry) => generateLtr(entry, options)),
   );
   const rtlStyles = objMap(expandedObject, (frame) =>
-    objMapEntry(frame, (entry) => generateRtl(entry) ?? entry),
+    objMapEntry(frame, (entry) => generateRtl(entry, options) ?? entry),
+  );
+  const stableStyles = objMap(expandedObject, (frame) =>
+    objMapEntry(frame, generateLtr),
   );
 
   const ltrString = constructKeyframesObj(ltrStyles);
   const rtlString = constructKeyframesObj(rtlStyles);
+  const stableString = constructKeyframesObj(stableStyles);
 
+  // NOTE: Use a direction-agnostic hash to keep LTR/RTL classnames stable across builds.
   // NOTE: '<>' and '-B' is used to keep existing hashes stable.
   // They should be removed in a future version.
-  const animationName = classNamePrefix + createHash('<>' + ltrString) + '-B';
+  const animationName =
+    classNamePrefix + createHash('<>' + stableString) + '-B';
 
   const ltr = `@keyframes ${animationName}{${ltrString}}`;
   const rtl =


### PR DESCRIPTION
Better follow up to https://github.com/facebook/stylex/pull/1222

We don't need to remove the options, just make a `animationName` that is stable across both LTR/RTL variants so we can serve the same JS per LTR/RTL CSS variant