### PR TITLE
[babel-plugin] open up media query order enforcing

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-call-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-call-test.js
@@ -614,9 +614,9 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject2("@media (min-width: 1000px) and (max-width: 1999.99px){.xw6up8c.xw6up8c{background-color:blue}}", 3200);
         _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
-        "xrkmrrc xc445zv x1ssfqz5";"
+        "xrkmrrc xw6up8c x1ssfqz5";"
       `);
     });
 

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -218,7 +218,7 @@ describe('@stylexjs/babel-plugin', () => {
             "margin-kogj98": "margin-xymmreb",
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
             "outlineColor-kjBf7l": "outlineColor-x184ctg8",
-            "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-x1cmij7u",
+            "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-xtj17id",
             "padding-kmVPX3": "padding-xss17vw",
             "float-kyUFMd": "float-x1kmio9f",
             $$css: "app/main.js:33"
@@ -263,7 +263,7 @@ describe('@stylexjs/babel-plugin', () => {
         html[dir='rtl'] .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:right}
         .outlineColor-x184ctg8:not(#\\#):not(#\\#):not(#\\#){outline-color:var(--colorTokens-xkxfyv)}
         .textShadow-x1skrh0i:not(#\\#):not(#\\#):not(#\\#){text-shadow:1px 2px 3px 4px red}
-        @media (min-width:320px){.textShadow-x1cmij7u.textShadow-x1cmij7u:not(#\\#):not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}"
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id:not(#\\#):not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}"
       `);
     });
 
@@ -306,7 +306,7 @@ describe('@stylexjs/babel-plugin', () => {
             "margin-kogj98": "margin-xymmreb",
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
             "outlineColor-kjBf7l": "outlineColor-x184ctg8",
-            "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-x1cmij7u",
+            "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-xtj17id",
             "padding-kmVPX3": "padding-xss17vw",
             "float-kyUFMd": "float-x1kmio9f",
             $$css: "app/main.js:33"
@@ -358,7 +358,7 @@ describe('@stylexjs/babel-plugin', () => {
         html[dir='rtl'] .float-x1kmio9f{float:right}
         .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
         .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        @media (min-width:320px){.textShadow-x1cmij7u.textShadow-x1cmij7u{text-shadow:10px 20px 30px 40px green}}
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
         }"
       `);
     });
@@ -400,7 +400,7 @@ describe('@stylexjs/babel-plugin', () => {
             "margin-kogj98": "margin-xymmreb",
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
             "outlineColor-kjBf7l": "outlineColor-x184ctg8",
-            "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-x1cmij7u",
+            "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-xtj17id",
             "padding-kmVPX3": "padding-xss17vw",
             "float-kyUFMd": "float-x1kmio9f",
             $$css: "app/main.js:33"
@@ -446,7 +446,7 @@ describe('@stylexjs/babel-plugin', () => {
         html[dir='rtl'] .float-x1kmio9f{float:right}
         .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
         .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        @media (min-width:320px){.textShadow-x1cmij7u.textShadow-x1cmij7u{text-shadow:10px 20px 30px 40px green}}"
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}"
       `);
     });
 
@@ -629,7 +629,7 @@ describe('@stylexjs/babel-plugin', () => {
         /* @rtl begin */.x1kmio9f{float:right}/* @rtl end */
         .x18abd1y{outline-color:var(--xkxfyv)}
         .x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        @media (min-width:320px){.x1cmij7u.x1cmij7u{text-shadow:10px 20px 30px 40px green}}"
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}"
       `);
     });
 
@@ -668,7 +668,7 @@ describe('@stylexjs/babel-plugin', () => {
         /* @rtl begin */.x1kmio9f{float:right}/* @rtl end */
         .x1skrh0i{text-shadow:1px 2px 3px 4px red}
         .xrkmrrc{background-color:red}
-        @media (min-width:320px){.x1cmij7u.x1cmij7u{text-shadow:10px 20px 30px 40px green}}"
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}"
       `);
     });
   });

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -1987,7 +1987,7 @@ describe('@stylexjs/babel-plugin', () => {
       });
 
       describe('object values: queries', () => {
-        test('media queries with last query wins', () => {
+        test('media queries without last query wins', () => {
           const { code, metadata } = transform(
             `
             import * as stylex from '@stylexjs/stylex';
@@ -2053,6 +2053,72 @@ describe('@stylexjs/babel-plugin', () => {
           `);
         });
 
+        test('media queries without last query wins', () => {
+          const { code, metadata } = transform(
+            `
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                backgroundColor: {
+                  default: 'red',
+                  '@media (max-width: 900px)': 'blue',
+                  '@media (max-width: 500px)': 'purple',
+                  '@media (max-width: 400px)': 'green',
+                }
+              },
+            });
+          `,
+            { enableMediaQueryOrder: false },
+          );
+          expect(code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              root: {
+                kWkggS: "xrkmrrc xn8cmr1 x1lr89ez x856a2w",
+                $$css: true
+              }
+            };"
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "xrkmrrc",
+                  {
+                    "ltr": ".xrkmrrc{background-color:red}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+                [
+                  "xn8cmr1",
+                  {
+                    "ltr": "@media (max-width: 900px){.xn8cmr1.xn8cmr1{background-color:blue}}",
+                    "rtl": null,
+                  },
+                  3200,
+                ],
+                [
+                  "x1lr89ez",
+                  {
+                    "ltr": "@media (max-width: 500px){.x1lr89ez.x1lr89ez{background-color:purple}}",
+                    "rtl": null,
+                  },
+                  3200,
+                ],
+                [
+                  "x856a2w",
+                  {
+                    "ltr": "@media (max-width: 400px){.x856a2w.x856a2w{background-color:green}}",
+                    "rtl": null,
+                  },
+                  3200,
+                ],
+              ],
+            }
+          `);
+        });
+
         test('media queries', () => {
           const { code, metadata } = transform(
             `
@@ -2072,7 +2138,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: {
-                kWkggS: "xrkmrrc xc445zv x1ssfqz5",
+                kWkggS: "xrkmrrc xw6up8c x1ssfqz5",
                 $$css: true
               }
             };"
@@ -2089,9 +2155,9 @@ describe('@stylexjs/babel-plugin', () => {
                   3000,
                 ],
                 [
-                  "xc445zv",
+                  "xw6up8c",
                   {
-                    "ltr": "@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}",
+                    "ltr": "@media (min-width: 1000px) and (max-width: 1999.99px){.xw6up8c.xw6up8c{background-color:blue}}",
                     "rtl": null,
                   },
                   3200,
@@ -4389,7 +4455,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (a, b, c) => [{
-                kzqmXN: "x11ymkkh " + (b != null ? "x17gmrvw " : b) + (c != null ? "x1bai16n" : c),
+                kzqmXN: "x11ymkkh " + "x38mdg9 " + (c != null ? "x1bai16n" : c),
                 $$css: true
               }, {
                 "--x-1xmrurk": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)('color-mix(' + color + ', blue)'),
@@ -4410,9 +4476,9 @@ describe('@stylexjs/babel-plugin', () => {
                   4000,
                 ],
                 [
-                  "x17gmrvw",
+                  "x38mdg9",
                   {
-                    "ltr": "@media (min-width: 1000px){.x17gmrvw.x17gmrvw{width:var(--x-wm47pl)}}",
+                    "ltr": "@media (min-width: 1000px) and (max-width: 1999.99px){.x38mdg9.x38mdg9{width:var(--x-wm47pl)}}",
                     "rtl": null,
                   },
                   4200,

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
@@ -591,10 +591,10 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2(".xrkmrrc{background-color:red}", 3000);
-        _inject2("@media (min-width: 1000px){.xc445zv.xc445zv{background-color:blue}}", 3200);
+        _inject2("@media (min-width: 1000px) and (max-width: 1999.99px){.xw6up8c.xw6up8c{background-color:blue}}", 3200);
         _inject2("@media (min-width: 2000px){.x1ssfqz5.x1ssfqz5{background-color:purple}}", 3200);
         ({
-          className: "xrkmrrc xc445zv x1ssfqz5"
+          className: "xrkmrrc xw6up8c x1ssfqz5"
         });"
       `);
     });

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -249,8 +249,8 @@ export default class StateManager {
     const enableMediaQueryOrder: StyleXStateOptions['enableMediaQueryOrder'] =
       z.logAndDefault(
         z.boolean(),
-        options.enableMediaQueryOrder ?? false,
-        false,
+        options.enableMediaQueryOrder ?? true,
+        true,
         'options.enableMediaQueryOrder',
       );
 


### PR DESCRIPTION
Let's open this up for OSS testing before we introduce this internally. Added some tests to snapshot the old non-transformed behaviour.