### PR TITLE
docs: update `stylex.defaultMarker` usage to properly invoke it

### DIFF
--- a/packages/docs/blog/2025-09-25-Release-v0.16.0.mdx
+++ b/packages/docs/blog/2025-09-25-Release-v0.16.0.mdx
@@ -34,7 +34,7 @@ const styles = stylex.create({
     },
 });
 
-<div {...stylex.props(stylex.defaultMarker)}>
+<div {...stylex.props(stylex.defaultMarker())}>
   <div {...stylex.props(styles.foo)}> Some Content </div>
 </div>
 ```


### PR DESCRIPTION
## What changed / motivation ?

While migrating to newer version and using `stylex.defaultMarker` I spotted that it must be invoked. In opposite to the release blog post, where it's just passed in.

## Linked PR/Issues

N/A

## Additional Context

TypeScript complaining it's a function:

<img width="1045" height="64" alt="image" src="https://github.com/user-attachments/assets/62c2507b-61ba-4c66-8af1-26116bd468ad" />

I also verified and it correctly works when invoking + tests assume this, so the blog post has a small mistake here.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code