### PR TITLE
fix: handle file suffixes with query params (e.g., Vite) correctly

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -823,11 +823,15 @@ const addFileExtension = (
   return importedFilePath + fileExtension;
 };
 
-export const matchesFileSuffix: (string) => (string) => boolean =
-  (allowedSuffix) => (filename) =>
-    ['', ...EXTENSIONS].some((extension) =>
-      filename.endsWith(`${allowedSuffix}${extension}`),
+export const matchesFileSuffix: (allowedSuffix: string) => (filename: string) => boolean =
+  (allowedSuffix) => (filename) => {
+    // Extract the pure filename by removing everything after '?' or '#' (e.g., handling Vite's '?v=' cache busting).
+    const cleanFilename = filename.split(/[?#]/)[0];
+
+    return ['', ...EXTENSIONS].some((extension) =>
+      cleanFilename.endsWith(`${allowedSuffix}${extension}`),
     );
+  };
 
 export function getRelativePath(from: string, to: string): string {
   const relativePath = path.relative(path.parse(from).dir, to);


### PR DESCRIPTION
## What changed / motivation ?

When using external StyleX libraries (e.g., `@stylex/shared-ui`) in a **Vite** environment, specifically when running **`vite dev`**, Vite appends query strings (like `?v=c165e250`) to file paths for cache busting.

Currently, `matchesFileSuffix` does not account for these query strings, treating them as part of the file extension. This causes the file matching logic to fail during development, resulting in the following `Pre-transform error` in `@stylexjs/unplugin`:
```bash
Pre-transform error: /Users/.../node_modules/@example/tokens/dist/semantic.stylex.js?v=c165e250: Unable to generate hash for defineVars(). Check that the file has a valid extension and that unstable_moduleResolution is configured. Plugin: @stylexjs/unplugin
```

**Changes:**
- Updated `matchesFileSuffix` to strip any characters following `?` or `#` from the filename before validating the extension.
- This ensures that files loaded with query strings (e.g., `filename.stylex.js?v=123`) in the **dev environment** are correctly identified as valid StyleX files.

## Linked PR/Issues

Fixes # (issue)

## Additional Context

- This issue is specific to the **`vite dev`** environment where cache busting query strings are appended to requests.
- The logic uses `filename.split(/[?#]/)[0]` to safely extract the base filename.


```ts
// vite.config.ts
import stylex from "@stylexjs/unplugin";
import react from "@vitejs/plugin-react";
import { defineConfig } from "vite";

export default defineConfig({
  plugins: [react(), stylex.vite({})],
});

```

```tsx
// index.tsx
import { create, props } from "@stylexjs/stylex";
import { createRoot } from "react-dom/client";

import { semantic } from "@example/semantic.stylex";
import "./index.css";

function Playground() {
  return <div className={props(styles.root).className}>Hello</div>;
}

const root = createRoot(document.getElementById("root")!);

root.render(<Playground />);

const styles = create({
  root: {
    backgroundColor: semantic.colorSurfacePrimary,
  },
});

```


## Pre-flight checklist

- [X] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code