### PR TITLE
Add example on chaining keyframes

### DIFF
--- a/packages/docs/docs/api/javascript/keyframes.mdx
+++ b/packages/docs/docs/api/javascript/keyframes.mdx
@@ -41,21 +41,13 @@ const styles = stylex.create({
 To chain multiple keyframes, provide comma-separated values to animation properties: 
 ```tsx
 const expand = stylex.keyframes({
-  from: {
-    maxHeight: '0px'; 
-  }, 
-  to: {
-    maxHeight: '1000px'; 
-  }
+  from: {maxHeight: '0px'}, 
+  to: {maxHeight: '1000px'},
 });
 
 const fadeIn = stylex.keyframes({
-  from: {
-    opacity: 0; 
-  }, 
-  to: {
-    opacity: 1; 
-  }
+  from: {opacity: 0}, 
+  to: {opacity: 1}, 
 })
 
 const styles = stylex.create({


### PR DESCRIPTION
## What changed / motivation ?

Please include relevant motivation and context

This PR adds an example on how to chain multiple keyframes in the keyframes docs. 
Chaining multiple keyframes is very common and adding a doc on how to do it using stylex.keyframes would be a nice addition. 

## Linked PR/Issues

Fixes # (issue)

Related to this reported issue: https://github.com/facebook/stylex/issues/213 

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code