### PR TITLE
[babel-plugin] custom module resolution support

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/utils/__tests__/state-manager-test.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/__tests__/state-manager-test.js
@@ -544,6 +544,22 @@ describe('StateManager config parsing', () => {
       expect(warnings).toEqual([]);
     });
 
+    test('"custom" type', () => {
+      const stateManager = makeState({
+        unstable_moduleResolution: {
+          type: 'custom',
+          filePathResolver() {},
+          getCanonicalFilePath() {},
+        },
+      });
+      expect(stateManager.options.unstable_moduleResolution).toEqual({
+        type: 'custom',
+        filePathResolver: expect.any(Function),
+        getCanonicalFilePath: expect.any(Function),
+      });
+      expect(warnings).toEqual([]);
+    });
+
     test('"rootDir" option', () => {
       const stateManager = makeState({
         unstable_moduleResolution: { type: 'commonJS', rootDir: '/test/' },

--- a/packages/@stylexjs/babel-plugin/src/utils/validate.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/validate.js
@@ -78,6 +78,15 @@ export const number: PrimitiveChecker<number> =
     return value;
   };
 
+export const func: <T: Function>(msg?: Msg) => Check<T> =
+  (message = defaultMessage('a function')) =>
+  (value: mixed, name?: string) => {
+    if (typeof value !== 'function') {
+      return new Error(message(value, name));
+    }
+    return value as $FlowFixMe;
+  };
+
 export const literal: <T: string | number | boolean>(
   T,
   msg?: Msg,


### PR DESCRIPTION
## What changed / motivation ?

At HubSpot we use a homegrown package manager for frontend packages that is optimized for our (mostly) closed ecosystem. This can present challenges when integrating third-party tooling but, more often than not, the tooling will support a way to configure module resolution. 

This PR introduces a `"custom"` type to the `unstable_moduleResolution` configuration option that will allow us and others to plug-in our own resolution algorithm without relying on forks or error-prone `patch-package` patches. When using `"custom"` module resolution the consumer will need to provide their implementations for `filePathResolver()`, and `getCanonicalFilePath()`. 

I have tested this branch locally and it works for our needs. I am currently using `patch-package` on top of `0.16.2`, although patching bundled code can be tricky and hard to maintain. 

### Acknowledgments
- The usage of `filePathResolver()` and `getCanonicalFilePath()` leaks implementation details, or at least internal function naming, to the public API. If you prefer something more generic please recommend something.
- This change will introduce config values of type `function`. I wasn't sure if you were intentionally trying to limit the config only static values but I don't see another way. 

### Omissions
- I skipped updating docs as I don't expect this feature to be widely used. I considered prefixing like`experimental_crossFileParsing`.
- `createShortFilename()` still has a implicit dependency on node_modules resolution for non-`"haste"` module resolution. I'm not familiar enough with that part of the codebase but we can add support in the future.

## Linked PR/Issues

This seems like it could be useful to resolve/workaround #1282

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code