### PR TITLE
[eslint-plugin] feat: add option to allow raw CSS variable overrides in valid-styles

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -1796,6 +1796,18 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
           },
         });`,
     },
+    // test for allowed raw CSS variable overrides
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          foo: {
+            '--bar': '0',
+          }
+        })
+      `,
+      options: [{ allowRawCSSVars: true }],
+    },
   ],
   invalid: [
     {
@@ -2141,6 +2153,23 @@ initial
 inherit
 unset
 revert`,
+        },
+      ],
+    },
+    // test for disallowed raw CSS variable overrides
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          foo: {
+            '--bar': '0',
+          }
+        })
+      `,
+      options: [{ allowRawCSSVars: false }],
+      errors: [
+        {
+          message: 'This is not a key that is allowed by stylex',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -102,6 +102,10 @@ const stylexValidStyles = {
             },
             default: ['stylex', '@stylexjs/stylex'],
           },
+          allowRawCSSVars: {
+            type: 'boolean',
+            default: false,
+          },
           allowOuterPseudoAndMedia: {
             type: 'boolean',
             default: false,
@@ -162,6 +166,7 @@ const stylexValidStyles = {
             as: string,
           },
       >,
+      allowRawCSSVars: boolean,
       allowOuterPseudoAndMedia: boolean,
       banPropsForLegacy: boolean,
       propLimits?: PropLimits,
@@ -180,6 +185,7 @@ const stylexValidStyles = {
 
     const {
       validImports: importsToLookFor = ['stylex', '@stylexjs/stylex'],
+      allowRawCSSVars = false,
       allowOuterPseudoAndMedia,
       banPropsForLegacy = false,
       propLimits = {},
@@ -459,6 +465,10 @@ const stylexValidStyles = {
         }
         const ruleChecker = CSSPropertiesWithOverrides[key];
         if (ruleChecker == null) {
+          if (allowRawCSSVars && micromatch.isMatch(key, '--*')) {
+            return;
+          }
+
           const closestKey = CSSPropertyKeys.find((cssProp) => {
             const distance = getDistance(key, cssProp, 2);
             return distance <= 2;

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -104,7 +104,7 @@ const stylexValidStyles = {
           },
           allowRawCSSVars: {
             type: 'boolean',
-            default: false,
+            default: true,
           },
           allowOuterPseudoAndMedia: {
             type: 'boolean',
@@ -185,7 +185,7 @@ const stylexValidStyles = {
 
     const {
       validImports: importsToLookFor = ['stylex', '@stylexjs/stylex'],
-      allowRawCSSVars = false,
+      allowRawCSSVars = true,
       allowOuterPseudoAndMedia,
       banPropsForLegacy = false,
       propLimits = {},


### PR DESCRIPTION
## What changed / motivation ?

Add an option `allowRawCSSVars` to `valid-styles` to allow styles to target raw CSS variables.

## Linked PR/Issues

Fixes [#1226](https://github.com/facebook/stylex/issues/1226)

## Additional Context

Simple test cases added and are passing.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code