### PR TITLE
[babel-plugin] bump specificity of stylex.when selectors over defaults

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -117,7 +117,16 @@ export const styles = stylex.create({
         color: constants.ORANGE
       }
     }),
-    backgroundColor: 'red',
+    backgroundColor: {
+      default: 'red',
+      ':hover': 'blue',
+      [stylex.when.ancestor(':focus')]: 'green',
+      '@media (max-width: 1000px)': {
+        default: 'yellow',
+        [stylex.when.descendant(':focus')]: 'purple',
+        [stylex.when.anySibling(':active')]: 'orange',
+      }
+    },
     margin: vars.marginTokens,
     borderColor: {
       default: 'green',
@@ -214,7 +223,7 @@ describe('@stylexjs/babel-plugin', () => {
         export const styles = {
           root: {
             "animationName-kKVMdj": "animationName-x13ah0pd",
-            "backgroundColor-kWkggS": "backgroundColor-xrkmrrc",
+            "backgroundColor-kWkggS": "backgroundColor-xrkmrrc backgroundColor-xbrh7vm backgroundColor-xfy810d backgroundColor-xahc4vn backgroundColor-x1t4kl4c backgroundColor-x975j7z",
             "margin-kogj98": "margin-xymmreb",
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
             "outlineColor-kjBf7l": "outlineColor-x184ctg8",
@@ -225,11 +234,11 @@ describe('@stylexjs/babel-plugin', () => {
           },
           overrideColor: {
             "--orange-theme-color": "--orange-theme-color-xufgesz",
-            $$css: "app/main.js:62"
+            $$css: "app/main.js:71"
           },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:65"
+            $$css: "app/main.js:74"
           }, {
             "--x-color": color != null ? color : undefined
           }]
@@ -263,7 +272,12 @@ describe('@stylexjs/babel-plugin', () => {
         html[dir='rtl'] .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:right}
         .outlineColor-x184ctg8:not(#\\#):not(#\\#):not(#\\#){outline-color:var(--colorTokens-xkxfyv)}
         .textShadow-x1skrh0i:not(#\\#):not(#\\#):not(#\\#){text-shadow:1px 2px 3px 4px red}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id:not(#\\#):not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}"
+        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *):not(#\\#):not(#\\#):not(#\\#){background-color:green}
+        .backgroundColor-xbrh7vm:hover:not(#\\#):not(#\\#):not(#\\#){background-color:blue}
+        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn:not(#\\#):not(#\\#):not(#\\#){background-color:yellow}}
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id:not(#\\#):not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)):not(#\\#):not(#\\#):not(#\\#){background-color:purple}}
+        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)):not(#\\#):not(#\\#):not(#\\#){background-color:orange}}"
       `);
     });
 
@@ -302,7 +316,7 @@ describe('@stylexjs/babel-plugin', () => {
         export const styles = {
           root: {
             "animationName-kKVMdj": "animationName-x13ah0pd",
-            "backgroundColor-kWkggS": "backgroundColor-xrkmrrc",
+            "backgroundColor-kWkggS": "backgroundColor-xrkmrrc backgroundColor-xbrh7vm backgroundColor-xfy810d backgroundColor-xahc4vn backgroundColor-x1t4kl4c backgroundColor-x975j7z",
             "margin-kogj98": "margin-xymmreb",
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
             "outlineColor-kjBf7l": "outlineColor-x184ctg8",
@@ -313,11 +327,11 @@ describe('@stylexjs/babel-plugin', () => {
           },
           overrideColor: {
             "--orange-theme-color": "--orange-theme-color-xufgesz",
-            $$css: "app/main.js:62"
+            $$css: "app/main.js:71"
           },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:65"
+            $$css: "app/main.js:74"
           }, {
             "--x-color": color != null ? color : undefined
           }]
@@ -358,7 +372,12 @@ describe('@stylexjs/babel-plugin', () => {
         html[dir='rtl'] .float-x1kmio9f{float:right}
         .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
         .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .backgroundColor-xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
         @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
         }"
       `);
     });
@@ -396,7 +415,7 @@ describe('@stylexjs/babel-plugin', () => {
         export const styles = {
           root: {
             "animationName-kKVMdj": "animationName-x13ah0pd",
-            "backgroundColor-kWkggS": "backgroundColor-xrkmrrc",
+            "backgroundColor-kWkggS": "backgroundColor-xrkmrrc backgroundColor-xbrh7vm backgroundColor-xfy810d backgroundColor-xahc4vn backgroundColor-x1t4kl4c backgroundColor-x975j7z",
             "margin-kogj98": "margin-xymmreb",
             "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
             "outlineColor-kjBf7l": "outlineColor-x184ctg8",
@@ -407,11 +426,11 @@ describe('@stylexjs/babel-plugin', () => {
           },
           overrideColor: {
             "--orange-theme-color": "--orange-theme-color-xufgesz",
-            $$css: "app/main.js:62"
+            $$css: "app/main.js:71"
           },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:65"
+            $$css: "app/main.js:74"
           }, {
             "--x-color": color != null ? color : undefined
           }]
@@ -446,7 +465,12 @@ describe('@stylexjs/babel-plugin', () => {
         html[dir='rtl'] .float-x1kmio9f{float:right}
         .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
         .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}"
+        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .backgroundColor-xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}"
       `);
     });
 
@@ -636,7 +660,12 @@ describe('@stylexjs/babel-plugin', () => {
         /* @rtl begin */.x1kmio9f{float:right}/* @rtl end */
         .x18abd1y{outline-color:var(--xkxfyv)}
         .x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}"
+        .xfy810d.xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.xahc4vn.xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1t4kl4c.x1t4kl4c.x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.x975j7z.x975j7z.x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}"
       `);
     });
 
@@ -675,7 +704,12 @@ describe('@stylexjs/babel-plugin', () => {
         /* @rtl begin */.x1kmio9f{float:right}/* @rtl end */
         .x1skrh0i{text-shadow:1px 2px 3px 4px red}
         .xrkmrrc{background-color:red}
-        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}"
+        .xfy810d.xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.xahc4vn.xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1t4kl4c.x1t4kl4c.x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.x975j7z.x975j7z.x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}"
       `);
     });
   });

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-when-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-when-test.js
@@ -76,7 +76,7 @@ describe('@stylexjs/babel-plugin', () => {
           [
             "x148kuu",
             {
-              "ltr": ".x148kuu:where(.x-default-marker:hover *){background-color:red}",
+              "ltr": ".x148kuu.x148kuu:where(.x-default-marker:hover *){background-color:red}",
               "rtl": null,
             },
             3011.3,
@@ -125,7 +125,7 @@ describe('@stylexjs/babel-plugin', () => {
           [
             "x1i6rnlt",
             {
-              "ltr": ".x1i6rnlt:where(.x-default-marker:focus ~ *){background-color:red}",
+              "ltr": ".x1i6rnlt.x1i6rnlt:where(.x-default-marker:focus ~ *){background-color:red}",
               "rtl": null,
             },
             3031.5,
@@ -178,7 +178,7 @@ describe('@stylexjs/babel-plugin', () => {
           [
             "x148kuu",
             {
-              "ltr": ".x148kuu:where(.x-default-marker:hover *){background-color:red}",
+              "ltr": ".x148kuu.x148kuu:where(.x-default-marker:hover *){background-color:red}",
               "rtl": null,
             },
             3011.3,
@@ -186,7 +186,7 @@ describe('@stylexjs/babel-plugin', () => {
           [
             "xpijypl",
             {
-              "ltr": ".xpijypl:where(.x-default-marker:focus ~ *){background-color:green}",
+              "ltr": ".xpijypl.xpijypl:where(.x-default-marker:focus ~ *){background-color:green}",
               "rtl": null,
             },
             3031.5,
@@ -194,7 +194,7 @@ describe('@stylexjs/babel-plugin', () => {
           [
             "xoev4mv",
             {
-              "ltr": ".xoev4mv:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:yellow}",
+              "ltr": ".xoev4mv.xoev4mv:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:yellow}",
               "rtl": null,
             },
             3021.7,
@@ -202,7 +202,7 @@ describe('@stylexjs/babel-plugin', () => {
           [
             "x1v1vkh3",
             {
-              "ltr": ".x1v1vkh3:where(:has(~ .x-default-marker:focus)){background-color:purple}",
+              "ltr": ".x1v1vkh3.x1v1vkh3:where(:has(~ .x-default-marker:focus)){background-color:purple}",
               "rtl": null,
             },
             3041.5,
@@ -210,7 +210,7 @@ describe('@stylexjs/babel-plugin', () => {
           [
             "x9zntq3",
             {
-              "ltr": ".x9zntq3:where(:has(.x-default-marker:focus)){background-color:orange}",
+              "ltr": ".x9zntq3.x9zntq3:where(:has(.x-default-marker:focus)){background-color:orange}",
               "rtl": null,
             },
             3016.5,
@@ -260,7 +260,7 @@ describe('@stylexjs/babel-plugin', () => {
           [
             "x148kuu",
             {
-              "ltr": ".x148kuu:where(.x-default-marker:hover *){background-color:red}",
+              "ltr": ".x148kuu.x148kuu:where(.x-default-marker:hover *){background-color:red}",
               "rtl": null,
             },
             3011.3,
@@ -268,7 +268,7 @@ describe('@stylexjs/babel-plugin', () => {
           [
             "xpijypl",
             {
-              "ltr": ".xpijypl:where(.x-default-marker:focus ~ *){background-color:green}",
+              "ltr": ".xpijypl.xpijypl:where(.x-default-marker:focus ~ *){background-color:green}",
               "rtl": null,
             },
             3031.5,
@@ -373,7 +373,7 @@ describe('@stylexjs/babel-plugin', () => {
         import 'custom-marker.stylex';
         import { customMarker } from 'custom-marker.stylex';
         _inject2(".x1t391ir{background-color:blue}", 3000);
-        _inject2(".x7rpj1w:where(.x1lc2aw:hover *){background-color:red}", 3011.3);
+        _inject2(".x7rpj1w.x7rpj1w:where(.x1lc2aw:hover *){background-color:red}", 3011.3);
         const container = stylex.props(customMarker);
         const classNames = {
           className: "x1t391ir x7rpj1w"

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/generate-css-rule.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/generate-css-rule.js
@@ -32,8 +32,13 @@ function buildNestedCSSRule(
   const pseudo = pseudos.filter((p) => p !== '::thumb').join('');
   const combinedAtRules = atRules.concat(constRules);
 
+  // Bump specificity of stylex.when selectors
+  const hasWhere = pseudo.includes(':where(');
+  const extraClassForWhere = hasWhere ? `.${className}` : '';
+
   let selectorForAtRules =
     `.${className}` +
+    extraClassForWhere +
     combinedAtRules.map(() => `.${className}`).join('') +
     pseudo;
 


### PR DESCRIPTION
We need to bump the specificity of `.stylex.when` selectors over default styles to make them stable with multiple StyleX sheets.

For a given contextual style:
```
const styles = stylex.create({
  foo: {
    backgroundColor: {
      default: 'red',
      ':hover': 'blue',
      [stylex.when.ancestor(':focus')]: 'green',
      '@media (max-width: 1000px)': {
        default: 'yellow',
        [stylex.when.descendant(':focus')]: 'purple',
      },
    },
  },
});
```

The priority is now as follows, with non-determinism as expected between the same number of classes. This is preferable behaviour (imo) than having `.when` selectors easily overwritten by default styles
- Default styles (0, 1, 0)
- Regular .when selectors (0, 2, 0) 
- Pseudo-classes (0, 2, 0) 
- Media queries (0, 2, 0)
- Media queries + .when (0, 3, 0) 
- Media queries + pseudos(0, 3, 0) 