### PR TITLE
[eslint-plugin] declare `postcss-value-parser` as dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27169,7 +27169,8 @@
       "license": "MIT",
       "dependencies": {
         "css-shorthand-expand": "^1.2.0",
-        "micromatch": "^4.0.5"
+        "micromatch": "^4.0.5",
+        "postcss-value-parser": "^4.2.0"
       }
     },
     "packages/@stylexjs/postcss-plugin": {

--- a/packages/@stylexjs/eslint-plugin/package.json
+++ b/packages/@stylexjs/eslint-plugin/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "css-shorthand-expand": "^1.2.0",
-    "micromatch": "^4.0.5"
+    "micromatch": "^4.0.5",
+    "postcss-value-parser": "^4.2.0"
   },
   "files": [
     "flow_modules/*",


### PR DESCRIPTION
## What changed / motivation ?

`@stylexjs/eslint-plugin` still uses `postcss-value-parser`:

https://github.com/facebook/stylex/blob/f585df9713c73fc2eddec8900158e4402f718dc1/packages/%40stylexjs/eslint-plugin/src/utils/splitShorthands.js#L10

But `postcss-value-parser` is not declared as a dependency of `@stylexjs/eslint-plugin`, which sometimes causes ESLint/Node.js to scream `Error: Cannot find module 'postcss-value-parser'` (due to transitive dependencies being disallowed).

The PR adds `postcss-value-parser` to `@stylexjs/eslint-plugin`'s deps list to prevent the module not found error.

## Linked PR/Issues

N/A

## Additional Context

In the future, `postcss-value-parser` would be replaced by `style-value-parser`, but for now, let's just add `postcss-value-parser` to the deps to stop the module not found error from screaming.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code