### PR TITLE
feat(eslint-plugin): enhance validation for ternary and logical expressions in style properties

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -619,6 +619,108 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       },
     });
     `,
+    // test for ternary and logical expressions
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          basicTernary: (condition) => ({
+            color: condition ? 'blue' : 'red',
+            display: condition ? 'block' : 'none',
+            fontSize: condition ? '10px' : '20px',
+            fontWeight: condition ? 'bold' : 'normal',
+            opacity: condition ? 0.5 : 1,
+            zIndex: condition ? 10 + 10 : Math.max(10, 20),
+          }),
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const COLOR = 'blue';
+        const sizeSmall = '10px';
+        const sizeMedium = '20px';
+        const sizeLarge = '30px';
+        const styles = stylex.create({
+          ternaryWithVars: (condition) => ({
+            fontSize: condition ? sizeSmall : sizeMedium,
+          }),
+          nestedTernaryWithVars: (conditionA, conditionB) => ({
+            backgroundColor: conditionA ? COLOR : conditionB ? 'green' : 'yellow',
+            fontSize: conditionA ? sizeSmall : conditionB ? sizeMedium : sizeLarge,
+          }),
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const COLOR = 'blue';
+        const styles = stylex.create({
+          nestedTernaryWithVars: (conditionA, conditionB) => ({
+            backgroundColor: conditionA ? COLOR : conditionB ? 'green' : 'yellow',
+            fontSize: conditionA ? 14 : conditionB ? 16 : 18,
+            opacity: conditionA ? 0.5 : conditionB ? 1 : 0.2,
+          }),
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const condition = true;
+        const styles = stylex.create({
+          default: {
+            width: condition ? '50%' : '100%',
+            '@media (max-width: 600px)': {
+              width: condition ? '100%' : '200%',
+            }
+          }
+        });
+      `,
+      options: [{ allowOuterPseudoAndMedia: true }],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const condition = true;
+        const styles = stylex.create({
+          default: {
+            float: condition ? 'inline-start' : 'inline-end',
+            clear: condition ? 'inline-start' : 'left',
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          emptyString: (condition) => ({
+            '::before': {
+              content: condition ? '""' : '"*"',
+            },
+          })
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const zIndexConst = 10;
+        const widthConst = 0;
+        const widthConst2 = 3;
+        const isMobile = false;
+        const styles = stylex.create({
+          container: {
+            color: "blue" || "green",
+            zIndex: zIndexConst ?? 10,
+            width: isMobile ? (widthConst || "100%") : (widthConst2 ?? "200%"),
+          }
+        });
+      `,
+    },
   ],
   invalid: [
     {
@@ -1716,6 +1818,103 @@ revert`,
             float: 'inline-end',
             clear: 'inline-end',
           }
+        });
+      `,
+    },
+    // test for ternary and logical expressions
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          ternaryWithBasicInvalidStyles: (condition) => ({
+            color: condition ? 'red' : 123,
+            fontSize: condition ? true : '10px',
+            transition: condition ? 'transform 1s' : ' ',
+            zIndex: condition ?? 'red'
+          }),
+        });
+      `,
+      errors: [
+        {
+          message: /^color value must be one of:\n/,
+        },
+        {
+          message: /^fontSize value must be one of:\n/,
+        },
+        {
+          message: 'The empty string is not allowed by Stylex.',
+        },
+        {
+          message: /^zIndex value must be one of:\n/,
+        },
+      ],
+    },
+    {
+      code: `import * as stylex from '@stylexjs/stylex';
+const styles = stylex.create({
+  ternaryWithBasicInvalidStyles: (condition) => ({
+    float: condition ? 'start' : 'inline-end',
+  }),
+});`,
+      errors: [
+        {
+          message:
+            'The value "start" is not a standard CSS value for "float". Did you mean "inline-start"?',
+          suggestions: [
+            {
+              desc: 'Replace "start" with "inline-start"?',
+            },
+          ],
+        },
+      ],
+      output: `import * as stylex from '@stylexjs/stylex';
+const styles = stylex.create({
+  ternaryWithBasicInvalidStyles: (condition) => ({
+    float: condition ? 'inline-start' : 'inline-end',
+  }),
+});`,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          nestedInvalidStyles: (conditionA, conditionB) => ({
+            display: conditionA ?  conditionB ? 'grid' : 'invalid-display' : 'block',
+          }),
+        });
+      `,
+      errors: [
+        {
+          message: /^display value must be one of:\n/,
+        },
+      ],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          ternaryWithInvalidType: (condition) => ({
+            fontWeight: condition ? sasasa : 'bold',
+            marginStart: condition ? '10px' : '20px',
+          }),
+        });
+      `,
+      errors: [
+        {
+          message: /^fontWeight value must be one of:\n/,
+        },
+        {
+          message:
+            'The key "marginStart" is not a standard CSS property. Did you mean "marginInlineStart"?',
+        },
+      ],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          ternaryWithInvalidType: (condition) => ({
+            fontWeight: condition ? sasasa : 'bold',
+            marginInlineStart: condition ? '10px' : '20px',
+          }),
         });
       `,
     },

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -1830,7 +1830,8 @@ revert`,
             color: condition ? 'red' : 123,
             fontSize: condition ? true : '10px',
             transition: condition ? 'transform 1s' : ' ',
-            zIndex: condition ?? 'red'
+            zIndex: condition ?? 'red',
+            display: 'invalid-display' || 'block',
           }),
         });
       `,
@@ -1846,6 +1847,9 @@ revert`,
         },
         {
           message: /^zIndex value must be one of:\n/,
+        },
+        {
+          message: /^display value must be one of:\n/,
         },
       ],
     },


### PR DESCRIPTION
## What changed / motivation ?
ESLint rule was incorrectly flagging valid style properties when values were assigned conditionally using ternary operators (`? :`) or logical operators (`||`, `??`, `&&`).

Enhanced the validation logic to properly traverse and validate both branches of conditional expressions:
- **Ternary expressions**: Validates both consequent and alternate branches
- **Logical expressions**: Validates both left and right operands for `||`, `??`, and `&&` operators

Please let me know if I’ve missed any scenarios or if you’d suggest further refactoring. I’m happy to incorporate feedback.

## Linked PR/Issues

Fixes: #1259 

## Additional Context

Before:
<img width="387" height="152" alt="Screenshot 2025-10-04 at 6 13 46 PM" src="https://github.com/user-attachments/assets/b55e0ff6-0b1e-4f98-a8bd-1a37992ae6c3" />

After:
<img width="387" height="152" alt="Screenshot 2025-10-04 at 6 15 54 PM" src="https://github.com/user-attachments/assets/574525c5-50e3-4e61-b01a-f16d38ab5b58" />

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code