### PR TITLE
Fix sample commands in READMEs for webpack and nextjs examples

### DIFF
--- a/examples/example-nextjs/README.md
+++ b/examples/example-nextjs/README.md
@@ -7,13 +7,13 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 First, run the development server:
 
 ```bash
-npm run dev
+npm run example:dev
 # or
-yarn dev
+yarn example:dev
 # or
-pnpm dev
+pnpm example:dev
 # or
-bun dev
+bun example:dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/examples/example-webpack/README.md
+++ b/examples/example-webpack/README.md
@@ -81,7 +81,7 @@ module.exports = {
   plugins: ['@stylexjs'],
   rules: {
     '@stylexjs/valid-styles': 'error',
-    '@stylexjs/no-unused': 'error', 
+    '@stylexjs/no-unused': 'error',
     '@stylexjs/valid-shorthands': 'warn',
     '@stylexjs/sort-keys': 'warn'
   },
@@ -114,11 +114,11 @@ The CSS file includes the StyleX injection point:
 
 ```bash
 # Development server
-npm run dev
+npm run example:dev
 
-# Production build  
-npm run build
+# Production build
+npm run example:build
 
 # Serve built files
-npm run serve
+npm run example:serve
 ```


### PR DESCRIPTION
## What changed / motivation ?

Adds missing `example:` prefix to the sample commands listed in the READMEs for [example-webpack](https://github.com/facebook/stylex/blob/main/examples/example-webpack/README.md) and [example-nextjs](https://github.com/facebook/stylex/blob/main/examples/example-nextjs/README.md)

## Linked PR/Issues

See https://github.com/facebook/stylex/pull/1228/files#r2347909446

## Additional Context

Without the `example:` prefix, these commands can't be found!

```
$ npm run dev
npm error Missing script: "dev"

$ npm run example:dev
> example-webpack@0.16.2 example:dev
> webpack serve --config ./webpack.config.js --mode development
..
```

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code