### PR TITLE
[babel-plugin] fix defineVars at-rules priorities

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -33,7 +33,18 @@ function transform(source, opts = {}) {
       mediaSmall: '@media (max-width: 500px)'
     });
     export const vars = stylex.defineVars({
-      blue: 'blue'
+      blue: 'blue',
+      marginTokens: {
+        default: "10px",
+        "@media (min-width: 600px)": "20px"
+      },
+      colorTokens: {
+        default: 'red',
+        '@media (prefers-color-scheme: dark)': {
+          default: 'lightblue',
+          '@supports (color: oklab(0 0 0))': 'oklab(0.7 -0.3 -0.4)',
+        }
+      },
     });
     `,
     {
@@ -107,6 +118,7 @@ export const styles = stylex.create({
       }
     }),
     backgroundColor: 'red',
+    margin: vars.marginTokens,
     borderColor: {
       default: 'green',
       [constants.mediaBig]: {
@@ -114,6 +126,7 @@ export const styles = stylex.create({
         [constants.mediaSmall]: 'yellow',
       }
     },
+    outlineColor: vars.colorTokens,
     textShadow: {
       default: '1px 2px 3px 4px red',
       '@media (min-width:320px)': '10px 20px 30px 40px green'
@@ -143,6 +156,8 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           blue: "var(--blue-xpqh4lw)",
+          marginTokens: "var(--marginTokens-x8nt2k2)",
+          colorTokens: "var(--colorTokens-xkxfyv)",
           __varGroupHash__: "xsg933n"
         };
         export const spacing = {
@@ -158,8 +173,11 @@ describe('@stylexjs/babel-plugin', () => {
           enableLTRRTLComments: false,
         }),
       ).toMatchInlineSnapshot(`
-        ":root, .xsg933n{--blue-xpqh4lw:blue;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}"
+        ":root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}"
       `);
     });
 
@@ -175,6 +193,8 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           blue: "var(--blue-xpqh4lw)",
+          marginTokens: "var(--marginTokens-x8nt2k2)",
+          colorTokens: "var(--colorTokens-xkxfyv)",
           __varGroupHash__: "xsg933n"
         };
         export const spacing = {
@@ -195,20 +215,21 @@ describe('@stylexjs/babel-plugin', () => {
           root: {
             "animationName-kKVMdj": "animationName-x13ah0pd",
             "backgroundColor-kWkggS": "backgroundColor-xrkmrrc",
+            "margin-kogj98": "margin-xymmreb",
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
+            "outlineColor-kjBf7l": "outlineColor-x184ctg8",
             "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-x1cmij7u",
             "padding-kmVPX3": "padding-xss17vw",
-            "margin-kogj98": "margin-xymmreb",
             "float-kyUFMd": "float-x1kmio9f",
-            $$css: "app/main.js:31"
+            $$css: "app/main.js:33"
           },
           overrideColor: {
             "--orange-theme-color": "--orange-theme-color-xufgesz",
-            $$css: "app/main.js:58"
+            $$css: "app/main.js:62"
           },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:61"
+            $$css: "app/main.js:65"
           }, {
             "--x-color": color != null ? color : undefined
           }]
@@ -222,8 +243,11 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "@property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;}
+        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
         .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
         .--orange-theme-color-xufgesz{--orange-theme-color:red}
@@ -237,6 +261,7 @@ describe('@stylexjs/babel-plugin', () => {
         .color-x14rh7hd:not(#\\#):not(#\\#):not(#\\#){color:var(--x-color)}
         html:not([dir='rtl']) .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:left}
         html[dir='rtl'] .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:right}
+        .outlineColor-x184ctg8:not(#\\#):not(#\\#):not(#\\#){outline-color:var(--colorTokens-xkxfyv)}
         .textShadow-x1skrh0i:not(#\\#):not(#\\#):not(#\\#){text-shadow:1px 2px 3px 4px red}
         @media (min-width:320px){.textShadow-x1cmij7u.textShadow-x1cmij7u:not(#\\#):not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}"
       `);
@@ -256,6 +281,8 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           blue: "var(--blue-xpqh4lw)",
+          marginTokens: "var(--marginTokens-x8nt2k2)",
+          colorTokens: "var(--colorTokens-xkxfyv)",
           __varGroupHash__: "xsg933n"
         };
         export const spacing = {
@@ -276,20 +303,21 @@ describe('@stylexjs/babel-plugin', () => {
           root: {
             "animationName-kKVMdj": "animationName-x13ah0pd",
             "backgroundColor-kWkggS": "backgroundColor-xrkmrrc",
+            "margin-kogj98": "margin-xymmreb",
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
+            "outlineColor-kjBf7l": "outlineColor-x184ctg8",
             "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-x1cmij7u",
             "padding-kmVPX3": "padding-xss17vw",
-            "margin-kogj98": "margin-xymmreb",
             "float-kyUFMd": "float-x1kmio9f",
-            $$css: "app/main.js:31"
+            $$css: "app/main.js:33"
           },
           overrideColor: {
             "--orange-theme-color": "--orange-theme-color-xufgesz",
-            $$css: "app/main.js:58"
+            $$css: "app/main.js:62"
           },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:61"
+            $$css: "app/main.js:65"
           }, {
             "--x-color": color != null ? color : undefined
           }]
@@ -305,8 +333,11 @@ describe('@stylexjs/babel-plugin', () => {
         @layer priority1, priority2, priority3, priority4;
         @property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;}
+        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
         .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
         .--orange-theme-color-xufgesz{--orange-theme-color:red}
@@ -325,6 +356,7 @@ describe('@stylexjs/babel-plugin', () => {
         .color-x14rh7hd{color:var(--x-color)}
         html:not([dir='rtl']) .float-x1kmio9f{float:left}
         html[dir='rtl'] .float-x1kmio9f{float:right}
+        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
         .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
         @media (min-width:320px){.textShadow-x1cmij7u.textShadow-x1cmij7u{text-shadow:10px 20px 30px 40px green}}
         }"
@@ -343,6 +375,8 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           blue: "var(--blue-xpqh4lw)",
+          marginTokens: "var(--marginTokens-x8nt2k2)",
+          colorTokens: "var(--colorTokens-xkxfyv)",
           __varGroupHash__: "xsg933n"
         };
         export const spacing = {
@@ -363,20 +397,21 @@ describe('@stylexjs/babel-plugin', () => {
           root: {
             "animationName-kKVMdj": "animationName-x13ah0pd",
             "backgroundColor-kWkggS": "backgroundColor-xrkmrrc",
+            "margin-kogj98": "margin-xymmreb",
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
+            "outlineColor-kjBf7l": "outlineColor-x184ctg8",
             "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-x1cmij7u",
             "padding-kmVPX3": "padding-xss17vw",
-            "margin-kogj98": "margin-xymmreb",
             "float-kyUFMd": "float-x1kmio9f",
-            $$css: "app/main.js:31"
+            $$css: "app/main.js:33"
           },
           overrideColor: {
             "--orange-theme-color": "--orange-theme-color-xufgesz",
-            $$css: "app/main.js:58"
+            $$css: "app/main.js:62"
           },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:61"
+            $$css: "app/main.js:65"
           }, {
             "--x-color": color != null ? color : undefined
           }]
@@ -391,8 +426,11 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "@property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;}
+        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
         .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
         .--orange-theme-color-xufgesz{--orange-theme-color:red}
@@ -406,6 +444,7 @@ describe('@stylexjs/babel-plugin', () => {
         .color-x14rh7hd{color:var(--x-color)}
         html:not([dir='rtl']) .float-x1kmio9f{float:left}
         html[dir='rtl'] .float-x1kmio9f{float:right}
+        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
         .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
         @media (min-width:320px){.textShadow-x1cmij7u.textShadow-x1cmij7u{text-shadow:10px 20px 30px 40px green}}"
       `);
@@ -439,6 +478,8 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const vars = {
           blue: "var(--blue-xpqh4lw)",
+          marginTokens: "var(--marginTokens-x8nt2k2)",
+          colorTokens: "var(--colorTokens-xkxfyv)",
           __varGroupHash__: "xsg933n"
         };
         export const spacing = {
@@ -458,7 +499,7 @@ describe('@stylexjs/babel-plugin', () => {
             "paddingBottom-kGO01o": "paddingBottom-xs9asl8",
             "paddingInlineStart-kZCmMZ": "paddingInlineStart-x1gx403c",
             "float-kyUFMd": "float-x1kmio9f",
-            $$css: "app/main.js:23"
+            $$css: "app/main.js:25"
           }
         };"
       `);
@@ -469,8 +510,11 @@ describe('@stylexjs/babel-plugin', () => {
           enableLTRRTLComments: true,
         }),
       ).toMatchInlineSnapshot(`
-        ":root, .xsg933n{--blue-xpqh4lw:blue;}
+        ":root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
         /* @ltr begin */.float-x1kmio9f:not(#\\#){float:left}/* @ltr end */
         /* @rtl begin */.float-x1kmio9f:not(#\\#){float:right}/* @rtl end */
         /* @ltr begin */.marginInlineStart-xqsn43r:not(#\\#){margin-left:20px}/* @ltr end */
@@ -512,8 +556,11 @@ describe('@stylexjs/babel-plugin', () => {
           enableLTRRTLComments: false,
         }),
       ).toMatchInlineSnapshot(`
-        ":root, .xsg933n{--blue-xpqh4lw:blue;}
+        ":root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
         .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}"
       `);
@@ -563,7 +610,10 @@ describe('@stylexjs/babel-plugin', () => {
         "@property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
         :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
-        :root, .xsg933n{--xpqh4lw:blue;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
         .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
         .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
         .xufgesz{--orange-theme-color:red}
@@ -577,6 +627,7 @@ describe('@stylexjs/babel-plugin', () => {
         .x14rh7hd{color:var(--x-color)}
         /* @ltr begin */.x1kmio9f{float:left}/* @ltr end */
         /* @rtl begin */.x1kmio9f{float:right}/* @rtl end */
+        .x18abd1y{outline-color:var(--xkxfyv)}
         .x1skrh0i{text-shadow:1px 2px 3px 4px red}
         @media (min-width:320px){.x1cmij7u.x1cmij7u{text-shadow:10px 20px 30px 40px green}}"
       `);
@@ -598,7 +649,10 @@ describe('@stylexjs/babel-plugin', () => {
         "@property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
         :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
-        :root, .xsg933n{--xpqh4lw:blue;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
         .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
         .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
         .xufgesz{--orange-theme-color:red}
@@ -609,6 +663,7 @@ describe('@stylexjs/babel-plugin', () => {
         @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys{border-color:yellow}}}
         .x13ah0pd{animation-name:x35atj5-B}
         .x14rh7hd{color:var(--x-color)}
+        .x18abd1y{outline-color:var(--xkxfyv)}
         /* @ltr begin */.x1kmio9f{float:left}/* @ltr end */
         /* @rtl begin */.x1kmio9f{float:right}/* @rtl end */
         .x1skrh0i{text-shadow:1px 2px 3px 4px red}

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-createTheme-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-createTheme-test.js
@@ -128,7 +128,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -136,7 +136,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -144,7 +144,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x4aw18j",
@@ -209,7 +209,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -217,7 +217,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -225,7 +225,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x4aw18j",
@@ -289,7 +289,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .x1xohuxq{--xt4ziaz:blue;--x1e3it8h:grey;--x1onrunl:10;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x1xohuxq-1lveb7",
@@ -297,7 +297,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .x1xohuxq{--xt4ziaz:lightblue;--x1e3it8h:rgba(0, 0, 0, 0.8);}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x1xohuxq-bdddrq",
@@ -305,7 +305,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .x1xohuxq{--xt4ziaz:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xv0nx9o",
@@ -372,7 +372,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--color:blue;--otherColor:grey;--radius:10;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -380,7 +380,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--color:lightblue;--otherColor:rgba(0, 0, 0, 0.8);}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -388,7 +388,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--color:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x1l2ihi1",
@@ -443,7 +443,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -451,7 +451,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -459,7 +459,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x4aw18j",
@@ -521,7 +521,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -529,7 +529,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -537,7 +537,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x1s6ff5p",
@@ -583,7 +583,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -591,7 +591,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -599,7 +599,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xp8mj21",
@@ -645,7 +645,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -653,7 +653,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -661,7 +661,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x1et03wi",
@@ -716,7 +716,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -724,7 +724,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -732,7 +732,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x5gq8ml",
@@ -798,7 +798,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -806,7 +806,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -814,7 +814,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x4aw18j",
@@ -904,7 +904,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -912,7 +912,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -920,7 +920,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x4aw18j",
@@ -959,7 +959,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .x1ngxneg{--x103gslp:blue;--x1e7put6:grey;--xm3n3tg:10;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x1ngxneg-1lveb7",
@@ -967,7 +967,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .x1ngxneg{--x103gslp:lightblue;--x1e7put6:rgba(0, 0, 0, 0.8);}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x1ngxneg-bdddrq",
@@ -975,7 +975,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .x1ngxneg{--x103gslp:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xgl5cw9",
@@ -1068,7 +1068,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-1lveb7",
@@ -1076,7 +1076,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-bdddrq",
@@ -1084,7 +1084,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xowvtgn",
@@ -1136,7 +1136,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-1lveb7",
@@ -1144,7 +1144,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-bdddrq",
@@ -1152,7 +1152,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xowvtgn",
@@ -1205,7 +1205,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-1lveb7",
@@ -1213,7 +1213,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-bdddrq",
@@ -1221,7 +1221,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xowvtgn",
@@ -1274,7 +1274,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-1lveb7",
@@ -1282,7 +1282,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-bdddrq",
@@ -1290,7 +1290,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xowvtgn",
@@ -1345,7 +1345,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-1lveb7",
@@ -1353,7 +1353,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-bdddrq",
@@ -1361,7 +1361,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xowvtgn",
@@ -1418,7 +1418,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-1lveb7",
@@ -1426,7 +1426,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;--xaaua2w:rgba(0, 0, 0, 0.8);}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-bdddrq",
@@ -1434,7 +1434,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media print{:root, .xop34xu{--xwx8imx:white;}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xowvtgn",

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineVars-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineVars-test.js
@@ -105,7 +105,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -113,7 +113,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xaaua2w:lightblue;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -121,7 +121,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--xaaua2w:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -170,7 +170,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -178,7 +178,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xaaua2w:lightblue;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -186,7 +186,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--xaaua2w:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -224,7 +224,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .x1xohuxq{--xt4ziaz:red;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -262,7 +262,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -270,7 +270,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1e6ryz3",
@@ -278,7 +278,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:oklab(0.7 -0.3 -0.4);}}}",
                 "rtl": null,
               },
-              0.2,
+              0.30000000000000004,
             ],
           ],
         }
@@ -315,7 +315,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--color:red;--otherColor:blue;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1tdxo4z",
@@ -323,7 +323,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":hover{:root, .xop34xu{--otherColor:lightblue;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -377,7 +377,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--color:red;--nextColor:green;--otherColor:blue;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -385,7 +385,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--otherColor:lightblue;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -393,7 +393,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--otherColor:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -427,7 +427,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -461,7 +461,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xu6xznv:10rem;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -495,7 +495,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xbbre8:20;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -539,7 +539,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-1lveb7",
@@ -547,7 +547,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:white;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "xop34xu-bdddrq",
@@ -555,7 +555,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@media print{:root, .xop34xu{--xwx8imx:black;}}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -594,7 +594,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x1pfrffu",
@@ -602,7 +602,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .x1pfrffu{--xnjepv0:orange;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -641,7 +641,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
             [
               "x1pfrffu",
@@ -649,7 +649,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .x1pfrffu{--xnjepv0:var(--xwx8imx);}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -695,7 +695,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -709,7 +709,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .x1pfrffu{--xnjepv0:orange;}",
                 "rtl": null,
               },
-              0.1,
+              0.2,
             ],
           ],
         }
@@ -754,7 +754,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--color-xwx8imx:blue;--otherColor-xaaua2w:green;}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-1lveb7",
@@ -762,7 +762,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--color-xwx8imx:lightblue;}}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
               [
                 "xop34xu-1e6ryz3",
@@ -770,7 +770,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xop34xu{--color-xwx8imx:oklab(0.7 -0.3 -0.4);}}}",
                   "rtl": null,
                 },
-                0.2,
+                0.30000000000000004,
               ],
             ],
           }
@@ -812,7 +812,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--_10-x187fpdw:green;--_1_5_pixels-x15ahj5d:blue;--corner_radius-x2ajqv2:purple;--__primary-x13tvx0f:pink;}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
             ],
           }
@@ -854,7 +854,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--color-xwx8imx:red;--nextColor-xk6xtqk:green;--otherColor-xaaua2w:blue;}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
             ],
           }
@@ -881,7 +881,7 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import * as stylex from '@stylexjs/stylex';
-          _inject2(":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}", 0.1);
+          _inject2(":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}", 0.2);
           export const vars = {
             color: "var(--xwx8imx)",
             nextColor: "var(--xk6xtqk)",
@@ -899,7 +899,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
             ],
           }
@@ -945,7 +945,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .x1bxutiz{--color-x1lzcbr1:red;}",
                   "rtl": null,
                 },
-                0.1,
+                0.2,
               ],
             ],
           }

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-define-vars.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-define-vars.js
@@ -125,7 +125,7 @@ function constructCssVariablesString(
     result[varGroupHash + suffix] = {
       ltr,
       rtl: null,
-      priority: priorityForAtRule(atRule) * 0.1,
+      priority: 0.1 + priorityForAtRule(atRule) * 0.1,
     };
   }
 


### PR DESCRIPTION
We need the priorities of variables with at-rules higher than the priorities of plain variables. In https://github.com/facebook/stylex/pull/1087 we bumped the specificity of plain variables by 0.1, causing the priorities to break when wrapped with one at-rule.

This works when building the prod sheet because `:root` is lexicographically before `@media`, (and in the legacy Haste sort, because the appended hash) but it breaks in runtime injection. 

Now:
```
        export const vars = stylex.defineVars({
          color: {
            default: 'blue',
            '@media (prefers-color-scheme: dark)': {
              default: 'lightblue',
              '@supports (color: oklab(0 0 0))': 'oklab(0.7 -0.3 -0.4)',
            }
          },
        });
```
Transforms to 
```
{
  "stylex": [
    [
      "xop34xu",
      {
        "ltr": ":root, .xop34xu{--xwx8imx:blue;}",
        "rtl": null,
      },
      0.1,
    ],
    [
      "xop34xu-1lveb7",
      {
        "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;}}",
        "rtl": null,
      },
      0.2,
    ],
    [
      "xop34xu-1e6ryz3",
      {
        "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:oklab(0.7 -0.3 -0.4);}}}",
        "rtl": null,
      },
      0.3,
    ],
  ],
}
```