### PR TITLE
[fix] Compile named legacyMerge import to match types

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/visitors/imports.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/imports.js
@@ -61,6 +61,9 @@ export function readImportDeclarations(
             if (importedName === 'props') {
               state.stylexPropsImport.add(localName);
             }
+            if (importedName === 'legacyMerge') {
+              state.stylexImport.add(localName);
+            }
             if (importedName === 'keyframes') {
               state.stylexKeyframesImport.add(localName);
             }
@@ -142,6 +145,9 @@ export function readRequires(
           }
           if (prop.key.name === 'props') {
             state.stylexPropsImport.add(value.name);
+          }
+          if (prop.key.name === 'legacyMerge') {
+            state.stylexImport.add(value.name);
           }
           if (prop.key.name === 'keyframes') {
             state.stylexKeyframesImport.add(value.name);


### PR DESCRIPTION
## What changed / motivation ?

The old legacy function `stylex()` was replaced by `legacyMerge` in the `@stylexjs/stylex` package a while ago, but the Babel transform continues to compile the old default export and does not compile `legacyMerge`.

This PR, will pre-compile `legacyMerge` when possible, improving performance for those using this deprecated API.
