### PR TITLE
[fix] Fix a mistake in the custom typescript typedef file

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts
@@ -55,7 +55,6 @@ export type StyleXOptions = Readonly<{
     | 'property-specificity'
     | 'legacy-expand-shorthands';
   test: boolean;
-  ...
 }>;
 export type MutableCompiledNamespaces = { [key: string]: FlatCompiledStyles };
 export type CompiledNamespaces = Readonly<MutableCompiledNamespaces>;


### PR DESCRIPTION
## What changed / motivation ?

A small mistake where one of the TS typedef files in the Babel plugin uses invalid TS syntax.
