### PR TITLE
[stylex] add runtime injection support for defineConsts constants

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
@@ -618,4 +618,294 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
   });
+
+  describe('[transform] stylex.defineConsts() with runtimeInjection', () => {
+    test('constants object with runtimeInjection: true', () => {
+      const options = { runtimeInjection: true };
+      const { code, metadata } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const breakpoints = stylex.defineConsts({
+          sm: '(min-width: 768px)',
+          md: '(min-width: 1024px)',
+          lg: '(min-width: 1280px)',
+        });
+      `,
+        options,
+      );
+
+      expect(code).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import * as stylex from '@stylexjs/stylex';
+        _inject2("", 0, "x1izlsax", "(min-width: 768px)");
+        _inject2("", 0, "xe5hjsi", "(min-width: 1024px)");
+        _inject2("", 0, "xmbwnbr", "(min-width: 1280px)");
+        export const breakpoints = {
+          sm: "(min-width: 768px)",
+          md: "(min-width: 1024px)",
+          lg: "(min-width: 1280px)"
+        };"
+      `);
+
+      expect(metadata.stylex).toMatchInlineSnapshot(`
+        [
+          [
+            "x1izlsax",
+            {
+              "constKey": "x1izlsax",
+              "constVal": "(min-width: 768px)",
+              "ltr": "",
+              "rtl": null,
+            },
+            0,
+          ],
+          [
+            "xe5hjsi",
+            {
+              "constKey": "xe5hjsi",
+              "constVal": "(min-width: 1024px)",
+              "ltr": "",
+              "rtl": null,
+            },
+            0,
+          ],
+          [
+            "xmbwnbr",
+            {
+              "constKey": "xmbwnbr",
+              "constVal": "(min-width: 1280px)",
+              "ltr": "",
+              "rtl": null,
+            },
+            0,
+          ],
+        ]
+      `);
+    });
+
+    test('numeric constants with runtimeInjection: true', () => {
+      const options = { runtimeInjection: true };
+      const { code } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const sizes = stylex.defineConsts({
+          small: 8,
+          medium: 16,
+          large: 24,
+        });
+      `,
+        options,
+      );
+
+      expect(code).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import * as stylex from '@stylexjs/stylex';
+        _inject2("", 0, "x1mllmr4", 8);
+        _inject2("", 0, "x1g9nw8d", 16);
+        _inject2("", 0, "x1c5h197", 24);
+        export const sizes = {
+          small: 8,
+          medium: 16,
+          large: 24
+        };"
+      `);
+    });
+
+    test('string constants with runtimeInjection: true', () => {
+      const options = { runtimeInjection: true };
+      const { code } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const colors = stylex.defineConsts({
+          primary: 'rebeccapurple',
+          secondary: 'coral',
+          tertiary: 'turquoise',
+        });
+      `,
+        options,
+      );
+
+      expect(code).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import * as stylex from '@stylexjs/stylex';
+        _inject2("", 0, "xbx9tme", "rebeccapurple");
+        _inject2("", 0, "x1is3lfz", "coral");
+        _inject2("", 0, "x1uyqs0n", "turquoise");
+        export const colors = {
+          primary: "rebeccapurple",
+          secondary: "coral",
+          tertiary: "turquoise"
+        };"
+      `);
+    });
+
+    test('mixed string and numeric constants with runtimeInjection: true', () => {
+      const options = { runtimeInjection: true };
+      const { code } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const theme = stylex.defineConsts({
+          spacing: 16,
+          color: 'blue',
+          breakpoint: '(min-width: 768px)',
+        });
+      `,
+        options,
+      );
+
+      expect(code).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import * as stylex from '@stylexjs/stylex';
+        _inject2("", 0, "xtp8oqr", 16);
+        _inject2("", 0, "xzwxy2o", "blue");
+        _inject2("", 0, "x1dhodo0", "(min-width: 768px)");
+        export const theme = {
+          spacing: 16,
+          color: "blue",
+          breakpoint: "(min-width: 768px)"
+        };"
+      `);
+    });
+
+    test('constants with special characters with runtimeInjection: true', () => {
+      const options = { runtimeInjection: true };
+      const { code } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const urls = stylex.defineConsts({
+          background: 'url("bg.png")',
+        });
+      `,
+        options,
+      );
+
+      expect(code).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import * as stylex from '@stylexjs/stylex';
+        _inject2("", 0, "x1abznok", "url(\\"bg.png\\")");
+        export const urls = {
+          background: "url(\\"bg.png\\")"
+        };"
+      `);
+    });
+
+    test('constants with custom inject path with runtimeInjection', () => {
+      const options = {
+        runtimeInjection: '@custom/inject-path',
+      };
+      const { code } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const breakpoints = stylex.defineConsts({
+          sm: '(min-width: 768px)',
+        });
+      `,
+        options,
+      );
+
+      expect(code).toMatchInlineSnapshot(`
+        "import _inject from "@custom/inject-path";
+        var _inject2 = _inject;
+        import * as stylex from '@stylexjs/stylex';
+        _inject2("", 0, "x1izlsax", "(min-width: 768px)");
+        export const breakpoints = {
+          sm: "(min-width: 768px)"
+        };"
+      `);
+    });
+
+    test('haste module with runtimeInjection: true', () => {
+      const options = {
+        unstable_moduleResolution: { type: 'haste' },
+        runtimeInjection: true,
+      };
+
+      const { code } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const breakpoints = stylex.defineConsts({
+          sm: '(min-width: 768px)',
+          md: '(min-width: 1024px)',
+        });
+      `,
+        options,
+      );
+
+      expect(code).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import * as stylex from '@stylexjs/stylex';
+        _inject2("", 0, "x1izlsax", "(min-width: 768px)");
+        _inject2("", 0, "xe5hjsi", "(min-width: 1024px)");
+        export const breakpoints = {
+          sm: "(min-width: 768px)",
+          md: "(min-width: 1024px)"
+        };"
+      `);
+    });
+
+    test('constants with numeric keys with runtimeInjection: true', () => {
+      const options = { runtimeInjection: true };
+      const { code } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const levels = stylex.defineConsts({
+          0: 'zero',
+          1: 'one',
+          2: 'two',
+        });
+      `,
+        options,
+      );
+
+      expect(code).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import * as stylex from '@stylexjs/stylex';
+        _inject2("", 0, "x1t8zjeu", "zero");
+        _inject2("", 0, "xr91grk", "one");
+        _inject2("", 0, "x5diukc", "two");
+        export const levels = {
+          "0": "zero",
+          "1": "one",
+          "2": "two"
+        };"
+      `);
+    });
+
+    test('multiple defineConsts calls with runtimeInjection: true', () => {
+      const options = { runtimeInjection: true };
+      const { code } = transform(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        export const breakpoints = stylex.defineConsts({
+          sm: '(min-width: 768px)',
+        });
+        export const colors = stylex.defineConsts({
+          primary: 'blue',
+        });
+      `,
+        options,
+      );
+
+      expect(code).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import * as stylex from '@stylexjs/stylex';
+        _inject2("", 0, "x1izlsax", "(min-width: 768px)");
+        export const breakpoints = {
+          sm: "(min-width: 768px)"
+        };
+        _inject2("", 0, "xbx9tme", "blue");
+        export const colors = {
+          primary: "blue"
+        };"
+      `);
+    });
+  });
 });

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -688,15 +688,26 @@ export default class StateManager {
 
       this.injectImportInserted = injectName;
     }
-    for (const [_key, { ltr, rtl }, priority] of styles) {
+    for (const [_key, styleObj, priority] of styles) {
+      const { ltr, rtl } = styleObj;
+      const args = [
+        t.stringLiteral(ltr),
+        t.numericLiteral(priority),
+        ...(rtl != null ? [t.stringLiteral(rtl)] : []),
+      ];
+
+      if ('constKey' in styleObj && 'constVal' in styleObj) {
+        const { constKey, constVal } = styleObj;
+        args.push(
+          t.stringLiteral(constKey),
+          typeof constVal === 'number'
+            ? t.numericLiteral(constVal)
+            : t.stringLiteral(String(constVal)),
+        );
+      }
+
       statementPath.insertBefore(
-        t.expressionStatement(
-          t.callExpression(injectName, [
-            t.stringLiteral(ltr),
-            t.numericLiteral(priority),
-            ...(rtl != null ? [t.stringLiteral(rtl)] : []),
-          ]),
-        ),
+        t.expressionStatement(t.callExpression(injectName, args)),
       );
     }
   }

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-consts.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-consts.js
@@ -89,7 +89,7 @@ export default function transformStyleXDefineConsts(
       obj.priority,
     ]);
 
-    state.registerStyles(styles);
+    state.registerStyles(styles, variableDeclaratorPath);
   }
 }
 

--- a/packages/@stylexjs/stylex/__tests__/createSheet-test.js
+++ b/packages/@stylexjs/stylex/__tests__/createSheet-test.js
@@ -21,6 +21,7 @@ describe('createSheet', () => {
       const sheet = createSheet();
       expect(typeof sheet.getTextContent()).toBe('string');
       expect(typeof sheet.insert).toBe('function');
+      expect(typeof sheet.update).toBe('function');
     });
 
     test('creates multiple sheets', () => {
@@ -28,8 +29,10 @@ describe('createSheet', () => {
       const sheet2 = createSheet();
       expect(typeof sheet1.getTextContent()).toBe('string');
       expect(typeof sheet1.insert).toBe('function');
+      expect(typeof sheet1.update).toBe('function');
       expect(typeof sheet2.getTextContent()).toBe('string');
       expect(typeof sheet2.insert).toBe('function');
+      expect(typeof sheet2.update).toBe('function');
     });
 
     test('reuses existing sheet for given root', () => {
@@ -80,6 +83,32 @@ describe('createSheet', () => {
       sheet.insert('.test-shadow { opacity: 0 }', 3);
       expect(shadowSheet.getTextContent().includes('test-shadow')).toBe(true);
     });
+
+    test('update method updates rules across all sheets', () => {
+      const sheet = createSheet();
+      sheet.insert('.update-test { color: red }', 3);
+      expect(sheet.getTextContent().includes('color: red')).toBe(true);
+
+      const iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+      const iframeDoc = iframe.contentWindow.document;
+      const iframeRootTag = document.createElement('div');
+      iframeRootTag.id = 'test';
+      iframeDoc.body.appendChild(iframeRootTag);
+      const iframeSheet = createSheet(iframeRootTag);
+
+      expect(iframeSheet.getTextContent().includes('color: red')).toBe(true);
+
+      sheet.update(
+        '.update-test { color: red }',
+        '.update-test { color: blue }',
+        3,
+      );
+
+      expect(sheet.getTextContent().includes('color: blue')).toBe(true);
+      expect(sheet.getTextContent().includes('color: red')).toBe(false);
+      expect(iframeSheet.getTextContent().includes('color: blue')).toBe(true);
+    });
   });
 
   describe('server side', () => {
@@ -97,6 +126,7 @@ describe('createSheet', () => {
       const sheet = createSheet();
       expect(typeof sheet.getTextContent()).toBe('string');
       expect(typeof sheet.insert).toBe('function');
+      expect(typeof sheet.update).toBe('function');
     });
 
     test('creates multiple sheets', () => {
@@ -104,8 +134,10 @@ describe('createSheet', () => {
       const sheet2 = createSheet();
       expect(typeof sheet1.getTextContent()).toBe('string');
       expect(typeof sheet1.insert).toBe('function');
+      expect(typeof sheet1.update).toBe('function');
       expect(typeof sheet2.getTextContent()).toBe('string');
       expect(typeof sheet2.insert).toBe('function');
+      expect(typeof sheet2.update).toBe('function');
     });
   });
 });

--- a/packages/@stylexjs/stylex/__tests__/inject-test.js
+++ b/packages/@stylexjs/stylex/__tests__/inject-test.js
@@ -59,4 +59,340 @@ describe('inject', () => {
       '".color:not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#)::before:hover { color: red }"',
     );
   });
+
+  describe('defineConsts runtime injection', () => {
+    test('registers a constant', () => {
+      const result = inject('', 0, 'x1abc123', 'rebeccapurple');
+      expect(result).toBe('');
+    });
+
+    test('inlines constant in CSS rule', () => {
+      inject('', 0, 'x2def456', 'blue');
+
+      const cssText = '.test { color: var(--x2def456) }';
+      const result = inject(cssText, 3000);
+
+      expect(result).toMatchInlineSnapshot(
+        '".test:not(#\\#):not(#\\#):not(#\\#){ color: blue }"',
+      );
+    });
+
+    test('inlines multiple constants in one rule', () => {
+      inject('', 0, 'xcolor1', 'red');
+      inject('', 0, 'xcolor2', 'green');
+
+      const cssText =
+        '.multi { color: var(--xcolor1); background-color: var(--xcolor2) }';
+      const result = inject(cssText, 3000);
+
+      expect(result).toMatchInlineSnapshot(
+        '".multi:not(#\\#):not(#\\#):not(#\\#){ color: red; background-color: green }"',
+      );
+    });
+
+    test('handles numeric constants', () => {
+      inject('', 0, 'xnum123', 10);
+
+      const cssText = '.numeric { padding: var(--xnum123) }';
+      const result = inject(cssText, 1000);
+
+      expect(result).toMatchInlineSnapshot(
+        '".numeric:not(#\\#){ padding: 10 }"',
+      );
+    });
+
+    test('leaves unreferenced constants unchanged in CSS', () => {
+      inject('', 0, 'xunused', 'purple');
+
+      const cssText = '.normal { color: orange }';
+      const result = inject(cssText, 3000);
+
+      expect(result).toMatchInlineSnapshot(
+        '".normal:not(#\\#):not(#\\#):not(#\\#){ color: orange }"',
+      );
+    });
+
+    test('handles constants in media queries', () => {
+      inject('', 0, 'xbp768', '@media (min-width: 768px)');
+
+      const cssText = 'var(--xbp768){.xbs0o1n.xbs0o1n{color:blue}}';
+      const result = inject(cssText, 6000);
+
+      expect(result).toMatchInlineSnapshot(
+        '"@media (min-width: 768px){.xbs0o1n.xbs0o1n:not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#){color:blue}}"',
+      );
+    });
+
+    test('handles nested at-rules with constants', () => {
+      inject('', 0, 'xbig', '@media (min-width: 1024px)');
+      inject('', 0, 'xsmall', '@media (min-width: 768px)');
+
+      const cssText =
+        'var(--xsmall){var(--xbig){.xrf68et.xrf68et.xrf68et{color:red}}}';
+      const result = inject(cssText, 9000);
+
+      expect(result).toMatchInlineSnapshot(
+        '"@media (min-width: 768px){@media (min-width: 1024px){.xrf68et.xrf68et.xrf68et:not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#){color:red}}}"',
+      );
+    });
+
+    test('handles constants for container queries', () => {
+      inject('', 0, 'xcq500', '@media (min-width: 500px)');
+
+      const cssText = 'var(--xcq500){.container-class{padding:20px}}';
+      const result = inject(cssText, 6000);
+
+      expect(result).toMatchInlineSnapshot(
+        '"@media (min-width: 500px){.container-class:not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#){padding:20px}}"',
+      );
+    });
+
+    test('handles constants for supports queries', () => {
+      inject('', 0, 'xsupports', '@media (display: grid)');
+
+      const cssText = 'var(--xsupports){.grid-container{display:grid}}';
+      const result = inject(cssText, 6000);
+
+      expect(result).toMatchInlineSnapshot(
+        '"@media (display: grid){.grid-container:not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#){display:grid}}"',
+      );
+    });
+
+    test('handles constants in CSS variable definitions', () => {
+      inject('', 0, 'xprimary', 'rebeccapurple');
+
+      const cssText = ':root { --my-color: var(--xprimary) }';
+      const result = inject(cssText, 0.1);
+
+      expect(result).toMatchInlineSnapshot(
+        '":root { --my-color: rebeccapurple }"',
+      );
+    });
+
+    test('handles constants with special characters in values', () => {
+      inject('', 0, 'xspecial', 'url("image.png")');
+
+      const cssText = '.bg { background-image: var(--xspecial) }';
+      const result = inject(cssText, 3000);
+
+      expect(result).toMatchInlineSnapshot(
+        '".bg:not(#\\#):not(#\\#):not(#\\#){ background-image: url("image.png") }"',
+      );
+    });
+
+    test('preserves other var() references that are not constants', () => {
+      inject('', 0, 'xknown', 'blue');
+
+      const cssText =
+        '.mixed { color: var(--xknown); background: var(--unknown-var) }';
+      const result = inject(cssText, 3000);
+
+      expect(result).toMatchInlineSnapshot(
+        '".mixed:not(#\\#):not(#\\#):not(#\\#){ color: blue; background: var(--unknown-var) }"',
+      );
+    });
+
+    test('updates dependent rules when constant changes', () => {
+      inject('', 0, 'xdynamic', 'red');
+
+      const cssText = '.dynamic { color: var(--xdynamic) }';
+      const result1 = inject(cssText, 3000);
+      expect(result1).toMatchInlineSnapshot(
+        '".dynamic:not(#\\#):not(#\\#):not(#\\#){ color: red }"',
+      );
+
+      inject('', 0, 'xdynamic', 'green');
+
+      const cssText2 = '.dynamic2 { background: var(--xdynamic) }';
+      const result2 = inject(cssText2, 3000);
+      expect(result2).toMatchInlineSnapshot(
+        '".dynamic2:not(#\\#):not(#\\#):not(#\\#){ background: green }"',
+      );
+    });
+
+    test('handles constants with zero values', () => {
+      inject('', 0, 'xzero', 0);
+
+      const cssText = '.zero { margin: var(--xzero) }';
+      const result = inject(cssText, 1000);
+
+      expect(result).toMatchInlineSnapshot('".zero:not(#\\#){ margin: 0 }"');
+    });
+
+    test('handles constants in complex selectors', () => {
+      inject('', 0, 'xhover', 'blue');
+
+      const cssText = '.link:hover::after { color: var(--xhover) }';
+      const result = inject(cssText, 5000);
+
+      expect(result).toMatchInlineSnapshot(
+        '".link:hover:not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#)::after { color: blue }"',
+      );
+    });
+
+    test('updates multiple dependent rules when constant changes', () => {
+      inject('', 0, 'xchanging', 'red');
+
+      const cssText1 = '.rule1 { color: var(--xchanging) }';
+      const result1 = inject(cssText1, 3000);
+      expect(result1).toMatchInlineSnapshot(
+        '".rule1:not(#\\#):not(#\\#):not(#\\#){ color: red }"',
+      );
+
+      const cssText2 = '.rule2 { background: var(--xchanging) }';
+      const result2 = inject(cssText2, 3000);
+      expect(result2).toMatchInlineSnapshot(
+        '".rule2:not(#\\#):not(#\\#):not(#\\#){ background: red }"',
+      );
+
+      const cssText3 = '.rule3 { border-color: var(--xchanging) }';
+      const result3 = inject(cssText3, 3000);
+      expect(result3).toMatchInlineSnapshot(
+        '".rule3:not(#\\#):not(#\\#):not(#\\#){ border-color: red }"',
+      );
+
+      inject('', 0, 'xchanging', 'blue');
+
+      const cssText4 = '.rule4 { fill: var(--xchanging) }';
+      const result4 = inject(cssText4, 3000);
+      expect(result4).toMatchInlineSnapshot(
+        '".rule4:not(#\\#):not(#\\#):not(#\\#){ fill: blue }"',
+      );
+    });
+
+    test('does not update dependent rules if constant value stays the same', () => {
+      inject('', 0, 'xstatic', 'purple');
+
+      const cssText = '.static { color: var(--xstatic) }';
+      const result1 = inject(cssText, 3000);
+      expect(result1).toMatchInlineSnapshot(
+        '".static:not(#\\#):not(#\\#):not(#\\#){ color: purple }"',
+      );
+
+      inject('', 0, 'xstatic', 'purple');
+
+      const cssText2 = '.static2 { background: var(--xstatic) }';
+      const result2 = inject(cssText2, 3000);
+      expect(result2).toMatchInlineSnapshot(
+        '".static2:not(#\\#):not(#\\#):not(#\\#){ background: purple }"',
+      );
+    });
+
+    test('updates dependent at-rules when constant changes', () => {
+      inject('', 0, 'xbpchanging', '@media (min-width: 768px)');
+
+      const cssText1 = 'var(--xbpchanging){.responsive{display:flex}}';
+      const result1 = inject(cssText1, 6000);
+      expect(result1).toMatchInlineSnapshot(
+        '"@media (min-width: 768px){.responsive:not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#){display:flex}}"',
+      );
+
+      inject('', 0, 'xbpchanging', '@media (min-width: 1024px)');
+
+      const cssText2 = 'var(--xbpchanging){.responsive2{display:grid}}';
+      const result2 = inject(cssText2, 6000);
+      expect(result2).toMatchInlineSnapshot(
+        '"@media (min-width: 1024px){.responsive2:not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#){display:grid}}"',
+      );
+    });
+
+    test('prevents duplicate dependency tracking', () => {
+      inject('', 0, 'xnodupe', 'purple');
+
+      const cssText = '.nodupe { color: var(--xnodupe) }';
+      inject(cssText, 3000);
+      inject(cssText, 3000);
+      inject(cssText, 3000);
+
+      inject('', 0, 'xnodupe', 'orange');
+
+      const cssText2 = '.nodupe2 { background: var(--xnodupe) }';
+      const result = inject(cssText2, 3000);
+      expect(result).toMatchInlineSnapshot(
+        '".nodupe2:not(#\\#):not(#\\#):not(#\\#){ background: orange }"',
+      );
+    });
+
+    test('tracks dependencies for multiple constants in one rule', () => {
+      inject('', 0, 'xmulti1', 'red');
+      inject('', 0, 'xmulti2', 'blue');
+
+      const cssText =
+        '.multi { color: var(--xmulti1); background: var(--xmulti2) }';
+      const result1 = inject(cssText, 3000);
+      expect(result1).toMatchInlineSnapshot(
+        '".multi:not(#\\#):not(#\\#):not(#\\#){ color: red; background: blue }"',
+      );
+
+      inject('', 0, 'xmulti1', 'green');
+
+      const cssText2 = '.multi2 { border-color: var(--xmulti1) }';
+      const result2 = inject(cssText2, 3000);
+      expect(result2).toMatchInlineSnapshot(
+        '".multi2:not(#\\#):not(#\\#):not(#\\#){ border-color: green }"',
+      );
+
+      inject('', 0, 'xmulti2', 'yellow');
+
+      const cssText3 = '.multi3 { fill: var(--xmulti2) }';
+      const result3 = inject(cssText3, 3000);
+      expect(result3).toMatchInlineSnapshot(
+        '".multi3:not(#\\#):not(#\\#):not(#\\#){ fill: yellow }"',
+      );
+    });
+
+    test('correctly updates stylesheet when constant value changes', () => {
+      inject('', 0, 'xupdatetest', 'red');
+
+      const cssText = '.updatetest { color: var(--xupdatetest) }';
+      const result1 = inject(cssText, 3000);
+      expect(result1).toMatchInlineSnapshot(
+        '".updatetest:not(#\\#):not(#\\#):not(#\\#){ color: red }"',
+      );
+
+      inject('', 0, 'xupdatetest', 'green');
+
+      const cssText2 = '.updatetest2 { background: var(--xupdatetest) }';
+      const result2 = inject(cssText2, 3000);
+      expect(result2).toMatchInlineSnapshot(
+        '".updatetest2:not(#\\#):not(#\\#):not(#\\#){ background: green }"',
+      );
+    });
+
+    test('handles constant updates with at-rules and regular properties', () => {
+      inject('', 0, 'xflexible', 'red');
+
+      const cssText1 = '.prop { color: var(--xflexible) }';
+      const result1 = inject(cssText1, 3000);
+      expect(result1).toMatchInlineSnapshot(
+        '".prop:not(#\\#):not(#\\#):not(#\\#){ color: red }"',
+      );
+
+      inject('', 0, 'xflexible', 'blue');
+
+      const cssText2 = '.prop2 { border-color: var(--xflexible) }';
+      const result2 = inject(cssText2, 3000);
+      expect(result2).toMatchInlineSnapshot(
+        '".prop2:not(#\\#):not(#\\#):not(#\\#){ border-color: blue }"',
+      );
+    });
+
+    test('handles mixed constant and non-constant values', () => {
+      inject('', 0, 'xmixed', '10px');
+
+      const cssText = '.mixed { padding: var(--xmixed); margin: 20px }';
+      const result1 = inject(cssText, 3000);
+      expect(result1).toMatchInlineSnapshot(
+        '".mixed:not(#\\#):not(#\\#):not(#\\#){ padding: 10px; margin: 20px }"',
+      );
+
+      inject('', 0, 'xmixed', '15px');
+
+      const cssText2 = '.mixed2 { padding: var(--xmixed); margin: 20px }';
+      const result2 = inject(cssText2, 3000);
+      expect(result2).toMatchInlineSnapshot(
+        '".mixed2:not(#\\#):not(#\\#):not(#\\#){ padding: 15px; margin: 20px }"',
+      );
+    });
+  });
 });

--- a/packages/@stylexjs/stylex/src/stylesheet/createSheet.js
+++ b/packages/@stylexjs/stylex/src/stylesheet/createSheet.js
@@ -66,5 +66,10 @@ export function createSheet(root?: HTMLElement): Sheet {
         s.insert(cssText, groupValue);
       });
     },
+    update(oldCssText: string, newCssText: string, groupValue: number) {
+      sheets.forEach((s) => {
+        s.update(oldCssText, newCssText, groupValue);
+      });
+    },
   };
 }

--- a/packages/@stylexjs/stylex/src/stylesheet/utils.js
+++ b/packages/@stylexjs/stylex/src/stylesheet/utils.js
@@ -29,8 +29,12 @@ export function addSpecificityLevel(cssText: string, index: number): string {
   const lastOpenCurly = cssText.includes('::')
     ? cssText.indexOf('::')
     : cssText.lastIndexOf('{');
-  const beforeCurly = cssText.slice(0, lastOpenCurly);
+  let beforeCurly = cssText.slice(0, lastOpenCurly);
   const afterCurly = cssText.slice(lastOpenCurly);
+
+  if (index > 0) {
+    beforeCurly = beforeCurly.trimEnd();
+  }
 
   return `${beforeCurly}${pseudoSelector}${afterCurly}`;
 }

--- a/packages/docs/babel.config.js
+++ b/packages/docs/babel.config.js
@@ -13,6 +13,8 @@ const isProd = process.env.NODE_ENV === 'production';
 const options = {
   dev: !isProd,
   runtimeInjection: !isProd,
+  enableDebugClassNames: false,
+  enableDevClassNames: false,
   test: false,
   stylexSheetName: '<>',
   unstable_moduleResolution: {


### PR DESCRIPTION
This PR adds runtime injection support to `defineConsts` for HMR support with constants. We need to add special handling here because `defineConsts` does not have a CSS string in the rules metadata. Most of the runtime injection implementation is forked from the internal runtime injection logic (for historical SSR reasons - we may be able to unfork), but this PR also fixes the inject calls necessary for internal runtime support.

The injection happens in two steps:
- We build up a consts map of all hash: value pairs and replace any placeholder hashes in CSS rules with the constant value
- We build a dependency map of all the rules that depend on a defineConsts constant, and update those CSS rules when any constants change
- There was also a bug in the inject calls in the AST visitor. Now the babel plugin correctly generates `inject("", 0, constKey, constVal)` calls for each constant defined in stylex.defineConsts()

Tested HMR:
- [x] Using constant values in stylex.create calls
- [x] Updating constants

In follow up:
- [x] Using at-rules in stylex.create calls
- [x] Updating at rules

