### PR TITLE
[babel-plugin] Fix hoisiting stylex.create with duplicate names correctly 

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
@@ -1793,5 +1793,72 @@ describe('@stylexjs/babel-plugin', () => {
         }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];"
       `);
     });
+
+    test('hoisting correctly with duplicte names', () => {
+      expect(
+        transform(
+          `
+            import * as stylex from "@stylexjs/stylex";
+            import * as React from "react";
+
+            function Foo() {
+              const styles = stylex.create({
+                div: { color: "red" },
+              });
+              return <div {...stylex.props(styles.div)}>Hello, foo!</div>;
+            }
+
+            function Bar() {
+              const styles = stylex.create({
+                div: { color: "blue" },
+              });
+              return <div {...stylex.props(styles.div)}>Hello, bar!</div>;
+            }
+
+            export function App() {
+              return (
+                <>
+                  <Foo />
+                  <Bar />
+                </>
+              );
+            }
+          `,
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import * as stylex from "@stylexjs/stylex";
+        import * as React from "react";
+        _inject2(".x1e2nbdu{color:red}", 3000);
+        const _styles = {
+          div: {
+            kMwMTN: "x1e2nbdu",
+            $$css: true
+          }
+        };
+        function Foo() {
+          const styles = _styles;
+          return <div {...stylex.props(styles.div)}>Hello, foo!</div>;
+        }
+        _inject2(".xju2f9n{color:blue}", 3000);
+        const _styles2 = {
+          div: {
+            kMwMTN: "xju2f9n",
+            $$css: true
+          }
+        };
+        function Bar() {
+          const styles = _styles2;
+          return <div {...stylex.props(styles.div)}>Hello, bar!</div>;
+        }
+        export function App() {
+          return <>
+                          <Foo />
+                          <Bar />
+                        </>;
+        }"
+      `);
+    });
   });
 });

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
@@ -259,7 +259,7 @@ export default function transformStyleXCreate(
       };
     }
 
-    if (varName != null) {
+    if (varName != null && isTopLevel(path)) {
       const stylesToRemember = removeObjectsWithSpreads(compiledStyles);
       state.styleMap.set(varName, stylesToRemember);
       state.styleVars.set(varName, path.parentPath as $FlowFixMe);
@@ -507,4 +507,13 @@ function legacyExpandShorthands(
     .filter(Boolean);
 
   return expandedKeysToKeyPaths;
+}
+
+function isTopLevel(path: NodePath<>): boolean {
+  if (path.isStatement()) {
+    return (
+      path.parentPath?.isProgram() || path.parentPath?.isExportDeclaration()
+    );
+  }
+  return path.parentPath != null && isTopLevel(path.parentPath);
 }


### PR DESCRIPTION
## What changed / motivation ?

Hoisting `stylex.create` can today result in a bug when `stylex.props` is pre-compiled.
This is because we manually memoize various `stylex.create` definitions by name.

This is not safe when the definition isn't already top-level as the same constant in two different contexts can conflict with each other.

This PR disables memoization of `stylex.create` calls that are not at the top level. As of right now, this means that it results in fewer compile-time optimizations of `stylex.props()` calls, but it does fix the bug.

There is already work underway to optimize `stylex.props` pre-compilation that will re-introduce the intended optimizations.

## Linked PR/Issues

Fixes #1252


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code