### PR TITLE
[docs] fix color prop type to reference enabled/disabled variants

### DIFF
--- a/packages/docs/docs/learn/06-recipes/02-variants.mdx
+++ b/packages/docs/docs/learn/06-recipes/02-variants.mdx
@@ -198,7 +198,7 @@ const colorVariantsDisabled = stylex.create({
 const sizeVariants = stylex.create({...});
 
 type Props = {
-  color?: keyof typeof colorVariants,
+  color?: keyof (typeof colorVariantsEnabled | typeof colorVariantsDisabled),
   size?: keyof typeof sizeVariants,
   disabled?: boolean,
   ...


### PR DESCRIPTION
## What changed / motivation ?

The example code block was faulty, referencing an undefined `colorVariants` variable

## Linked PR/Issues

None

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code