### PR TITLE
[eslint-plugin] update documentation URLs to reflect correct package path

### DIFF
--- a/packages/@stylexjs/eslint-plugin/src/stylex-no-legacy-contextual-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-no-legacy-contextual-styles.js
@@ -26,7 +26,7 @@ const stylexNoLegacyContextualStyles = {
     docs: {
       description: 'Disallow legacy media query/pseudo class syntax',
       recommended: true,
-      url: 'https://github.com/facebook/stylex/tree/main/packages/eslint-plugin',
+      url: 'https://github.com/facebook/stylex/tree/main/packages/@stylexjs/eslint-plugin',
     },
     schema: [
       {

--- a/packages/@stylexjs/eslint-plugin/src/stylex-sort-keys.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-sort-keys.js
@@ -62,7 +62,7 @@ const stylexSortKeys = {
     docs: {
       description: 'Require style properties to be sorted by key',
       recommended: false,
-      url: 'https://github.com/facebook/stylex/tree/main/packages/eslint-plugin',
+      url: 'https://github.com/facebook/stylex/tree/main/packages/@stylexjs/eslint-plugin',
     },
     fixable: 'code',
     schema: [

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
@@ -68,7 +68,7 @@ const stylexValidShorthands = {
       description:
         'Require shorthand properties to be split into individual properties',
       recommended: false,
-      url: 'https://github.com/facebook/stylex/tree/main/packages/eslint-plugin',
+      url: 'https://github.com/facebook/stylex/tree/main/packages/@stylexjs/eslint-plugin',
     },
     fixable: 'code',
     schema: [


### PR DESCRIPTION
## What changed / motivation ?
While working on collecting context for issue #787 related to sort-keys, I noticed that the docs link points to an outdated package structure URL and currently redirects to a 404 page.

## Additional Context
Before:

https://github.com/user-attachments/assets/15b7ba4e-6081-423a-ae55-f6ea33953c16

After:

https://github.com/user-attachments/assets/91055b04-fe7f-498b-b498-7d0a3c698792



## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code