### PR TITLE
[babel-plugin][legacy] add legacyClassnamesSort config in `processStylexRules`

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -546,5 +546,75 @@ describe('@stylexjs/babel-plugin', () => {
         stylexPlugin.processStylexRules(metadata);
       }).not.toThrow();
     });
+
+    test('useLegacyClassnamesSort: false (default behavior)', () => {
+      const { _code, metadata } = transform(fixture, {
+        enableDebugClassNames: false,
+      });
+
+      expect(
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: false,
+          enableLTRRTLComments: true,
+          useLegacyClassnamesSort: false,
+          legacyDisableLayers: true,
+        }),
+      ).toMatchInlineSnapshot(`
+        "@property --x-color { syntax: "*"; inherits: false;}
+        @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
+        .xufgesz{--orange-theme-color:red}
+        .xymmreb{margin:10px 20px}
+        .x1s2izit{padding:var(--x1ec7iuc)}
+        .x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.xio2edn.xio2edn{border-color:var(--xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys{border-color:yellow}}}
+        .x13ah0pd{animation-name:x35atj5-B}
+        .xrkmrrc{background-color:red}
+        .x14rh7hd{color:var(--x-color)}
+        /* @ltr begin */.x1kmio9f{float:left}/* @ltr end */
+        /* @rtl begin */.x1kmio9f{float:right}/* @rtl end */
+        .x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        @media (min-width:320px){.x1cmij7u.x1cmij7u{text-shadow:10px 20px 30px 40px green}}"
+      `);
+    });
+
+    test('useLegacyClassnamesSort: true (legacy behavior)', () => {
+      const { _code, metadata } = transform(fixture, {
+        enableDebugClassNames: false,
+      });
+
+      expect(
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: false,
+          enableLTRRTLComments: true,
+          useLegacyClassnamesSort: true,
+          legacyDisableLayers: true,
+        }),
+      ).toMatchInlineSnapshot(`
+        "@property --x-color { syntax: "*"; inherits: false;}
+        @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .xufgesz{--orange-theme-color:red}
+        .x1s2izit{padding:var(--x1ec7iuc)}
+        .xymmreb{margin:10px 20px}
+        .x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.xio2edn.xio2edn{border-color:var(--xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys{border-color:yellow}}}
+        .x13ah0pd{animation-name:x35atj5-B}
+        .x14rh7hd{color:var(--x-color)}
+        /* @ltr begin */.x1kmio9f{float:left}/* @ltr end */
+        /* @rtl begin */.x1kmio9f{float:right}/* @rtl end */
+        .x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .xrkmrrc{background-color:red}
+        @media (min-width:320px){.x1cmij7u.x1cmij7u{text-shadow:10px 20px 30px 40px green}}"
+      `);
+    });
   });
 });

--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -365,6 +365,7 @@ function processStylexRules(
         useLayers?: boolean,
         enableLTRRTLComments?: boolean,
         legacyDisableLayers?: boolean,
+        useLegacyClassnamesSort?: boolean,
         ...
       },
 ): string {
@@ -372,6 +373,7 @@ function processStylexRules(
     useLayers = false,
     enableLTRRTLComments = false,
     legacyDisableLayers = false,
+    useLegacyClassnamesSort = false,
   } = typeof config === 'boolean' ? { useLayers: config } : config ?? {};
   if (rules.length === 0) {
     return '';
@@ -424,21 +426,26 @@ function processStylexRules(
 
   const sortedRules = nonConstantRules.sort(
     (
-      [, { ltr: rule1 }, firstPriority]: [string, any, number],
-      [, { ltr: rule2 }, secondPriority]: [string, any, number],
+      [classname1, { ltr: rule1 }, firstPriority]: [string, any, number],
+      [classname2, { ltr: rule2 }, secondPriority]: [string, any, number],
     ) => {
       const priorityComparison = firstPriority - secondPriority;
       if (priorityComparison !== 0) return priorityComparison;
-      if (rule1.startsWith('@') && !rule2.startsWith('@')) {
-        const query1 = rule1.slice(0, rule1.indexOf('{'));
-        const query2 = rule2.slice(0, rule2.indexOf('{'));
-        if (query1 !== query2) {
-          return query1.localeCompare(query2);
+
+      if (useLegacyClassnamesSort) {
+        return classname1.localeCompare(classname2);
+      } else {
+        if (rule1.startsWith('@') && !rule2.startsWith('@')) {
+          const query1 = rule1.slice(0, rule1.indexOf('{'));
+          const query2 = rule2.slice(0, rule2.indexOf('{'));
+          if (query1 !== query2) {
+            return query1.localeCompare(query2);
+          }
         }
+        const property1 = rule1.slice(rule1.lastIndexOf('{'));
+        const property2 = rule2.slice(rule2.lastIndexOf('{'));
+        return property1.localeCompare(property2);
       }
-      const property1 = rule1.slice(rule1.lastIndexOf('{'));
-      const property2 = rule2.slice(rule2.lastIndexOf('{'));
-      return property1.localeCompare(property2);
     },
   );
 


### PR DESCRIPTION
Similar logic to https://github.com/facebook/stylex/pull/1244. Let's migrate to `processStylexRules` in steps. We use classnames alphanumeric sort internally, let's start with that to avoid visual regressions.

1. Rollout to `processStylexRules` with `useLegacyClassnamesSort: true` and `legacyDisableLayers: true` 
2. Codemod legacy css to bump specificity when needed
3. Rollout with `legacyDisableLayers: false` (add selector hack for CSS ordering)
4. (stretch) Rollout with `useLegacyClassnamesSort: false` for size win (nice to have)

The stylesheets with these legacy configs should be identical to what we have internally.
