### PR TITLE
[types] Remove duplicate property declaration

### DIFF
--- a/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.js
@@ -951,7 +951,6 @@ export type SupportedVendorSpecificCSSProperties = $ReadOnly<{
 export type CSSProperties = $ReadOnly<{
   // NOTE: adding a non-CSS property here for support themes in Stylex.
   theme?: all | string,
-  marker?: string,
 
   // ...$Exact<SupportedVendorSpecificCSSProperties>, for TypeScript compatibility
   MozOsxFontSmoothing?: all | 'grayscale',


### PR DESCRIPTION
## What changed / motivation ?

The `CSSProperties['marker']` property is defined twice.

https://github.com/facebook/stylex/blob/d6175b0e58d7315ec96996966ac3e5ffbf1a25c5/packages/%40stylexjs/stylex/src/types/StyleXCSSTypes.js#L954

https://github.com/facebook/stylex/blob/d6175b0e58d7315ec96996966ac3e5ffbf1a25c5/packages/%40stylexjs/stylex/src/types/StyleXCSSTypes.js#L1308

This does not error in FlowJS but will with TypeScript

```
../@stylexjs/stylex/lib/es/types/StyleXCSSTypes.d.ts:935:3 - error TS2300: Duplicate identifier 'marker'.

935   marker?: string;
      ~~~~~~

../@stylexjs/stylex/lib/es/types/StyleXCSSTypes.d.ts:1247:3 - error TS2300: Duplicate identifier 'marker'.

1247   marker?: all | marker;
       ~~~~~~

../@stylexjs/stylex/lib/es/types/StyleXCSSTypes.d.ts:1247:3 - error TS2717: Subsequent property declarations must have the same type.  Property 'marker' must be of type 'string | undefined', but here has type 'string | null | undefined'.

1247   marker?: all | marker;
       ~~~~~~
```

My fix for this PR is to remove the first definition with Flow will just ignore it anyway (according to my understanding). I'm not super familiar with why the clashing property was added but maybe it should be renamed instead? 

In terms of testing I feel like it would be helpful to just set `skipLibCheck: false` in the `typescript-test` packge, which would have caught this and #1306. Thanks!

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code