### PR TITLE
[fix] Enforce ordering for .when selectors lower than regular pseudos

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/when-functions-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/when-functions-test.js
@@ -70,7 +70,7 @@ describe('@stylexjs/babel-plugin', () => {
               "ltr": ".x148kuu:where(.x-default-marker:hover *){background-color:red}",
               "rtl": null,
             },
-            3040,
+            3011.3,
           ],
         ]
       `);
@@ -119,7 +119,7 @@ describe('@stylexjs/babel-plugin', () => {
               "ltr": ".x1i6rnlt:where(.x-default-marker:focus ~ *){background-color:red}",
               "rtl": null,
             },
-            3040,
+            3021.5,
           ],
         ]
       `);
@@ -149,7 +149,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         const styles = {
           container: {
-            kWkggS: "x1t391ir x148kuu xpijypl xoev4mv xczfykd x1r4rfca",
+            kWkggS: "x1t391ir x148kuu xpijypl xoev4mv x1v1vkh3 x9zntq3",
             $$css: true
           }
         };
@@ -172,7 +172,7 @@ describe('@stylexjs/babel-plugin', () => {
               "ltr": ".x148kuu:where(.x-default-marker:hover *){background-color:red}",
               "rtl": null,
             },
-            3040,
+            3011.3,
           ],
           [
             "xpijypl",
@@ -180,7 +180,7 @@ describe('@stylexjs/babel-plugin', () => {
               "ltr": ".xpijypl:where(.x-default-marker:focus ~ *){background-color:green}",
               "rtl": null,
             },
-            3040,
+            3021.5,
           ],
           [
             "xoev4mv",
@@ -188,23 +188,23 @@ describe('@stylexjs/babel-plugin', () => {
               "ltr": ".xoev4mv:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:yellow}",
               "rtl": null,
             },
-            3040,
+            3041.7,
           ],
           [
-            "xczfykd",
+            "x1v1vkh3",
             {
-              "ltr": ".xczfykd:has(~ .x-default-marker:focus){background-color:purple}",
+              "ltr": ".x1v1vkh3:where(:has(~ .x-default-marker:focus)){background-color:purple}",
               "rtl": null,
             },
-            3045,
+            3031.5,
           ],
           [
-            "x1r4rfca",
+            "x9zntq3",
             {
-              "ltr": ".x1r4rfca:has(.x-default-marker:focus){background-color:orange}",
+              "ltr": ".x9zntq3:where(:has(.x-default-marker:focus)){background-color:orange}",
               "rtl": null,
             },
-            3045,
+            3016.5,
           ],
         ]
       `);
@@ -254,7 +254,7 @@ describe('@stylexjs/babel-plugin', () => {
               "ltr": ".x148kuu:where(.x-default-marker:hover *){background-color:red}",
               "rtl": null,
             },
-            3040,
+            3011.3,
           ],
           [
             "xpijypl",
@@ -262,7 +262,7 @@ describe('@stylexjs/babel-plugin', () => {
               "ltr": ".xpijypl:where(.x-default-marker:focus ~ *){background-color:green}",
               "rtl": null,
             },
-            3040,
+            3021.5,
           ],
         ]
       `);

--- a/packages/@stylexjs/babel-plugin/src/shared/when/when.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/when/when.js
@@ -65,7 +65,7 @@ export function descendant(
   validatePseudoSelector(pseudo);
   const defaultMarker =
     typeof options === 'string' ? options : getDefaultMarkerClassName(options);
-  return `:has(.${defaultMarker}${pseudo})`;
+  return `:where(:has(.${defaultMarker}${pseudo}))`;
 }
 
 /**
@@ -99,7 +99,7 @@ export function siblingAfter(
   validatePseudoSelector(pseudo);
   const defaultMarker =
     typeof options === 'string' ? options : getDefaultMarkerClassName(options);
-  return `:has(~ .${defaultMarker}${pseudo})`;
+  return `:where(:has(~ .${defaultMarker}${pseudo}))`;
 }
 
 /**


### PR DESCRIPTION
## What changed / motivation ?

The new `.when.*` utility based selectors are currently implemented to all have the same low priority. This correctly ensures that `:when` always loses to pseudo classes on the element itself, however, when using multiple `.when` selectors, their order is currently alphabetical.

This PR fixes that to ensure that `.when` selectors have the same ordering as other pseudo classes. (e.g. `:hover` will lose to `:active`)

## Linked PR/Issues

Fixes #1251

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code