### PR TITLE
[fix] Show full debug file paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1025,7 +1025,8 @@
         "react": "19.3.0-canary-561ee24d-20251101",
         "react-dom": "19.3.0-canary-561ee24d-20251101",
         "react-server-dom-webpack": "19.3.0-canary-561ee24d-20251101",
-        "rwsdk": "1.0.0-beta.31"
+        "rwsdk": "1.0.0-beta.31",
+        "shared-ui": "*"
       },
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.15.2",
@@ -3706,6 +3707,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-server-dom-webpack": "19.2.0",
+        "shared-ui": "*",
         "waku": "0.27.1"
       },
       "devDependencies": {

--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-call-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-call-test.js
@@ -1691,7 +1691,7 @@ describe('@stylexjs/babel-plugin', () => {
             "gridColumn-kBCFzs": null,
             "gridColumnStart-kEXP64": null,
             "gridColumnEnd-kWZpDQ": null,
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::4"
           },
           content: {
             "gridArea-kJuA4N": "gridArea-x1fdo2jl",
@@ -1701,13 +1701,13 @@ describe('@stylexjs/babel-plugin', () => {
             "gridColumn-kBCFzs": null,
             "gridColumnStart-kEXP64": null,
             "gridColumnEnd-kWZpDQ": null,
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::8"
           },
           root: {
             "display-k1xSpc": "display-xrvj5dj",
             "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
             "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::11"
           },
           withSidebar: {
             "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
@@ -1716,11 +1716,11 @@ describe('@stylexjs/babel-plugin', () => {
             "@media (max-width: 640px)_gridTemplateRows-k9pwkU": "gridTemplateRows-xmr4b4k",
             "@media (max-width: 640px)_gridTemplateAreas-kOnEH4": "gridTemplateAreas-xesbpuc",
             "@media (max-width: 640px)_gridTemplateColumns-k1JLwA": "gridTemplateColumns-x15nfgh4",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::16"
           },
           noSidebar: {
             "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::26"
           }
         };
         ({
@@ -1800,7 +1800,7 @@ describe('@stylexjs/babel-plugin', () => {
             "gridColumn-kBCFzs": null,
             "gridColumnStart-kEXP64": null,
             "gridColumnEnd-kWZpDQ": null,
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::4"
           },
           content: {
             "gridArea-kJuA4N": "gridArea-x1fdo2jl",
@@ -1810,13 +1810,13 @@ describe('@stylexjs/babel-plugin', () => {
             "gridColumn-kBCFzs": null,
             "gridColumnStart-kEXP64": null,
             "gridColumnEnd-kWZpDQ": null,
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::8"
           },
           root: {
             "display-k1xSpc": "display-xrvj5dj",
             "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
             "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::11"
           },
           withSidebar: {
             "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
@@ -1825,11 +1825,11 @@ describe('@stylexjs/babel-plugin', () => {
             "@media (max-width: 640px)_gridTemplateRows-k9pwkU": "gridTemplateRows-xmr4b4k",
             "@media (max-width: 640px)_gridTemplateAreas-kOnEH4": "gridTemplateAreas-xesbpuc",
             "@media (max-width: 640px)_gridTemplateColumns-k1JLwA": "gridTemplateColumns-x15nfgh4",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::16"
           },
           noSidebar: {
             "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::26"
           }
         };
         stylex(styles.root, sidebar == null ? styles.noSidebar : styles.withSidebar);"

--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
@@ -338,7 +338,7 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
             "paddingBottom-kGO01o": "paddingBottom-xs9asl8",
             "paddingInlineStart-kZCmMZ": "paddingInlineStart-xaso8d8",
             "paddingInlineEnd-kwRFfy": "paddingInlineEnd-x2vl965",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::4"
           },
           bar: {
             "paddingTop-kLKAdn": "paddingTop-x1nn3v0j",
@@ -346,7 +346,7 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
             "paddingLeft-kE3dHu": "paddingLeft-xnljgj5",
             "paddingInlineStart-kZCmMZ": null,
             "paddingInlineEnd-kwRFfy": null,
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::9"
           }
         };
         "paddingTop-x1nn3v0j paddingBottom-x1120s5i paddingLeft-xnljgj5";
@@ -777,31 +777,31 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
             "listStyleType-kH6xsr": "listStyleType-x3ct3a4",
             "listStylePosition-kpqbRz": null,
             "listStyleImage-khnUzm": null,
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::4"
           },
           square: {
             "listStyleType-kH6xsr": "listStyleType-x152237o",
             "listStylePosition-kpqbRz": null,
             "listStyleImage-khnUzm": null,
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::7"
           },
           inside: {
             "listStyleType-kH6xsr": null,
             "listStylePosition-kpqbRz": "listStylePosition-x1cy9i3i",
             "listStyleImage-khnUzm": null,
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::10"
           },
           custom1: {
             "listStyleType-kH6xsr": "listStyleType-x1jzm7bx",
             "listStylePosition-kpqbRz": null,
             "listStyleImage-khnUzm": null,
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::13"
           },
           custom2: {
             "listStyleType-kH6xsr": "listStyleType-x1tpmu87",
             "listStylePosition-kpqbRz": null,
             "listStyleImage-khnUzm": null,
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::16"
           }
         };"
       `);
@@ -850,25 +850,25 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
             "listStyleType-kH6xsr": "listStyleType-x3ct3a4",
             "listStylePosition-kpqbRz": "listStylePosition-x1cy9i3i",
             "listStyleImage-khnUzm": null,
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::4"
           },
           two: {
             "listStyleType-kH6xsr": "listStyleType-x152237o",
             "listStylePosition-kpqbRz": null,
             "listStyleImage-khnUzm": "listStyleImage-xnbnhf8",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::7"
           },
           three: {
             "listStyleType-kH6xsr": "listStyleType-xl2um64",
             "listStylePosition-kpqbRz": null,
             "listStyleImage-khnUzm": "listStyleImage-x1qcowux",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::10"
           },
           four: {
             "listStyleType-kH6xsr": "listStyleType-xqkogtj",
             "listStylePosition-kpqbRz": "listStylePosition-x43c9pm",
             "listStyleImage-khnUzm": "listStyleImage-x1qcowux",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::13"
           }
         };"
       `);
@@ -921,25 +921,25 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
             "listStylePosition-kpqbRz": "listStylePosition-x1cy9i3i",
             "listStyleImage-khnUzm": null,
             "listStyleType-kH6xsr": "listStyleType-x152237o",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::4"
           },
           two: {
             "listStyleType-kH6xsr": "listStyleType-x12kno0j",
             "listStyleImage-khnUzm": "listStyleImage-xnbnhf8",
             "listStylePosition-kpqbRz": "listStylePosition-x43c9pm",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::8"
           },
           three: {
             "listStyleImage-khnUzm": "listStyleImage-x1qcowux",
             "listStylePosition-kpqbRz": "listStylePosition-x43c9pm",
             "listStyleType-kH6xsr": "listStyleType-x152237o",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::12"
           },
           four: {
             "listStyleImage-khnUzm": "listStyleImage-x1qcowux",
             "listStylePosition-kpqbRz": "listStylePosition-x43c9pm",
             "listStyleType-kH6xsr": "listStyleType-x152237o",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::17"
           }
         };"
       `);

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -80,7 +80,7 @@ function transform(source, opts = {}) {
   ${source.replace("import * as stylex from '@stylexjs/stylex';", '')}
   `,
     {
-      filename: '/src/app/main.js',
+      filename: opts.filename ?? '/src/app/main.js',
       parserOpts: { flow: 'all' },
       babelrc: false,
       plugins: [[stylexPlugin, pluginOpts]],
@@ -192,7 +192,9 @@ describe('@stylexjs/babel-plugin', () => {
     });
 
     test('all rules (useLayers:false)', () => {
-      const { code, metadata } = transform(fixture);
+      const { code, metadata } = transform(fixture, {
+        filename: '/src/app/components/main.js',
+      });
       expect(code).toMatchInlineSnapshot(`
         "import * as stylex from '@stylexjs/stylex';
         export const constants = {
@@ -231,15 +233,15 @@ describe('@stylexjs/babel-plugin', () => {
             "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-xtj17id",
             "padding-kmVPX3": "padding-xss17vw",
             "float-kyUFMd": "float-x1kmio9f",
-            $$css: "app/main.js:33"
+            $$css: "components/main.js:33"
           },
           overrideColor: {
             "--orange-theme-color": "--orange-theme-color-xufgesz",
-            $$css: "app/main.js:71"
+            $$css: "components/main.js:71"
           },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:74"
+            $$css: "components/main.js:74"
           }, {
             "--x-color": color != null ? color : undefined
           }]
@@ -324,15 +326,15 @@ describe('@stylexjs/babel-plugin', () => {
             "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-xtj17id",
             "padding-kmVPX3": "padding-xss17vw",
             "float-kyUFMd": "float-x1kmio9f",
-            $$css: "app/main.js:33"
+            $$css: "main.js:33"
           },
           overrideColor: {
             "--orange-theme-color": "--orange-theme-color-xufgesz",
-            $$css: "app/main.js:71"
+            $$css: "main.js:71"
           },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:74"
+            $$css: "main.js:74"
           }, {
             "--x-color": color != null ? color : undefined
           }]
@@ -423,15 +425,15 @@ describe('@stylexjs/babel-plugin', () => {
             "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-xtj17id",
             "padding-kmVPX3": "padding-xss17vw",
             "float-kyUFMd": "float-x1kmio9f",
-            $$css: "app/main.js:33"
+            $$css: "main.js:33"
           },
           overrideColor: {
             "--orange-theme-color": "--orange-theme-color-xufgesz",
-            $$css: "app/main.js:71"
+            $$css: "main.js:71"
           },
           dynamic: color => [{
             "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
-            $$css: "app/main.js:74"
+            $$css: "main.js:74"
           }, {
             "--x-color": color != null ? color : undefined
           }]
@@ -524,7 +526,7 @@ describe('@stylexjs/babel-plugin', () => {
             "paddingBottom-kGO01o": "paddingBottom-xs9asl8",
             "paddingInlineStart-kZCmMZ": "paddingInlineStart-x1gx403c",
             "float-kyUFMd": "float-xj87blo",
-            $$css: "app/main.js:25"
+            $$css: "main.js:25"
           }
         };"
       `);

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
@@ -115,9 +115,9 @@ describe('@stylexjs/babel-plugin', () => {
           _inject2(".color-x1e2nbdu{color:red}", 3000);
           function Foo() {
             return <>
-                            <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:components/Foo.react.js:4">Hello World</div>
-                            <div className="test" className="color-x1e2nbdu" data-style-src="npm-package:components/Foo.react.js:4" id="test">Hello World</div>
-                            <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:components/Foo.react.js:4" className="test">Hello World</div>
+                            <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:../../../../../../../../../js/node_modules/npm-package/dist/components/Foo.react.js:4">Hello World</div>
+                            <div className="test" className="color-x1e2nbdu" data-style-src="npm-package:../../../../../../../../../js/node_modules/npm-package/dist/components/Foo.react.js:4" id="test">Hello World</div>
+                            <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:../../../../../../../../../js/node_modules/npm-package/dist/components/Foo.react.js:4" className="test">Hello World</div>
                           </>;
           }"
         `);
@@ -156,11 +156,11 @@ describe('@stylexjs/babel-plugin', () => {
           const styles = {
             red: {
               "color-kMwMTN": "color-x1e2nbdu",
-              $$css: "npm-package:components/Foo.react.js:4"
+              $$css: "npm-package:../../../../../../../../../js/node_modules/npm-package/dist/components/Foo.react.js:4"
             },
             opacity: opacity => [{
               "opacity-kSiTet": opacity != null ? "opacity-xb4nw82" : opacity,
-              $$css: "npm-package:components/Foo.react.js:7"
+              $$css: "npm-package:../../../../../../../../../js/node_modules/npm-package/dist/components/Foo.react.js:7"
             }, {
               "--x-opacity": opacity != null ? opacity : undefined
             }]
@@ -201,7 +201,7 @@ describe('@stylexjs/babel-plugin', () => {
           const styles = {
             red: {
               "color-kMwMTN": "color-x1e2nbdu",
-              $$css: "npm-package:components/Foo.react.js:4"
+              $$css: "npm-package:../../../../../../../../../js/node_modules/npm-package/dist/components/Foo.react.js:4"
             }
           };
           function Foo(props) {
@@ -1033,7 +1033,7 @@ describe('@stylexjs/babel-plugin', () => {
           _inject2(".color-x1e2nbdu{color:red}", 3000);
           ({
             className: "color-x1e2nbdu",
-            "data-style-src": "js/FooBar.react.js:4"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:4"
           });"
         `);
 
@@ -1063,14 +1063,14 @@ describe('@stylexjs/babel-plugin', () => {
           const styles = {
             default: {
               "color-kMwMTN": "color-x1e2nbdu",
-              $$css: "js/FooBar.react.js:4"
+              $$css: "../../../../../../../../../html/js/FooBar.react.js:4"
             }
           };
           _inject2(".backgroundColor-x1t391ir{background-color:blue}", 3000);
           const otherStyles = {
             default: {
               "backgroundColor-kWkggS": "backgroundColor-x1t391ir",
-              $$css: "js/FooBar.react.js:9"
+              $$css: "../../../../../../../../../html/js/FooBar.react.js:9"
             }
           };
           stylex.props([styles.default, isActive && otherStyles.default]);"
@@ -1111,11 +1111,11 @@ describe('@stylexjs/babel-plugin', () => {
           ({
             0: {
               className: "color-x1e2nbdu",
-              "data-style-src": "js/FooBar.react.js:4"
+              "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:4"
             },
             1: {
               className: "color-x1e2nbdu backgroundColor-x1t391ir",
-              "data-style-src": "js/FooBar.react.js:4; js/FooBar.react.js:9"
+              "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:4; ../../../../../../../../../html/js/FooBar.react.js:9"
             }
           })[!!isActive << 0];"
         `);
@@ -1145,11 +1145,11 @@ describe('@stylexjs/babel-plugin', () => {
           ({
             0: {
               className: "color-x1e2nbdu",
-              "data-style-src": "js/FooBar.react.js:4"
+              "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:4"
             },
             1: {
               className: "color-xju2f9n",
-              "data-style-src": "js/FooBar.react.js:4; js/FooBar.react.js:7"
+              "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:4; ../../../../../../../../../html/js/FooBar.react.js:7"
             }
           })[!!isActive << 0];"
         `);
@@ -1490,17 +1490,17 @@ describe('@stylexjs/babel-plugin', () => {
           sidebar: {
             "boxSizing-kB7OPa": "boxSizing-x9f619",
             "gridArea-kJuA4N": "gridArea-x1yc5d2u",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::4"
           },
           content: {
             "gridArea-kJuA4N": "gridArea-x1fdo2jl",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::8"
           },
           root: {
             "display-k1xSpc": "display-xrvj5dj",
             "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
             "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::11"
           },
           withSidebar: {
             "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
@@ -1509,19 +1509,21 @@ describe('@stylexjs/babel-plugin', () => {
             "@media (max-width: 640px)_gridTemplateRows-k9pwkU": "gridTemplateRows-xmr4b4k",
             "@media (max-width: 640px)_gridTemplateAreas-kOnEH4": "gridTemplateAreas-xesbpuc",
             "@media (max-width: 640px)_gridTemplateColumns-k1JLwA": "gridTemplateColumns-x15nfgh4",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::16"
           },
           noSidebar: {
             "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
-            $$css: true
+            $$css: "@stylexjs/babel-plugin::26"
           }
         };
         ({
           0: {
-            className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4"
+            className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
+            "data-style-src": "@stylexjs/babel-plugin::11; @stylexjs/babel-plugin::16"
           },
           1: {
-            className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x"
+            className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x",
+            "data-style-src": "@stylexjs/babel-plugin::11; @stylexjs/babel-plugin::26"
           }
         })[!!(sidebar == null) << 0];"
       `);
@@ -1592,35 +1594,35 @@ describe('@stylexjs/babel-plugin', () => {
         const complex = {
           0: {
             className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:16"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:16"
           },
           4: {
             className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:26"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:26"
           },
           2: {
             className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1yc5d2u",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:16; js/FooBar.react.js:4"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:16; ../../../../../../../../../html/js/FooBar.react.js:4"
           },
           6: {
             className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1yc5d2u",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:26; js/FooBar.react.js:4"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:26; ../../../../../../../../../html/js/FooBar.react.js:4"
           },
           1: {
             className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 gridArea-x1fdo2jl",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:16; js/FooBar.react.js:8"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:16; ../../../../../../../../../html/js/FooBar.react.js:8"
           },
           5: {
             className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x gridArea-x1fdo2jl",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:26; js/FooBar.react.js:8"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:26; ../../../../../../../../../html/js/FooBar.react.js:8"
           },
           3: {
             className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1fdo2jl",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:16; js/FooBar.react.js:4; js/FooBar.react.js:8"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:16; ../../../../../../../../../html/js/FooBar.react.js:4; ../../../../../../../../../html/js/FooBar.react.js:8"
           },
           7: {
             className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1fdo2jl",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:26; js/FooBar.react.js:4; js/FooBar.react.js:8"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:26; ../../../../../../../../../html/js/FooBar.react.js:4; ../../../../../../../../../html/js/FooBar.react.js:8"
           }
         }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];"
       `);
@@ -1692,35 +1694,35 @@ describe('@stylexjs/babel-plugin', () => {
         const complex = {
           0: {
             className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:16"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:16"
           },
           4: {
             className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:26"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:26"
           },
           2: {
             className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1yc5d2u",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:16; js/FooBar.react.js:4"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:16; ../../../../../../../../../html/js/FooBar.react.js:4"
           },
           6: {
             className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1yc5d2u",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:26; js/FooBar.react.js:4"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:26; ../../../../../../../../../html/js/FooBar.react.js:4"
           },
           1: {
             className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 gridArea-x1fdo2jl",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:16; js/FooBar.react.js:8"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:16; ../../../../../../../../../html/js/FooBar.react.js:8"
           },
           5: {
             className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x gridArea-x1fdo2jl",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:26; js/FooBar.react.js:8"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:26; ../../../../../../../../../html/js/FooBar.react.js:8"
           },
           3: {
             className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1fdo2jl",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:16; js/FooBar.react.js:4; js/FooBar.react.js:8"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:16; ../../../../../../../../../html/js/FooBar.react.js:4; ../../../../../../../../../html/js/FooBar.react.js:8"
           },
           7: {
             className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1fdo2jl",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:26; js/FooBar.react.js:4; js/FooBar.react.js:8"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:26; ../../../../../../../../../html/js/FooBar.react.js:4; ../../../../../../../../../html/js/FooBar.react.js:8"
           }
         }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];"
       `);
@@ -1792,35 +1794,35 @@ describe('@stylexjs/babel-plugin', () => {
         const complex = {
           0: {
             className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:16"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:16"
           },
           4: {
             className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:26"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:26"
           },
           2: {
             className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1yc5d2u",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:16; js/FooBar.react.js:4"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:16; ../../../../../../../../../html/js/FooBar.react.js:4"
           },
           6: {
             className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1yc5d2u",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:26; js/FooBar.react.js:4"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:26; ../../../../../../../../../html/js/FooBar.react.js:4"
           },
           1: {
             className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x1fdo2jl",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:16; js/FooBar.react.js:8"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:16; ../../../../../../../../../html/js/FooBar.react.js:8"
           },
           5: {
             className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x1fdo2jl",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:26; js/FooBar.react.js:8"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:26; ../../../../../../../../../html/js/FooBar.react.js:8"
           },
           3: {
             className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1fdo2jl",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:16; js/FooBar.react.js:4; js/FooBar.react.js:8"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:16; ../../../../../../../../../html/js/FooBar.react.js:4; ../../../../../../../../../html/js/FooBar.react.js:8"
           },
           7: {
             className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1fdo2jl",
-            "data-style-src": "js/FooBar.react.js:11; js/FooBar.react.js:26; js/FooBar.react.js:4; js/FooBar.react.js:8"
+            "data-style-src": "../../../../../../../../../html/js/FooBar.react.js:11; ../../../../../../../../../html/js/FooBar.react.js:26; ../../../../../../../../../html/js/FooBar.react.js:4; ../../../../../../../../../html/js/FooBar.react.js:8"
           }
         }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];"
       `);


### PR DESCRIPTION
## What changed / motivation ?

For the `data-style-src` attribute to be useful for chrome dev tools extensions etc, it is important to have the full file path available.

Today the path always just shows the arbitrary last two parts of the path.

This new implementation searches for the nearest `pcakage.json` file uses that as the "root" to show the relative file path from. The package name from the `package.json` file is used as a prefix

Additionally, it detects your own `package.json` file by walking up from `cwd` and drops the package name prefix if the file is not from a third-party package.

This code, similar to the code used by theming APIs, looks for package.json files so it can work with esoteric package managers where the package may or may not be in a `node_modules` folder. We do, however, expect the existance of the `package.json` file for this to work.

--

As a fallback, it will use the configured `rootDir` as a fallback root.

## TODO:

- [ ] Improve tests, to avoid long `../../` prefixes
- [ ] Verify that files within `node_modules` folder are being treated correctly.