### PR TITLE
[eslint] Split nonstandard rules into stylex-no-nonstandard-styles.js

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-no-nonstandard-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-no-nonstandard-styles-test.js
@@ -1,0 +1,874 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const { RuleTester: ESLintTester } = require('eslint');
+const rule = require('../src/stylex-no-nonstandard-styles');
+
+const eslintTester = new ESLintTester({
+  parser: require.resolve('hermes-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+eslintTester.run('stylex-no-nonstandard-styles', rule.default, {
+  valid: [
+    `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        validStyle: {
+          marginInlineStart: "10px",
+          marginInlineEnd: "5px",
+          marginInline: "15px",
+          marginBlock: "20px",
+          paddingInlineStart: "8px",
+          paddingInlineEnd: "12px",
+          paddingInline: "10px",
+          paddingBlock: "16px",
+        },
+      });
+    `,
+    `
+      const stylex = require('@stylexjs/stylex');
+      
+      const styles = stylex.create({
+        validStyle: {
+          marginInlineStart: "10px",
+          marginInlineEnd: "5px",
+          marginInline: "15px",
+          marginBlock: "20px",
+          paddingInlineStart: "8px",
+          paddingInlineEnd: "12px",
+          paddingInline: "10px",
+          paddingBlock: "16px",
+        },
+      });
+    `,
+    `
+      import * as stylex from '@stylexjs/stylex';
+      const start = 'start';
+      const grayscale = 'grayscale';
+      const styles = stylex.create({
+        default: {
+          textAlign: start,
+          MozOsxFontSmoothing: grayscale,
+          WebkitFontSmoothing: 'antialiased',
+          transitionProperty: 'opacity, transform',
+          transitionDuration: '0.3s',
+          transitionTimingFunction: 'ease',
+        }
+      });
+    `,
+    `
+      import * as stylex from '@stylexjs/stylex';
+      const bounce = stylex.keyframes({
+        '0%': {
+          transform: 'translateY(0)',
+        },
+        '50%': {
+          transform: 'translateY(-10px)',
+        },
+        '100%': {
+          transform: 'translateY(0)',
+        },
+      });
+      const styles = stylex.create({
+        default: {
+          animationName: bounce,
+          animationDuration: '1s',
+          animationIterationCount: 'infinite',
+        }
+      });
+    `,
+    `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        default: {
+          animationName: stylex.keyframes({
+            '0%': {
+              transform: 'translateY(0)',
+            },
+            '50%': {
+              transform: 'translateY(-10px)',
+            },
+            '100%': {
+              transform: 'translateY(0)',
+            },
+          }),
+          animationDuration: '1s',
+          animationIterationCount: 'infinite',
+        }
+      });
+    `,
+    `
+      import * as stylex from '@stylexjs/stylex';
+      const bounce = stylex.keyframes({
+        '0%': {
+          transform: 'translateY(0)',
+        },
+        '50%': {
+          transform: 'translateY(-10px)',
+        },
+        '100%': {
+          transform: 'translateY(0)',
+        },
+      });
+      const shimmy = stylex.keyframes({
+        '0%': {
+          backgroundPosition: '-468px 0',
+        },
+        '100%': {
+          backgroundPosition: '468px 0',
+        },
+      });
+      const styles = stylex.create({
+        default: {
+          animationName: \`\${bounce}, \${shimmy}\`,
+          animationDuration: '1s',
+          animationIterationCount: 'infinite',
+        }
+      });
+    `,
+    // test for positive numbers
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {marginInlineStart: 5}});",
+    // test for literals as namespaces
+    'import * as stylex from \'@stylexjs/stylex\'; stylex.create({"default-1": {marginInlineStart: 5}});',
+    'import * as stylex from \'@stylexjs/stylex\'; stylex.create({["default-1"]: {marginInlineStart: 5}});',
+    // test for numbers as namespaces
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({0: {marginInlineStart: 5}});",
+    // test for computed numbers as namespaces
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({[0]: {marginInlineStart: 5}});",
+    // test for negative values.
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {marginInlineStart: -5}});",
+    // test for unitless length value 0
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {margin: 0}});",
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {padding: '0'}});",
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {textAlign: 'start'}});",
+    // test for presets
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         textAlign: 'start',
+       }
+     });`,
+    // test for Math
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         marginInlineStart: Math.abs(-1),
+         marginInlineEnd: \`\${Math.floor(5 / 2)}px\`,
+         paddingInlineStart: Math.ceil(5 / 2),
+         paddingInlineEnd: Math.round(5 / 2),
+       },
+     })`,
+    // test for locally declared constants
+    `import * as stylex from '@stylexjs/stylex';
+    const FOO = 5;
+     stylex.create({
+       default: {
+         scrollMarginTop: FOO + 5,
+         scrollMarginBottom: FOO * 5,
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     const x = 5;
+     stylex.create({
+       default: {
+         marginInlineStart: Math.abs(x),
+         marginInlineEnd: \`\${Math.floor(x)}px\`,
+         paddingInlineStart: Math.ceil(-x),
+         paddingInlineEnd: Math.round(x / 2),
+       },
+     })`,
+    // test for Search
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'WebkitAppearance': 'textfield',
+         '::-webkit-search-decoration': {
+           appearance: 'none',
+         },
+         '::-webkit-search-cancel-button': {
+           appearance: 'none',
+         },
+         '::-webkit-search-results-button': {
+           appearance: 'none',
+         },
+         '::-webkit-search-results-decoration': {
+           appearance: 'none',
+         },
+       },
+     })`,
+    // test for input ranges
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'WebkitAppearance': 'textfield',
+         '::-webkit-slider-thumb': {
+           appearance: 'none',
+         },
+         '::-webkit-slider-runnable-track': {
+           appearance: 'none',
+         },
+         '::-moz-range-thumb': {
+           appearance: 'none',
+         },
+         '::-moz-range-track': {
+           appearance: 'none',
+         },
+         '::-moz-range-progress': {
+           appearance: 'none',
+         },
+       },
+     })`,
+    // test for color
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'color': 'red',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'color': '#fff',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'color': '#fafbfc',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'color': '#fafbfcfc',
+       },
+     })`,
+    // test for relative width
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '30rem',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '30em',
+       },
+      })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '30ch',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '30ex',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '30vh',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '30vw',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'contain': '300px',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'containIntrinsicSize': '300px',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'containIntrinsicSize': 'auto 300px',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       a: {
+         interpolateSize: 'numeric-only',
+       },
+       b: {
+         interpolateSize: 'allow-keywords',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'containIntrinsicInlineSize': '300px',
+         'containIntrinsicBlockSize': '200px',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'containIntrinsicInlineSize': 'auto 300px',
+         'containIntrinsicBlockSize': 'auto 200px',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'containIntrinsicWidth': '300px',
+         'containIntrinsicHeight': '200px',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'containIntrinsicWidth': 'auto 300px',
+         'containIntrinsicHeight': 'auto 200px',
+       },
+     })`,
+
+    // test for absolute width
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '30px',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '30cm',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '30mm',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '30in',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '30pc',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '30pt',
+       },
+     })`,
+    // test for percentage
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'width': '50%',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         fontWeight: 'var(--weight)',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+      default: {
+        fontWeight: 'var(--🔴)',
+      },
+    })`,
+    `
+    import * as stylex from '@stylexjs/stylex';
+    const red = 'var(--🔴)';
+    stylex.create({
+      default: {
+        fontWeight: red,
+      },
+    })`,
+    // test for field-sizing
+    `
+    import * as stylex from '@stylexjs/stylex';
+    const red = 'var(--🔴)';
+    stylex.create({
+      default: {
+        fieldSizing: 'fixed',
+      },
+    })`,
+    `
+    import * as stylex from '@stylexjs/stylex';
+    const red = 'var(--🔴)';
+    stylex.create({
+      default: {
+        fieldSizing: 'content',
+      },
+    })`,
+    // test for stylex create vars tokens
+    `
+    import * as stylex from '@stylexjs/stylex';
+    import {TextTypeTokens as TextType, ColorTokens} from 'DspSharedTextTokens.stylex';
+    stylex.create({
+      root: {
+        fontSize: TextType.fontSize,
+        borderColor: ColorTokens.borderColor,
+        paddingBottom: TextType.paddingBottom,
+        fontFamily: \`\${TextType.defaultFontFamily}, \${TextType.fallbackFontFamily}\`,
+      }
+    })
+    `,
+    // test using vars as keys
+    `
+    import * as stylex from '@stylexjs/stylex';
+    import { componentVars } from './bug.stylex';
+    stylex.create({
+      host: {
+        [componentVars.color]: 'blue',
+      },
+    })
+    `,
+    // test using vars as keys in dynamic styles
+    `
+    import * as stylex from'stylex';
+    import { tokens } from 'tokens.stylex';
+    stylex.create({
+      root: (position) => ({
+        [tokens.position]: \`\${position}px\`,
+      })
+    })
+    `,
+    // test importing vars from paths including code file extension
+    `
+    import * as stylex from '@stylexjs/stylex';
+    import { vars } from './vars.stylex';
+    import { varsJs } from './vars.stylex.js';
+    import { varsTs } from './vars.stylex.ts';
+    import { varsTsx } from './vars.stylex.tsx';
+    import { varsJsx } from './vars.stylex.jsx';
+    import { varsMjs } from './vars.stylex.mjs';
+    import { varsCjs } from './vars.stylex.cjs';
+    stylex.create({
+      root: {
+        [vars.color]: 'blue',
+        [varsJs.color]: 'blue',
+        [varsTs.color]: 'blue',
+        [varsTsx.color]: 'blue',
+        [varsJsx.color]: 'blue',
+        [varsMjs.color]: 'blue',
+        [varsCjs.color]: 'blue',
+      },
+    })
+    `,
+    // test for positionTryFallbacks with 'none'
+    `
+    import * as stylex from '@stylexjs/stylex';
+    stylex.create({
+      default: {
+        positionTryFallbacks: 'none',
+      },
+    });
+    `,
+    // test for positionTryFallbacks with `positionTry` references
+    `
+    import * as stylex from '@stylexjs/stylex';
+    const fallback = stylex.positionTry({
+      positionAnchor: '--anchor',
+      top: '0',
+      left: '0',
+      width: '100px',
+      height: '100px'
+    });
+    stylex.create({
+      anchor: {
+        positionTryFallbacks: fallback,
+      },
+    });
+    `,
+    // test for positionTryFallbacks with a template literal containing multiple `positionTry` references
+    `
+    import * as stylex from '@stylexjs/stylex';
+    const fallback1 = stylex.positionTry({
+      positionAnchor: '--anchor',
+      top: '0',
+      left: '0',
+      width: '100px',
+      height: '100px'
+    });
+    const fallback2 = stylex.positionTry({
+      positionAnchor: '--anchor',
+      bottom: '0',
+      right: '0',
+      width: '100px',
+      height: '100px'
+    });
+    stylex.create({
+      anchor: {
+        positionTryFallbacks: \`\${fallback1}, \${fallback2}\`,
+      },
+    });
+    `,
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {':focus': {textAlign: 'lfet'}}});",
+    `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            ':focus': {
+              ':hover': {
+                ':active': {
+                  color: 'red'
+                }
+              }
+            }
+          }
+        });
+      `,
+    `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = {default: {width: '30pt'}};
+        stylex.create(styles);
+      `,
+    `import * as stylex from '@stylexjs/stylex';
+    import { FOO } from 'foo';
+     stylex.create({
+       default: {
+         scrollMarginTop: FOO + 5,
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+    const FOO = 'bad string';
+     stylex.create({
+       default: {
+         scrollMarginTop: FOO + 5,
+       },
+     })`,
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {textAlin: 'left'}});",
+    "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {[\"textAlin\"]: 'left'}});",
+    `
+        import * as stylex from '@stylexjs/stylex';
+        stylex.create({
+          default: {
+            ':focs': {
+              textAlign: 'left'
+            }
+          }
+        });
+      `,
+    `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            border: "1px blue solid",
+          }
+        });
+      `,
+    `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            border: "1px solid",
+          }
+        });
+      `,
+  ],
+  invalid: [
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            marginStart: '10px',
+            marginEnd: '5px',
+            marginHorizontal: '15px',
+            marginVertical: '15px',
+            paddingStart: '10px',
+            paddingEnd: '5px',
+            paddingHorizontal: '5px',
+            paddingVertical: '15px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'The key "marginStart" is not a standard CSS property. Did you mean "marginInlineStart"?',
+        },
+        {
+          message:
+            'The key "marginEnd" is not a standard CSS property. Did you mean "marginInlineEnd"?',
+        },
+        {
+          message:
+            'The key "marginHorizontal" is not a standard CSS property. Did you mean "marginInline"?',
+        },
+        {
+          message:
+            'The key "marginVertical" is not a standard CSS property. Did you mean "marginBlock"?',
+        },
+        {
+          message:
+            'The key "paddingStart" is not a standard CSS property. Did you mean "paddingInlineStart"?',
+        },
+        {
+          message:
+            'The key "paddingEnd" is not a standard CSS property. Did you mean "paddingInlineEnd"?',
+        },
+        {
+          message:
+            'The key "paddingHorizontal" is not a standard CSS property. Did you mean "paddingInline"?',
+        },
+        {
+          message:
+            'The key "paddingVertical" is not a standard CSS property. Did you mean "paddingBlock"?',
+        },
+      ],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            marginInlineStart: '10px',
+            marginInlineEnd: '5px',
+            marginInline: '15px',
+            marginBlock: '15px',
+            paddingInlineStart: '10px',
+            paddingInlineEnd: '5px',
+            paddingInline: '5px',
+            paddingBlock: '15px',
+          },
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            borderVerticalWidth: '2px',
+            borderVerticalStyle: 'solid',
+            borderVerticalColor: 'red',
+            borderHorizontalWidth: '1px',
+            borderHorizontalStyle: 'dashed',
+            borderHorizontalColor: 'blue',
+            borderStartWidth: '2px',
+            borderStartStyle: 'solid',
+            borderStartColor: 'green',
+            borderEndWidth: '3px',
+            borderEndStyle: 'dotted',
+            borderEndColor: 'purple',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'The key "borderVerticalWidth" is not a standard CSS property. Did you mean "borderBlockWidth"?',
+        },
+        {
+          message:
+            'The key "borderVerticalStyle" is not a standard CSS property. Did you mean "borderBlockStyle"?',
+        },
+        {
+          message:
+            'The key "borderVerticalColor" is not a standard CSS property. Did you mean "borderBlockColor"?',
+        },
+        {
+          message:
+            'The key "borderHorizontalWidth" is not a standard CSS property. Did you mean "borderInlineWidth"?',
+        },
+        {
+          message:
+            'The key "borderHorizontalStyle" is not a standard CSS property. Did you mean "borderInlineStyle"?',
+        },
+        {
+          message:
+            'The key "borderHorizontalColor" is not a standard CSS property. Did you mean "borderInlineColor"?',
+        },
+        {
+          message:
+            'The key "borderStartWidth" is not a standard CSS property. Did you mean "borderInlineStartWidth"?',
+        },
+        {
+          message:
+            'The key "borderStartStyle" is not a standard CSS property. Did you mean "borderInlineStartStyle"?',
+        },
+        {
+          message:
+            'The key "borderStartColor" is not a standard CSS property. Did you mean "borderInlineStartColor"?',
+        },
+        {
+          message:
+            'The key "borderEndWidth" is not a standard CSS property. Did you mean "borderInlineEndWidth"?',
+        },
+        {
+          message:
+            'The key "borderEndStyle" is not a standard CSS property. Did you mean "borderInlineEndStyle"?',
+        },
+        {
+          message:
+            'The key "borderEndColor" is not a standard CSS property. Did you mean "borderInlineEndColor"?',
+        },
+      ],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            borderBlockWidth: '2px',
+            borderBlockStyle: 'solid',
+            borderBlockColor: 'red',
+            borderInlineWidth: '1px',
+            borderInlineStyle: 'dashed',
+            borderInlineColor: 'blue',
+            borderInlineStartWidth: '2px',
+            borderInlineStartStyle: 'solid',
+            borderInlineStartColor: 'green',
+            borderInlineEndWidth: '3px',
+            borderInlineEndStyle: 'dotted',
+            borderInlineEndColor: 'purple',
+          },
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            borderTopStartRadius: '4px',
+            borderTopEndRadius: '5px',
+            borderBottomStartRadius: '6px',
+            borderBottomEndRadius: '7px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'The key "borderTopStartRadius" is not a standard CSS property. Did you mean "borderStartStartRadius"?',
+        },
+        {
+          message:
+            'The key "borderTopEndRadius" is not a standard CSS property. Did you mean "borderStartEndRadius"?',
+        },
+        {
+          message:
+            'The key "borderBottomStartRadius" is not a standard CSS property. Did you mean "borderEndStartRadius"?',
+        },
+        {
+          message:
+            'The key "borderBottomEndRadius" is not a standard CSS property. Did you mean "borderEndEndRadius"?',
+        },
+      ],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            borderStartStartRadius: '4px',
+            borderStartEndRadius: '5px',
+            borderEndStartRadius: '6px',
+            borderEndEndRadius: '7px',
+          },
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            end: '5px',
+            start: '10px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'The key "end" is not a standard CSS property. Did you mean "insetInlineEnd"?',
+        },
+        {
+          message:
+            'The key "start" is not a standard CSS property. Did you mean "insetInlineStart"?',
+        },
+      ],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            insetInlineEnd: '5px',
+            insetInlineStart: '10px',
+          },
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          foo: {
+            float: 'start',
+            clear: 'start',
+          },
+          bar: {
+            float: 'end',
+            clear: 'end',
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            'The value "start" is not a standard CSS value for "float". Did you mean "inline-start"?',
+        },
+        {
+          message:
+            'The value "start" is not a standard CSS value for "clear". Did you mean "inline-start"?',
+        },
+        {
+          message:
+            'The value "end" is not a standard CSS value for "float". Did you mean "inline-end"?',
+        },
+        {
+          message:
+            'The value "end" is not a standard CSS value for "clear". Did you mean "inline-end"?',
+        },
+      ],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          foo: {
+            float: 'inline-start',
+            clear: 'inline-start',
+          },
+          bar: {
+            float: 'inline-end',
+            clear: 'inline-end',
+          }
+        });
+      `,
+    },
+  ],
+});

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -53,6 +53,22 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       });
     `,
     `
+      const stylex = require('@stylexjs/stylex');
+      
+      const styles = stylex.create({
+        validStyle: {
+          marginInlineStart: "10px",
+          marginInlineEnd: "5px",
+          marginInline: "15px",
+          marginBlock: "20px",
+          paddingInlineStart: "8px",
+          paddingInlineEnd: "12px",
+          paddingInline: "10px",
+          paddingBlock: "16px",
+        },
+      });
+    `,
+    `
       import * as stylex from '@stylexjs/stylex';
       const start = 'start';
       const grayscale = 'grayscale';
@@ -619,6 +635,74 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       },
     });
     `,
+    // tests what is covered by stylex-no-nonstandard-styles
+    `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            marginStart: '10px',
+            marginEnd: '5px',
+            marginHorizontal: '15px',
+            marginVertical: '15px',
+            paddingStart: '10px',
+            paddingEnd: '5px',
+            paddingHorizontal: '5px',
+            paddingVertical: '15px',
+          },
+        });
+      `,
+    `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            borderVerticalWidth: '2px',
+            borderVerticalStyle: 'solid',
+            borderVerticalColor: 'red',
+            borderHorizontalWidth: '1px',
+            borderHorizontalStyle: 'dashed',
+            borderHorizontalColor: 'blue',
+            borderStartWidth: '2px',
+            borderStartStyle: 'solid',
+            borderStartColor: 'green',
+            borderEndWidth: '3px',
+            borderEndStyle: 'dotted',
+            borderEndColor: 'purple',
+          },
+        });
+      `,
+    `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            end: '5px',
+            start: '10px',
+          },
+        });
+      `,
+    `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            borderTopStartRadius: '4px',
+            borderTopEndRadius: '5px',
+            borderBottomStartRadius: '6px',
+            borderBottomEndRadius: '7px',
+          },
+        });
+      `,
+    `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          foo: {
+            float: 'start',
+            clear: 'start',
+          },
+          bar: {
+            float: 'end',
+            clear: 'end',
+          }
+        });
+      `,
   ],
   invalid: [
     {
@@ -743,234 +827,6 @@ eslintTester.run('stylex-valid-styles', rule.default, {
           ],
         },
       ],
-    },
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          invalidStyle: {
-            marginStart: '10px',
-            marginEnd: '5px',
-            marginHorizontal: '15px',
-            marginVertical: '15px',
-            paddingStart: '10px',
-            paddingEnd: '5px',
-            paddingHorizontal: '5px',
-            paddingVertical: '15px',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'The key "marginStart" is not a standard CSS property. Did you mean "marginInlineStart"?',
-        },
-        {
-          message:
-            'The key "marginEnd" is not a standard CSS property. Did you mean "marginInlineEnd"?',
-        },
-        {
-          message:
-            'The key "marginHorizontal" is not a standard CSS property. Did you mean "marginInline"?',
-        },
-        {
-          message:
-            'The key "marginVertical" is not a standard CSS property. Did you mean "marginBlock"?',
-        },
-        {
-          message:
-            'The key "paddingStart" is not a standard CSS property. Did you mean "paddingInlineStart"?',
-        },
-        {
-          message:
-            'The key "paddingEnd" is not a standard CSS property. Did you mean "paddingInlineEnd"?',
-        },
-        {
-          message:
-            'The key "paddingHorizontal" is not a standard CSS property. Did you mean "paddingInline"?',
-        },
-        {
-          message:
-            'The key "paddingVertical" is not a standard CSS property. Did you mean "paddingBlock"?',
-        },
-      ],
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          invalidStyle: {
-            marginInlineStart: '10px',
-            marginInlineEnd: '5px',
-            marginInline: '15px',
-            marginBlock: '15px',
-            paddingInlineStart: '10px',
-            paddingInlineEnd: '5px',
-            paddingInline: '5px',
-            paddingBlock: '15px',
-          },
-        });
-      `,
-    },
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          invalidStyle: {
-            borderVerticalWidth: '2px',
-            borderVerticalStyle: 'solid',
-            borderVerticalColor: 'red',
-            borderHorizontalWidth: '1px',
-            borderHorizontalStyle: 'dashed',
-            borderHorizontalColor: 'blue',
-            borderStartWidth: '2px',
-            borderStartStyle: 'solid',
-            borderStartColor: 'green',
-            borderEndWidth: '3px',
-            borderEndStyle: 'dotted',
-            borderEndColor: 'purple',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'The key "borderVerticalWidth" is not a standard CSS property. Did you mean "borderBlockWidth"?',
-        },
-        {
-          message:
-            'The key "borderVerticalStyle" is not a standard CSS property. Did you mean "borderBlockStyle"?',
-        },
-        {
-          message:
-            'The key "borderVerticalColor" is not a standard CSS property. Did you mean "borderBlockColor"?',
-        },
-        {
-          message:
-            'The key "borderHorizontalWidth" is not a standard CSS property. Did you mean "borderInlineWidth"?',
-        },
-        {
-          message:
-            'The key "borderHorizontalStyle" is not a standard CSS property. Did you mean "borderInlineStyle"?',
-        },
-        {
-          message:
-            'The key "borderHorizontalColor" is not a standard CSS property. Did you mean "borderInlineColor"?',
-        },
-        {
-          message:
-            'The key "borderStartWidth" is not a standard CSS property. Did you mean "borderInlineStartWidth"?',
-        },
-        {
-          message:
-            'The key "borderStartStyle" is not a standard CSS property. Did you mean "borderInlineStartStyle"?',
-        },
-        {
-          message:
-            'The key "borderStartColor" is not a standard CSS property. Did you mean "borderInlineStartColor"?',
-        },
-        {
-          message:
-            'The key "borderEndWidth" is not a standard CSS property. Did you mean "borderInlineEndWidth"?',
-        },
-        {
-          message:
-            'The key "borderEndStyle" is not a standard CSS property. Did you mean "borderInlineEndStyle"?',
-        },
-        {
-          message:
-            'The key "borderEndColor" is not a standard CSS property. Did you mean "borderInlineEndColor"?',
-        },
-      ],
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          invalidStyle: {
-            borderBlockWidth: '2px',
-            borderBlockStyle: 'solid',
-            borderBlockColor: 'red',
-            borderInlineWidth: '1px',
-            borderInlineStyle: 'dashed',
-            borderInlineColor: 'blue',
-            borderInlineStartWidth: '2px',
-            borderInlineStartStyle: 'solid',
-            borderInlineStartColor: 'green',
-            borderInlineEndWidth: '3px',
-            borderInlineEndStyle: 'dotted',
-            borderInlineEndColor: 'purple',
-          },
-        });
-      `,
-    },
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          invalidStyle: {
-            borderTopStartRadius: '4px',
-            borderTopEndRadius: '5px',
-            borderBottomStartRadius: '6px',
-            borderBottomEndRadius: '7px',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'The key "borderTopStartRadius" is not a standard CSS property. Did you mean "borderStartStartRadius"?',
-        },
-        {
-          message:
-            'The key "borderTopEndRadius" is not a standard CSS property. Did you mean "borderStartEndRadius"?',
-        },
-        {
-          message:
-            'The key "borderBottomStartRadius" is not a standard CSS property. Did you mean "borderEndStartRadius"?',
-        },
-        {
-          message:
-            'The key "borderBottomEndRadius" is not a standard CSS property. Did you mean "borderEndEndRadius"?',
-        },
-      ],
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          invalidStyle: {
-            borderStartStartRadius: '4px',
-            borderStartEndRadius: '5px',
-            borderEndStartRadius: '6px',
-            borderEndEndRadius: '7px',
-          },
-        });
-      `,
-    },
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          invalidStyle: {
-            end: '5px',
-            start: '10px',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'The key "end" is not a standard CSS property. Did you mean "insetInlineEnd"?',
-        },
-        {
-          message:
-            'The key "start" is not a standard CSS property. Did you mean "insetInlineStart"?',
-        },
-      ],
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          invalidStyle: {
-            insetInlineEnd: '5px',
-            insetInlineStart: '10px',
-          },
-        });
-      `,
     },
     {
       code: "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {textAlign: 'lfet'}});",
@@ -1672,52 +1528,6 @@ revert`,
             'revert',
         },
       ],
-    },
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          foo: {
-            float: 'start',
-            clear: 'start',
-          },
-          bar: {
-            float: 'end',
-            clear: 'end',
-          }
-        });
-      `,
-      errors: [
-        {
-          message:
-            'The value "start" is not a standard CSS value for "float". Did you mean "inline-start"?',
-        },
-        {
-          message:
-            'The value "start" is not a standard CSS value for "clear". Did you mean "inline-start"?',
-        },
-        {
-          message:
-            'The value "end" is not a standard CSS value for "float". Did you mean "inline-end"?',
-        },
-        {
-          message:
-            'The value "end" is not a standard CSS value for "clear". Did you mean "inline-end"?',
-        },
-      ],
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          foo: {
-            float: 'inline-start',
-            clear: 'inline-start',
-          },
-          bar: {
-            float: 'inline-end',
-            clear: 'inline-end',
-          }
-        });
-      `,
     },
   ],
 });

--- a/packages/@stylexjs/eslint-plugin/src/stylex-no-nonstandard-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-no-nonstandard-styles.js
@@ -1,0 +1,576 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+import getDistance from './utils/getDistance';
+import type {
+  CallExpression,
+  Directive,
+  Expression,
+  Identifier,
+  ModuleDeclaration,
+  Node,
+  ObjectExpression,
+  Pattern,
+  Program,
+  Property,
+  Literal,
+  Statement,
+  VariableDeclaration,
+  VariableDeclarator,
+  PrivateIdentifier,
+} from 'estree';
+import micromatch from 'micromatch';
+/*:: import { Rule } from 'eslint'; */
+import makeLiteralRule from './rules/makeLiteralRule';
+import isString from './rules/isString';
+import makeUnionRule from './rules/makeUnionRule';
+import isNumber from './rules/isNumber';
+import isAnimationName from './rules/isAnimationName';
+import isPositionTryFallbacks from './rules/isPositionTryFallbacks';
+import isStylexResolvedVarsToken from './rules/isStylexResolvedVarsToken';
+import isCSSVariable from './rules/isCSSVariable';
+import evaluate from './utils/evaluate';
+import resolveKey from './utils/resolveKey';
+import {
+  CSSPropertyKeys,
+  CSSProperties,
+  convertToStandardProperties,
+  all,
+} from './reference/cssProperties';
+import createImportTracker from './utils/createImportTracker';
+
+export type Variables = $ReadOnlyMap<string, Expression | 'ARG'>;
+export type RuleCheck = (
+  node: $ReadOnly<Expression | Pattern>,
+  variables?: Variables,
+  prop?: $ReadOnly<Property>,
+  context?: Rule.RuleContext,
+) => RuleResponse;
+export type RuleResponse = void | {
+  message: string,
+  distance?: number,
+  suggest?: {
+    fix: Rule.ReportFixer,
+    desc: string,
+  },
+};
+
+const showError =
+  (message: string): RuleCheck =>
+  () => ({ message });
+
+const stylexValidStyles = {
+  meta: {
+    type: 'problem',
+    hasSuggestions: true,
+    fixable: 'code',
+    docs: {
+      descriptions:
+        'Enforce that you create standard CSS values and properties for stylex',
+      category: 'Possible Errors',
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validImports: {
+            type: 'array',
+            items: {
+              oneOf: [
+                { type: 'string' },
+                {
+                  type: 'object',
+                  properties: {
+                    from: { type: 'string' },
+                    as: { type: 'string' },
+                  },
+                },
+              ],
+            },
+            default: ['stylex', '@stylexjs/stylex'],
+          },
+          banPropsForLegacy: {
+            type: 'boolean',
+            default: false,
+          },
+          propLimits: {
+            type: 'object',
+            additionalProperties: {
+              type: 'object',
+              properties: {
+                limit: {
+                  oneOf: [
+                    { type: 'null' },
+                    { type: 'string' },
+                    { type: 'number' },
+                    {
+                      type: 'array',
+                      items: {
+                        oneOf: [
+                          { type: 'null' },
+                          { type: 'string' },
+                          { type: 'number' },
+                        ],
+                      },
+                    },
+                  ],
+                },
+                reason: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+  create(context: Rule.RuleContext): { ... } {
+    type Schema = {
+      validImports: Array<
+        | string
+        | {
+            from: string,
+            as: string,
+          },
+      >,
+      banPropsForLegacy: boolean,
+      propLimits?: PropLimits,
+    };
+    const {
+      banPropsForLegacy = false,
+      validImports: importsToLookFor = ['stylex', '@stylexjs/stylex'],
+      propLimits = {},
+    }: Schema = context.options[0] || {};
+    const importTracker = createImportTracker(importsToLookFor);
+    const variables = new Map<string, Expression | 'ARG'>();
+    const dynamicStyleVariables = new Set<string>();
+
+    type PropLimits = {
+      [string]: {
+        limit: null | string | number | Array<string | number>,
+        reason: string,
+      },
+    };
+
+    const legacyReason =
+      'This property is not supported in legacy StyleX resolution.';
+    const legacyProps: PropLimits = {
+      'grid*': { limit: null, reason: legacyReason },
+      'mask+([a-zA-Z])': { limit: null, reason: legacyReason },
+      blockOverflow: { limit: null, reason: legacyReason },
+      inlineOverflow: { limit: null, reason: legacyReason },
+      transitionProperty: {
+        limit: ['opacity', 'transform', 'opacity, transform', 'none'],
+        reason: legacyReason,
+      },
+    };
+
+    const stylexResolvedVarsTokenImports = new Set<string>();
+    const styleXDefaultImports = new Set<string>();
+    const styleXCreateImports = new Set<string>();
+    const styleXKeyframesImports = new Set<string>();
+    const styleXPositionTryImports = new Set<string>();
+
+    const overrides: PropLimits = {
+      ...(banPropsForLegacy ? legacyProps : {}),
+      ...propLimits,
+    };
+
+    const CSSPropertiesWithOverrides: { [string]: RuleCheck } = {
+      ...CSSProperties,
+      // TODO change this to a special function that looks for stylex.keyframes call
+      animationName: makeUnionRule(
+        makeLiteralRule('none'),
+        isAnimationName(styleXDefaultImports, styleXKeyframesImports),
+        all,
+      ),
+      positionTryFallbacks: makeUnionRule(
+        makeLiteralRule('none'),
+        isCSSVariable,
+        isPositionTryFallbacks(styleXDefaultImports, styleXPositionTryImports),
+        all,
+      ),
+    };
+    for (const overrideKey in overrides) {
+      const { limit, reason } = overrides[overrideKey];
+      const overrideValue =
+        limit === null
+          ? showError(reason)
+          : limit === '*'
+            ? makeUnionRule(isString, isNumber, all)
+            : limit === 'string'
+              ? makeUnionRule(isString, all)
+              : limit === 'number'
+                ? makeUnionRule(isNumber, all)
+                : typeof limit === 'string' || typeof limit === 'number'
+                  ? makeUnionRule(limit, all)
+                  : Array.isArray(limit)
+                    ? makeUnionRule(
+                        ...limit.map((l) => {
+                          if (l === '*') {
+                            return makeUnionRule(isString, isNumber);
+                          }
+                          if (l === 'string') {
+                            return isString;
+                          }
+                          if (l === 'number') {
+                            return isNumber;
+                          }
+                          return l;
+                        }),
+                        all,
+                      )
+                    : undefined;
+      if (overrideValue === undefined) {
+        // skip
+        continue;
+      }
+      if (overrideKey.includes('*') || overrideKey.includes('+')) {
+        for (const key in CSSPropertiesWithOverrides) {
+          if (micromatch.isMatch(key, overrideKey)) {
+            CSSPropertiesWithOverrides[key] = overrideValue;
+          }
+        }
+      } else {
+        CSSPropertiesWithOverrides[overrideKey] = overrideValue;
+      }
+    }
+
+    function isStylexCreateCallee(node: Node) {
+      return (
+        (node.type === 'MemberExpression' &&
+          node.object.type === 'Identifier' &&
+          importTracker.isStylexDefaultImport(node.object.name) &&
+          node.property.type === 'Identifier' &&
+          node.property.name === 'create') ||
+        (node.type === 'Identifier' &&
+          importTracker.isStylexNamedImport('create', node.name))
+      );
+    }
+
+    function isStylexCreateDeclaration(node: Node) {
+      return (
+        node &&
+        node.type === 'CallExpression' &&
+        isStylexCreateCallee(node.callee) &&
+        node.arguments.length === 1
+      );
+    }
+
+    function checkStyleProperty(
+      style: Node,
+      level: number,
+      propName: null | string,
+      outerIsPseudoElement: boolean,
+    ): void {
+      if (style.type !== 'Property') {
+        return;
+      }
+      if (style.value.type === 'ObjectExpression') {
+        const styleValue: ObjectExpression = style.value;
+        if (
+          level > 0 &&
+          propName == null &&
+          !(outerIsPseudoElement && level === 1)
+        ) {
+          return;
+        }
+        const key = style.key;
+        if (key.type === 'PrivateIdentifier') {
+          return;
+        }
+        const keyName =
+          key.type === 'Literal'
+            ? key.value
+            : key.type === 'Identifier'
+              ? !style.computed
+                ? key.name
+                : resolveKey(key, variables)
+              : null;
+        if (isStylexResolvedVarsToken(key, stylexResolvedVarsTokenImports)) {
+          return;
+        }
+        if (
+          typeof keyName !== 'string' ||
+          (key.type !== 'Literal' && key.type !== 'Identifier')
+        ) {
+          return;
+        }
+        return styleValue.properties.forEach((prop) => {
+          const nestedKeyName =
+            propName ??
+            (keyName.startsWith('@') ||
+            keyName.startsWith(':') ||
+            keyName === 'default'
+              ? null
+              : keyName);
+          if (nestedKeyName == null) {
+            return undefined;
+          }
+          return checkStyleProperty(
+            prop,
+            level + 1,
+            nestedKeyName,
+            outerIsPseudoElement || keyName.startsWith('::'),
+          );
+        });
+      }
+      let styleKey: Expression | PrivateIdentifier = style.key;
+      if (
+        styleKey.type === 'PrivateIdentifier' ||
+        isStylexResolvedVarsToken(styleKey, stylexResolvedVarsTokenImports)
+      ) {
+        return;
+      }
+      if (style.computed && styleKey.type !== 'Literal') {
+        const val = evaluate(styleKey, variables);
+        if (val != null && val !== 'ARG') {
+          styleKey = val;
+        }
+      }
+      const key =
+        propName ??
+        (styleKey.type === 'Identifier' ? styleKey.name : styleKey.value);
+      if (typeof key !== 'string') {
+        return;
+      }
+
+      const ruleChecker = CSSPropertiesWithOverrides[key];
+      if (ruleChecker == null) {
+        const closestKey = CSSPropertyKeys.find((cssProp) => {
+          const distance = getDistance(key, cssProp, 2);
+          return distance <= 2;
+        });
+        const replacementKey =
+          style.key.type === 'Identifier' &&
+          convertToStandardProperties[style.key.name]
+            ? convertToStandardProperties[style.key.name]
+            : style.key.type === 'Literal' &&
+                typeof style.key.value === 'string' &&
+                convertToStandardProperties[style.key.value]
+              ? convertToStandardProperties[style.key.value]
+              : null;
+
+        let originalKey = '';
+
+        if (style.key.type === 'Identifier') {
+          originalKey = style.key.name;
+        } else if (
+          style.key.type === 'Literal' &&
+          typeof style.key.value === 'string'
+        ) {
+          originalKey = style.key.value;
+        }
+        if (
+          replacementKey &&
+          (style.key.type === 'Identifier' || style.key.type === 'Literal')
+        ) {
+          return context.report({
+            node: style.key,
+            loc: style.key.loc,
+            message: `The key "${originalKey}" is not a standard CSS property. Did you mean "${replacementKey}"?`,
+            fix: (fixer) => {
+              return fixer.replaceText(style.key, replacementKey);
+            },
+            suggest:
+              closestKey != null
+                ? [
+                    {
+                      desc: `Did you mean "${closestKey}"?`,
+                      fix: (fixer) => {
+                        if (style.key.type === 'Identifier') {
+                          return fixer.replaceText(style.key, closestKey);
+                        } else if (
+                          style.key.type === 'Literal' &&
+                          (typeof style.key.value === 'string' ||
+                            typeof style.key.value === 'number' ||
+                            typeof style.key.value === 'boolean' ||
+                            style.key.value == null)
+                        ) {
+                          const styleKey: Literal = style.key;
+                          const raw = style.key.raw;
+                          if (raw != null) {
+                            const quoteType = raw.substr(0, 1);
+                            return fixer.replaceText(
+                              styleKey,
+                              `${quoteType}${closestKey}${quoteType}`,
+                            );
+                          }
+                        }
+                        return null;
+                      },
+                    },
+                  ]
+                : undefined,
+          } as Rule.ReportDescriptor);
+        }
+        return;
+      }
+      if (typeof ruleChecker !== 'function') {
+        throw new TypeError(`CSSProperties[${key}] is not a function`);
+      }
+
+      const isReferencingStylexDefineVarsTokens =
+        stylexResolvedVarsTokenImports.size > 0 &&
+        isStylexResolvedVarsToken(style.value, stylexResolvedVarsTokenImports);
+      if (
+        !isReferencingStylexDefineVarsTokens &&
+        (key === 'float' || key === 'clear') &&
+        style.value.type === 'Literal' &&
+        typeof style.value.value === 'string' &&
+        (style.value.value === 'start' || style.value.value === 'end')
+      ) {
+        const replacement =
+          style.value.value === 'start' ? 'inline-start' : 'inline-end';
+        return context.report({
+          node: style.value,
+          loc: style.value.loc,
+          message: `The value "${style.value.value}" is not a standard CSS value for "${key}". Did you mean "${replacement}"?`,
+          fix: (fixer) => fixer.replaceText(style.value, `'${replacement}'`),
+          suggest: [
+            {
+              desc: `Replace "${style.value.value}" with "${replacement}"?`,
+              fix: (fixer) =>
+                fixer.replaceText(style.value, `'${replacement}'`),
+            },
+          ],
+        } as Rule.ReportDescriptor);
+      }
+    }
+
+    return {
+      ImportDeclaration: importTracker.ImportDeclaration,
+      Program(node: Program) {
+        // Keep track of all the top-level local variable declarations
+        // This is because stylex allows you to use local constants in your styles
+
+        // const body = node.body;
+        // for (let statement of body) {
+
+        // }
+
+        const vars = node.body
+          .reduce(
+            (
+              collection: Array<VariableDeclaration>,
+              node: Statement | ModuleDeclaration | Directive,
+            ) => {
+              if (node.type === 'VariableDeclaration') {
+                collection.push(node);
+              }
+              return collection;
+            },
+            [],
+          )
+          .map(
+            (
+              constDecl: VariableDeclaration,
+            ): $ReadOnlyArray<VariableDeclarator> => constDecl.declarations,
+          )
+          .reduce(
+            (
+              arr: $ReadOnlyArray<VariableDeclarator>,
+              curr: $ReadOnlyArray<VariableDeclarator>,
+            ) => arr.concat(curr),
+            [],
+          );
+
+        const [requires, others] = vars.reduce(
+          (acc, decl) => {
+            if (
+              decl.init != null &&
+              decl.init.type === 'CallExpression' &&
+              decl.init.callee.type === 'Identifier' &&
+              decl.init.callee.name === 'require'
+            ) {
+              acc[0].push(decl);
+            } else {
+              acc[1].push(decl);
+            }
+            return acc;
+          },
+          [[] as Array<VariableDeclarator>, [] as Array<VariableDeclarator>],
+        );
+
+        requires.forEach((decl: VariableDeclarator) => {
+          // detect requires of "stylex" and "@stylexjs/stylex"
+          if (
+            decl.init != null &&
+            decl.init.type === 'CallExpression' &&
+            decl.init.callee.type === 'Identifier' &&
+            decl.init.callee.name === 'require' &&
+            decl.init.arguments.length === 1 &&
+            decl.init.arguments[0].type === 'Literal' &&
+            importsToLookFor.includes(decl.init.arguments[0].value)
+          ) {
+            if (decl.id.type === 'Identifier') {
+              styleXDefaultImports.add(decl.id.name);
+            }
+            if (decl.id.type === 'ObjectPattern') {
+              decl.id.properties.forEach((prop) => {
+                if (
+                  prop.type === 'Property' &&
+                  prop.key.type === 'Identifier' &&
+                  prop.key.name === 'create' &&
+                  !prop.computed &&
+                  prop.value.type === 'Identifier'
+                ) {
+                  styleXCreateImports.add(prop.value.name);
+                }
+              });
+            }
+          }
+        });
+
+        others
+          .filter((decl) => decl.id.type === 'Identifier')
+          .forEach((decl: VariableDeclarator) => {
+            const id: ?Identifier =
+              decl.id.type === 'Identifier' ? decl.id : null;
+            const init = decl.init;
+            if (id != null && init != null) {
+              variables.set(id.name, init);
+            }
+          });
+      },
+      CallExpression(node: CallExpression) {
+        const namespaces = node.arguments[0];
+        if (
+          !isStylexCreateDeclaration(node) ||
+          namespaces.type !== 'ObjectExpression'
+        ) {
+          return;
+        }
+
+        namespaces.properties.forEach((namespace) => {
+          // we only care about properties with object values
+          if (
+            namespace.type !== 'Property' ||
+            namespace.value.type !== 'ObjectExpression'
+          ) {
+            return;
+          }
+          namespace.value.properties.forEach((prop) =>
+            checkStyleProperty(prop, 0, null, false),
+          );
+          // Reset local variables.
+          dynamicStyleVariables.clear();
+        });
+      },
+      'Program:exit'() {
+        importTracker.clear();
+        variables.clear();
+      },
+    };
+  },
+};
+export default stylexValidStyles as typeof stylexValidStyles;
+/* eslint-enable object-shorthand */

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -491,62 +491,47 @@ const stylexValidStyles = {
                 ? convertToStandardProperties[style.key.value]
                 : null;
 
-          let originalKey = '';
-
-          if (style.key.type === 'Identifier') {
-            originalKey = style.key.name;
-          } else if (
-            style.key.type === 'Literal' &&
-            typeof style.key.value === 'string'
+          if (
+            replacementKey == null ||
+            !(style.key.type === 'Identifier' || style.key.type === 'Literal')
           ) {
-            originalKey = style.key.value;
-          }
-
-          return context.report({
-            node: style.key,
-            loc: style.key.loc,
-            message:
-              replacementKey &&
-              (style.key.type === 'Identifier' || style.key.type === 'Literal')
-                ? `The key "${originalKey}" is not a standard CSS property. Did you mean "${replacementKey}"?`
-                : 'This is not a key that is allowed by stylex',
-            fix: (fixer) => {
-              if (replacementKey) {
-                return fixer.replaceText(style.key, replacementKey);
-              }
-              return null;
-            },
-            suggest:
-              closestKey != null
-                ? [
-                    {
-                      desc: `Did you mean "${closestKey}"?`,
-                      fix: (fixer) => {
-                        if (style.key.type === 'Identifier') {
-                          return fixer.replaceText(style.key, closestKey);
-                        } else if (
-                          style.key.type === 'Literal' &&
-                          (typeof style.key.value === 'string' ||
-                            typeof style.key.value === 'number' ||
-                            typeof style.key.value === 'boolean' ||
-                            style.key.value == null)
-                        ) {
-                          const styleKey: Literal = style.key;
-                          const raw = style.key.raw;
-                          if (raw != null) {
-                            const quoteType = raw.substr(0, 1);
-                            return fixer.replaceText(
-                              styleKey,
-                              `${quoteType}${closestKey}${quoteType}`,
-                            );
+            return context.report({
+              node: style.key,
+              loc: style.key.loc,
+              message: 'This is not a key that is allowed by stylex',
+              suggest:
+                closestKey != null
+                  ? [
+                      {
+                        desc: `Did you mean "${closestKey}"?`,
+                        fix: (fixer) => {
+                          if (style.key.type === 'Identifier') {
+                            return fixer.replaceText(style.key, closestKey);
+                          } else if (
+                            style.key.type === 'Literal' &&
+                            (typeof style.key.value === 'string' ||
+                              typeof style.key.value === 'number' ||
+                              typeof style.key.value === 'boolean' ||
+                              style.key.value == null)
+                          ) {
+                            const styleKey: Literal = style.key;
+                            const raw = style.key.raw;
+                            if (raw != null) {
+                              const quoteType = raw.substr(0, 1);
+                              return fixer.replaceText(
+                                styleKey,
+                                `${quoteType}${closestKey}${quoteType}`,
+                              );
+                            }
                           }
-                        }
-                        return null;
+                          return null;
+                        },
                       },
-                    },
-                  ]
-                : undefined,
-          } as Rule.ReportDescriptor);
+                    ]
+                  : undefined,
+            } as Rule.ReportDescriptor);
+          }
+          return;
         }
         if (typeof ruleChecker !== 'function') {
           throw new TypeError(`CSSProperties[${key}] is not a function`);
@@ -576,22 +561,7 @@ const stylexValidStyles = {
             typeof style.value.value === 'string' &&
             (style.value.value === 'start' || style.value.value === 'end')
           ) {
-            const replacement =
-              style.value.value === 'start' ? 'inline-start' : 'inline-end';
-            return context.report({
-              node: style.value,
-              loc: style.value.loc,
-              message: `The value "${style.value.value}" is not a standard CSS value for "${key}". Did you mean "${replacement}"?`,
-              fix: (fixer) =>
-                fixer.replaceText(style.value, `'${replacement}'`),
-              suggest: [
-                {
-                  desc: `Replace "${style.value.value}" with "${replacement}"?`,
-                  fix: (fixer) =>
-                    fixer.replaceText(style.value, `'${replacement}'`),
-                },
-              ],
-            } as Rule.ReportDescriptor);
+            return;
           }
 
           const check = ruleChecker(


### PR DESCRIPTION
## What changed / motivation ?

We wan to split fixable rules related to non-standard properties and values on a separate eslint rule, out of stylex-valid-styles.
Why? Because having fixable rules will serve as an education leverage for users to understand the pool of properties and values that are non-standard and its equivalent standard alternatives.  It will alleviate the extreme burden of checking for way too many rules with different purposes on a single eslint rule.

It also adds some cases for `require('@stylexjs/stylex')` to comply the test coverage threashold.

## Linked PR/Issues

Nothing so far, the issue in question is in progress (issue [1201](https://github.com/facebook/stylex/issues/1201))

## Additional Context

Tests for the rule have also been ported from one test file to a new one

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code