### PR TITLE
[eslint-plugin] allow one inner level when outer/top layer is pseudo-element

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -624,6 +624,28 @@ eslintTester.run('stylex-valid-styles', rule.default, {
     {
       code: `
         import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            ':focus': {
+              ':hover': {
+                ':active': {
+                  color: 'red'
+                }
+              }
+            }
+          }
+        });
+      `,
+      options: [{ allowOuterPseudoAndMedia: true }],
+      errors: [
+        {
+          message: 'You cannot nest styles more than one level deep',
+        },
+      ],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
         const styles = {default: {width: '30pt'}};
         stylex.create(styles);
       `,
@@ -1808,6 +1830,21 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
       `,
       options: [{ allowRawCSSVars: true }],
     },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            '::after': {
+              ':hover': {
+                content: ''
+              }
+            }
+          }
+        });
+      `,
+      options: [{ allowOuterPseudoAndMedia: true }],
+    },
   ],
   invalid: [
     {
@@ -1839,6 +1876,26 @@ initial
 inherit
 unset
 revert`,
+        },
+      ],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        stylex.create({
+          default: {
+            ':focus': {
+              '::after': {
+                content: ''
+              }
+            }
+          }
+        });
+      `,
+      options: [{ allowOuterPseudoAndMedia: true }],
+      errors: [
+        {
+          message: 'You cannot nest styles more than one level deep',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -304,6 +304,7 @@ const stylexValidStyles = {
       style: Node,
       level: number,
       propName: null | string,
+      outerIsPseudoElement: boolean,
     ): void {
       // currently ignoring preset spreads.
       if (style.type === 'Property') {
@@ -312,7 +313,12 @@ const stylexValidStyles = {
           const styleValue: ObjectExpression = style.value;
           // TODO: Remove this soon
           // But we want to make sure that the same "condition" isn't repeated
-          if (level > 0 && propName == null) {
+          if (
+            level > 0 &&
+            propName == null &&
+            // Allow exactly one inner level when the outer/top nested layer is a pseudo-element
+            !(outerIsPseudoElement && level === 1)
+          ) {
             return context.report({
               node: style.value as Node,
               loc: style.value.loc,
@@ -394,6 +400,7 @@ const stylexValidStyles = {
                 keyName === 'default'
                   ? null
                   : keyName),
+              outerIsPseudoElement || keyName.startsWith('::'),
             ),
           );
         }
@@ -851,7 +858,7 @@ const stylexValidStyles = {
             }
           }
           styles.properties.forEach((prop) =>
-            checkStyleProperty(prop, 0, null),
+            checkStyleProperty(prop, 0, null, false),
           );
           // Reset local variables.
           dynamicStyleVariables.clear();


### PR DESCRIPTION
## What changed / motivation ?

- Updated `valid-styles` to allow one extra nesting level when the outer selector is a pseudo-element (`::...`).
- Implemented a propagation flag to detect top-level pseudo-elements and permit exactly one deeper level.
- Added tests: 
   - valid `::after` > `:hover`
   - invalid `:focus` > `::after`
   - invalid triple nesting depth.
- Motivation: match expected authoring pattern for pseudo-elements while preserving overall nesting limits.

## Linked PR/Issues

Fixes #1230

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

See added tests in `packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js`

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code