### PR TITLE
[babel-plugin] replace `canBeIdentifier()`

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/utils/__tests__/js-to-ast-test.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/__tests__/js-to-ast-test.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+jest.autoMockOff();
+
+import { convertObjectToAST } from '../js-to-ast';
+import generate from '@babel/generator';
+
+describe('convertObjectToAST', () => {
+  test('converts empty object', () => {
+    const result = convertObjectToAST({});
+    expect(generate(result).code).toMatchInlineSnapshot('"{}"');
+  });
+
+  test('converts object with values', () => {
+    const result = convertObjectToAST({
+      base: {
+        width: {
+          default: 800,
+          '@media (max-width: 800px)': '100%',
+          '@media (min-width: 1540px)': 1366,
+        },
+      },
+    });
+    expect(generate(result).code).toMatchInlineSnapshot(`
+      "{
+        base: {
+          width: {
+            default: 800,
+            "@media (max-width: 800px)": "100%",
+            "@media (min-width: 1540px)": 1366
+          }
+        }
+      }"
+    `);
+  });
+});

--- a/packages/@stylexjs/babel-plugin/src/utils/js-to-ast.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/js-to-ast.js
@@ -21,7 +21,9 @@ export function convertObjectToAST(
   return t.objectExpression(
     Object.entries(obj).map(([key, value]) =>
       t.objectProperty(
-        canBeIdentifier(key) ? t.identifier(key) : t.stringLiteral(key),
+        t.isValidIdentifier(key, false)
+          ? t.identifier(key)
+          : t.stringLiteral(key),
         typeof value === 'string'
           ? t.stringLiteral(value)
           : typeof value === 'number'
@@ -40,8 +42,4 @@ export function removeObjectsWithSpreads(obj: {
   +[string]: FlatCompiledStyles,
 }): { +[string]: FlatCompiledStyles } {
   return Object.fromEntries(Object.entries(obj).filter(Boolean));
-}
-
-function canBeIdentifier(str: string): boolean {
-  return str.match(/^[a-zA-Z_$][a-zA-Z0-9_$]*$/) != null;
 }


### PR DESCRIPTION
## What changed / motivation ?

This PR refactors `convertObjectToAST()` to use the [`isValidIdentifier()` function from Babel](https://github.com/babel/babel/blob/ce8d9885635b254c86cec68706b1fe46e5a28bfe/packages/babel-types/src/validators/isValidIdentifier.ts#L11-L22) instead of the hand-rolled `canBeIdentifier()` function.  This was just something I noticed when reading through the code because I have written something similar in the past. Thanks!

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code