### PR TITLE
[eslint-plugin] Remove `valid-styles` check for non-objects in favor of flow

### DIFF
--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -846,13 +846,8 @@ const stylexValidStyles = {
                 }
               });
             } else {
-              return context.report({
-                node: namespace.value,
-                loc: namespace.value.loc,
-                message:
-                  'Styles must be represented as JavaScript objects, not ' +
-                  styles.type,
-              });
+              // This case should be already handled by type checking.
+              return;
             }
           }
           styles.properties.forEach((prop) =>

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.js
@@ -145,7 +145,7 @@ export type MapNamespaces<+S: { +[string]: mixed }> = $ReadOnly<{
     ? (...args: Args) => $ReadOnly<[MapNamespace<Obj>, InlineStyles]>
     : MapNamespace<S[Key]>,
 }>;
-export type StyleX$Create = <S: { +[string]: mixed }>(
+export type StyleX$Create = <S: { +[string]: { ... } }>(
   styles: S,
 ) => MapNamespaces<S>;
 


### PR DESCRIPTION
## What changed / motivation ?

We want to let flow to account for styles being valid objects.

## Linked PR/Issues

This is also to simplify the reporting of the styles/valid-styles eslint rule
Partially Fixes #1201 

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code