### PR TITLE
[babel-plugin] additional externals for rollup build

### DIFF
--- a/packages/@stylexjs/babel-plugin/rollup.config.mjs
+++ b/packages/@stylexjs/babel-plugin/rollup.config.mjs
@@ -21,6 +21,7 @@ const external = [
   '@babel/traverse',
   '@babel/types',
   '@babel/core',
+  '@babel/helper-module-imports',
   'node:crypto',
   'node:fs',
   'node:module',
@@ -31,7 +32,8 @@ const external = [
   'fs',
   'module',
   'path',
-  'url'
+  'postcss-value-parser',
+  'url',
 ];
 
 const config = {
@@ -42,18 +44,14 @@ const config = {
   },
   external: process.env['HASTE']
     ? external
-    : [
-        ...external,
-        '@dual-bundle/import-meta-resolve',
-        '@stylexjs/stylex',
-      ],
+    : [...external, '@dual-bundle/import-meta-resolve', '@stylexjs/stylex'],
   plugins: [
     babel({ babelHelpers: 'bundled', extensions, include: ['./src/**/*'] }),
     nodeResolve({
       preferBuiltins: false,
       extensions,
       allowExportsFolderMapping: true,
-      rootDir
+      rootDir,
     }),
     commonjs(),
     json(),


### PR DESCRIPTION
## What changed / motivation ?

This is not causing any issues but I noticed that the rollup config for `@stylexjs/babel-plugin` was not externalizing a couple packages that could be:

- `@babel/helper-module-imports`
- `postcss-value-parser`

This should be safe since those packages are listed as `dependencies` and will be installed by consumers. This will reduce bundle by ~8% and seems appropriate by following the existing pattern of externalizing third-party packages. 

Note: some changes were from prettier formatting. It looks like the `prettier:report` script does not check `.mjs` files so these `rollup.config.mjs` files have not been formatted. Let me know if I should update `prettier:report` in a separate PR. 

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code