### PR TITLE
[release] v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.17.2 (Dec 1, 2025)
+
+- Pass importSources to babel plugin in `unplugin` plugin.
+- Fix custom typescript typedef mistake.
+
+## 0.17.1 (Nov 26, 2025)
+
+- Add support for compiling stylex from imported packages.
+- Add runtime injection support for `defineConsts` constants.
+- Show full debug file paths.
+- Fix media query ordering for queries with 'screen and'.
+- Add `debugFilePath` config option.
+- Fix unitless zoom bug for float values.
+- Fix props compilation for array mutations.
+
 ## 0.17.0 (Nov 18, 2025)
 
 - Add docs for ESLint rules and `stylex.when` API.

--- a/examples/example-cli/package.json
+++ b/examples/example-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-cli",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "scripts": {
     "example:build": "stylex --config .stylex.json5"
   },
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.25.7",
     "@babel/preset-typescript": "^7.25.7",
-    "@stylexjs/cli": "0.17.1",
+    "@stylexjs/cli": "0.17.2",
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.3",
     "typescript": "^5.9.3"

--- a/examples/example-esbuild/package.json
+++ b/examples/example-esbuild/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-esbuild",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Simple esbuild example for @stylexjs/unplugin",
   "main": "src/App.jsx",
   "scripts": {
@@ -10,13 +10,13 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.17.1",
+    "@stylexjs/stylex": "0.17.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.17.1",
-    "@stylexjs/eslint-plugin": "0.17.1",
+    "@stylexjs/unplugin": "0.17.2",
+    "@stylexjs/eslint-plugin": "0.17.2",
     "esbuild": "^0.27.0",
     "eslint": "^8.57.1"
   }

--- a/examples/example-nextjs/package.json
+++ b/examples/example-nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-nextjs",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "scripts": {
     "clean": "rimraf .next",
     "example:build": "next build",
@@ -10,15 +10,15 @@
     "example:start": "next start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.17.1",
+    "@stylexjs/stylex": "0.17.2",
     "next": "14.2.21",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "styled-jsx": "^5.1.1"
   },
   "devDependencies": {
-    "@stylexjs/eslint-plugin": "0.17.1",
-    "@stylexjs/postcss-plugin": "0.17.1",
+    "@stylexjs/eslint-plugin": "0.17.2",
+    "@stylexjs/postcss-plugin": "0.17.2",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^22.7.6",
     "@types/react": "^18.3.0",

--- a/examples/example-react-router/package.json
+++ b/examples/example-react-router/package.json
@@ -9,8 +9,8 @@
     "example:typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.17.1",
-    "@stylexjs/shared-ui": "0.17.1",
+    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/shared-ui": "0.17.2",
     "@remix-run/node-fetch-server": "0.12.0",
     "compression": "^1.8.0",
     "express": "^5.1.0",
@@ -19,7 +19,7 @@
     "react-router": "7.9.2"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.17.1",
+    "@stylexjs/unplugin": "0.17.2",
     "@types/compression": "^1.8.1",
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.3",
@@ -32,5 +32,5 @@
     "vite": "^7.2.4",
     "vite-plugin-devtools-json": "0.2.0"
   },
-  "version": "0.17.1"
+  "version": "0.17.2"
 }

--- a/examples/example-redwoodsdk/package.json
+++ b/examples/example-redwoodsdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/starter",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "A bare-bones RedwoodSDK starter",
   "main": "index.js",
   "type": "module",
@@ -22,15 +22,15 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.17.1",
+    "@stylexjs/stylex": "0.17.2",
     "react": "19.3.0-canary-561ee24d-20251101",
     "react-dom": "19.3.0-canary-561ee24d-20251101",
     "react-server-dom-webpack": "19.3.0-canary-561ee24d-20251101",
     "rwsdk": "1.0.0-beta.31",
-    "@stylexjs/shared-ui": "0.17.1"
+    "@stylexjs/shared-ui": "0.17.2"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.17.1",
+    "@stylexjs/unplugin": "0.17.2",
     "@cloudflare/vite-plugin": "^1.15.2",
     "@cloudflare/workers-types": "4.20251121.0",
     "@types/node": "^24.10.1",

--- a/examples/example-rollup/package.json
+++ b/examples/example-rollup/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-rollup",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "A simple rollup example to test stylexjs/rollup-plugin",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.17.1",
+    "@stylexjs/stylex": "0.17.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },
@@ -23,7 +23,7 @@
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.7",
-    "@stylexjs/rollup-plugin": "0.17.1",
+    "@stylexjs/rollup-plugin": "0.17.2",
     "rollup": "^4.24.0",
     "serve": "^14.2.4"
   }

--- a/examples/example-rspack/package.json
+++ b/examples/example-rspack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-rspack",
   "private": true,
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Example: StyleX with Rspack via @stylexjs/unplugin",
   "scripts": {
     "example:build": "rspack build --config ./rspack.config.js",
@@ -10,12 +10,12 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.17.1"
+    "@stylexjs/stylex": "0.17.2"
   },
   "devDependencies": {
     "@rspack/cli": "^1.6.4",
     "@rspack/core": "^1.6.4",
     "css-loader": "^7.1.2",
-    "@stylexjs/unplugin": "0.17.1"
+    "@stylexjs/unplugin": "0.17.2"
   }
 }

--- a/examples/example-storybook/package.json
+++ b/examples/example-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-storybook",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "scripts": {
     "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build",
@@ -15,10 +15,10 @@
     "@storybook/addon-links": "^9.1.7",
     "@storybook/addon-vitest": "^9.1.7",
     "@storybook/react-vite": "^9.1.7",
-    "@stylexjs/babel-plugin": "0.17.1",
-    "@stylexjs/eslint-plugin": "0.17.1",
-    "@stylexjs/postcss-plugin": "0.17.1",
-    "@stylexjs/stylex": "0.17.1",
+    "@stylexjs/babel-plugin": "0.17.2",
+    "@stylexjs/eslint-plugin": "0.17.2",
+    "@stylexjs/postcss-plugin": "0.17.2",
+    "@stylexjs/stylex": "0.17.2",
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.44.0",
     "@vitejs/plugin-react": "^5.0.3",

--- a/examples/example-vite-react/package.json
+++ b/examples/example-vite-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vite-react",
   "private": true,
-  "version": "0.17.1",
+  "version": "0.17.2",
   "type": "module",
   "scripts": {
     "example:dev": "vite",
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.17.1",
-    "@stylexjs/shared-ui": "0.17.1"
+    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/shared-ui": "0.17.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
@@ -21,7 +21,7 @@
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.0.4",
-    "@stylexjs/unplugin": "0.17.1",
+    "@stylexjs/unplugin": "0.17.2",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/examples/example-vite-rsc/package.json
+++ b/examples/example-vite-rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitejs/plugin-rsc-examples-starter",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": true,
   "license": "MIT",
   "type": "module",
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.17.1",
-    "@stylexjs/shared-ui": "0.17.1"
+    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/shared-ui": "0.17.2"
   },
   "devDependencies": {
     "@types/react": "^19.2.6",
@@ -22,6 +22,6 @@
     "@vitejs/plugin-rsc": "latest",
     "rsc-html-stream": "^0.0.7",
     "vite": "^7.1.12",
-    "@stylexjs/unplugin": "0.17.1"
+    "@stylexjs/unplugin": "0.17.2"
   }
 }

--- a/examples/example-vite/package.json
+++ b/examples/example-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vite",
   "private": true,
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Example: StyleX with Vite via @stylexjs/unplugin",
   "scripts": {
     "example:dev": "vite",
@@ -11,12 +11,12 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.17.1",
-    "@stylexjs/shared-ui": "0.17.1"
+    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/shared-ui": "0.17.2"
   },
   "devDependencies": {
     "vite": "^7.2.4",
-    "@stylexjs/unplugin": "0.17.1",
+    "@stylexjs/unplugin": "0.17.2",
     "@vitejs/plugin-react": "latest"
   }
 }

--- a/examples/example-waku/package.json
+++ b/examples/example-waku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-waku",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "type": "module",
   "private": true,
   "scripts": {
@@ -9,15 +9,15 @@
     "example:serve": "waku start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.17.1",
+    "@stylexjs/stylex": "0.17.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-server-dom-webpack": "19.2.0",
     "waku": "0.27.1",
-    "@stylexjs/shared-ui": "0.17.1"
+    "@stylexjs/shared-ui": "0.17.2"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.17.1",
+    "@stylexjs/unplugin": "0.17.2",
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "5.1.0",

--- a/examples/example-webpack/package.json
+++ b/examples/example-webpack/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-webpack",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Example: StyleX with Webpack via @stylexjs/unplugin",
   "main": "index.js",
   "scripts": {
@@ -15,8 +15,8 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.1",
-    "@stylexjs/eslint-plugin": "0.17.1",
-    "@stylexjs/unplugin": "0.17.1",
+    "@stylexjs/eslint-plugin": "0.17.2",
+    "@stylexjs/unplugin": "0.17.2",
     "babel-loader": "^10.0.0",
     "css-loader": "^7.1.2",
     "file-loader": "^6.2.0",
@@ -29,7 +29,7 @@
     "webpack-dev-server": "^5.2.2"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.17.1",
+    "@stylexjs/stylex": "0.17.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       }
     },
     "examples/example-cli": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -48,7 +48,7 @@
       "devDependencies": {
         "@babel/preset-react": "^7.25.7",
         "@babel/preset-typescript": "^7.25.7",
-        "@stylexjs/cli": "0.17.1",
+        "@stylexjs/cli": "0.17.2",
         "@types/react": "^19.2.6",
         "@types/react-dom": "^19.2.3",
         "typescript": "^5.9.3"
@@ -102,16 +102,16 @@
       "license": "MIT"
     },
     "examples/example-esbuild": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/stylex": "0.17.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
-        "@stylexjs/eslint-plugin": "0.17.1",
-        "@stylexjs/unplugin": "0.17.1",
+        "@stylexjs/eslint-plugin": "0.17.2",
+        "@stylexjs/unplugin": "0.17.2",
         "esbuild": "^0.27.0",
         "eslint": "^8.57.1"
       }
@@ -609,17 +609,17 @@
       "license": "MIT"
     },
     "examples/example-nextjs": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/stylex": "0.17.2",
         "next": "14.2.21",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "styled-jsx": "^5.1.1"
       },
       "devDependencies": {
-        "@stylexjs/eslint-plugin": "0.17.1",
-        "@stylexjs/postcss-plugin": "0.17.1",
+        "@stylexjs/eslint-plugin": "0.17.2",
+        "@stylexjs/postcss-plugin": "0.17.2",
         "@types/json-schema": "^7.0.15",
         "@types/node": "^22.7.6",
         "@types/react": "^18.3.0",
@@ -921,11 +921,11 @@
       "license": "MIT"
     },
     "examples/example-react-router": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "@remix-run/node-fetch-server": "0.12.0",
-        "@stylexjs/shared-ui": "0.17.1",
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/shared-ui": "0.17.2",
+        "@stylexjs/stylex": "0.17.2",
         "compression": "^1.8.0",
         "express": "^5.1.0",
         "react": "^19.2.0",
@@ -933,7 +933,7 @@
         "react-router": "7.9.2"
       },
       "devDependencies": {
-        "@stylexjs/unplugin": "0.17.1",
+        "@stylexjs/unplugin": "0.17.2",
         "@types/compression": "^1.8.1",
         "@types/express": "^5.0.3",
         "@types/node": "^24.0.3",
@@ -1438,11 +1438,11 @@
     },
     "examples/example-redwoodsdk": {
       "name": "@redwoodjs/starter",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/shared-ui": "0.17.1",
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/shared-ui": "0.17.2",
+        "@stylexjs/stylex": "0.17.2",
         "react": "19.3.0-canary-561ee24d-20251101",
         "react-dom": "19.3.0-canary-561ee24d-20251101",
         "react-server-dom-webpack": "19.3.0-canary-561ee24d-20251101",
@@ -1451,7 +1451,7 @@
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.15.2",
         "@cloudflare/workers-types": "4.20251121.0",
-        "@stylexjs/unplugin": "0.17.1",
+        "@stylexjs/unplugin": "0.17.2",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.6",
         "@types/react-dom": "^19.2.3",
@@ -2243,10 +2243,10 @@
       }
     },
     "examples/example-rollup": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/stylex": "0.17.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -2258,7 +2258,7 @@
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-replace": "^5.0.7",
-        "@stylexjs/rollup-plugin": "0.17.1",
+        "@stylexjs/rollup-plugin": "0.17.2",
         "rollup": "^4.24.0",
         "serve": "^14.2.4"
       }
@@ -2285,16 +2285,16 @@
       "license": "MIT"
     },
     "examples/example-rspack": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/stylex": "0.17.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
         "@rspack/cli": "^1.6.4",
         "@rspack/core": "^1.6.4",
-        "@stylexjs/unplugin": "0.17.1",
+        "@stylexjs/unplugin": "0.17.2",
         "css-loader": "^7.1.2"
       }
     },
@@ -2365,7 +2365,7 @@
       }
     },
     "examples/example-storybook": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.1",
         "@storybook/addon-a11y": "^9.1.7",
@@ -2373,10 +2373,10 @@
         "@storybook/addon-links": "^9.1.7",
         "@storybook/addon-vitest": "^9.1.7",
         "@storybook/react-vite": "^9.1.7",
-        "@stylexjs/babel-plugin": "0.17.1",
-        "@stylexjs/eslint-plugin": "0.17.1",
-        "@stylexjs/postcss-plugin": "0.17.1",
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/babel-plugin": "0.17.2",
+        "@stylexjs/eslint-plugin": "0.17.2",
+        "@stylexjs/postcss-plugin": "0.17.2",
+        "@stylexjs/stylex": "0.17.2",
         "@typescript-eslint/eslint-plugin": "^8.44.0",
         "@typescript-eslint/parser": "^8.44.0",
         "@vitejs/plugin-react": "^5.0.3",
@@ -3275,30 +3275,30 @@
       }
     },
     "examples/example-vite": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
-        "@stylexjs/shared-ui": "0.17.1",
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/shared-ui": "0.17.2",
+        "@stylexjs/stylex": "0.17.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
-        "@stylexjs/unplugin": "0.17.1",
+        "@stylexjs/unplugin": "0.17.2",
         "@vitejs/plugin-react": "latest",
         "vite": "^7.2.4"
       }
     },
     "examples/example-vite-react": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
-        "@stylexjs/shared-ui": "0.17.1",
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/shared-ui": "0.17.2",
+        "@stylexjs/stylex": "0.17.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
-        "@stylexjs/unplugin": "0.17.1",
+        "@stylexjs/unplugin": "0.17.2",
         "@types/node": "^24.6.0",
         "@types/react": "^19.2.6",
         "@types/react-dom": "^19.2.3",
@@ -3683,16 +3683,16 @@
     },
     "examples/example-vite-rsc": {
       "name": "@vitejs/plugin-rsc-examples-starter",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/shared-ui": "0.17.1",
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/shared-ui": "0.17.2",
+        "@stylexjs/stylex": "0.17.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
-        "@stylexjs/unplugin": "0.17.1",
+        "@stylexjs/unplugin": "0.17.2",
         "@types/react": "^19.2.6",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "latest",
@@ -4072,17 +4072,17 @@
       }
     },
     "examples/example-waku": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
-        "@stylexjs/shared-ui": "0.17.1",
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/shared-ui": "0.17.2",
+        "@stylexjs/stylex": "0.17.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-server-dom-webpack": "19.2.0",
         "waku": "0.27.1"
       },
       "devDependencies": {
-        "@stylexjs/unplugin": "0.17.1",
+        "@stylexjs/unplugin": "0.17.2",
         "@types/react": "^19.2.6",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "5.1.0",
@@ -4338,10 +4338,10 @@
       }
     },
     "examples/example-webpack": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/stylex": "0.17.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -4350,8 +4350,8 @@
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.6.1",
-        "@stylexjs/eslint-plugin": "0.17.1",
-        "@stylexjs/unplugin": "0.17.1",
+        "@stylexjs/eslint-plugin": "0.17.2",
+        "@stylexjs/unplugin": "0.17.2",
         "babel-loader": "^10.0.0",
         "css-loader": "^7.1.2",
         "file-loader": "^6.2.0",
@@ -36026,7 +36026,7 @@
       }
     },
     "packages/@stylexjs/babel-plugin": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
@@ -36034,8 +36034,8 @@
         "@babel/traverse": "^7.26.8",
         "@babel/types": "^7.26.8",
         "@dual-bundle/import-meta-resolve": "^4.1.0",
-        "@stylexjs/shared": "0.17.1",
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/shared": "0.17.2",
+        "@stylexjs/stylex": "0.17.2",
         "postcss-value-parser": "^4.1.0"
       },
       "devDependencies": {
@@ -36047,7 +36047,7 @@
         "@rollup/plugin-replace": "^6.0.1",
         "babel-plugin-syntax-hermes-parser": "^0.32.1",
         "rollup": "^4.24.0",
-        "scripts": "0.17.1"
+        "scripts": "0.17.2"
       }
     },
     "packages/@stylexjs/babel-plugin/node_modules/@rollup/plugin-commonjs": {
@@ -36120,14 +36120,14 @@
       }
     },
     "packages/@stylexjs/cli": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.5",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
         "@babel/types": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.17.1",
+        "@stylexjs/babel-plugin": "0.17.2",
         "ansis": "^3.3.2",
         "fb-watchman": "^2.0.2",
         "json5": "^2.2.3",
@@ -36138,25 +36138,25 @@
         "stylex": "lib/index.js"
       },
       "devDependencies": {
-        "scripts": "0.17.1"
+        "scripts": "0.17.2"
       }
     },
     "packages/@stylexjs/eslint-plugin": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/shared": "0.17.1",
+        "@stylexjs/shared": "0.17.2",
         "css-shorthand-expand": "^1.2.0",
         "micromatch": "^4.0.5",
         "postcss-value-parser": "^4.2.0"
       }
     },
     "packages/@stylexjs/postcss-plugin": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.17.1",
+        "@stylexjs/babel-plugin": "0.17.2",
         "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
@@ -36164,14 +36164,14 @@
       }
     },
     "packages/@stylexjs/rollup-plugin": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
         "@babel/plugin-syntax-flow": "^7.26.0",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
-        "@stylexjs/babel-plugin": "0.17.1",
+        "@stylexjs/babel-plugin": "0.17.2",
         "lightningcss": "^1.29.1"
       },
       "devDependencies": {
@@ -36231,7 +36231,7 @@
       }
     },
     "packages/@stylexjs/shared": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.23.9",
@@ -36239,7 +36239,7 @@
       }
     },
     "packages/@stylexjs/stylex": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
         "css-mediaquery": "^0.1.2",
@@ -36266,7 +36266,7 @@
         "cross-env": "^10.1.0",
         "rimraf": "^6.1.2",
         "rollup": "^4.24.0",
-        "scripts": "0.17.1"
+        "scripts": "0.17.2"
       }
     },
     "packages/@stylexjs/stylex/node_modules/@rollup/plugin-commonjs": {
@@ -36339,14 +36339,14 @@
       }
     },
     "packages/@stylexjs/unplugin": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
         "@babel/plugin-syntax-flow": "^7.26.0",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
-        "@stylexjs/babel-plugin": "0.17.1",
+        "@stylexjs/babel-plugin": "0.17.2",
         "browserslist": "^4.24.0",
         "lightningcss": "^1.29.1"
       },
@@ -36355,11 +36355,11 @@
       }
     },
     "packages/benchmarks": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/babel-plugin": "0.17.1",
-        "@stylexjs/rollup-plugin": "0.17.1",
+        "@stylexjs/babel-plugin": "0.17.2",
+        "@stylexjs/rollup-plugin": "0.17.2",
         "benchmark": "^2.1.4",
         "brotli-size": "^4.0.0",
         "clean-css": "^5.3.3",
@@ -36372,7 +36372,7 @@
       }
     },
     "packages/docs": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "@docusaurus/core": "2.4.1",
         "@docusaurus/preset-classic": "2.4.1",
@@ -36381,7 +36381,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.1",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@mdx-js/react": "^1.6.22",
-        "@stylexjs/stylex": "0.17.1",
+        "@stylexjs/stylex": "0.17.2",
         "@webcontainer/api": "^1.3.0",
         "clsx": "^1.2.1",
         "codemirror": "^5.65.16",
@@ -36392,9 +36392,9 @@
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.17.1",
-        "@stylexjs/eslint-plugin": "0.17.1",
-        "@stylexjs/unplugin": "0.17.1",
+        "@stylexjs/babel-plugin": "0.17.2",
+        "@stylexjs/eslint-plugin": "0.17.2",
+        "@stylexjs/unplugin": "0.17.2",
         "clean-css": "^5.3.2",
         "eslint": "^8.57.1",
         "eslint-config-airbnb": "^19.0.4",
@@ -36406,7 +36406,7 @@
       }
     },
     "packages/scripts": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
         "flow-api-translator": "^0.32.1",
@@ -36419,7 +36419,7 @@
     },
     "packages/shared-ui": {
       "name": "@stylexjs/shared-ui",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "peerDependencies": {
         "@stylexjs/stylex": "*",
         "react": ">=18"
@@ -36436,7 +36436,7 @@
       }
     },
     "packages/style-value-parser": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
         "@csstools/css-tokenizer": "^3.0.3"
@@ -36449,10 +36449,10 @@
       }
     },
     "packages/typescript-tests": {
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.17.1"
+        "@stylexjs/stylex": "0.17.2"
       },
       "devDependencies": {
         "@types/react": "^19.2.3",

--- a/packages/@stylexjs/babel-plugin/package.json
+++ b/packages/@stylexjs/babel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/babel-plugin",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "StyleX babel plugin.",
   "main": "lib/index.js",
   "repository": {
@@ -21,8 +21,8 @@
     "@babel/traverse": "^7.26.8",
     "@babel/types": "^7.26.8",
     "@dual-bundle/import-meta-resolve": "^4.1.0",
-    "@stylexjs/shared": "0.17.1",
-    "@stylexjs/stylex": "0.17.1",
+    "@stylexjs/shared": "0.17.2",
+    "@stylexjs/stylex": "0.17.2",
     "postcss-value-parser": "^4.1.0"
   },
   "devDependencies": {
@@ -34,7 +34,7 @@
     "@rollup/plugin-replace": "^6.0.1",
     "babel-plugin-syntax-hermes-parser": "^0.32.1",
     "rollup": "^4.24.0",
-    "scripts": "0.17.1"
+    "scripts": "0.17.2"
   },
   "files": [
     "flow_modules/*",

--- a/packages/@stylexjs/cli/package.json
+++ b/packages/@stylexjs/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/cli",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "A cli to compile a folder with StyleX",
   "main": "./lib/transform.js",
   "repository": "https://www.github.com/facebook/stylex",
@@ -19,7 +19,7 @@
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
     "@babel/types": "^7.26.8",
-    "@stylexjs/babel-plugin": "0.17.1",
+    "@stylexjs/babel-plugin": "0.17.2",
     "ansis": "^3.3.2",
     "fb-watchman": "^2.0.2",
     "json5": "^2.2.3",
@@ -27,7 +27,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "scripts": "0.17.1"
+    "scripts": "0.17.2"
   },
   "bin": {
     "stylex": "./lib/index.js"

--- a/packages/@stylexjs/eslint-plugin/package.json
+++ b/packages/@stylexjs/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/eslint-plugin",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "StyleX eslint plugin.",
   "main": "lib/index.js",
   "repository": {
@@ -16,7 +16,7 @@
     "test": "jest --detectOpenHandles --coverage"
   },
   "dependencies": {
-    "@stylexjs/shared": "0.17.1",
+    "@stylexjs/shared": "0.17.2",
     "css-shorthand-expand": "^1.2.0",
     "micromatch": "^4.0.5",
     "postcss-value-parser": "^4.2.0"

--- a/packages/@stylexjs/postcss-plugin/package.json
+++ b/packages/@stylexjs/postcss-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/postcss-plugin",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "PostCSS plugin for StyleX",
   "main": "src/index.js",
   "repository": {
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.26.8",
-    "@stylexjs/babel-plugin": "0.17.1",
+    "@stylexjs/babel-plugin": "0.17.2",
     "postcss": "^8.4.49",
     "fast-glob": "^3.3.2",
     "glob-parent": "^6.0.2",

--- a/packages/@stylexjs/rollup-plugin/package.json
+++ b/packages/@stylexjs/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/rollup-plugin",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Rollup plugin for StyleX",
   "main": "./lib/index.js",
   "module": "./lib/es/index.mjs",
@@ -35,7 +35,7 @@
     "@babel/plugin-syntax-flow": "^7.26.0",
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
-    "@stylexjs/babel-plugin": "0.17.1",
+    "@stylexjs/babel-plugin": "0.17.2",
     "lightningcss": "^1.29.1"
   },
   "devDependencies": {

--- a/packages/@stylexjs/shared/package.json
+++ b/packages/@stylexjs/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/shared",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "main": "lib/index.js",
   "repository": {
     "type": "git",

--- a/packages/@stylexjs/stylex/package.json
+++ b/packages/@stylexjs/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/stylex",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "A library for defining styles for optimized user interfaces.",
   "main": "./lib/cjs/stylex.js",
   "module": "./lib/es/stylex.mjs",
@@ -61,7 +61,7 @@
     "cross-env": "^10.1.0",
     "rimraf": "^6.1.2",
     "rollup": "^4.24.0",
-    "scripts": "0.17.1"
+    "scripts": "0.17.2"
   },
   "files": [
     "lib/*"

--- a/packages/@stylexjs/unplugin/package.json
+++ b/packages/@stylexjs/unplugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/unplugin",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": false,
   "description": "Universal bundler plugin for StyleX using unplugin",
   "license": "MIT",
@@ -35,7 +35,7 @@
     "@babel/plugin-syntax-flow": "^7.26.0",
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
-    "@stylexjs/babel-plugin": "0.17.1",
+    "@stylexjs/babel-plugin": "0.17.2",
     "browserslist": "^4.24.0",
     "lightningcss": "^1.29.1"
   },

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "benchmarks",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "scripts": {
     "perf": "node ./perf/run.js",
     "size": "NODE_ENV=production rollup --config ./size/rollup.config.mjs && node ./size/run.js",
@@ -9,8 +9,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/babel-plugin": "0.17.1",
-    "@stylexjs/rollup-plugin": "0.17.1",
+    "@stylexjs/babel-plugin": "0.17.2",
+    "@stylexjs/rollup-plugin": "0.17.2",
     "benchmark": "^2.1.4",
     "brotli-size": "^4.0.0",
     "clean-css": "^5.3.3",

--- a/packages/docs/blog/2025-11-25-Release-v0.17.1.mdx
+++ b/packages/docs/blog/2025-11-25-Release-v0.17.1.mdx
@@ -13,23 +13,19 @@ tags:
 # Release 0.17.1
 
 StyleX v0.17 introduces an all new unplugin package for improved integration with various modern bundlers,
-the ability to define custom markers to be be used alongside the `stylex.when.*` APIs, and a slew of bug-fixes
+the ability to define custom markers for use with `stylex.when.*` APIs, and a slew of bug-fixes
 and improvements.
 
 ## New `@stylexjs/unplugin` package
 
 Stylex 0.17 comes with a new `@stylexjs/unplugin` package that use the excellent `unplugin` library to create a near-universal bundler
 plugin that works with Vite, Rollup, Webpack, Rspack, Esbuild, and more. In supported project setups, this new package should offer
-the best developer experience and performance for StyleX integration. We have introduced new 
-[examples](https://github.com/facebook/stylex/tree/main/examples) in the github repository for using
-Webpack, RSPack and various Vite setups, (including RSCs, React-Router, Waky and RedwoodSDK). 
-When applicable we are testing both production builds and HMR in development builds.
-
-We look forward to expanding this set of examples with more common frameworks and bundler setups.
-
-For frameworks that are not yet supported by our unplugin package, we continue to maintain the `@stylexjs/postcss-plugin` and 
+the best developer experience and performance for StyleX integration. We've introduced new
+[examples](https://github.com/facebook/stylex/tree/main/examples) for
+Webpack, RSPack, and various Vite setups (RSCs, React-Router, Waky and RedwoodSDK) with testing for both production builds and HMR in development builds when applicable. For frameworks that are not yet supported by our unplugin package, we continue to maintain the `@stylexjs/postcss-plugin` and
 and `@stylexjs/cli` packages for maximum compatibitiy.
 
+We look forward to expanding this set of examples with more common frameworks and bundler setups.
 
 ## Custom Markers for `stylex.when.*` APIs
 
@@ -111,7 +107,7 @@ and production and improve the developer experience in many scenarios.
 
 ### `enableDebugClassNames` is now disabled by default
 
-Enabling this option will emit classNames that reference the CSS property being applied, and CSS variable names 
+Enabling this option will emit classNames that reference the CSS property being applied, and CSS variable names
 that are prefixed with the name used in source. However, generating incompatible CSS in development and production
 can cause caching-related bugs in some setups and so we are disabling this option by default.
 
@@ -128,17 +124,17 @@ include the package name itself.
 
 The `dev` option inserts additional classNames that help identify where various classNames are coming from.
 
+### `enableMediaQueryOrder` is now enabled by default
+
+This config ensures that authored media query order is respected, with later queries taking precedence over earlier ones.
+
 
 ## Other Improvements
 
 - Added support for handling `defineConsts` correctly when runtime injection is enabled.
-- Fixed a bug sometimes that caused invalid CSS output when Media Queries use `screen and` conditionals
-- Dependency updates, including Jest, to pick up the latest fixes.
+- Fixed a bug sometimes that caused invalid CSS output when media queries use `screen and` conditionals
+- Dependency updates, including Jest, to pick up the latest fixes. (Thanks [@vincentriemer](https://github.com/vincentriemer), [@jcperez-ch](https://github.com/jcperez-ch)!)
 - Specificity improvements when using `stylex.when.*` selectors alongside regular pseudo-classes.
 - Expand how often `stylex.props` is precompiled to improve performance.
-- Various improvements to Flow and Typescript types (thanks, @j-malt, @henryqdineen)
-- Various improvements and fixes to the ESlint plugin (thanks, @hiteshshetty-dev, @yjoer)
-
-
-
-
+- Various improvements to Flow and Typescript types. (Thanks [@j-malt](https://github.com/j-malt), [@henryqdineen](https://github.com/henryqdineen)!)
+- Various improvements and fixes to the ESlint plugin, including support for `defineConsts` in `enforce-extension`, and improvements to `sort-key` ordering. (Thanks [@hiteshshetty-dev](https://github.com/hiteshshetty-dev), [@yjoer](https://github.com/yjoer), [@dwei-figma](https://github.com/dwei-figma)!)

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "docs",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "scripts": {
     "build": "rimraf ./build ./docusaurus && cross-env NODE_ENV=production docusaurus build",
     "clear": "docusaurus clear",
@@ -17,7 +17,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.1",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mdx-js/react": "^1.6.22",
-    "@stylexjs/stylex": "0.17.1",
+    "@stylexjs/stylex": "0.17.2",
     "@webcontainer/api": "^1.3.0",
     "clsx": "^1.2.1",
     "codemirror": "^5.65.16",
@@ -28,9 +28,9 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.26.8",
-    "@stylexjs/unplugin": "0.17.1",
-    "@stylexjs/eslint-plugin": "0.17.1",
-    "@stylexjs/babel-plugin": "0.17.1",
+    "@stylexjs/unplugin": "0.17.2",
+    "@stylexjs/eslint-plugin": "0.17.2",
+    "@stylexjs/babel-plugin": "0.17.2",
     "clean-css": "^5.3.2",
     "eslint": "^8.57.1",
     "eslint-config-airbnb": "^19.0.4",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "scripts",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Helper scripts for stylex monorepo.",
   "license": "MIT",
   "bin": {

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/shared-ui",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": true,
   "main": "src/index.tsx",
   "exports": {

--- a/packages/style-value-parser/package.json
+++ b/packages/style-value-parser/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "style-value-parser",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "type": "module",
   "main": "lib/index.js",
   "license": "MIT",

--- a/packages/typescript-tests/package.json
+++ b/packages/typescript-tests/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "typescript-tests",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "type": "module",
   "scripts": {
     "test": "tsc --noEmit"
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.17.1"
+    "@stylexjs/stylex": "0.17.2"
   },
   "devDependencies": {
     "typescript": "^5.8.3",


### PR DESCRIPTION
## 0.17.2 (Dec 1, 2025)

- Pass importSources to babel plugin in `unplugin` plugin.
- Fix custom typescript typedef mistake.

Unblocks https://github.com/facebook/stylex/pull/1353