### PR TITLE
[babel-plugin] create new defineConsts file extension

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -458,7 +458,7 @@ export default class StateManager {
     const themeFileExtension =
       this.options.unstable_moduleResolution?.themeFileExtension ?? '.stylex';
 
-    const constsFileExtension = `${themeFileExtension}.const}`;
+    const constsFileExtension = `${themeFileExtension}.const`;
 
     if (filename == null || this.options.unstable_moduleResolution == null) {
       return null;
@@ -528,7 +528,7 @@ export default class StateManager {
     const themeFileExtension =
       this.options.unstable_moduleResolution?.themeFileExtension ?? '.stylex';
 
-    const constsFileExtension = `${themeFileExtension}.const}`;
+    const constsFileExtension = `${themeFileExtension}.const`;
 
     const transformedVarsFileExtension = '.transformed';
 

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -594,7 +594,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       })
     })
     `,
-    // test importing vars from paths including code file extension
+    // test importing vars from paths including theme file extension
     `
     import * as stylex from '@stylexjs/stylex';
     import { vars } from './vars.stylex';
@@ -616,6 +616,43 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       },
     })
     `,
+    // test importing consts from paths including consts file extension
+    `
+        import * as stylex from '@stylexjs/stylex';
+        import { consts } from './vars.stylex.const.js';
+        import { constsJs } from './consts.stylex.const.js';
+        import { constsTs } from './consts.stylex.const.ts';
+        import { constsTsx } from './consts.stylex.const.tsx';
+        import { constsJsx } from './consts.stylex.const.jsx';
+        import { constsMjs } from './consts.stylex.const.mjs';
+        import { constsCjs } from './consts.stylex.const.cjs';
+        stylex.create({
+          root: {
+            borderRadius: consts.borderRadius,
+            margin: constsJs.margin,
+            padding: constsTs.padding,
+            height: constsTsx.height,
+            width: constsJsx.width,
+            minHeight: constsMjs.minHeight,
+            maxWidth: constsCjs.maxWidth,
+          },
+        })
+        `,
+    // test importing vars from paths including custom theme file extension
+    {
+      code: `
+    import * as stylex from '@stylexjs/stylex';
+    import { vars } from './vars.css.js';
+    import { consts } from './consts.css.const.js';
+    stylex.create({
+      root: {
+        borderRadius: vars.borderRadius,
+        margin: consts.margin,
+      },
+    })
+    `,
+      options: [{ themeFileExtension: '.css' }],
+    },
     // test for positionTryFallbacks with 'none'
     `
     import * as stylex from '@stylexjs/stylex';

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -147,6 +147,8 @@ const stylexValidStyles = {
   create(context: Rule.RuleContext): { ... } {
     const variables = new Map<string, Expression | 'ARG'>();
     const dynamicStyleVariables = new Set<string>();
+    const options = context.options[0] || {};
+    const themeFileExtension = options.themeFileExtension || '.stylex';
 
     const legacyReason =
       'This property is not supported in legacy StyleX resolution.';
@@ -206,8 +208,15 @@ const stylexValidStyles = {
      *   transform that pre-resolve StyleX variables to silence ESLint/compiler errors.
      *
      */
-    function isValidStylexResolvedVarsFileExtension(filename: string) {
-      const baseExtensions = ['.stylex', '.stylex.const', '.transformed'];
+    function isValidStylexResolvedVarsFileExtension(
+      filename: string,
+      themeFileExtension: string,
+    ) {
+      const baseExtensions = [
+        themeFileExtension,
+        `${themeFileExtension}.const`,
+        '.transformed',
+      ];
       const extensions = ['.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs'];
       return ['', ...extensions].some((ext) =>
         baseExtensions.some((base) => filename.endsWith(`${base}${ext}`)),
@@ -804,7 +813,10 @@ const stylexValidStyles = {
 
         const isStylexImport = foundImportSource !== undefined;
         const isStylexResolvedVarsImport =
-          isValidStylexResolvedVarsFileExtension(sourceValue);
+          isValidStylexResolvedVarsFileExtension(
+            sourceValue,
+            themeFileExtension,
+          );
 
         if (!(isStylexImport || isStylexResolvedVarsImport)) {
           return;


### PR DESCRIPTION
Depending on the way users serve their CSS, you may want to declare a separate filepath for constants. For example, when using directory-based bundling, you'd need to include all constants files alongside each folder to have constants work globally. 

This PR adds a `.const` appended variant to the suffix defined in `themeFileExtension` (`.stylex.js` by default) so packagers can statically analyze which files contain constants. I considered making this configurable like `themeFileExtension`, but decided to keep this hardcoded for now for simplicity. 

As a follow up, we should update the `enforce-extension` lint rule to handle `defineConsts` under the new extension, with a config to allow users to hard enforce the `.stylex.const.js` extension (ie. no `defineConsts` in the default theme extension). The default behaviour will be that both `.stylex.js` and `.stylex.const.js` will be considered valid extensions for files declaring `defineConsts` exports.

Also contains a fix to `valid-styles` to respect user configured `themeFileExtension`