### PR TITLE
chore: remove deprecated open-props package from nextjs example.

### DIFF
--- a/examples/example-nextjs/app/Counter.tsx
+++ b/examples/example-nextjs/app/Counter.tsx
@@ -10,8 +10,7 @@
 'use client';
 
 import * as stylex from '@stylexjs/stylex';
-import { spacing, text, globalTokens as $ } from './globalTokens.stylex';
-import { colors } from '@stylexjs/open-props/lib/colors.stylex';
+import { spacing, text, globalTokens as $, colors } from './globalTokens.stylex';
 import { useState } from 'react';
 
 export default function Counter() {

--- a/examples/example-nextjs/app/globalTokens.stylex.ts
+++ b/examples/example-nextjs/app/globalTokens.stylex.ts
@@ -290,3 +290,13 @@ export const scales = stylex.defineVars({
   medium: 'scale(1)',
   large: 'scale(1.2)',
 });
+
+export const colors = stylex.defineVars({
+  blue3: '#74c0fc',
+  blue7: '#1c7ed6',
+  gray3: '#dee2e6',
+  gray4: '#ced4da',
+  gray8: '#343a40',
+  gray9: '#212529',
+  lime7: '#74b816'
+})

--- a/examples/example-nextjs/components/Card.tsx
+++ b/examples/example-nextjs/components/Card.tsx
@@ -8,8 +8,7 @@
  */
 
 import * as stylex from '@stylexjs/stylex';
-import { globalTokens as $, spacing, text } from '@/app/globalTokens.stylex';
-import { colors } from '@stylexjs/open-props/lib/colors.stylex';
+import { globalTokens as $, spacing, text, colors } from '@/app/globalTokens.stylex';
 import { tokens } from '@/app/CardTokens.stylex';
 
 type Props = Readonly<{

--- a/examples/example-nextjs/next.config.js
+++ b/examples/example-nextjs/next.config.js
@@ -12,7 +12,6 @@
 const path = require('path');
 
 module.exports = {
-  transpilePackages: ['@stylexjs/open-props'],
   eslint: { ignoreDuringBuilds: true },
   webpack: (config, { dev, isServer }) => {
     // Process only files that require StyleX compilation using babel-loader

--- a/examples/example-nextjs/package.json
+++ b/examples/example-nextjs/package.json
@@ -10,7 +10,6 @@
     "example:start": "next start"
   },
   "dependencies": {
-    "@stylexjs/open-props": "0.11.1",
     "@stylexjs/stylex": "0.16.1",
     "next": "14.2.21",
     "react": "^18.3.0",

--- a/examples/example-nextjs/postcss.config.js
+++ b/examples/example-nextjs/postcss.config.js
@@ -7,51 +7,14 @@
  *
  */
 
-const fs = require('fs');
 const path = require('path');
-
-const projectRoot = __dirname;
-const monorepoRoot = path.join(projectRoot, '../../');
-
-function getPackageIncludePaths(packageName, nodeModulePaths) {
-  let packagePath = null;
-
-  for (const nodeModulePath of nodeModulePaths) {
-    const packageJsonPath = path.resolve(
-      nodeModulePath,
-      packageName,
-      'package.json',
-    );
-    if (fs.existsSync(packageJsonPath)) {
-      packagePath = path.dirname(packageJsonPath);
-      break;
-    }
-  }
-  if (!packagePath) {
-    throw new Error(`Could not find package ${packageName}`);
-  }
-
-  return [
-    path.join(packagePath, '**/*.{js,mjs}'),
-    '!' + path.join(packagePath, 'node_modules/**/*.{js,mjs}'),
-  ];
-}
-
-const openPropsIncludePaths = getPackageIncludePaths('@stylexjs/open-props', [
-  path.join(projectRoot, 'node_modules'),
-  path.join(monorepoRoot, 'node_modules'),
-]);
 
 const dev = process.env.NODE_ENV !== 'production';
 
 module.exports = {
   plugins: {
     '@stylexjs/postcss-plugin': {
-      include: [
-        'app/**/*.{js,jsx,ts,tsx}',
-        'components/**/*.{js,jsx,ts,tsx}',
-        ...openPropsIncludePaths,
-      ],
+      include: ['app/**/*.{js,jsx,ts,tsx}', 'components/**/*.{js,jsx,ts,tsx}'],
       babelConfig: {
         babelrc: false,
         parserOpts: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,6 @@
     "examples/example-nextjs": {
       "version": "0.16.1",
       "dependencies": {
-        "@stylexjs/open-props": "0.11.1",
         "@stylexjs/stylex": "0.16.1",
         "next": "14.2.21",
         "react": "^18.3.0",
@@ -163,6 +162,136 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.21.tgz",
+      "integrity": "sha512-TSAA2ROgNzm4FhKbTbyJOBrsREOMVdDIltZ6aZiKvCi/v0UwFmwigBGeqXDA97TFMpR3LNNpw52CbVelkoQBxA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.21.tgz",
+      "integrity": "sha512-0Dqjn0pEUz3JG+AImpnMMW/m8hRtl1GQCNbO66V1yp6RswSTiKmnHf3pTX6xMdJYSemf3O4Q9ykiL0jymu0TuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.21.tgz",
+      "integrity": "sha512-Ggfw5qnMXldscVntwnjfaQs5GbBbjioV4B4loP+bjqNEb42fzZlAaK+ldL0jm2CTJga9LynBMhekNfV8W4+HBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.21.tgz",
+      "integrity": "sha512-uokj0lubN1WoSa5KKdThVPRffGyiWlm/vCc/cMkWOQHw69Qt0X1o3b2PyLLx8ANqlefILZh1EdfLRz9gVpG6tg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.21.tgz",
+      "integrity": "sha512-iAEBPzWNbciah4+0yI4s7Pce6BIoxTQ0AGCkxn/UBuzJFkYyJt71MadYQkjPqCQCJAFQ26sYh7MOKdU+VQFgPg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.21.tgz",
+      "integrity": "sha512-plykgB3vL2hB4Z32W3ktsfqyuyGAPxqwiyrAi2Mr8LlEUhNn9VgkiAl5hODSBpzIfWweX3er1f5uNpGDygfQVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.21.tgz",
+      "integrity": "sha512-w5bacz4Vxqrh06BjWgua3Yf7EMDb8iMcVhNrNx8KnJXt8t+Uu0Zg4JHLDL/T7DkTCEEfKXO/Er1fcfWxn2xfPA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.21.tgz",
+      "integrity": "sha512-sT6+llIkzpsexGYZq8cjjthRyRGe5cJVhqh12FmlbxHqna6zsDDK8UNaV7g41T6atFHCJUPeLb3uyAwrBwy0NA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/example-nextjs/node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
       }
     },
     "examples/example-nextjs/node_modules/@types/node": {
@@ -500,6 +629,60 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/example-storybook/node_modules/@stylexjs/babel-plugin": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@stylexjs/babel-plugin/-/babel-plugin-0.15.4.tgz",
+      "integrity": "sha512-QfL2j3VCU+KTyIEoPBhdwq8KW1Gv0FVvwSzfjjdQ0J2Ei/DJBx2AXVsDYzBcVw0WI+KsEfQUHFZ1Fk2t1U/9Iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.26.8",
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/traverse": "^7.26.8",
+        "@babel/types": "^7.26.8",
+        "@dual-bundle/import-meta-resolve": "^4.1.0",
+        "@stylexjs/stylex": "0.15.4",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "examples/example-storybook/node_modules/@stylexjs/eslint-plugin": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@stylexjs/eslint-plugin/-/eslint-plugin-0.15.4.tgz",
+      "integrity": "sha512-P33h+QdudEI3oSzIvVXhNHeAfbUzG4xGYW7tt4hdMizAl+bwIj58+8TK7fxQPV01yBMMNGrBlA/aCmzfQOP8Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-shorthand-expand": "^1.2.0",
+        "micromatch": "^4.0.5"
+      }
+    },
+    "examples/example-storybook/node_modules/@stylexjs/postcss-plugin": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@stylexjs/postcss-plugin/-/postcss-plugin-0.15.4.tgz",
+      "integrity": "sha512-VN02UG7cVWJok/LOX+Zb0Our6kTg+UW/YYj/x7UfY6DvbXfjLb6URB7fwjh+AyvEbY1YL4sIiIuw1U14M7ImHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.26.8",
+        "@stylexjs/babel-plugin": "0.15.4",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "postcss": "^8.4.49"
+      }
+    },
+    "examples/example-storybook/node_modules/@stylexjs/stylex": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@stylexjs/stylex/-/stylex-0.15.4.tgz",
+      "integrity": "sha512-UQT75p3qxwCIsVpH87YfgHvzWGDyMbQcFKhguj4noBZCc+npEh5h7J4BIHMgrxpyJa9mislLfXv+M5TmP2YH5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-mediaquery": "^0.1.2",
+        "invariant": "^2.2.4",
+        "styleq": "0.2.1"
       }
     },
     "examples/example-storybook/node_modules/@typescript-eslint/eslint-plugin": {
@@ -7551,6 +7734,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@next/env": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.21.tgz",
+      "integrity": "sha512-lXcwcJd5oR01tggjWJ6SrNNYFGuOOMB9c251wUNkjCpkoXOPkDeF/15c3mnVlBqrW4JJXb2kVxDFhC4GduJt2A==",
+      "license": "MIT"
+    },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.0.1.tgz",
@@ -9648,6 +9837,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
       }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -13060,6 +13255,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -27906,6 +28112,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/string_decoder": {


### PR DESCRIPTION
## What changed / motivation ?

The @stylexjs/open-props package was deprecated in StyleX v0.12.0. While working with the Next.js example, I noticed it was still using this deprecated dependency, which could mislead developers following the example. 
For now, I’ve replaced the dependency by defining only the required color tokens locally. Would you recommend sticking with this approach, or should we migrate from `@stylexjs/open-props` to `@stylextras/open-props` as suggested in the [v0.12.0 release notes](https://stylexjs.com/blog/v0.12.0/#deprecations)?

## Linked PR/Issues

Fixes #996 

## Additional Context

There is no visual change in the example app preview:
<img width="1440" height="779" alt="Screenshot 2025-10-02 at 3 31 09 PM" src="https://github.com/user-attachments/assets/4f57bcbb-1df1-4468-9748-68a455ebc415" />


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code