### PR TITLE
[babel-plugin] improve AST detection of named exports for defineVars/defineMarker/defineConsts 

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-defineConsts-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-defineConsts-test.js
@@ -130,12 +130,32 @@ describe('@stylexjs/babel-plugin', () => {
       }).toThrow(messages.nonExportNamedDeclaration('defineConsts'));
     });
 
+    test('invalid export: renamed re-export from another file does not count', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          const constants = stylex.defineConsts({});
+          export { constants as otherConstants } from './other.stylex.js';
+        `);
+      }).toThrow(messages.nonExportNamedDeclaration('defineConsts'));
+    });
+
     test('invalid export: default export does not count', () => {
       expect(() => {
         transform(`
           import * as stylex from '@stylexjs/stylex';
           const constants = stylex.defineConsts({});
           export default constants;
+        `);
+      }).toThrow(messages.nonExportNamedDeclaration('defineConsts'));
+    });
+
+    test('invalid export: renamed export with as syntax', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          const constants = stylex.defineConsts({});
+          export { constants as themeConstants };
         `);
       }).toThrow(messages.nonExportNamedDeclaration('defineConsts'));
     });

--- a/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-defineMarker-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-defineMarker-test.js
@@ -85,12 +85,32 @@ describe('@stylexjs/babel-plugin', () => {
       }).toThrow(messages.nonExportNamedDeclaration('defineMarker'));
     });
 
+    test('invalid export: renamed re-export from another file does not count', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          const marker = stylex.defineMarker();
+          export { marker as otherMarker } from './other.stylex.js';
+        `);
+      }).toThrow(messages.nonExportNamedDeclaration('defineMarker'));
+    });
+
     test('invalid export: default export does not count', () => {
       expect(() => {
         transform(`
           import * as stylex from '@stylexjs/stylex';
           const marker = stylex.defineMarker();
           export default marker;
+        `);
+      }).toThrow(messages.nonExportNamedDeclaration('defineMarker'));
+    });
+
+    test('invalid export: renamed export with as syntax', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          const marker = stylex.defineMarker();
+          export { marker as themeMarker };
         `);
       }).toThrow(messages.nonExportNamedDeclaration('defineMarker'));
     });

--- a/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-defineVars-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-defineVars-test.js
@@ -123,12 +123,32 @@ describe('@stylexjs/babel-plugin', () => {
       }).toThrow(messages.nonExportNamedDeclaration('defineVars'));
     });
 
+    test('invalid export: renamed re-export from another file does not count', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          const vars = stylex.defineVars({});
+          export { vars as otherVars } from './other.stylex.js';
+        `);
+      }).toThrow(messages.nonExportNamedDeclaration('defineVars'));
+    });
+
     test('invalid export: default export does not count', () => {
       expect(() => {
         transform(`
           import * as stylex from '@stylexjs/stylex';
           const vars = stylex.defineVars({});
           export default vars;
+        `);
+      }).toThrow(messages.nonExportNamedDeclaration('defineVars'));
+    });
+
+    test('invalid export: renamed export with as syntax', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          const vars = stylex.defineVars({});
+          export { vars as themeVars };
         `);
       }).toThrow(messages.nonExportNamedDeclaration('defineVars'));
     });

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-consts.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-consts.js
@@ -110,9 +110,7 @@ function validateStyleXDefineConsts(
     );
   }
 
-  const variableName = variableDeclaratorPath.node.id.name;
-
-  if (!isVariableNamedExported(callExpressionPath, variableName)) {
+  if (!isVariableNamedExported(variableDeclaratorPath)) {
     throw callExpressionPath.buildCodeFrameError(
       messages.nonExportNamedDeclaration('defineConsts'),
       SyntaxError,

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-marker.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-marker.js
@@ -97,9 +97,7 @@ function validateStyleXDefineMarker(path: NodePath<t.CallExpression>) {
     );
   }
 
-  const variableName = variableDeclaratorPath.node.id.name;
-
-  if (!isVariableNamedExported(path, variableName)) {
+  if (!isVariableNamedExported(variableDeclaratorPath)) {
     throw path.buildCodeFrameError(
       messages.nonExportNamedDeclaration('defineMarker'),
       SyntaxError,

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-vars.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-define-vars.js
@@ -194,9 +194,7 @@ function validateStyleXDefineVars(
     );
   }
 
-  const variableName = variableDeclaratorPath.node.id.name;
-
-  if (!isVariableNamedExported(callExpressionPath, variableName)) {
+  if (!isVariableNamedExported(variableDeclaratorPath)) {
     throw callExpressionPath.buildCodeFrameError(
       messages.nonExportNamedDeclaration('defineVars'),
       SyntaxError,


### PR DESCRIPTION
We enforce named exports for APIs like `defineVars` for cacheability reasons. Previously, we only allowed named exports like `export const x;`, we should expand this to allow for syntax like below. This issue has been reported a few times and is a blocker for some internal migrations.

```jsx
// allowed
export const x = stylex.defineVars(...)

// allowed
const x = stylex.defineVars(...)
export { x }

// not allowed
export default x;

// not allowed
export { x } from './y'
```

Tested:
- [x] export const x = stylex.defineVars(...)
- [x] const x; export { x }
- [x] export default x
- [x] export { x } from './y'
- [x] const x; export {x as y};
- [x] export {x as y} from './y';

Fixes https://github.com/facebook/stylex/issues/348, https://github.com/facebook/stylex/issues/1098