### PR TITLE
[babel-plugin] refine createTheme and defineVars priorities

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -174,9 +174,9 @@ describe('@stylexjs/babel-plugin', () => {
         }),
       ).toMatchInlineSnapshot(`
         ":root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
         @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}"
       `);
     });
@@ -244,9 +244,9 @@ describe('@stylexjs/babel-plugin', () => {
         "@property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
         :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
         @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
         .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
@@ -334,9 +334,9 @@ describe('@stylexjs/babel-plugin', () => {
         @property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
         :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
         @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
         .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
@@ -427,9 +427,9 @@ describe('@stylexjs/babel-plugin', () => {
         "@property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
         :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
         @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
         .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
@@ -511,9 +511,9 @@ describe('@stylexjs/babel-plugin', () => {
         }),
       ).toMatchInlineSnapshot(`
         ":root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
         @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
         /* @ltr begin */.float-x1kmio9f:not(#\\#){float:left}/* @ltr end */
         /* @rtl begin */.float-x1kmio9f:not(#\\#){float:right}/* @rtl end */
@@ -557,9 +557,9 @@ describe('@stylexjs/babel-plugin', () => {
         }),
       ).toMatchInlineSnapshot(`
         ":root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
         @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
         @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
         .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}"

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-createTheme-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-createTheme-test.js
@@ -94,7 +94,10 @@ const themeObject = `{
   },
   otherColor: {
     default: 'antiquewhite',
-    '@media (prefers-color-scheme: dark)': 'floralwhite',
+    '@media (prefers-color-scheme: dark)': {
+      default: 'floralwhite',
+      '@supports (color: oklab(0 0 0))': 'oklab(0.7 -0.3 -0.4)',
+    }
   },
   radius: '6px'
 }`;
@@ -115,7 +118,7 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "xop34xu"
         };
         export const theme = {
-          xop34xu: "x4aw18j xop34xu",
+          xop34xu: "x10yrbfs xop34xu",
           $$css: true
         };"
       `);
@@ -128,7 +131,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -147,28 +150,36 @@ describe('@stylexjs/babel-plugin', () => {
               0.2,
             ],
             [
-              "x4aw18j",
+              "x10yrbfs",
               {
-                "ltr": ".x4aw18j, .x4aw18j:root{--xwx8imx:green;--xaaua2w:antiquewhite;--xbbre8:6px;}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:green;--xaaua2w:antiquewhite;--xbbre8:6px;}",
                 "rtl": null,
               },
               0.5,
             ],
             [
-              "x4aw18j-1lveb7",
+              "x10yrbfs-1lveb7",
               {
-                "ltr": "@media (prefers-color-scheme: dark){.x4aw18j, .x4aw18j:root{--xwx8imx:lightgreen;--xaaua2w:floralwhite;}}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:lightgreen;--xaaua2w:floralwhite;}",
                 "rtl": null,
               },
-              0.6,
+              0.6000000000000001,
             ],
             [
-              "x4aw18j-bdddrq",
+              "x10yrbfs-1e6ryz3",
               {
-                "ltr": "@media print{.x4aw18j, .x4aw18j:root{--xwx8imx:transparent;}}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xaaua2w:oklab(0.7 -0.3 -0.4);}",
                 "rtl": null,
               },
-              0.6,
+              0.7,
+            ],
+            [
+              "x10yrbfs-bdddrq",
+              {
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:transparent;}",
+                "rtl": null,
+              },
+              0.6000000000000001,
             ],
           ],
         }
@@ -196,7 +207,7 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "xop34xu"
         };
         export const theme = {
-          xop34xu: "x4aw18j xop34xu",
+          xop34xu: "x10yrbfs xop34xu",
           $$css: true
         };"
       `);
@@ -209,7 +220,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -228,28 +239,36 @@ describe('@stylexjs/babel-plugin', () => {
               0.2,
             ],
             [
-              "x4aw18j",
+              "x10yrbfs",
               {
-                "ltr": ".x4aw18j, .x4aw18j:root{--xwx8imx:green;--xaaua2w:antiquewhite;--xbbre8:6px;}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:green;--xaaua2w:antiquewhite;--xbbre8:6px;}",
                 "rtl": null,
               },
               0.5,
             ],
             [
-              "x4aw18j-1lveb7",
+              "x10yrbfs-1lveb7",
               {
-                "ltr": "@media (prefers-color-scheme: dark){.x4aw18j, .x4aw18j:root{--xwx8imx:lightgreen;--xaaua2w:floralwhite;}}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:lightgreen;--xaaua2w:floralwhite;}",
                 "rtl": null,
               },
-              0.6,
+              0.6000000000000001,
             ],
             [
-              "x4aw18j-bdddrq",
+              "x10yrbfs-1e6ryz3",
               {
-                "ltr": "@media print{.x4aw18j, .x4aw18j:root{--xwx8imx:transparent;}}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xaaua2w:oklab(0.7 -0.3 -0.4);}",
                 "rtl": null,
               },
-              0.6,
+              0.7,
+            ],
+            [
+              "x10yrbfs-bdddrq",
+              {
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:transparent;}",
+                "rtl": null,
+              },
+              0.6000000000000001,
             ],
           ],
         }
@@ -276,7 +295,7 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "x1xohuxq"
         };
         export const theme = {
-          x1xohuxq: "xv0nx9o x1xohuxq",
+          x1xohuxq: "x1qn30me x1xohuxq",
           $$css: true
         };"
       `);
@@ -289,7 +308,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .x1xohuxq{--xt4ziaz:blue;--x1e3it8h:grey;--x1onrunl:10;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "x1xohuxq-1lveb7",
@@ -308,28 +327,36 @@ describe('@stylexjs/babel-plugin', () => {
               0.2,
             ],
             [
-              "xv0nx9o",
+              "x1qn30me",
               {
-                "ltr": ".xv0nx9o, .xv0nx9o:root{--xt4ziaz:green;--x1e3it8h:antiquewhite;--x1onrunl:6px;}",
+                "ltr": ".x1qn30me, .x1qn30me:root{--xt4ziaz:green;--x1e3it8h:antiquewhite;--x1onrunl:6px;}",
                 "rtl": null,
               },
               0.5,
             ],
             [
-              "xv0nx9o-1lveb7",
+              "x1qn30me-1lveb7",
               {
-                "ltr": "@media (prefers-color-scheme: dark){.xv0nx9o, .xv0nx9o:root{--xt4ziaz:lightgreen;--x1e3it8h:floralwhite;}}",
+                "ltr": ".x1qn30me, .x1qn30me:root{--xt4ziaz:lightgreen;--x1e3it8h:floralwhite;}",
                 "rtl": null,
               },
-              0.6,
+              0.6000000000000001,
             ],
             [
-              "xv0nx9o-bdddrq",
+              "x1qn30me-1e6ryz3",
               {
-                "ltr": "@media print{.xv0nx9o, .xv0nx9o:root{--xt4ziaz:transparent;}}",
+                "ltr": ".x1qn30me, .x1qn30me:root{--x1e3it8h:oklab(0.7 -0.3 -0.4);}",
                 "rtl": null,
               },
-              0.6,
+              0.7,
+            ],
+            [
+              "x1qn30me-bdddrq",
+              {
+                "ltr": ".x1qn30me, .x1qn30me:root{--xt4ziaz:transparent;}",
+                "rtl": null,
+              },
+              0.6000000000000001,
             ],
           ],
         }
@@ -372,7 +399,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--color:blue;--otherColor:grey;--radius:10;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -425,12 +452,15 @@ describe('@stylexjs/babel-plugin', () => {
           },
           otherColor: {
             default: 'antiquewhite',
-            '@media (prefers-color-scheme: dark)': 'floralwhite'
+            '@media (prefers-color-scheme: dark)': {
+              default: 'floralwhite',
+              '@supports (color: oklab(0 0 0))': 'oklab(0.7 -0.3 -0.4)'
+            }
           },
           radius: '6px'
         };
         export const theme = {
-          xop34xu: "x4aw18j xop34xu",
+          xop34xu: "x10yrbfs xop34xu",
           $$css: true
         };"
       `);
@@ -443,7 +473,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -462,28 +492,36 @@ describe('@stylexjs/babel-plugin', () => {
               0.2,
             ],
             [
-              "x4aw18j",
+              "x10yrbfs",
               {
-                "ltr": ".x4aw18j, .x4aw18j:root{--xwx8imx:green;--xaaua2w:antiquewhite;--xbbre8:6px;}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:green;--xaaua2w:antiquewhite;--xbbre8:6px;}",
                 "rtl": null,
               },
               0.5,
             ],
             [
-              "x4aw18j-1lveb7",
+              "x10yrbfs-1lveb7",
               {
-                "ltr": "@media (prefers-color-scheme: dark){.x4aw18j, .x4aw18j:root{--xwx8imx:lightgreen;--xaaua2w:floralwhite;}}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:lightgreen;--xaaua2w:floralwhite;}",
                 "rtl": null,
               },
-              0.6,
+              0.6000000000000001,
             ],
             [
-              "x4aw18j-bdddrq",
+              "x10yrbfs-1e6ryz3",
               {
-                "ltr": "@media print{.x4aw18j, .x4aw18j:root{--xwx8imx:transparent;}}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xaaua2w:oklab(0.7 -0.3 -0.4);}",
                 "rtl": null,
               },
-              0.6,
+              0.7,
+            ],
+            [
+              "x10yrbfs-bdddrq",
+              {
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:transparent;}",
+                "rtl": null,
+              },
+              0.6000000000000001,
             ],
           ],
         }
@@ -521,7 +559,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -583,7 +621,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -645,7 +683,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -716,7 +754,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -745,18 +783,18 @@ describe('@stylexjs/babel-plugin', () => {
             [
               "x5gq8ml-1lveb7",
               {
-                "ltr": "@media (prefers-color-scheme: dark){.x5gq8ml, .x5gq8ml:root{--xwx8imx:lightgreen;--xaaua2w:floralwhite;}}",
+                "ltr": ".x5gq8ml, .x5gq8ml:root{--xwx8imx:lightgreen;--xaaua2w:floralwhite;}",
                 "rtl": null,
               },
-              0.6,
+              0.6000000000000001,
             ],
             [
               "x5gq8ml-bdddrq",
               {
-                "ltr": "@media print{.x5gq8ml, .x5gq8ml:root{--xwx8imx:transparent;}}",
+                "ltr": ".x5gq8ml, .x5gq8ml:root{--xwx8imx:transparent;}",
                 "rtl": null,
               },
-              0.6,
+              0.6000000000000001,
             ],
           ],
         }
@@ -781,7 +819,7 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "xop34xu"
         };
         export const theme = {
-          xop34xu: "x4aw18j xop34xu",
+          xop34xu: "x10yrbfs xop34xu",
           $$css: true
         };
         export const otherTheme = {
@@ -798,7 +836,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -817,28 +855,36 @@ describe('@stylexjs/babel-plugin', () => {
               0.2,
             ],
             [
-              "x4aw18j",
+              "x10yrbfs",
               {
-                "ltr": ".x4aw18j, .x4aw18j:root{--xwx8imx:green;--xaaua2w:antiquewhite;--xbbre8:6px;}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:green;--xaaua2w:antiquewhite;--xbbre8:6px;}",
                 "rtl": null,
               },
               0.5,
             ],
             [
-              "x4aw18j-1lveb7",
+              "x10yrbfs-1lveb7",
               {
-                "ltr": "@media (prefers-color-scheme: dark){.x4aw18j, .x4aw18j:root{--xwx8imx:lightgreen;--xaaua2w:floralwhite;}}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:lightgreen;--xaaua2w:floralwhite;}",
                 "rtl": null,
               },
-              0.6,
+              0.6000000000000001,
             ],
             [
-              "x4aw18j-bdddrq",
+              "x10yrbfs-1e6ryz3",
               {
-                "ltr": "@media print{.x4aw18j, .x4aw18j:root{--xwx8imx:transparent;}}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xaaua2w:oklab(0.7 -0.3 -0.4);}",
                 "rtl": null,
               },
-              0.6,
+              0.7,
+            ],
+            [
+              "x10yrbfs-bdddrq",
+              {
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:transparent;}",
+                "rtl": null,
+              },
+              0.6000000000000001,
             ],
             [
               "xw6msop",
@@ -876,7 +922,7 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "xop34xu"
         };
         export const theme = {
-          xop34xu: "x4aw18j xop34xu",
+          xop34xu: "x10yrbfs xop34xu",
           $$css: true
         };"
       `);
@@ -890,7 +936,7 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "x1ngxneg"
         };
         export const theme = {
-          x1ngxneg: "xgl5cw9 x1ngxneg",
+          x1ngxneg: "x1k4bs7r x1ngxneg",
           $$css: true
         };"
       `);
@@ -904,7 +950,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -923,28 +969,36 @@ describe('@stylexjs/babel-plugin', () => {
               0.2,
             ],
             [
-              "x4aw18j",
+              "x10yrbfs",
               {
-                "ltr": ".x4aw18j, .x4aw18j:root{--xwx8imx:green;--xaaua2w:antiquewhite;--xbbre8:6px;}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:green;--xaaua2w:antiquewhite;--xbbre8:6px;}",
                 "rtl": null,
               },
               0.5,
             ],
             [
-              "x4aw18j-1lveb7",
+              "x10yrbfs-1lveb7",
               {
-                "ltr": "@media (prefers-color-scheme: dark){.x4aw18j, .x4aw18j:root{--xwx8imx:lightgreen;--xaaua2w:floralwhite;}}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:lightgreen;--xaaua2w:floralwhite;}",
                 "rtl": null,
               },
-              0.6,
+              0.6000000000000001,
             ],
             [
-              "x4aw18j-bdddrq",
+              "x10yrbfs-1e6ryz3",
               {
-                "ltr": "@media print{.x4aw18j, .x4aw18j:root{--xwx8imx:transparent;}}",
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xaaua2w:oklab(0.7 -0.3 -0.4);}",
                 "rtl": null,
               },
-              0.6,
+              0.7,
+            ],
+            [
+              "x10yrbfs-bdddrq",
+              {
+                "ltr": ".x10yrbfs, .x10yrbfs:root{--xwx8imx:transparent;}",
+                "rtl": null,
+              },
+              0.6000000000000001,
             ],
           ],
         }
@@ -959,7 +1013,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .x1ngxneg{--x103gslp:blue;--x1e7put6:grey;--xm3n3tg:10;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "x1ngxneg-1lveb7",
@@ -978,28 +1032,36 @@ describe('@stylexjs/babel-plugin', () => {
               0.2,
             ],
             [
-              "xgl5cw9",
+              "x1k4bs7r",
               {
-                "ltr": ".xgl5cw9, .xgl5cw9:root{--x103gslp:green;--x1e7put6:antiquewhite;--xm3n3tg:6px;}",
+                "ltr": ".x1k4bs7r, .x1k4bs7r:root{--x103gslp:green;--x1e7put6:antiquewhite;--xm3n3tg:6px;}",
                 "rtl": null,
               },
               0.5,
             ],
             [
-              "xgl5cw9-1lveb7",
+              "x1k4bs7r-1lveb7",
               {
-                "ltr": "@media (prefers-color-scheme: dark){.xgl5cw9, .xgl5cw9:root{--x103gslp:lightgreen;--x1e7put6:floralwhite;}}",
+                "ltr": ".x1k4bs7r, .x1k4bs7r:root{--x103gslp:lightgreen;--x1e7put6:floralwhite;}",
                 "rtl": null,
               },
-              0.6,
+              0.6000000000000001,
             ],
             [
-              "xgl5cw9-bdddrq",
+              "x1k4bs7r-1e6ryz3",
               {
-                "ltr": "@media print{.xgl5cw9, .xgl5cw9:root{--x103gslp:transparent;}}",
+                "ltr": ".x1k4bs7r, .x1k4bs7r:root{--x1e7put6:oklab(0.7 -0.3 -0.4);}",
                 "rtl": null,
               },
-              0.6,
+              0.7,
+            ],
+            [
+              "x1k4bs7r-bdddrq",
+              {
+                "ltr": ".x1k4bs7r, .x1k4bs7r:root{--x103gslp:transparent;}",
+                "rtl": null,
+              },
+              0.6000000000000001,
             ],
           ],
         }
@@ -1015,7 +1077,10 @@ describe('@stylexjs/babel-plugin', () => {
           radius: '6px',
           otherColor: {
             default: 'antiquewhite',
-            '@media (prefers-color-scheme: dark)': 'floralwhite',
+            '@media (prefers-color-scheme: dark)': {
+              default: 'floralwhite',
+              '@supports (color: oklab(0 0 0))': 'oklab(0.7 -0.3 -0.4)',
+            }
           },
           color: {
             default: 'green',
@@ -1068,7 +1133,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                   "rtl": null,
                 },
-                0.2,
+                0.1,
               ],
               [
                 "xop34xu-1lveb7",
@@ -1136,7 +1201,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                   "rtl": null,
                 },
-                0.2,
+                0.1,
               ],
               [
                 "xop34xu-1lveb7",
@@ -1205,7 +1270,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                   "rtl": null,
                 },
-                0.2,
+                0.1,
               ],
               [
                 "xop34xu-1lveb7",
@@ -1274,7 +1339,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                   "rtl": null,
                 },
-                0.2,
+                0.1,
               ],
               [
                 "xop34xu-1lveb7",
@@ -1345,7 +1410,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                   "rtl": null,
                 },
-                0.2,
+                0.1,
               ],
               [
                 "xop34xu-1lveb7",
@@ -1418,7 +1483,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:grey;--xbbre8:10;}",
                   "rtl": null,
                 },
-                0.2,
+                0.1,
               ],
               [
                 "xop34xu-1lveb7",

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineVars-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineVars-test.js
@@ -105,7 +105,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -170,7 +170,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -224,7 +224,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .x1xohuxq{--xt4ziaz:red;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
           ],
         }
@@ -262,7 +262,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:blue;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -278,7 +278,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:oklab(0.7 -0.3 -0.4);}}}",
                 "rtl": null,
               },
-              0.30000000000000004,
+              0.3,
             ],
           ],
         }
@@ -315,7 +315,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--color:red;--otherColor:blue;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1tdxo4z",
@@ -377,7 +377,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--color:red;--nextColor:green;--otherColor:blue;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -427,7 +427,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
           ],
         }
@@ -461,7 +461,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xu6xznv:10rem;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
           ],
         }
@@ -495,7 +495,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xbbre8:20;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
           ],
         }
@@ -539,7 +539,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "xop34xu-1lveb7",
@@ -594,7 +594,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "x1pfrffu",
@@ -602,7 +602,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .x1pfrffu{--xnjepv0:orange;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
           ],
         }
@@ -641,7 +641,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
             [
               "x1pfrffu",
@@ -649,7 +649,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .x1pfrffu{--xnjepv0:var(--xwx8imx);}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
           ],
         }
@@ -695,7 +695,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .xop34xu{--xwx8imx:red;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
           ],
         }
@@ -709,7 +709,7 @@ describe('@stylexjs/babel-plugin', () => {
                 "ltr": ":root, .x1pfrffu{--xnjepv0:orange;}",
                 "rtl": null,
               },
-              0.2,
+              0.1,
             ],
           ],
         }
@@ -754,7 +754,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--color-xwx8imx:blue;--otherColor-xaaua2w:green;}",
                   "rtl": null,
                 },
-                0.2,
+                0.1,
               ],
               [
                 "xop34xu-1lveb7",
@@ -770,7 +770,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xop34xu{--color-xwx8imx:oklab(0.7 -0.3 -0.4);}}}",
                   "rtl": null,
                 },
-                0.30000000000000004,
+                0.3,
               ],
             ],
           }
@@ -812,7 +812,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--_10-x187fpdw:green;--_1_5_pixels-x15ahj5d:blue;--corner_radius-x2ajqv2:purple;--__primary-x13tvx0f:pink;}",
                   "rtl": null,
                 },
-                0.2,
+                0.1,
               ],
             ],
           }
@@ -854,7 +854,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--color-xwx8imx:red;--nextColor-xk6xtqk:green;--otherColor-xaaua2w:blue;}",
                   "rtl": null,
                 },
-                0.2,
+                0.1,
               ],
             ],
           }
@@ -881,7 +881,7 @@ describe('@stylexjs/babel-plugin', () => {
           "import _inject from "@stylexjs/stylex/lib/stylex-inject";
           var _inject2 = _inject;
           import * as stylex from '@stylexjs/stylex';
-          _inject2(":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}", 0.2);
+          _inject2(":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}", 0.1);
           export const vars = {
             color: "var(--xwx8imx)",
             nextColor: "var(--xk6xtqk)",
@@ -899,7 +899,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}",
                   "rtl": null,
                 },
-                0.2,
+                0.1,
               ],
             ],
           }
@@ -945,7 +945,7 @@ describe('@stylexjs/babel-plugin', () => {
                   "ltr": ":root, .x1bxutiz{--color-x1lzcbr1:red;}",
                   "rtl": null,
                 },
-                0.2,
+                0.1,
               ],
             ],
           }

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-create-theme.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-create-theme.js
@@ -58,7 +58,6 @@ export default function styleXCreateTheme(
     .map((atRule) => wrapWithAtRules(rulesByAtRule[atRule].join(''), atRule))
     .join('');
 
-  // Create a class name hash
   const overrideClassName = classNamePrefix + createHash(atRulesStringForHash);
 
   const stylesToInject: { [string]: InjectableStyle } = {};
@@ -67,19 +66,14 @@ export default function styleXCreateTheme(
     const decls = rulesByAtRule[atRule].join('');
     const rule = `.${overrideClassName}, .${overrideClassName}:root{${decls}}`;
 
-    if (atRule === 'default') {
-      stylesToInject[overrideClassName] = {
-        ltr: rule,
-        priority: 0.5,
-        rtl: null,
-      };
-    } else {
-      stylesToInject[overrideClassName + '-' + createHash(atRule)] = {
-        ltr: wrapWithAtRules(rule, atRule),
-        priority: 0.5 + 0.1 * priorityForAtRule(atRule),
-        rtl: null,
-      };
-    }
+    const priority = 0.4 + priorityForAtRule(atRule) / 10;
+    const suffix = atRule === 'default' ? '' : `-${createHash(atRule)}`;
+
+    stylesToInject[overrideClassName + suffix] = {
+      ltr: rule,
+      priority: priority,
+      rtl: null,
+    };
   }
 
   const themeClass = `${overrideClassName} ${themeVars.__varGroupHash__}`;

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-define-vars.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-define-vars.js
@@ -125,7 +125,7 @@ function constructCssVariablesString(
     result[varGroupHash + suffix] = {
       ltr,
       rtl: null,
-      priority: 0.1 + priorityForAtRule(atRule) * 0.1,
+      priority: priorityForAtRule(atRule) / 10,
     };
   }
 

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-vars-utils.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-vars-utils.js
@@ -65,7 +65,7 @@ export function priorityForAtRule(atRule: string): number {
   if (atRule === 'default') {
     return 1;
   }
-  return atRule.split(SPLIT_TOKEN).length;
+  return 1 + atRule.split(SPLIT_TOKEN).length;
 }
 
 export function getDefaultValue(value: VarsConfigValue): ?string {


### PR DESCRIPTION
Pushed up a bad revision in https://github.com/facebook/stylex/pull/1272, re-tweaking `priorityForAtRule`

Also simplifying some of the logic in `createTheme` as the `default` at-rule behaviour was previously forked 