### PR TITLE
[chore] Swizzle docusaurus components to use StyleX for everything

### DIFF
--- a/packages/docs/src/theme/Footer/Copyright/index.js
+++ b/packages/docs/src/theme/Footer/Copyright/index.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  copyright: {
+    textAlign: 'center',
+  },
+});
+
+export default function FooterCopyright({ copyright, xstyle }) {
+  return (
+    <div
+      {...stylex.props(styles.copyright, xstyle)}
+      // Developer provided the HTML, so assume it's safe.
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: copyright }}
+    />
+  );
+}

--- a/packages/docs/src/theme/Footer/Layout/index.js
+++ b/packages/docs/src/theme/Footer/Layout/index.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import * as stylex from '@stylexjs/stylex';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+
+const MOBILE = '@media (max-width: 996px)';
+const PRINT = '@media print';
+
+const styles = stylex.create({
+  footer: {
+    backgroundColor: 'var(--ifm-footer-background-color)',
+    color: 'var(--ifm-footer-color)',
+    paddingBlock: 'var(--ifm-footer-padding-vertical)',
+    paddingInline: {
+      default: 'var(--ifm-footer-padding-horizontal)',
+      [MOBILE]: 0,
+    },
+    textAlign: 'center',
+    display: {
+      [PRINT]: 'none',
+    },
+  },
+  footerDark: {
+    '--ifm-footer-background-color': '#303846',
+    '--ifm-footer-color': 'var(--ifm-footer-link-color)',
+    '--ifm-footer-link-color': 'var(--ifm-color-secondary)',
+    '--ifm-footer-title-color': 'var(--ifm-color-white)',
+  },
+  container: {
+    marginInline: 'auto',
+    maxWidth: 'var(--ifm-container-width)',
+    paddingInline: 'var(--ifm-spacing-horizontal)',
+    width: '100%',
+  },
+  containerFluid: {
+    maxWidth: 'inherit',
+  },
+  footerContainer: {
+    maxWidth: '960px',
+  },
+  footerBottom: {
+    textAlign: 'center',
+  },
+  marginBottomSm: {
+    marginBottom: '0.5rem',
+  },
+});
+
+export default function FooterLayout({ style, links, logo, copyright }) {
+  const footerStyleProps = stylex.props(
+    styles.footer,
+    style === 'dark' && styles.footerDark,
+  );
+  const footerClassName =
+    [footerStyleProps.className, ThemeClassNames.layout.footer.container]
+      .filter(Boolean)
+      .join(' ') || undefined;
+  const { className: _footerClass, ...footerProps } = footerStyleProps;
+
+  const containerProps = stylex.props(
+    styles.container,
+    styles.containerFluid,
+    styles.footerContainer,
+  );
+  const footerBottomProps = stylex.props(styles.footerBottom);
+  const logoMarginProps = stylex.props(styles.marginBottomSm);
+
+  return (
+    <footer {...footerProps} className={footerClassName}>
+      <div {...containerProps}>
+        {links}
+        {(logo || copyright) && (
+          <div {...footerBottomProps}>
+            {logo && <div {...logoMarginProps}>{logo}</div>}
+            {copyright}
+          </div>
+        )}
+      </div>
+    </footer>
+  );
+}

--- a/packages/docs/src/theme/Footer/LinkItem/index.js
+++ b/packages/docs/src/theme/Footer/LinkItem/index.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import * as stylex from '@stylexjs/stylex';
+import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import IconExternalLink from '@theme/Icon/ExternalLink';
+
+const MOBILE = '@media (max-width: 996px)';
+
+const styles = stylex.create({
+  linkItem: {
+    color: {
+      default: 'var(--ifm-footer-link-color)',
+      ':hover': 'var(--ifm-footer-link-hover-color)',
+    },
+    lineHeight: 2,
+    display: {
+      [MOBILE]: 'block',
+    },
+  },
+});
+
+export default function FooterLinkItem({ item, xstyle }) {
+  const { to, href, label, prependBaseUrlToHref, ...props } = item;
+  const toUrl = useBaseUrl(to);
+  const normalizedHref = useBaseUrl(href, { forcePrependBaseUrl: true });
+
+  return (
+    <Link
+      {...stylex.props(styles.linkItem, xstyle)}
+      {...(href
+        ? {
+            href: prependBaseUrlToHref ? normalizedHref : href,
+          }
+        : {
+            to: toUrl,
+          })}
+      {...props}
+    >
+      {label}
+      {href && !isInternalUrl(href) && <IconExternalLink />}
+    </Link>
+  );
+}

--- a/packages/docs/src/theme/Footer/Links/MultiColumn/index.js
+++ b/packages/docs/src/theme/Footer/Links/MultiColumn/index.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import * as stylex from '@stylexjs/stylex';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import LinkItem from '@theme/Footer/LinkItem';
+
+const MOBILE = '@media (max-width: 996px)';
+
+const styles = stylex.create({
+  row: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    marginInline: 'calc(var(--ifm-spacing-horizontal) * -1)',
+    marginBottom: '1rem',
+  },
+  col: {
+    // '--ifm-col-width': '100%',
+    // flexBasis: 'var(--ifm-col-width)',
+    flexGrow: 1,
+    flexShrink: 0,
+    marginLeft: 0,
+    // maxWidth: 'var(--ifm-col-width)',
+    paddingInline: 'var(--ifm-spacing-horizontal)',
+    width: {
+      [MOBILE]: '100%',
+    },
+    marginBottom: {
+      [MOBILE]: 'calc(var(--ifm-spacing-vertical) * 3)',
+    },
+  },
+  title: {
+    color: 'var(--ifm-footer-title-color)',
+    fontFamily: 'var(--ifm-font-family-base)',
+    fontSize: 'var(--ifm-h4-font-size)',
+    fontWeight: 'var(--ifm-font-weight-bold)',
+    lineHeight: 'var(--ifm-heading-line-height)',
+    marginBottom: 'var(--ifm-heading-margin-bottom)',
+  },
+  list: {
+    listStyle: 'none',
+    marginBottom: 0,
+    paddingLeft: 0,
+  },
+  item: {
+    marginTop: 0,
+  },
+});
+
+function ColumnLinkItem({ item, xstyle }) {
+  return item.html ? (
+    <li
+      {...stylex.props(styles.item, xstyle)}
+      // Developer provided the HTML, so assume it's safe.
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: item.html }}
+    />
+  ) : (
+    <li key={item.href ?? item.to} {...stylex.props(styles.item, xstyle)}>
+      <LinkItem item={item} />
+    </li>
+  );
+}
+
+function Column({ column, xstyle }) {
+  const columnProps = stylex.props(styles.col, xstyle);
+  const { className: _colClass, ...columnRest } = columnProps;
+  const columnClassName =
+    [ThemeClassNames.layout.footer.column, columnProps.className]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
+  return (
+    <div {...columnRest} className={columnClassName}>
+      <div {...stylex.props(styles.title)}>{column.title}</div>
+      <ul {...stylex.props(styles.list)}>
+        {column.items.map((item, i) => (
+          <ColumnLinkItem item={item} key={i} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default function FooterLinksMultiColumn({ columns, xstyle }) {
+  return (
+    <div {...stylex.props(styles.row, xstyle)}>
+      {columns.map((column, i) => (
+        <Column column={column} key={i} />
+      ))}
+    </div>
+  );
+}

--- a/packages/docs/src/theme/Footer/Links/Simple/index.js
+++ b/packages/docs/src/theme/Footer/Links/Simple/index.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import * as stylex from '@stylexjs/stylex';
+import LinkItem from '@theme/Footer/LinkItem';
+
+const MOBILE = '@media (max-width: 996px)';
+
+const styles = stylex.create({
+  wrapper: {
+    textAlign: 'center',
+    marginBottom: '1rem',
+  },
+  links: {
+    marginBottom: '1rem',
+  },
+  separator: {
+    marginInline: 'var(--ifm-footer-link-horizontal-spacing)',
+    display: {
+      [MOBILE]: 'none',
+    },
+  },
+  linkItem: {
+    color: {
+      default: 'var(--ifm-footer-link-color)',
+      ':hover': 'var(--ifm-footer-link-hover-color)',
+    },
+    lineHeight: 2,
+    display: {
+      [MOBILE]: 'block',
+    },
+    width: {
+      [MOBILE]: 'max-content',
+    },
+  },
+});
+
+function Separator({ xstyle }) {
+  return <span {...stylex.props(styles.separator, xstyle)} />;
+}
+
+function SimpleLinkItem({ item, xstyle }) {
+  return item.html ? (
+    <span
+      {...stylex.props(styles.linkItem, xstyle)}
+      // Developer provided the HTML, so assume it's safe.
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: item.html }}
+    />
+  ) : (
+    <LinkItem item={item} xstyle={xstyle} />
+  );
+}
+
+export default function FooterLinksSimple({ links, xstyle }) {
+  return (
+    <div {...stylex.props(styles.wrapper, xstyle)}>
+      <div {...stylex.props(styles.links)}>
+        {links.map((item, i) => (
+          <React.Fragment key={i}>
+            <SimpleLinkItem item={item} />
+            {links.length !== i + 1 && <Separator />}
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/docs/src/theme/Footer/Links/index.js
+++ b/packages/docs/src/theme/Footer/Links/index.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import { isMultiColumnFooterLinks } from '@docusaurus/theme-common';
+import FooterLinksMultiColumn from '@theme/Footer/Links/MultiColumn';
+import FooterLinksSimple from '@theme/Footer/Links/Simple';
+
+export default function FooterLinks({ links }) {
+  return isMultiColumnFooterLinks(links) ? (
+    <FooterLinksMultiColumn columns={links} />
+  ) : (
+    <FooterLinksSimple links={links} />
+  );
+}

--- a/packages/docs/src/theme/Footer/Logo/index.js
+++ b/packages/docs/src/theme/Footer/Logo/index.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import * as stylex from '@stylexjs/stylex';
+import Link from '@docusaurus/Link';
+import { useBaseUrlUtils } from '@docusaurus/useBaseUrl';
+import ThemedImage from '@theme/ThemedImage';
+
+const styles = stylex.create({
+  logo: {
+    marginTop: '1rem',
+    maxWidth: 'var(--ifm-footer-logo-max-width)',
+  },
+  logoLink: {
+    opacity: {
+      default: 0.5,
+      ':hover': 1,
+    },
+    transitionDuration: 'var(--ifm-transition-fast)',
+    transitionProperty: 'opacity',
+    transitionTimingFunction: 'var(--ifm-transition-timing-default)',
+  },
+});
+
+function LogoImage({ logo, xstyle }) {
+  const { withBaseUrl } = useBaseUrlUtils();
+  const sources = {
+    light: withBaseUrl(logo.src),
+    dark: withBaseUrl(logo.srcDark ?? logo.src),
+  };
+
+  return (
+    <ThemedImage
+      {...stylex.props(styles.logo, xstyle)}
+      alt={logo.alt}
+      height={logo.height}
+      sources={sources}
+      width={logo.width}
+    />
+  );
+}
+
+export default function FooterLogo({ logo, xstyle }) {
+  if (logo.href) {
+    return (
+      <Link
+        {...stylex.props(styles.logoLink, xstyle)}
+        href={logo.href}
+        target={logo.target}
+      >
+        <LogoImage logo={logo} xstyle={xstyle} />
+      </Link>
+    );
+  }
+
+  return <LogoImage logo={logo} xstyle={xstyle} />;
+}

--- a/packages/docs/src/theme/ThemedImage/index.js
+++ b/packages/docs/src/theme/ThemedImage/index.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import { ThemedComponent } from '@docusaurus/theme-common';
+export default function ThemedImage(props) {
+  const { sources, ...propsRest } = props;
+  return (
+    <ThemedComponent>
+      {({ theme }) => <img src={sources[theme]} {...propsRest} />}
+    </ThemedComponent>
+  );
+}

--- a/packages/docs/src/theme/ThemedImage/styles.module.css
+++ b/packages/docs/src/theme/ThemedImage/styles.module.css
@@ -1,0 +1,11 @@
+.themedImage {
+  display: none;
+}
+
+[data-theme='light'] .themedImage--light {
+  display: initial;
+}
+
+[data-theme='dark'] .themedImage--dark {
+  display: initial;
+}


### PR DESCRIPTION
## What changed / motivation ?

Docusaurus allows the ability to "eject" the built in theme components so they can be customized. This is being done to migrate the styling from CSS files to StyleX for everything.

- [x] Footer components
- [x] ThemedImage
- [ ] ... Everything else ...