### PR TITLE
[release] v0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,32 @@
 # Changelog
 
+## 0.16.3 (Oct 27, 2025)
+
+- Add configs to `sort-keys` property ordering.
+- Create new `defineConsts` specific file extension.
+- Add `defineConsts` and various file extension support to `enforce-extension`.
+- Add config for custom module resolution.
+- Turn `enableMediaQueryOrder` on by default.
+- Updates to docs and Flow.
+
 ## 0.16.2 (Oct 13, 2025)
+
 - Handle descendant selector styles in `valid-styles` rule.
 - Adjust descendant selector `.when` priorities.
 - Fix `defineVars` and `createTheme` at-rules priorities.
 - Update `defineConsts` types for non-stylex usage.
 
 ## 0.16.1 (Oct 2, 2025)
-- New `no-lookahead-selector` lint rule to flag certain descendant and sibling selectors.
+
+- New `no-lookahead-selector` lint rule to flag certain descendant and sibling
+  selectors.
 - Fix priorities for descendant and sibling selectors.
 - Fix color functions for `valid-shorthands` rule.
 - Fix hoisting issues with duplicate keys in `create` calls.
 - Add storybook example.
 
 ## 0.16.0 (Sep 25, 2025)
+
 - Added support for descendant and shared selectors.
 - Support CSS variable overrides with `defineConsts`.
 - Add `valid-styles` support to CSS variable overrides in `create` calls.
@@ -22,7 +35,8 @@
 ## 0.15.4 (Sep 7, 2025)
 
 - Add configuration modes to `processStylexRules`.
-- Support local resolved constants, `positionTry`, and '0' values in `valid-styles` ESLint rule.
+- Support local resolved constants, `positionTry`, and '0' values in
+  `valid-styles` ESLint rule.
 - Implement `defineConsts` for dynamic styles.
 - Create `.transformed` file extension for preresolved variables.
 
@@ -41,7 +55,8 @@
 
 ### Fixes
 
-- Hoist stylex.create and static className objects to the top level for support inside functions.
+- Hoist stylex.create and static className objects to the top level for support
+  inside functions.
 
 ## 0.15.0 (Jul 31, 2025)
 

--- a/examples/example-cli/package.json
+++ b/examples/example-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-cli",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "scripts": {
     "example:build": "stylex --config .stylex.json5"
   },
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.25.7",
     "@babel/preset-typescript": "^7.25.7",
-    "@stylexjs/cli": "0.16.2",
+    "@stylexjs/cli": "0.16.3",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5"

--- a/examples/example-esbuild/package.json
+++ b/examples/example-esbuild/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-esbuild",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Simple esbuild example for @stylexjs/esbuild-plugin",
   "main": "src/App.jsx",
   "scripts": {
@@ -10,13 +10,13 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.16.2",
+    "@stylexjs/stylex": "0.16.3",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },
   "devDependencies": {
     "@stylexjs/esbuild-plugin": "0.11.1",
-    "@stylexjs/eslint-plugin": "0.16.2",
+    "@stylexjs/eslint-plugin": "0.16.3",
     "esbuild": "^0.25.0",
     "eslint": "^8.57.1"
   }

--- a/examples/example-nextjs/package.json
+++ b/examples/example-nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-nextjs",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "scripts": {
     "clean": "rimraf .next",
     "example:build": "next build",
@@ -10,15 +10,15 @@
     "example:start": "next start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.16.2",
+    "@stylexjs/stylex": "0.16.3",
     "next": "14.2.21",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "styled-jsx": "^5.1.1"
   },
   "devDependencies": {
-    "@stylexjs/eslint-plugin": "0.16.2",
-    "@stylexjs/postcss-plugin": "0.16.2",
+    "@stylexjs/eslint-plugin": "0.16.3",
+    "@stylexjs/postcss-plugin": "0.16.3",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^22.7.6",
     "@types/react": "^18.3.0",

--- a/examples/example-rollup/package.json
+++ b/examples/example-rollup/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-rollup",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "A simple rollup example to test stylexjs/rollup-plugin",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.16.2",
+    "@stylexjs/stylex": "0.16.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -23,7 +23,7 @@
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.7",
-    "@stylexjs/rollup-plugin": "0.16.2",
+    "@stylexjs/rollup-plugin": "0.16.3",
     "rollup": "^4.24.0",
     "serve": "^14.2.4"
   }

--- a/examples/example-storybook/package.json
+++ b/examples/example-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-storybook",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "scripts": {
     "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build",
@@ -15,10 +15,10 @@
     "@storybook/addon-links": "^9.1.7",
     "@storybook/addon-vitest": "^9.1.7",
     "@storybook/react-vite": "^9.1.7",
-    "@stylexjs/babel-plugin": "0.16.2",
-    "@stylexjs/eslint-plugin": "0.16.2",
-    "@stylexjs/postcss-plugin": "0.16.2",
-    "@stylexjs/stylex": "0.16.2",
+    "@stylexjs/babel-plugin": "0.16.3",
+    "@stylexjs/eslint-plugin": "0.16.3",
+    "@stylexjs/postcss-plugin": "0.16.3",
+    "@stylexjs/stylex": "0.16.3",
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.44.0",
     "@vitejs/plugin-react": "^5.0.3",

--- a/examples/example-webpack/package.json
+++ b/examples/example-webpack/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-webpack",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "A simple webpack example to test stylexjs/webpack-plugin",
   "main": "index.js",
   "scripts": {
@@ -15,9 +15,9 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.1",
-    "@stylexjs/babel-plugin": "0.16.2",
-    "@stylexjs/eslint-plugin": "0.16.2",
-    "@stylexjs/postcss-plugin": "0.16.2",
+    "@stylexjs/babel-plugin": "0.16.3",
+    "@stylexjs/eslint-plugin": "0.16.3",
+    "@stylexjs/postcss-plugin": "0.16.3",
     "autoprefixer": "^10.4.21",
     "babel-loader": "^10.0.0",
     "css-loader": "^7.1.2",
@@ -33,7 +33,7 @@
     "webpack-dev-server": "^5.2.2"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.16.2",
+    "@stylexjs/stylex": "0.16.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
       }
     },
     "examples/example-cli": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "dependencies": {
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
@@ -49,7 +49,7 @@
       "devDependencies": {
         "@babel/preset-react": "^7.25.7",
         "@babel/preset-typescript": "^7.25.7",
-        "@stylexjs/cli": "0.16.2",
+        "@stylexjs/cli": "0.16.3",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "typescript": "^5"
@@ -84,16 +84,16 @@
       }
     },
     "examples/example-esbuild": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.2",
+        "@stylexjs/stylex": "0.16.3",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
       },
       "devDependencies": {
         "@stylexjs/esbuild-plugin": "0.11.1",
-        "@stylexjs/eslint-plugin": "0.16.2",
+        "@stylexjs/eslint-plugin": "0.16.3",
         "esbuild": "^0.25.0",
         "eslint": "^8.57.1"
       }
@@ -127,17 +127,17 @@
       }
     },
     "examples/example-nextjs": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.2",
+        "@stylexjs/stylex": "0.16.3",
         "next": "14.2.21",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "styled-jsx": "^5.1.1"
       },
       "devDependencies": {
-        "@stylexjs/eslint-plugin": "0.16.2",
-        "@stylexjs/postcss-plugin": "0.16.2",
+        "@stylexjs/eslint-plugin": "0.16.3",
+        "@stylexjs/postcss-plugin": "0.16.3",
         "@types/json-schema": "^7.0.15",
         "@types/node": "^22.7.6",
         "@types/react": "^18.3.0",
@@ -430,10 +430,10 @@
       "license": "MIT"
     },
     "examples/example-rollup": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.2",
+        "@stylexjs/stylex": "0.16.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -445,7 +445,7 @@
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-replace": "^5.0.7",
-        "@stylexjs/rollup-plugin": "0.16.2",
+        "@stylexjs/rollup-plugin": "0.16.3",
         "rollup": "^4.24.0",
         "serve": "^14.2.4"
       }
@@ -472,7 +472,7 @@
       "license": "MIT"
     },
     "examples/example-storybook": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.1",
         "@storybook/addon-a11y": "^9.1.7",
@@ -480,10 +480,10 @@
         "@storybook/addon-links": "^9.1.7",
         "@storybook/addon-vitest": "^9.1.7",
         "@storybook/react-vite": "^9.1.7",
-        "@stylexjs/babel-plugin": "0.16.2",
-        "@stylexjs/eslint-plugin": "0.16.2",
-        "@stylexjs/postcss-plugin": "0.16.2",
-        "@stylexjs/stylex": "0.16.2",
+        "@stylexjs/babel-plugin": "0.16.3",
+        "@stylexjs/eslint-plugin": "0.16.3",
+        "@stylexjs/postcss-plugin": "0.16.3",
+        "@stylexjs/stylex": "0.16.3",
         "@typescript-eslint/eslint-plugin": "^8.44.0",
         "@typescript-eslint/parser": "^8.44.0",
         "@vitejs/plugin-react": "^5.0.3",
@@ -1305,10 +1305,10 @@
       }
     },
     "examples/example-webpack": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.2",
+        "@stylexjs/stylex": "0.16.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -1317,9 +1317,9 @@
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.6.1",
-        "@stylexjs/babel-plugin": "0.16.2",
-        "@stylexjs/eslint-plugin": "0.16.2",
-        "@stylexjs/postcss-plugin": "0.16.2",
+        "@stylexjs/babel-plugin": "0.16.3",
+        "@stylexjs/eslint-plugin": "0.16.3",
+        "@stylexjs/postcss-plugin": "0.16.3",
         "autoprefixer": "^10.4.21",
         "babel-loader": "^10.0.0",
         "css-loader": "^7.1.2",
@@ -33125,7 +33125,7 @@
       }
     },
     "packages/@stylexjs/babel-plugin": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
@@ -33133,7 +33133,7 @@
         "@babel/traverse": "^7.26.8",
         "@babel/types": "^7.26.8",
         "@dual-bundle/import-meta-resolve": "^4.1.0",
-        "@stylexjs/stylex": "0.16.2",
+        "@stylexjs/stylex": "0.16.3",
         "postcss-value-parser": "^4.1.0"
       },
       "devDependencies": {
@@ -33145,7 +33145,7 @@
         "@rollup/plugin-replace": "^6.0.1",
         "babel-plugin-syntax-hermes-parser": "^0.26.0",
         "rollup": "^4.24.0",
-        "scripts": "0.16.2"
+        "scripts": "0.16.3"
       }
     },
     "packages/@stylexjs/babel-plugin/node_modules/@rollup/plugin-commonjs": {
@@ -33218,14 +33218,14 @@
       }
     },
     "packages/@stylexjs/cli": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.26.8",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
         "@babel/types": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.16.2",
+        "@stylexjs/babel-plugin": "0.16.3",
         "ansis": "^3.3.2",
         "fb-watchman": "^2.0.2",
         "json5": "^2.2.3",
@@ -33236,7 +33236,7 @@
         "stylex": "lib/index.js"
       },
       "devDependencies": {
-        "scripts": "0.16.2"
+        "scripts": "0.16.3"
       }
     },
     "packages/@stylexjs/cli/node_modules/@babel/core": {
@@ -33269,7 +33269,7 @@
       }
     },
     "packages/@stylexjs/eslint-plugin": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
         "css-shorthand-expand": "^1.2.0",
@@ -33278,11 +33278,11 @@
       }
     },
     "packages/@stylexjs/postcss-plugin": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.16.2",
+        "@stylexjs/babel-plugin": "0.16.3",
         "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
@@ -33290,14 +33290,14 @@
       }
     },
     "packages/@stylexjs/rollup-plugin": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
         "@babel/plugin-syntax-flow": "^7.26.0",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
-        "@stylexjs/babel-plugin": "0.16.2",
+        "@stylexjs/babel-plugin": "0.16.3",
         "lightningcss": "^1.29.1"
       },
       "devDependencies": {
@@ -33357,7 +33357,7 @@
       }
     },
     "packages/@stylexjs/stylex": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
         "css-mediaquery": "^0.1.2",
@@ -33384,7 +33384,7 @@
         "cross-env": "^7.0.3",
         "rimraf": "^5.0.10",
         "rollup": "^4.24.0",
-        "scripts": "0.16.2"
+        "scripts": "0.16.3"
       }
     },
     "packages/@stylexjs/stylex/node_modules/@rollup/plugin-commonjs": {
@@ -33457,11 +33457,11 @@
       }
     },
     "packages/benchmarks": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/babel-plugin": "0.16.2",
-        "@stylexjs/rollup-plugin": "0.16.2",
+        "@stylexjs/babel-plugin": "0.16.3",
+        "@stylexjs/rollup-plugin": "0.16.3",
         "benchmark": "^2.1.4",
         "brotli-size": "^4.0.0",
         "clean-css": "^5.3.3",
@@ -33474,7 +33474,7 @@
       }
     },
     "packages/docs": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "dependencies": {
         "@docusaurus/core": "2.4.1",
         "@docusaurus/preset-classic": "2.4.1",
@@ -33483,7 +33483,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.1",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@mdx-js/react": "^1.6.22",
-        "@stylexjs/stylex": "0.16.2",
+        "@stylexjs/stylex": "0.16.3",
         "@webcontainer/api": "^1.3.0",
         "clsx": "^1.2.1",
         "codemirror": "^5.65.16",
@@ -33494,8 +33494,8 @@
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.16.2",
-        "@stylexjs/eslint-plugin": "0.16.2",
+        "@stylexjs/babel-plugin": "0.16.3",
+        "@stylexjs/eslint-plugin": "0.16.3",
         "clean-css": "^5.3.2",
         "eslint": "^8.57.1",
         "eslint-config-airbnb": "^19.0.4",
@@ -33519,7 +33519,7 @@
       }
     },
     "packages/scripts": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
         "flow-api-translator": "0.26.0",
@@ -33531,7 +33531,7 @@
       }
     },
     "packages/style-value-parser": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
         "@csstools/css-tokenizer": "^3.0.3"
@@ -33559,10 +33559,10 @@
       }
     },
     "packages/typescript-tests": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.2",
+        "@stylexjs/stylex": "0.16.3",
         "typescript": "^5.8.3"
       },
       "engines": {

--- a/packages/@stylexjs/babel-plugin/package.json
+++ b/packages/@stylexjs/babel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/babel-plugin",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "StyleX babel plugin.",
   "main": "lib/index.js",
   "repository": {
@@ -21,7 +21,7 @@
     "@babel/traverse": "^7.26.8",
     "@babel/types": "^7.26.8",
     "@dual-bundle/import-meta-resolve": "^4.1.0",
-    "@stylexjs/stylex": "0.16.2",
+    "@stylexjs/stylex": "0.16.3",
     "postcss-value-parser": "^4.1.0"
   },
   "devDependencies": {
@@ -33,7 +33,7 @@
     "@rollup/plugin-replace": "^6.0.1",
     "babel-plugin-syntax-hermes-parser": "^0.26.0",
     "rollup": "^4.24.0",
-    "scripts": "0.16.2"
+    "scripts": "0.16.3"
   },
   "files": [
     "flow_modules/*",

--- a/packages/@stylexjs/cli/package.json
+++ b/packages/@stylexjs/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/cli",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "A cli to compile a folder with StyleX",
   "main": "./lib/transform.js",
   "repository": "https://www.github.com/facebook/stylex",
@@ -19,7 +19,7 @@
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
     "@babel/types": "^7.26.8",
-    "@stylexjs/babel-plugin": "0.16.2",
+    "@stylexjs/babel-plugin": "0.16.3",
     "ansis": "^3.3.2",
     "fb-watchman": "^2.0.2",
     "json5": "^2.2.3",
@@ -27,7 +27,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "scripts": "0.16.2"
+    "scripts": "0.16.3"
   },
   "bin": {
     "stylex": "./lib/index.js"

--- a/packages/@stylexjs/eslint-plugin/package.json
+++ b/packages/@stylexjs/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/eslint-plugin",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "StyleX eslint plugin.",
   "main": "lib/index.js",
   "repository": {

--- a/packages/@stylexjs/postcss-plugin/package.json
+++ b/packages/@stylexjs/postcss-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/postcss-plugin",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "PostCSS plugin for StyleX",
   "main": "src/index.js",
   "repository": {
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.26.8",
-    "@stylexjs/babel-plugin": "0.16.2",
+    "@stylexjs/babel-plugin": "0.16.3",
     "postcss": "^8.4.49",
     "fast-glob": "^3.3.2",
     "glob-parent": "^6.0.2",

--- a/packages/@stylexjs/rollup-plugin/package.json
+++ b/packages/@stylexjs/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/rollup-plugin",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Rollup plugin for StyleX",
   "main": "./lib/index.js",
   "module": "./lib/es/index.mjs",
@@ -35,7 +35,7 @@
     "@babel/plugin-syntax-flow": "^7.26.0",
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
-    "@stylexjs/babel-plugin": "0.16.2",
+    "@stylexjs/babel-plugin": "0.16.3",
     "lightningcss": "^1.29.1"
   },
   "devDependencies": {

--- a/packages/@stylexjs/stylex/package.json
+++ b/packages/@stylexjs/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/stylex",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "A library for defining styles for optimized user interfaces.",
   "main": "./lib/cjs/stylex.js",
   "module": "./lib/es/stylex.mjs",
@@ -61,7 +61,7 @@
     "cross-env": "^7.0.3",
     "rimraf": "^5.0.10",
     "rollup": "^4.24.0",
-    "scripts": "0.16.2"
+    "scripts": "0.16.3"
   },
   "files": [
     "lib/*"

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "benchmarks",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "scripts": {
     "perf": "node ./perf/run.js",
     "size": "NODE_ENV=production rollup --config ./size/rollup.config.mjs && node ./size/run.js",
@@ -9,8 +9,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/babel-plugin": "0.16.2",
-    "@stylexjs/rollup-plugin": "0.16.2",
+    "@stylexjs/babel-plugin": "0.16.3",
+    "@stylexjs/rollup-plugin": "0.16.3",
     "benchmark": "^2.1.4",
     "brotli-size": "^4.0.0",
     "clean-css": "^5.3.3",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "docs",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "scripts": {
     "build": "rimraf ./build ./docusaurus && cross-env NODE_ENV=production docusaurus build && node ./scripts/make-stylex-sheet.js",
     "clear": "docusaurus clear",
@@ -17,7 +17,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.1",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mdx-js/react": "^1.6.22",
-    "@stylexjs/stylex": "0.16.2",
+    "@stylexjs/stylex": "0.16.3",
     "@webcontainer/api": "^1.3.0",
     "clsx": "^1.2.1",
     "codemirror": "^5.65.16",
@@ -28,8 +28,8 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.26.8",
-    "@stylexjs/eslint-plugin": "0.16.2",
-    "@stylexjs/babel-plugin": "0.16.2",
+    "@stylexjs/eslint-plugin": "0.16.3",
+    "@stylexjs/babel-plugin": "0.16.3",
     "clean-css": "^5.3.2",
     "eslint": "^8.57.1",
     "eslint-config-airbnb": "^19.0.4",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "scripts",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Helper scripts for stylex monorepo.",
   "license": "MIT",
   "bin": {

--- a/packages/style-value-parser/package.json
+++ b/packages/style-value-parser/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "style-value-parser",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "type": "module",
   "main": "lib/index.js",
   "license": "MIT",

--- a/packages/typescript-tests/package.json
+++ b/packages/typescript-tests/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "typescript-tests",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "type": "module",
   "scripts": {
     "test": "tsc"
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.16.2",
+    "@stylexjs/stylex": "0.16.3",
     "typescript": "^5.8.3"
   },
   "engines": {


### PR DESCRIPTION
## 0.16.3 (Oct 27, 2025)

- Add configs to `sort-keys` property ordering.
- Create new `defineConsts` specific file extension.
- Add `defineConsts` and various file extension support to `enforce-extension`.
- Add config for custom module resolution.
- Update `defineConsts` types for non-stylex usage.
- Turn `enableMediaQueryOrder` on by default.
- Updates to docs and Flow version.