### PR TITLE
[babel-plugin] Fix `index.d.ts`

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/index.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/index.d.ts
@@ -42,8 +42,7 @@ declare function processStylexRules(
         useLayers?: boolean,
         enableLTRRTLComments?: boolean,
         legacyDisableLayers?: boolean,
-        ...
-      },
+      }
 ): string;
 export type StyleXTransformObj = Readonly<{
   (): PluginObj;


### PR DESCRIPTION
## What changed / motivation ?

Some Flow-specific syntax seems to have sneaked into `0.16.1`'s `packages/@stylexjs/babel-plugin/src/index.d.ts`. 

Also TS objects are inexact by default, so the semantics are correct without the `...`.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code