### PR TITLE
[babel-plugin] Remove confusing removeObjectsWithSpreads() utility

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/utils/js-to-ast.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/js-to-ast.js
@@ -7,8 +7,6 @@
  * @flow strict
  */
 
-import type { FlatCompiledStyles } from '../shared/common-types';
-
 import * as t from '@babel/types';
 
 type NestedStringObject = $ReadOnly<{
@@ -36,10 +34,4 @@ export function convertObjectToAST(
       ),
     ),
   );
-}
-
-export function removeObjectsWithSpreads(obj: {
-  +[string]: FlatCompiledStyles,
-}): { +[string]: FlatCompiledStyles } {
-  return Object.fromEntries(Object.entries(obj).filter(Boolean));
 }

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
@@ -26,10 +26,7 @@ import {
   convertToTestStyles,
   injectDevClassNames,
 } from '../utils/dev-classname';
-import {
-  convertObjectToAST,
-  removeObjectsWithSpreads,
-} from '../utils/js-to-ast';
+import { convertObjectToAST } from '../utils/js-to-ast';
 import { messages } from '../shared';
 import { evaluateStyleXCreateArg } from './parse-stylex-create-arg';
 import flatMapExpandedShorthands from '../shared/preprocess-rules';
@@ -260,7 +257,9 @@ export default function transformStyleXCreate(
     }
 
     if (varName != null && isTopLevel(path)) {
-      const stylesToRemember = removeObjectsWithSpreads(compiledStyles);
+      const stylesToRemember = Object.fromEntries(
+        Object.entries(compiledStyles),
+      );
       state.styleMap.set(varName, stylesToRemember);
       state.styleVars.set(varName, path.parentPath as $FlowFixMe);
     }


### PR DESCRIPTION
## What changed / motivation ?

When working on #1290 I noticed the `Object.entries().filter(Boolean)` which seemed redundant as entries will always be truthy. It looks like the functionality that gave `removeObjectsWithSpreads()` its name was removed in #884. For this PR I chose to just inline the `Object.fromEntries(Object.entries())` call to preserve behavior but it doesn't look like anything specifically relies on the object being shallow cloned. Let me know if i'm missing something obvious. Thanks!

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code