### PR TITLE
[babel-plugin] fix unitless zoom bug

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-value-normalization-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-value-normalization-test.js
@@ -194,7 +194,8 @@ describe('@stylexjs/babel-plugin', () => {
             unitless: {
               fontWeight: 500,
               lineHeight: 1.5,
-              opacity: 0.5
+              opacity: 0.5,
+              zoom: 2,
             },
           });
         `),
@@ -208,6 +209,7 @@ describe('@stylexjs/babel-plugin', () => {
         _inject2(".xk50ysn{font-weight:500}", 3000);
         _inject2(".x1evy7pa{line-height:1.5}", 3000);
         _inject2(".xbyyjgo{opacity:.5}", 3000);"
+        _inject2(".xbyyjgo{zoom:2}", 3000);"
       `);
     });
 

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/transform-value.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/transform-value.js
@@ -136,6 +136,7 @@ const unitlessNumberProperties = new Set([
   'strokeWidth',
   'scale',
   'mathDepth',
+  'zoom',
 ]);
 
 // List of properties that have custom suffixes for numbers


### PR DESCRIPTION
We append `px` to all number values aside from our list of unitless properties. This list is currently missing the nonstandard property `zoom`, so values are transformed to invalid CSS.

```
// becomes zoom: '0.5px'
zoom: 0.5
```

For internal bug fix