### PR TITLE
feat: add proper error handling for color functions to valid-shorthands

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -1146,5 +1146,37 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         },
       ],
     },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            borderColor: 'hsl(220 3% 15%) hsl(240 3% 20%)',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "borderColor: hsl(220 3% 15%) hsl(240 3% 20%)" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            borderColor: 'oklch(0.7 0.15 180) rgb(255 0 0)',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "borderColor: oklch(0.7 0.15 180) rgb(255 0 0)" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## What changed / motivation ?
In fixing issue #1231, PR #1247 allowed any value containing a CSS color function to be completely exempted from shorthand expansion. This PR improves the handling so that only single modern color function values are treated as single values and not expanded.

Before this PR, this is not flagged:
```
borderColor: 'hsl(220 3% 15%) hsl(240 3% 20%)',
```
After it will be.
## Linked Issues

Fixes #1260
