### PR TITLE
[types]  Fix TypeScript constraint error in `CSSType` union

### DIFF
--- a/packages/@stylexjs/stylex/src/types/VarTypes.js
+++ b/packages/@stylexjs/stylex/src/types/VarTypes.js
@@ -49,7 +49,7 @@ declare export class Image<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class Integer<+T: number> implements ICSSType<T> {
+declare export class Integer<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
@@ -65,7 +65,7 @@ declare export class Percentage<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
-declare export class Num<+T: number> implements ICSSType<T> {
+declare export class Num<+T: InnerValue> implements ICSSType<T> {
   +value: ValueWithDefault<string>;
   +syntax: CSSSyntaxType;
 }
@@ -91,11 +91,11 @@ export type CSSType<+T: InnerValue> =
   | Color<T>
   | Url<T>
   | Image<T>
-  | Integer<number>
+  | Integer<T>
   | LengthPercentage<T>
   | Length<T>
   | Percentage<T>
-  | Num<number>
+  | Num<T>
   | Resolution<T>
   | Time<T>
   | TransformFunction<T>

--- a/packages/typescript-tests/tsconfig.json
+++ b/packages/typescript-tests/tsconfig.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "jsx": "react",
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "moduleDetection": "force",
     "isolatedModules": true,
     "incremental": true,


### PR DESCRIPTION
## What changed / motivation ?

We are getting TypeScript failures with `@stylexjs/stylex` that we traced back to some incorrect generated TypeScript in `VarTypes.d.ts` ([TS Playground link](https://www.typescriptlang.org/play/?#code/PQKhCgAIUhhB7ADgTwE4EsDmALALpACgGMBKSAWQFNcBDSABQBsbcAzeVAWwGcAaSAJIA7IgDpINIQBMJrVukboWlbqKgRokACrZ03SN3gBXVEUqQi8Keb2RFZod0oyj0yqki5s58gK130BydIdlcZdCFPb3VIABkBWABRADkAZUSQhRtIr3NUeHh8KXRUSiJcDmRIeFYo20MTM09SyjVodXVgcHBgYHRORA58XGREcwBvSAA1GkYjSgB1dC8AEUpWGiNGfABfEPzOSAByUWBUkcZKAA0AVVwFbiOAbnARsenZ+aXV9c3tgB4tAA+SAAXigkAAPtoIdCAEqUGhSeBCRjIf7jCGQbGQawbLa4ABcHzmi2W2DW+IBwJeOJxAG0ACSMgDSlGQzOJ3FwGCEmAAusSZqTvhTfgTAUDaTidlLupQAB6DVDDUbmWCpTXIIS0BVg2HHEBHA1Hf6XPleIHG7HQ01CIycABG7itJv+Y1MlB1NEwlFdNuOZq9mC8AFoPQ5aL7-VDA5ZGBwY7b-v0fX7rbHTSZGEnAxFcJRfahc6bJJhLiX-vdOOm3aVDHN7ijKzzJNx2FxQ6xXOV0M2M8miEZufBOKH0NYdS3UG2O2PFNyrS83urNaltbqtGqwXA1xuaArl9vhEJ3ML5jv7YxGLHubzMLH7U73C98+4Nk0Epqt2N-gB9fxFQLaR9BPM9Pj9SBMWxUokRRNFIAANwgoUINFSk-lwf47wiTA5RgxFkVRKpuH3BViQ1LVvQVH9KBeHZwEVZUijKZhSgsZhuH0ABBPlLkBSAgK9KRQKEU9UHPSD+kQS4ax1UDKNoyUoIhWCiIQ5DSVQkVyQwiUcL5fDIDU+CSLIii92o2j6MYpUhlxViaHYohOP0BAE1QAShJAwQxPA0kQWk2SvVwBTvzVZToOMwjTKQlCSS+XTxQBAy8OlEziIMczdyozc1Rspj7OsFynPMEquMgG5UEYLyFWAkTfPEyTAoGYL5MERSIuBFSCLgzLNPmbTEp+KksNSoyMoQ0jqIs3KD2s8AGMKlUHJK5zXMETg01q+rRKaiCWpkyg5NCjrwt-bqosmqoBsoIayRGzDsJ5XCJpizLpt1Wb1ys-LFts5jVrYsqNuEAsix24T9CfZ1i0gILjpCsLUiUy7VPejT4sk9DkrGl7DPSjGzJmnKfrysYCrslbiuBjiaAq2Jgy8eh3EjbbALqqHGv8+YgQhBGTuR1G+auom4q0hKHrFUbnvvN6+qm7LKLJ+a-qWqmWLWkH6f0RmLWwSGfLAiSDvh1rEfar8Ua6kFRYVm6sbQpKZfGwn7ayknlbIhb1cBmnSrpiqWc9b1fUNhrjeas2jsFs7rYu230fd277pxl38bSpP1OJr7Se9tWAaKxz1p1yBkgdcPoYdWHDra06reFnrouTx2dMe-SM-l7OPdzr3fop-7ls12nyv0BEGyMJshEr7mTYC6O66Fm2m+u8XBsltOntdrPYs+g9vvzgffaLrXA-0LR+koGfI9NgWkbjxu7e7lON+drfO7d7u9-IvP+7oweNZAwDqPbQM5HBzgAGI9intfPyc9eb83NrHBuNtwBP1ii-bGb8O5y0-rvJWllyb-2PtTYu2sKpaDAe2DgnBYh6CwhzXas9mqIJjvfFBCc0E736q3Ya0t364O4YrT2hDVZH0LitFcOVUaCU5kbOBUdwQBl4uWK+wIDTuQ4JKA0VUarqIDAILaYd9GxjBoWdw2iAx6xDNgYObNjF8ysUzA2JjoR2JCuzRxsZy6cEsbGce8BGx9mnq47Ql8-HQkobOGhUCRAwNCVE8BNC6HcklE8IAA))

```
node_modules/@stylexjs/stylex/lib/es/types/VarTypes.d.ts(96,13): error TS2344: Type 'T' does not satisfy the constraint 'number'.
  Type 'InnerValue' is not assignable to type 'number'.
    Type 'null' is not assignable to type 'number'.
node_modules/@stylexjs/stylex/lib/es/types/VarTypes.d.ts(100,9): error TS2344: Type 'T' does not satisfy the constraint 'number'.
  Type 'InnerValue' is not assignable to type 'number'.
    Type 'null' is not assignable to type 'number'.
```

My _original_ fix in this PR was to specify the type parameter as `number` for the problematic union members. This seemed to work in Flow and produced valid TypeScript with `flow-api-translator`. I realized that this broke the typescript tests so I changed my strategy (55d68cd5946e9606354de0681623f21c42fdb2b3) and instead widened the `Integer` and `Num` types and it seems to work. 

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code