### PR TITLE
[babel-plugin] various TypeScript fixes

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/index.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/index.d.ts
@@ -39,10 +39,10 @@ declare function processStylexRules(
   config?:
     | boolean
     | {
-        useLayers?: boolean,
-        enableLTRRTLComments?: boolean,
-        legacyDisableLayers?: boolean,
-      }
+        useLayers?: boolean;
+        enableLTRRTLComments?: boolean;
+        legacyDisableLayers?: boolean;
+      },
 ): string;
 export type StyleXTransformObj = Readonly<{
   (): PluginObj;
@@ -50,4 +50,4 @@ export type StyleXTransformObj = Readonly<{
   processStylexRules: typeof processStylexRules;
 }>;
 declare const $$EXPORT_DEFAULT_DECLARATION$$: StyleXTransformObj;
-export = $$EXPORT_DEFAULT_DECLARATION$$;
+export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+export type TRawValue = number | string | ReadonlyArray<number | string>;
+export type TStyleValue = null | TRawValue;
+export type TNestableStyleValue = TStyleValue | PrimitiveRawStyles;
+export type RawStyles = Readonly<{ [$$Key$$: string]: TNestableStyleValue }>;
+export type PrimitiveRawStyles = Readonly<{
+  [$$Key$$: string]: TNestableStyleValue;
+}>;
+export type InjectableStyle = {
+  readonly priority: number;
+  readonly ltr: string;
+  readonly rtl: null | string;
+};
+export type InjectableConstStyle = {
+  readonly priority: number;
+  readonly ltr: string;
+  readonly rtl: null | string;
+  readonly constKey: string;
+  readonly constVal: string | number;
+};
+export type StyleRule = [string, string, InjectableStyle];
+export type CompiledStyles = Readonly<{
+  [$$Key$$: string]:
+    | null
+    | string
+    | Readonly<{ [$$Key$$: string]: null | string }>;
+}>;
+export type FlatCompiledStyles = Readonly<
+  { [$$Key$$: string]: string | null } & { $$css: true | string }
+>;
+export type StyleXOptions = Readonly<{
+  classNamePrefix: string;
+  debug: null | undefined | boolean;
+  definedStylexCSSVariables?: { [key: string]: unknown };
+  dev: boolean;
+  enableDebugClassNames?: null | undefined | boolean;
+  enableDebugDataProp?: null | undefined | boolean;
+  enableDevClassNames?: null | undefined | boolean;
+  enableFontSizePxToRem?: null | undefined | boolean;
+  enableMediaQueryOrder?: null | undefined | boolean;
+  enableLegacyValueFlipping?: null | undefined | boolean;
+  enableLogicalStylesPolyfill?: null | undefined | boolean;
+  enableLTRRTLComments?: null | undefined | boolean;
+  enableMinifiedKeys?: null | undefined | boolean;
+  styleResolution:
+    | 'application-order'
+    | 'property-specificity'
+    | 'legacy-expand-shorthands';
+  test: boolean;
+}>;
+export type MutableCompiledNamespaces = { [key: string]: FlatCompiledStyles };
+export type CompiledNamespaces = Readonly<MutableCompiledNamespaces>;

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-create-theme.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-create-theme.d.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+import type { InjectableStyle, StyleXOptions } from './common-types';
+declare function styleXCreateTheme(
+  themeVars: {
+    readonly __varGroupHash__: string;
+    readonly [$$Key$$: string]: string;
+  },
+  variables: {
+    readonly [$$Key$$: string]:
+      | string
+      | { default: string; readonly [$$Key$$: string]: string };
+  },
+  options?: StyleXOptions,
+): [
+  { $$css: true } & { readonly [$$Key$$: string]: string },
+  { [$$Key$$: string]: InjectableStyle },
+];
+export default styleXCreateTheme;

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-define-vars.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-define-vars.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+import type { InjectableStyle, StyleXOptions } from './common-types';
+import type { VarsConfig } from './stylex-vars-utils';
+type VarsKeysWithStringValues<Vars extends VarsConfig> = Readonly<{
+  [$$Key$$ in keyof Vars]: string;
+}>;
+type VarsObject<Vars extends VarsConfig> = Readonly<
+  Omit<VarsKeysWithStringValues<Vars>, keyof { __varGroupHash__: string }> & {
+    __varGroupHash__: string;
+  }
+>;
+declare function styleXDefineVars<Vars extends VarsConfig>(
+  variables: Vars,
+  options: Readonly<
+    Omit<Partial<StyleXOptions>, keyof { exportId: string }> & {
+      exportId: string;
+    }
+  >,
+): [VarsObject<Vars>, { [$$Key$$: string]: InjectableStyle }];
+export default styleXDefineVars;


### PR DESCRIPTION
## What changed / motivation ?

We have been using `skipLibCheck: true` to suppress a handful TypeScript errors  (see below) coming from `@stylexjs/babel-plugin` and we would prefer to remove this workaround. This PR attempts to fix the issue by providing `.d.ts` files for the problematic modules instead of relying on `flow-api-translator`. This is supported by the `generate-types.js` script. 

Maintaining the `d.ts` files does seem like it could be a pain so I an open to other suggestions. I have considered:
- Rewriting the flow types so `flow-api-translator` generates correct TS (not sure I know Flow well enough)
- Implementing a codemod in `postProcessTSOutput()`

Thanks!

## Additional Context


The errors we were seeing:
```
node_modules/@stylexjs/babel-plugin/lib/shared/common-types.d.ts:38:3 - error TS2411: Property '$$css' of type 'string | true' is not assignable to 'string' index type 'string | null'.

38   $$css: true | string;
     ~~~~~

node_modules/@stylexjs/babel-plugin/lib/shared/stylex-define-vars.d.ts:13:4 - error TS1337: An index signature parameter type cannot be a literal type or generic type. Consider using a mapped object type instead.

13   [$$Key$$: keyof Vars]: string;
      ~~~~~~~

node_modules/@stylexjs/babel-plugin/lib/shared/stylex-create-theme.d.ts:23:5 - error TS2411: Property '$$css' of type 'true' is not assignable to 'string' index type 'string'.

23   { $$css: true; readonly [$$Key$$: string]: string },
       ~~~~~

node_modules/@stylexjs/babel-plugin/lib/index.d.ts:53:1 - error TS2309: An export assignment cannot be used in a module with other exported elements.

53 export = $$EXPORT_DEFAULT_DECLARATION$$;
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```


Diff of the previous generated `.d.ts` files to the ones added in this PR. (some changes just from prettier):

```diff
// node_modules/@stylexjs/babel-plugin/lib/index.d.ts 
@@ -39,10 +39,10 @@
   config?:
     | boolean
     | {
-        useLayers?: boolean,
-        enableLTRRTLComments?: boolean,
-        legacyDisableLayers?: boolean,
-      }
+        useLayers?: boolean;
+        enableLTRRTLComments?: boolean;
+        legacyDisableLayers?: boolean;
+      },
 ): string;
 export type StyleXTransformObj = Readonly<{
   (): PluginObj;
@@ -50,4 +50,4 @@
   processStylexRules: typeof processStylexRules;
 }>;
 declare const $$EXPORT_DEFAULT_DECLARATION$$: StyleXTransformObj;
-export = $$EXPORT_DEFAULT_DECLARATION$$;
+export default $$EXPORT_DEFAULT_DECLARATION$$;

// node_modules/@stylexjs/babel-plugin/lib/shared/common-types.d.ts 
@@ -33,10 +33,9 @@
     | string
     | Readonly<{ [$$Key$$: string]: null | string }>;
 }>;
-export type FlatCompiledStyles = Readonly<{
-  [$$Key$$: string]: string | null;
-  $$css: true | string;
-}>;
+export type FlatCompiledStyles = Readonly<
+  { [$$Key$$: string]: string | null } & { $$css: true | string }
+>;
 export type StyleXOptions = Readonly<{
   classNamePrefix: string;
   debug: null | undefined | boolean;

// node_modules/@stylexjs/babel-plugin/lib/shared/stylex-create-theme.d.ts 
@@ -20,7 +20,7 @@
   },
   options?: StyleXOptions,
 ): [
-  { $$css: true; readonly [$$Key$$: string]: string },
+  { $$css: true } & { readonly [$$Key$$: string]: string },
   { [$$Key$$: string]: InjectableStyle },
 ];
 export default styleXCreateTheme;

// node_modules/@stylexjs/babel-plugin/lib/shared/stylex-define-vars.d.ts 
@@ -10,17 +10,17 @@
 import type { InjectableStyle, StyleXOptions } from './common-types';
 import type { VarsConfig } from './stylex-vars-utils';
 type VarsKeysWithStringValues<Vars extends VarsConfig> = Readonly<{
-  [$$Key$$: keyof Vars]: string;
+  [$$Key$$ in keyof Vars]: string;
 }>;
 type VarsObject<Vars extends VarsConfig> = Readonly<
-  Omit<VarsKeysWithStringValues<Vars>, keyof ({ __varGroupHash__: string })> & {
+  Omit<VarsKeysWithStringValues<Vars>, keyof { __varGroupHash__: string }> & {
     __varGroupHash__: string;
   }
 >;
 declare function styleXDefineVars<Vars extends VarsConfig>(
   variables: Vars,
   options: Readonly<
-    Omit<Partial<StyleXOptions>, keyof ({ exportId: string })> & {
+    Omit<Partial<StyleXOptions>, keyof { exportId: string }> & {
       exportId: string;
     }
   >,
```

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code