### PR TITLE
[release] v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.17.0 (Nov 18, 2025)
+
+- Add docs for ESLint rules and `stylex.when` API.
+- Add `defineMarker()` for custom markers for selector combinators.
+- New unplugin bundler plugin implementation for various bundlers (Vite, Webpack, Rspack, Rollup, etc.).
+- Enhance `stylex.props` to precompile more often for better performance.
+- Order pseudo-classes and `stylex.when` selectors according to priorities in `sort-keys.
+- Add support for ternary and logical expressions in `valid-styles`.
+- Bump specificity of `stylex.when` selectors over defaults.
+- Add polyfill for logical float values in legacy mode.
+
 ## 0.16.3 (Oct 27, 2025)
 
 - Add configs to `sort-keys` property ordering.

--- a/examples/example-cli/package.json
+++ b/examples/example-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-cli",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "scripts": {
     "example:build": "stylex --config .stylex.json5"
   },
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.25.7",
     "@babel/preset-typescript": "^7.25.7",
-    "@stylexjs/cli": "0.16.3",
+    "@stylexjs/cli": "0.17.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5"

--- a/examples/example-esbuild/package.json
+++ b/examples/example-esbuild/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-esbuild",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "Simple esbuild example for @stylexjs/unplugin",
   "main": "src/App.jsx",
   "scripts": {
@@ -10,13 +10,13 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.16.3",
+    "@stylexjs/stylex": "0.17.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.16.3",
-    "@stylexjs/eslint-plugin": "0.16.3",
+    "@stylexjs/unplugin": "0.17.0",
+    "@stylexjs/eslint-plugin": "0.17.0",
     "esbuild": "^0.25.0",
     "eslint": "^8.57.1"
   }

--- a/examples/example-nextjs/package.json
+++ b/examples/example-nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-nextjs",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "scripts": {
     "clean": "rimraf .next",
     "example:build": "next build",
@@ -10,15 +10,15 @@
     "example:start": "next start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.16.3",
+    "@stylexjs/stylex": "0.17.0",
     "next": "14.2.21",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "styled-jsx": "^5.1.1"
   },
   "devDependencies": {
-    "@stylexjs/eslint-plugin": "0.16.3",
-    "@stylexjs/postcss-plugin": "0.16.3",
+    "@stylexjs/eslint-plugin": "0.17.0",
+    "@stylexjs/postcss-plugin": "0.17.0",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^22.7.6",
     "@types/react": "^18.3.0",

--- a/examples/example-react-router/package.json
+++ b/examples/example-react-router/package.json
@@ -9,7 +9,7 @@
     "example:typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.16.3",
+    "@stylexjs/stylex": "0.17.0",
     "@remix-run/node-fetch-server": "0.8.0",
     "compression": "^1.8.0",
     "cross-env": "^7.0.3",
@@ -19,7 +19,7 @@
     "react-router": "7.9.2"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.16.3",
+    "@stylexjs/unplugin": "0.17.0",
     "@types/compression": "^1.8.1",
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.3",
@@ -30,5 +30,6 @@
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
     "vite-plugin-devtools-json": "0.2.0"
-  }
+  },
+  "version": "0.17.0"
 }

--- a/examples/example-redwoodsdk/package.json
+++ b/examples/example-redwoodsdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/starter",
-  "version": "1.0.0",
+  "version": "0.17.0",
   "description": "A bare-bones RedwoodSDK starter",
   "main": "index.js",
   "type": "module",
@@ -22,14 +22,14 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.16.3",
+    "@stylexjs/stylex": "0.17.0",
     "react": "19.3.0-canary-561ee24d-20251101",
     "react-dom": "19.3.0-canary-561ee24d-20251101",
     "react-server-dom-webpack": "19.3.0-canary-561ee24d-20251101",
     "rwsdk": "1.0.0-beta.26"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.16.3",
+    "@stylexjs/unplugin": "0.17.0",
     "@cloudflare/vite-plugin": "1.13.18",
     "@cloudflare/workers-types": "4.20251014.0",
     "@types/node": "~24.5.2",

--- a/examples/example-rollup/package.json
+++ b/examples/example-rollup/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-rollup",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "A simple rollup example to test stylexjs/rollup-plugin",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.16.3",
+    "@stylexjs/stylex": "0.17.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -23,7 +23,7 @@
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.7",
-    "@stylexjs/rollup-plugin": "0.16.3",
+    "@stylexjs/rollup-plugin": "0.17.0",
     "rollup": "^4.24.0",
     "serve": "^14.2.4"
   }

--- a/examples/example-rspack/package.json
+++ b/examples/example-rspack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-rspack",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.17.0",
   "description": "Example: StyleX with Rspack via @stylexjs/unplugin",
   "scripts": {
     "example:build": "rspack build --config ./rspack.config.js",
@@ -10,12 +10,12 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@stylexjs/stylex": "0.16.3"
+    "@stylexjs/stylex": "0.17.0"
   },
   "devDependencies": {
     "@rspack/cli": "^0.7.0",
     "@rspack/core": "^0.7.0",
     "css-loader": "^7.1.2",
-    "@stylexjs/unplugin": "0.16.3"
+    "@stylexjs/unplugin": "0.17.0"
   }
 }

--- a/examples/example-storybook/package.json
+++ b/examples/example-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-storybook",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "scripts": {
     "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build",
@@ -15,10 +15,10 @@
     "@storybook/addon-links": "^9.1.7",
     "@storybook/addon-vitest": "^9.1.7",
     "@storybook/react-vite": "^9.1.7",
-    "@stylexjs/babel-plugin": "0.16.3",
-    "@stylexjs/eslint-plugin": "0.16.3",
-    "@stylexjs/postcss-plugin": "0.16.3",
-    "@stylexjs/stylex": "0.16.3",
+    "@stylexjs/babel-plugin": "0.17.0",
+    "@stylexjs/eslint-plugin": "0.17.0",
+    "@stylexjs/postcss-plugin": "0.17.0",
+    "@stylexjs/stylex": "0.17.0",
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.44.0",
     "@vitejs/plugin-react": "^5.0.3",

--- a/examples/example-vite-react/package.json
+++ b/examples/example-vite-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vite-react",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.17.0",
   "type": "module",
   "scripts": {
     "example:dev": "vite",
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "@stylexjs/stylex": "0.16.3"
+    "@stylexjs/stylex": "0.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
@@ -20,7 +20,7 @@
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.4",
-    "@stylexjs/unplugin": "0.16.3",
+    "@stylexjs/unplugin": "0.17.0",
     "babel-plugin-react-compiler": "^19.1.0-rc.3",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/examples/example-vite-rsc/package.json
+++ b/examples/example-vite-rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitejs/plugin-rsc-examples-starter",
-  "version": "0.0.0",
+  "version": "0.17.0",
   "private": true,
   "license": "MIT",
   "type": "module",
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.16.3"
+    "@stylexjs/stylex": "0.17.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.2",
@@ -21,6 +21,6 @@
     "@vitejs/plugin-rsc": "latest",
     "rsc-html-stream": "^0.0.7",
     "vite": "^7.1.12",
-    "@stylexjs/unplugin": "0.16.3"
+    "@stylexjs/unplugin": "0.17.0"
   }
 }

--- a/examples/example-vite/package.json
+++ b/examples/example-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vite",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.17.0",
   "description": "Example: StyleX with Vite via @stylexjs/unplugin",
   "scripts": {
     "example:dev": "vite",
@@ -11,11 +11,11 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@stylexjs/stylex": "0.16.3"
+    "@stylexjs/stylex": "0.17.0"
   },
   "devDependencies": {
     "vite": "^5.4.8",
-    "@stylexjs/unplugin": "0.16.3",
+    "@stylexjs/unplugin": "0.17.0",
     "@vitejs/plugin-react": "latest"
   }
 }

--- a/examples/example-waku/package.json
+++ b/examples/example-waku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-waku",
-  "version": "0.0.0",
+  "version": "0.17.0",
   "type": "module",
   "private": true,
   "scripts": {
@@ -9,14 +9,14 @@
     "example:serve": "waku start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.16.3",
+    "@stylexjs/stylex": "0.17.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-server-dom-webpack": "19.2.0",
     "waku": "0.27.0"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.16.3",
+    "@stylexjs/unplugin": "0.17.0",
     "@types/react": "19.2.2",
     "@types/react-dom": "19.2.2",
     "@vitejs/plugin-react": "5.1.0",

--- a/examples/example-webpack/package.json
+++ b/examples/example-webpack/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-webpack",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "Example: StyleX with Webpack via @stylexjs/unplugin",
   "main": "index.js",
   "scripts": {
@@ -15,8 +15,8 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.1",
-    "@stylexjs/eslint-plugin": "0.16.3",
-    "@stylexjs/unplugin": "0.16.3",
+    "@stylexjs/eslint-plugin": "0.17.0",
+    "@stylexjs/unplugin": "0.17.0",
     "babel-loader": "^10.0.0",
     "css-loader": "^7.1.2",
     "file-loader": "^6.2.0",
@@ -29,7 +29,7 @@
     "webpack-dev-server": "^5.2.2"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.16.3",
+    "@stylexjs/stylex": "0.17.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
       }
     },
     "examples/example-cli": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "dependencies": {
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
@@ -49,7 +49,7 @@
       "devDependencies": {
         "@babel/preset-react": "^7.25.7",
         "@babel/preset-typescript": "^7.25.7",
-        "@stylexjs/cli": "0.16.3",
+        "@stylexjs/cli": "0.17.0",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "typescript": "^5"
@@ -84,16 +84,16 @@
       }
     },
     "examples/example-esbuild": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
       },
       "devDependencies": {
-        "@stylexjs/eslint-plugin": "0.16.3",
-        "@stylexjs/unplugin": "0.16.3",
+        "@stylexjs/eslint-plugin": "0.17.0",
+        "@stylexjs/unplugin": "0.17.0",
         "esbuild": "^0.25.0",
         "eslint": "^8.57.1"
       }
@@ -127,17 +127,17 @@
       }
     },
     "examples/example-nextjs": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "next": "14.2.21",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "styled-jsx": "^5.1.1"
       },
       "devDependencies": {
-        "@stylexjs/eslint-plugin": "0.16.3",
-        "@stylexjs/postcss-plugin": "0.16.3",
+        "@stylexjs/eslint-plugin": "0.17.0",
+        "@stylexjs/postcss-plugin": "0.17.0",
         "@types/json-schema": "^7.0.15",
         "@types/node": "^22.7.6",
         "@types/react": "^18.3.0",
@@ -430,9 +430,10 @@
       "license": "MIT"
     },
     "examples/example-react-router": {
+      "version": "0.17.0",
       "dependencies": {
         "@remix-run/node-fetch-server": "0.8.0",
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "compression": "^1.8.0",
         "cross-env": "^7.0.3",
         "express": "^5.1.0",
@@ -441,7 +442,7 @@
         "react-router": "7.9.2"
       },
       "devDependencies": {
-        "@stylexjs/unplugin": "0.16.3",
+        "@stylexjs/unplugin": "0.17.0",
         "@types/compression": "^1.8.1",
         "@types/express": "^5.0.3",
         "@types/node": "^24.0.3",
@@ -1024,10 +1025,10 @@
     },
     "examples/example-redwoodsdk": {
       "name": "@redwoodjs/starter",
-      "version": "1.0.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "react": "19.3.0-canary-561ee24d-20251101",
         "react-dom": "19.3.0-canary-561ee24d-20251101",
         "react-server-dom-webpack": "19.3.0-canary-561ee24d-20251101",
@@ -1036,7 +1037,7 @@
       "devDependencies": {
         "@cloudflare/vite-plugin": "1.13.18",
         "@cloudflare/workers-types": "4.20251014.0",
-        "@stylexjs/unplugin": "0.16.3",
+        "@stylexjs/unplugin": "0.17.0",
         "@types/node": "~24.5.2",
         "@types/react": "19.1.2",
         "@types/react-dom": "19.1.2",
@@ -1972,10 +1973,10 @@
       }
     },
     "examples/example-rollup": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -1987,7 +1988,7 @@
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-replace": "^5.0.7",
-        "@stylexjs/rollup-plugin": "0.16.3",
+        "@stylexjs/rollup-plugin": "0.17.0",
         "rollup": "^4.24.0",
         "serve": "^14.2.4"
       }
@@ -2014,16 +2015,16 @@
       "license": "MIT"
     },
     "examples/example-rspack": {
-      "version": "0.0.0",
+      "version": "0.17.0",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@rspack/cli": "^0.7.0",
         "@rspack/core": "^0.7.0",
-        "@stylexjs/unplugin": "0.16.3",
+        "@stylexjs/unplugin": "0.17.0",
         "css-loader": "^7.1.2"
       }
     },
@@ -2111,7 +2112,7 @@
       }
     },
     "examples/example-storybook": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.1",
         "@storybook/addon-a11y": "^9.1.7",
@@ -2119,10 +2120,10 @@
         "@storybook/addon-links": "^9.1.7",
         "@storybook/addon-vitest": "^9.1.7",
         "@storybook/react-vite": "^9.1.7",
-        "@stylexjs/babel-plugin": "0.16.3",
-        "@stylexjs/eslint-plugin": "0.16.3",
-        "@stylexjs/postcss-plugin": "0.16.3",
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/babel-plugin": "0.17.0",
+        "@stylexjs/eslint-plugin": "0.17.0",
+        "@stylexjs/postcss-plugin": "0.17.0",
+        "@stylexjs/stylex": "0.17.0",
         "@typescript-eslint/eslint-plugin": "^8.44.0",
         "@typescript-eslint/parser": "^8.44.0",
         "@vitejs/plugin-react": "^5.0.3",
@@ -2908,28 +2909,28 @@
       }
     },
     "examples/example-vite": {
-      "version": "0.0.0",
+      "version": "0.17.0",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@stylexjs/unplugin": "0.16.3",
+        "@stylexjs/unplugin": "0.17.0",
         "@vitejs/plugin-react": "latest",
         "vite": "^5.4.8"
       }
     },
     "examples/example-vite-react": {
-      "version": "0.0.0",
+      "version": "0.17.0",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
-        "@stylexjs/unplugin": "0.16.3",
+        "@stylexjs/unplugin": "0.17.0",
         "@types/node": "^24.6.0",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",
@@ -3365,15 +3366,15 @@
     },
     "examples/example-vite-rsc": {
       "name": "@vitejs/plugin-rsc-examples-starter",
-      "version": "0.0.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
-        "@stylexjs/unplugin": "0.16.3",
+        "@stylexjs/unplugin": "0.17.0",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
         "@vitejs/plugin-react": "latest",
@@ -3623,16 +3624,16 @@
       }
     },
     "examples/example-waku": {
-      "version": "0.0.0",
+      "version": "0.17.0",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-server-dom-webpack": "19.2.0",
         "waku": "0.27.0"
       },
       "devDependencies": {
-        "@stylexjs/unplugin": "0.16.3",
+        "@stylexjs/unplugin": "0.17.0",
         "@types/react": "19.2.2",
         "@types/react-dom": "19.2.2",
         "@vitejs/plugin-react": "5.1.0",
@@ -3898,10 +3899,10 @@
       }
     },
     "examples/example-webpack": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -3910,8 +3911,8 @@
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.6.1",
-        "@stylexjs/eslint-plugin": "0.16.3",
-        "@stylexjs/unplugin": "0.16.3",
+        "@stylexjs/eslint-plugin": "0.17.0",
+        "@stylexjs/unplugin": "0.17.0",
         "babel-loader": "^10.0.0",
         "css-loader": "^7.1.2",
         "file-loader": "^6.2.0",
@@ -41546,7 +41547,7 @@
       }
     },
     "packages/@stylexjs/babel-plugin": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
@@ -41554,8 +41555,8 @@
         "@babel/traverse": "^7.26.8",
         "@babel/types": "^7.26.8",
         "@dual-bundle/import-meta-resolve": "^4.1.0",
-        "@stylexjs/shared": "0.16.3",
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/shared": "0.17.0",
+        "@stylexjs/stylex": "0.17.0",
         "postcss-value-parser": "^4.1.0"
       },
       "devDependencies": {
@@ -41567,7 +41568,7 @@
         "@rollup/plugin-replace": "^6.0.1",
         "babel-plugin-syntax-hermes-parser": "^0.26.0",
         "rollup": "^4.24.0",
-        "scripts": "0.16.3"
+        "scripts": "0.17.0"
       }
     },
     "packages/@stylexjs/babel-plugin/node_modules/@rollup/plugin-commonjs": {
@@ -41640,14 +41641,14 @@
       }
     },
     "packages/@stylexjs/cli": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.26.8",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
         "@babel/types": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.16.3",
+        "@stylexjs/babel-plugin": "0.17.0",
         "ansis": "^3.3.2",
         "fb-watchman": "^2.0.2",
         "json5": "^2.2.3",
@@ -41658,7 +41659,7 @@
         "stylex": "lib/index.js"
       },
       "devDependencies": {
-        "scripts": "0.16.3"
+        "scripts": "0.17.0"
       }
     },
     "packages/@stylexjs/cli/node_modules/@babel/core": {
@@ -41691,21 +41692,21 @@
       }
     },
     "packages/@stylexjs/eslint-plugin": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/shared": "0.16.3",
+        "@stylexjs/shared": "0.17.0",
         "css-shorthand-expand": "^1.2.0",
         "micromatch": "^4.0.5",
         "postcss-value-parser": "^4.2.0"
       }
     },
     "packages/@stylexjs/postcss-plugin": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.16.3",
+        "@stylexjs/babel-plugin": "0.17.0",
         "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
@@ -41713,14 +41714,14 @@
       }
     },
     "packages/@stylexjs/rollup-plugin": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
         "@babel/plugin-syntax-flow": "^7.26.0",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
-        "@stylexjs/babel-plugin": "0.16.3",
+        "@stylexjs/babel-plugin": "0.17.0",
         "lightningcss": "^1.29.1"
       },
       "devDependencies": {
@@ -41780,7 +41781,7 @@
       }
     },
     "packages/@stylexjs/shared": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.23.9",
@@ -41788,7 +41789,7 @@
       }
     },
     "packages/@stylexjs/stylex": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "css-mediaquery": "^0.1.2",
@@ -41815,7 +41816,7 @@
         "cross-env": "^7.0.3",
         "rimraf": "^5.0.10",
         "rollup": "^4.24.0",
-        "scripts": "0.16.3"
+        "scripts": "0.17.0"
       }
     },
     "packages/@stylexjs/stylex/node_modules/@rollup/plugin-commonjs": {
@@ -41888,14 +41889,14 @@
       }
     },
     "packages/@stylexjs/unplugin": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
         "@babel/plugin-syntax-flow": "^7.26.0",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
-        "@stylexjs/babel-plugin": "0.16.3",
+        "@stylexjs/babel-plugin": "0.17.0",
         "browserslist": "^4.24.0",
         "lightningcss": "^1.29.1"
       },
@@ -41904,11 +41905,11 @@
       }
     },
     "packages/benchmarks": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/babel-plugin": "0.16.3",
-        "@stylexjs/rollup-plugin": "0.16.3",
+        "@stylexjs/babel-plugin": "0.17.0",
+        "@stylexjs/rollup-plugin": "0.17.0",
         "benchmark": "^2.1.4",
         "brotli-size": "^4.0.0",
         "clean-css": "^5.3.3",
@@ -41921,7 +41922,7 @@
       }
     },
     "packages/docs": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "dependencies": {
         "@docusaurus/core": "2.4.1",
         "@docusaurus/preset-classic": "2.4.1",
@@ -41930,7 +41931,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.1",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@mdx-js/react": "^1.6.22",
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "@webcontainer/api": "^1.3.0",
         "clsx": "^1.2.1",
         "codemirror": "^5.65.16",
@@ -41941,8 +41942,8 @@
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.16.3",
-        "@stylexjs/eslint-plugin": "0.16.3",
+        "@stylexjs/babel-plugin": "0.17.0",
+        "@stylexjs/eslint-plugin": "0.17.0",
         "clean-css": "^5.3.2",
         "eslint": "^8.57.1",
         "eslint-config-airbnb": "^19.0.4",
@@ -41966,7 +41967,7 @@
       }
     },
     "packages/scripts": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "flow-api-translator": "0.26.0",
@@ -41978,7 +41979,7 @@
       }
     },
     "packages/style-value-parser": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@csstools/css-tokenizer": "^3.0.3"
@@ -41992,10 +41993,10 @@
       }
     },
     "packages/typescript-tests": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.16.3",
+        "@stylexjs/stylex": "0.17.0",
         "typescript": "^5.8.3"
       },
       "engines": {

--- a/packages/@stylexjs/babel-plugin/package.json
+++ b/packages/@stylexjs/babel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/babel-plugin",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "StyleX babel plugin.",
   "main": "lib/index.js",
   "repository": {
@@ -21,8 +21,8 @@
     "@babel/traverse": "^7.26.8",
     "@babel/types": "^7.26.8",
     "@dual-bundle/import-meta-resolve": "^4.1.0",
-    "@stylexjs/shared": "0.16.3",
-    "@stylexjs/stylex": "0.16.3",
+    "@stylexjs/shared": "0.17.0",
+    "@stylexjs/stylex": "0.17.0",
     "postcss-value-parser": "^4.1.0"
   },
   "devDependencies": {
@@ -34,7 +34,7 @@
     "@rollup/plugin-replace": "^6.0.1",
     "babel-plugin-syntax-hermes-parser": "^0.26.0",
     "rollup": "^4.24.0",
-    "scripts": "0.16.3"
+    "scripts": "0.17.0"
   },
   "files": [
     "flow_modules/*",

--- a/packages/@stylexjs/cli/package.json
+++ b/packages/@stylexjs/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/cli",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "A cli to compile a folder with StyleX",
   "main": "./lib/transform.js",
   "repository": "https://www.github.com/facebook/stylex",
@@ -19,7 +19,7 @@
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
     "@babel/types": "^7.26.8",
-    "@stylexjs/babel-plugin": "0.16.3",
+    "@stylexjs/babel-plugin": "0.17.0",
     "ansis": "^3.3.2",
     "fb-watchman": "^2.0.2",
     "json5": "^2.2.3",
@@ -27,7 +27,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "scripts": "0.16.3"
+    "scripts": "0.17.0"
   },
   "bin": {
     "stylex": "./lib/index.js"

--- a/packages/@stylexjs/eslint-plugin/package.json
+++ b/packages/@stylexjs/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/eslint-plugin",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "StyleX eslint plugin.",
   "main": "lib/index.js",
   "repository": {
@@ -16,7 +16,7 @@
     "test": "jest --detectOpenHandles --coverage"
   },
   "dependencies": {
-    "@stylexjs/shared": "0.16.3",
+    "@stylexjs/shared": "0.17.0",
     "css-shorthand-expand": "^1.2.0",
     "micromatch": "^4.0.5",
     "postcss-value-parser": "^4.2.0"

--- a/packages/@stylexjs/postcss-plugin/package.json
+++ b/packages/@stylexjs/postcss-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/postcss-plugin",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "PostCSS plugin for StyleX",
   "main": "src/index.js",
   "repository": {
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.26.8",
-    "@stylexjs/babel-plugin": "0.16.3",
+    "@stylexjs/babel-plugin": "0.17.0",
     "postcss": "^8.4.49",
     "fast-glob": "^3.3.2",
     "glob-parent": "^6.0.2",

--- a/packages/@stylexjs/rollup-plugin/package.json
+++ b/packages/@stylexjs/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/rollup-plugin",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "Rollup plugin for StyleX",
   "main": "./lib/index.js",
   "module": "./lib/es/index.mjs",
@@ -35,7 +35,7 @@
     "@babel/plugin-syntax-flow": "^7.26.0",
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
-    "@stylexjs/babel-plugin": "0.16.3",
+    "@stylexjs/babel-plugin": "0.17.0",
     "lightningcss": "^1.29.1"
   },
   "devDependencies": {

--- a/packages/@stylexjs/shared/package.json
+++ b/packages/@stylexjs/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/shared",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "main": "lib/index.js",
   "repository": {
     "type": "git",

--- a/packages/@stylexjs/stylex/package.json
+++ b/packages/@stylexjs/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/stylex",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "A library for defining styles for optimized user interfaces.",
   "main": "./lib/cjs/stylex.js",
   "module": "./lib/es/stylex.mjs",
@@ -61,7 +61,7 @@
     "cross-env": "^7.0.3",
     "rimraf": "^5.0.10",
     "rollup": "^4.24.0",
-    "scripts": "0.16.3"
+    "scripts": "0.17.0"
   },
   "files": [
     "lib/*"

--- a/packages/@stylexjs/unplugin/package.json
+++ b/packages/@stylexjs/unplugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/unplugin",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "private": false,
   "description": "Universal bundler plugin for StyleX using unplugin",
   "license": "MIT",
@@ -35,7 +35,7 @@
     "@babel/plugin-syntax-flow": "^7.26.0",
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
-    "@stylexjs/babel-plugin": "0.16.3",
+    "@stylexjs/babel-plugin": "0.17.0",
     "browserslist": "^4.24.0",
     "lightningcss": "^1.29.1"
   },

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "benchmarks",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "scripts": {
     "perf": "node ./perf/run.js",
     "size": "NODE_ENV=production rollup --config ./size/rollup.config.mjs && node ./size/run.js",
@@ -9,8 +9,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/babel-plugin": "0.16.3",
-    "@stylexjs/rollup-plugin": "0.16.3",
+    "@stylexjs/babel-plugin": "0.17.0",
+    "@stylexjs/rollup-plugin": "0.17.0",
     "benchmark": "^2.1.4",
     "brotli-size": "^4.0.0",
     "clean-css": "^5.3.3",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "docs",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "scripts": {
     "build": "rimraf ./build ./docusaurus && cross-env NODE_ENV=production docusaurus build && node ./scripts/make-stylex-sheet.js",
     "clear": "docusaurus clear",
@@ -17,7 +17,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.1",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mdx-js/react": "^1.6.22",
-    "@stylexjs/stylex": "0.16.3",
+    "@stylexjs/stylex": "0.17.0",
     "@webcontainer/api": "^1.3.0",
     "clsx": "^1.2.1",
     "codemirror": "^5.65.16",
@@ -28,8 +28,8 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.26.8",
-    "@stylexjs/eslint-plugin": "0.16.3",
-    "@stylexjs/babel-plugin": "0.16.3",
+    "@stylexjs/eslint-plugin": "0.17.0",
+    "@stylexjs/babel-plugin": "0.17.0",
     "clean-css": "^5.3.2",
     "eslint": "^8.57.1",
     "eslint-config-airbnb": "^19.0.4",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "scripts",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "Helper scripts for stylex monorepo.",
   "license": "MIT",
   "bin": {

--- a/packages/style-value-parser/package.json
+++ b/packages/style-value-parser/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "style-value-parser",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "type": "module",
   "main": "lib/index.js",
   "license": "MIT",

--- a/packages/typescript-tests/package.json
+++ b/packages/typescript-tests/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "typescript-tests",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "type": "module",
   "scripts": {
     "test": "tsc"
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.16.3",
+    "@stylexjs/stylex": "0.17.0",
     "typescript": "^5.8.3"
   },
   "engines": {


### PR DESCRIPTION
## 0.17.0 (Nov 18, 2025)

- Add docs for ESLint rules and `stylex.when` API.
- Add `defineMarker()` for custom markers for selector combinators.
- New unplugin bundler plugin implementation for various bundlers (Vite, Webpack, Rspack, Rollup, etc.).
- Enhance `stylex.props` to precompile more often for better performance.
- Order pseudo-classes and `stylex.when` selectors according to priorities in `sort-keys.
- Add support for ternary and logical expressions in `valid-styles`.
- Bump specificity of `stylex.when` selectors over defaults.
- Add polyfill for logical float values in legacy mode.