### PR TITLE
[babel-plugin] remove problematic externals from browser bundle

### DIFF
--- a/packages/@stylexjs/babel-plugin/rollup.config.mjs
+++ b/packages/@stylexjs/babel-plugin/rollup.config.mjs
@@ -64,24 +64,21 @@ const browserConfig = {
     file: './lib/index.browser.js',
     format: 'cjs',
   },
-  external: [
-    '@babel/traverse',
-    '@babel/types',
-    '@babel/core',
-    '@babel/helper-module-imports',
-    '@stylexjs/stylex',
-    'postcss-value-parser',
-  ],
+  external: ['@babel/standalone', '@stylexjs/stylex', 'postcss-value-parser'],
   plugins: [
     {
-      name: 'stub-node-dependent-modules',
+      name: 'stub-modules',
       resolveId(source, importer) {
         switch (source) {
           case 'node:path':
             return this.resolve('path-browserify', importer);
           case 'node:fs':
           case 'node:url':
+          case 'assert':
           case '@dual-bundle/import-meta-resolve':
+          case '@babel/core':
+          case '@babel/traverse':
+          case '@babel/types':
             return source;
           default:
             return null;
@@ -92,8 +89,29 @@ const browserConfig = {
           case 'node:fs':
           case 'node:url':
             return 'export default {};';
+          case 'assert':
+            return 'export default function assert(condition, message) { if (!condition) throw new Error(message || "Assertion failed"); }';
           case '@dual-bundle/import-meta-resolve':
             return 'export function moduleResolve() {}';
+          case '@babel/core':
+            return "import standalone from '@babel/standalone'; export const parseSync = standalone.packages.parser.parse;";
+          case '@babel/traverse':
+            return "import standalone from '@babel/standalone'; export default standalone.packages.traverse.default;";
+          case '@babel/types':
+            return `import standalone from '@babel/standalone';
+export const {
+  arrayExpression, arrowFunctionExpression, binaryExpression, booleanLiteral,
+  callExpression, conditionalExpression, expressionStatement, identifier,
+  importDeclaration, isAssignmentExpression, isBinaryExpression, isBooleanLiteral,
+  isCallExpression, isClass, isConditionalExpression, isExpression,
+  isExpressionStatement, isFunction, isIdentifier, isImportDeclaration,
+  isLogicalExpression, isMemberExpression, isNode, isNullLiteral,
+  isNumericLiteral, isObjectExpression, isObjectProperty, isPrivateName,
+  isSpreadElement, isStringLiteral, isTemplateLiteral, isUnaryExpression,
+  isUpdateExpression, isValidIdentifier, isVariableDeclaration, jsxAttribute,
+  jsxIdentifier, memberExpression, nullLiteral, numericLiteral, objectExpression,
+  objectProperty, stringLiteral, unaryExpression, variableDeclaration, variableDeclarator
+} = standalone.packages.types;`;
           default:
             return null;
         }


### PR DESCRIPTION
## What changed / motivation ?

In #1351 I introduced a browser bundle for `@stylexjs/babel-plugin` for use in the interactive playground. I finally got a chance to use the new browser bundle and ran into a couple issues that I fix in this PR. I pushed this commit to the [playground PR](#1317) but thought it would be useful to land this separately.

It turns out that externalizing some `@babel/*` modules was the wrong call as they assume NodeJs. My fix in this PR is to externalize `@babel/standalone` and use it to shim `@babel/traverse`, `@babel/core` and `@babel/types`. For `@babe/helper-module-imports`, which is not exported from `@babel/standalone`,  I chose to just internalize it, which required an `assert` shim. With these changes we no longer require docusaurus/webpack to provide any `resolve.fallback` configuration to polyfill NodeJs APIs.

The `@babel/types` shim is a bit ugly because we need to know all export that will be used since it imported as a namespace (e.g `import * as t from '@babel/types'`). This could create a small maintenance burden where every time you use a new export it would fail the build with an error like `"parenthesizedExpression is not exported by @babel/types"`.
 
## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code