### PR TITLE
[fix] Fix media query ordering for queries with 'screen and'

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -2074,7 +2074,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: {
-                kWkggS: "xrkmrrc x1yrnpot xe2d6hj x17z8iku",
+                kWkggS: "xrkmrrc x1qc147k x9qmkci x17z8iku",
                 $$css: true
               }
             };"
@@ -2091,17 +2091,17 @@ describe('@stylexjs/babel-plugin', () => {
                   3000,
                 ],
                 [
-                  "x1yrnpot",
+                  "x1qc147k",
                   {
-                    "ltr": "@media (((screen) and (max-width: 900px) and (not ((screen))) and (not ((screen)))) or ((screen) and (max-width: 900px) and (not ((screen))) and (not ((max-width: 400px))))) or (((screen) and (max-width: 900px) and (not ((max-width: 500px))) and (not ((screen)))) or ((screen) and (max-width: 900px) and (not ((max-width: 500px))) and (not ((max-width: 400px))))){.x1yrnpot.x1yrnpot{background-color:blue}}",
+                    "ltr": "@media (((screen) and (max-width: 900px) and (not (screen)) and (not (screen))) or ((screen) and (max-width: 900px) and (not (screen)) and (not (max-width: 400px)))) or (((screen) and (max-width: 900px) and (not (max-width: 500px)) and (not (screen))) or ((screen) and (max-width: 900px) and (not (max-width: 500px)) and (not (max-width: 400px)))){.x1qc147k.x1qc147k{background-color:blue}}",
                     "rtl": null,
                   },
                   3200,
                 ],
                 [
-                  "xe2d6hj",
+                  "x9qmkci",
                   {
-                    "ltr": "@media ((screen) and (max-width: 500px) and (not ((screen)))) or ((screen) and (max-width: 500px) and (not ((max-width: 400px)))){.xe2d6hj.xe2d6hj{background-color:purple}}",
+                    "ltr": "@media ((screen) and (max-width: 500px) and (not (screen))) or ((screen) and (max-width: 500px) and (not (max-width: 400px))){.x9qmkci.x9qmkci{background-color:purple}}",
                     "rtl": null,
                   },
                   3200,

--- a/packages/style-value-parser/src/at-queries/__tests__/media-query-transform-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/media-query-transform-test.js
@@ -268,7 +268,7 @@ describe('Media Query Transformer', () => {
     const expectedStyles = {
       width: {
         default: '100%',
-        '@media screen and (not (max-width: 500px)), (min-width: 500.01px) and (max-width: 800px)':
+        '@media (screen) and (not (max-width: 500px)), (min-width: 500.01px) and (max-width: 800px)':
           '80%',
         '@media (max-width: 500px)': '60%',
       },

--- a/packages/style-value-parser/src/at-queries/__tests__/parse-media-query-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/parse-media-query-test.js
@@ -96,7 +96,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media only print and (color)"',
+          '"@media only (print) and (color)"',
         );
       });
 
@@ -139,7 +139,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media not all and (monochrome)"',
+          '"@media not (all) and (monochrome)"',
         );
       });
     });
@@ -940,7 +940,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media not all and (monochrome)"',
+          '"@media not (all) and (monochrome)"',
         );
       });
 
@@ -973,7 +973,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media screen and (min-width: 400px)"',
+          '"@media (screen) and (min-width: 400px)"',
         );
       });
 
@@ -1037,7 +1037,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media screen and (device-aspect-ratio: 16 / 9)"',
+          '"@media (screen) and (device-aspect-ratio: 16 / 9)"',
         );
       });
 
@@ -1970,7 +1970,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (color) and (min-width: 400px), screen and (max-width: 700px)"',
+          '"@media (color) and (min-width: 400px), (screen) and (max-width: 700px)"',
         );
       });
     });
@@ -1997,7 +1997,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (not ((min-width: 400px)))"',
+          '"@media (not (min-width: 400px))"',
         );
       });
 
@@ -2050,7 +2050,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media not all and (monochrome) and (min-width: 600px)"',
+          '"@media not (all) and (monochrome) and (min-width: 600px)"',
         );
       });
 
@@ -2269,7 +2269,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media screen and (min-width: 500px) and (max-width: 800px) and (color)"',
+          '"@media (screen) and (min-width: 500px) and (max-width: 800px) and (color)"',
         );
       });
     });
@@ -2315,7 +2315,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (not ((hover: hover)))"',
+          '"@media (not (hover: hover))"',
         );
       });
 

--- a/packages/style-value-parser/src/at-queries/media-query.js
+++ b/packages/style-value-parser/src/at-queries/media-query.js
@@ -520,7 +520,7 @@ export class MediaQuery {
     switch (queries.type) {
       case 'media-keyword': {
         const prefix = queries.not ? 'not ' : queries.only ? 'only ' : '';
-        return prefix + queries.key;
+        return prefix + (isTopLevel ? queries.key : `(${queries.key})`);
       }
       case 'word-rule':
         return `(${queries.keyValue})`;
@@ -555,9 +555,11 @@ export class MediaQuery {
       }
       case 'not':
         return queries.rule &&
-          (queries.rule.type === 'and' || queries.rule.type === 'or')
+          (queries.rule.type === 'and' ||
+            queries.rule.type === 'or' ||
+            queries.rule.type === 'not')
           ? `(not (${this.#toString(queries.rule)}))`
-          : `(not (${this.#toString(queries.rule)}))`;
+          : `(not ${this.#toString(queries.rule)})`;
       case 'and':
         return queries.rules.map((rule) => this.#toString(rule)).join(' and ');
       case 'or': {


### PR DESCRIPTION
## What changed / motivation ?

Media query ordering breaks in scenarios where the queries contain `screen and`.

It generates invalid CSS that cannot be parsed by lightningcss. We should either fix this or opt-out of automatic ordering except in scenarios where we can parse reliably.

## TODO

- [x] Add a new test
- [x] Actually fix the bug