### PR TITLE
[eslint-plugin] allow multiple comma separated values for `backgroundBlendMode`

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -1845,6 +1845,26 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
       `,
       options: [{ allowOuterPseudoAndMedia: true }],
     },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          container: {
+            backgroundBlendMode: 'multiply',
+          },
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          container: {
+            backgroundBlendMode: 'multiply, darken, exclusion',
+          },
+        });
+      `,
+    },
   ],
   invalid: [
     {
@@ -2227,6 +2247,97 @@ revert`,
       errors: [
         {
           message: 'This is not a key that is allowed by stylex',
+        },
+      ],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          container: {
+            backgroundBlendMode: 'invalid-blend-mode',
+          },
+        });
+      `,
+      errors: [
+        {
+          message: `backgroundBlendMode value must be one of:
+normal
+multiply
+screen
+overlay
+darken
+lighten
+color-dodge
+color-burn
+hard-light
+soft-light
+difference
+exclusion
+hue
+saturation
+color
+luminosity
+null
+initial
+inherit
+unset
+revert`,
+        },
+      ],
+    },
+    // test for backgroundBlendMode with invalid blend mode value in comma-separated list
+    // 'darke' should be 'darken'
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          container: {
+            backgroundBlendMode: 'multiply, darke, exclusion',
+          },
+        });
+      `,
+      errors: [
+        {
+          message: `backgroundBlendMode value must be one of:
+normal
+multiply
+screen
+overlay
+darken
+lighten
+color-dodge
+color-burn
+hard-light
+soft-light
+difference
+exclusion
+hue
+saturation
+color
+luminosity
+null
+initial
+inherit
+unset
+revert`,
+        },
+      ],
+    },
+    // test for incorrect spacing around comma in backgroundBlendMode
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          container: {
+            backgroundBlendMode: 'multiply, darken,exclusion',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            "backgroundBlendMode values must be separated by a comma and a space (', ')",
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -602,14 +602,25 @@ const stylexValidStyles = {
           );
           if (check != null) {
             const { message, suggest } = check;
+            const isBackgroundBlendModeFormatError =
+              key === 'backgroundBlendMode' &&
+              typeof message === 'string' &&
+              message.indexOf(
+                'backgroundBlendMode values must be separated by a comma and a space',
+              ) !== -1;
+
+            const finalMessage = isBackgroundBlendModeFormatError
+              ? message.split('\n')[0]
+              : `${key} value must be one of:\n${message}${
+                  key === 'lineHeight'
+                    ? '\nBe careful when fixing: lineHeight: 10px is not the same as lineHeight: 10'
+                    : ''
+                }`;
+
             return context.report({
               node: style.value,
               loc: style.value.loc,
-              message: `${key} value must be one of:\n${message}${
-                key === 'lineHeight'
-                  ? '\nBe careful when fixing: lineHeight: 10px is not the same as lineHeight: 10'
-                  : ''
-              }`,
+              message: finalMessage,
               suggest: suggest != null ? [suggest] : undefined,
             } as Rule.ReportDescriptor);
           }


### PR DESCRIPTION
## What changed / motivation ?

- Improved backgroundBlendMode validator to parse comma-separated tokens and provide an auto-fix suggestion for missing spaces.
- When the comma+space formatting is wrong, we now show only the formatting hint and suppress the CSS-wide keyword list. _also all of the comma separated items are checked against the existing `blendMode` ruleset_


## Linked PR/Issues

Fixes #1213

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

ESLint rule tests extended in @stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js.

**Demonstration:**

<img width="1175" height="83" alt="Screenshot 2025-09-24 at 08 40 48" src="https://github.com/user-attachments/assets/cc55a9d1-e1b4-4689-86d4-35ab4cfc8fe5" /><br>

<img width="1175" height="83" alt="Screenshot 2025-09-24 at 08 41 00" src="https://github.com/user-attachments/assets/b8e64cf1-6d70-4ba2-b4f2-ee726cbfb550" /><br>

<img width="1175" height="83" alt="Screenshot 2025-09-24 at 08 41 30" src="https://github.com/user-attachments/assets/ac5529d1-a3b9-4dc7-a08b-9dbc82a8b8b2" /><br>

<img width="1175" height="83" alt="Screenshot 2025-09-24 at 08 53 16" src="https://github.com/user-attachments/assets/806d4dd0-70a8-4682-8a9b-73f5b26de218" /><br>

<img width="1175" height="83" alt="Screenshot 2025-09-24 at 08 41 46" src="https://github.com/user-attachments/assets/f2da6f1a-1269-4aab-908e-19a9b3f37bc0" /><br>

Comma fix:
<img width="1080" height="552" alt="Screenshot 2025-09-24 at 09 01 31" src="https://github.com/user-attachments/assets/88f05682-f65d-4eda-b4db-7a36b4f63c95" />


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code