### PR TITLE
fix: Allow `defineConsts` to take numbers as values with TypeScript

### DIFF
--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
@@ -248,9 +248,9 @@ export type IDFromVarGroup<T extends VarGroup<{}>> = T['__opaqueId'];
 
 type TTokens = Readonly<{
   [key: string]:
+    | NestedVarObject<null | string | number>
+    | StyleXVar<null | string | number>
     | CSSType<null | string | number>
-    | string
-    | { [key: string]: string };
 }>;
 
 type UnwrapVars<T> = T extends StyleXVar<infer U> ? U : T;
@@ -264,7 +264,7 @@ type NestedVarObject<T> =
   | T
   | Readonly<{
       default: NestedVarObject<T>;
-      [key: `@${string}`]: NestedVarObject<T>;
+      [key: AtRuleStr]: NestedVarObject<T>;
     }>;
 
 export type StyleX$DefineConsts = <

--- a/packages/typescript-tests/src/typetests.ts
+++ b/packages/typescript-tests/src/typetests.ts
@@ -294,3 +294,18 @@ styles8.foo satisfies StyleXStylesWithout<{ height: unknown }>;
 styles8.foo satisfies StyleXStylesWithout<{ color: unknown }>;
 
 stylex.props(styles8.foo);
+
+// StyleX consts
+
+const consts = stylex.defineConsts({
+  foo: 'bar',
+  bar: 123,
+  baz: {
+    default: 'qux',
+    '@media (max-width: 1000px)': 'quuz',
+  }
+} as const)
+
+consts.foo satisfies StyleXVar<'bar'>;
+consts.bar satisfies StyleXVar<123>;
+consts.baz satisfies StyleXVar<'qux' | 'quuz'>;


### PR DESCRIPTION
## What changed / motivation ?

There seems to be a divergence between the type of `TTokens` in Flow vs. in TypeScript. This causes `defineConsts` to reject number values in TypeScript, like so:
```ts
export const zIndex = stylex.defineConsts({
  // Type 'number' is not assignable to type 'string | CSSType<string | number | null> | { [key: string]: string; }'.ts(2322)
  connector: 1,
  bifurcatedPicker: 2,
})
```

Sync the type of `TTokens` in `packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts` against that of `packages/@stylexjs/stylex/src/types/StyleXTypes.js` to fix this.

## Additional Context

Test case added to `packages/typescript-tests/src/typetests.ts`.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code