### PR TITLE
fix playground link

### DIFF
--- a/packages/docs/blog/2025-09-25-Release-v0.16.0.mdx
+++ b/packages/docs/blog/2025-09-25-Release-v0.16.0.mdx
@@ -109,7 +109,7 @@ We also added support for positionTry styles (Thanks [@abhakat](https://github.c
 
 ## Miscellaneous
 
-- A [webpack example](https://stylex.org/playground/) was added to our suite of StyleX example integrations! (Thanks [@RavenColEvol](https://github.com/RavenColEvol)!)
+- A [webpack example](https://stylexjs.com/playground/) was added to our suite of StyleX example integrations! (Thanks [@RavenColEvol](https://github.com/RavenColEvol)!)
 - Support to hoist `stylex.create` and nested objects within functions.
 - Optimized precomputed props calls in JSX. (Thanks [@necolas](https://github.com/necolas)!)
 - More efficient handling of null/undefined in dynamic styles.


### PR DESCRIPTION
## What changed / motivation ?

I noticed an incorrect link to the Stylex playground and this PRs fixes that. In general linking to the playground seems incorrect here. Should it just link to https://github.com/facebook/stylex/tree/main/examples/example-webpack?

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code