### PR TITLE
[babel-plugin] introduce browser bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37458,6 +37458,7 @@
         "@rollup/plugin-node-resolve": "^15.3.0",
         "@rollup/plugin-replace": "^6.0.1",
         "babel-plugin-syntax-hermes-parser": "^0.32.1",
+        "path-browserify": "^1.0.1",
         "rollup": "^4.24.0",
         "scripts": "0.17.2"
       }

--- a/packages/@stylexjs/babel-plugin/package.json
+++ b/packages/@stylexjs/babel-plugin/package.json
@@ -3,6 +3,8 @@
   "version": "0.17.2",
   "description": "StyleX babel plugin.",
   "main": "lib/index.js",
+  "browser": "lib/index.browser.js",
+  "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/stylex.git"
@@ -33,6 +35,7 @@
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-replace": "^6.0.1",
     "babel-plugin-syntax-hermes-parser": "^0.32.1",
+    "path-browserify": "^1.0.1",
     "rollup": "^4.24.0",
     "scripts": "0.17.2"
   },

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
@@ -29,6 +29,7 @@ import * as t from '@babel/types';
 import StateManager from './state-manager';
 import { utils } from '../shared';
 import * as errMsgs from './evaluation-errors';
+import fs from 'node:fs';
 
 // This file contains Babels metainterpreter that can evaluate static code.
 
@@ -171,7 +172,6 @@ function evaluateImportedFile(
   state: State,
   bindingPath: NodePath<>,
 ): any {
-  const fs = require('node:fs');
   const fileContents = fs.readFileSync(filePath, 'utf8');
   // It's safe to use `.babelrc` here because we're only
   // interested in the JS runtime, and not the CSS.


### PR DESCRIPTION
## What changed / motivation ?

In #1317 I am using `@stylexjs/babel-plugin` with `@babel/standalone` (a [standalone build](https://babeljs.io/docs/babel-standalone) of Babel for use in browsers) but had to resort to custom webpack configuration to stub NodeJS built-ins. The StyleX Babel plugin does not need NodeJS unless you are using `unstable_moduleResolutions.type = 'commonJS'`, which we will not use in the playground. 

In this PR I introduce a second rollup bundle `index.bowser.js`, which polyfills `node:path` and stubs other node-specific modules that are only used with  `'commonJS'` module resolution. We should be able to use this bundle in an interactive browser playground without any bundler workarounds. I had to make a small change to `packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js` to hoist the `node:fs` require to module scope so rollup can actually try to resolve/stub it. This is safe before `node:fs` was already getting hoisted in the rollup bundle. 

#### Considerations
- If somebody does use `'commonJS'` module resolution with the browser bundler it could cause confusing errors since we are just stubbing these APIs. I guess we could have some `IS_BROWSER` global that we replace at build time that we can use to conditional throw an error in the browser build? 
- We probably don't need `  "browser": "lib/index.browser.js",` in the package.json if we don't expect the bundle to ever be used outside of the playground. 

## Linked PR/Issues

Supports https://github.com/facebook/stylex/pull/1317

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code