### PR TITLE
[release] v0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.17.3 (Dec 1, 2025)
+
+- Add docs for setup instructions.
+- Improve AST detection for `.stylex` named exports
+- Add browser rollup bundle.
+- Fix unplugin file suffix parsing.
+
 ## 0.17.2 (Dec 1, 2025)
 
 - Pass importSources to babel plugin in `unplugin` plugin.
@@ -19,9 +26,11 @@
 
 - Add docs for ESLint rules and `stylex.when` API.
 - Add `defineMarker()` for custom markers for selector combinators.
-- New unplugin bundler plugin implementation for various bundlers (Vite, Webpack, Rspack, Rollup, etc.).
+- New unplugin bundler plugin implementation for various bundlers (Vite,
+  Webpack, Rspack, Rollup, etc.).
 - Enhance `stylex.props` to precompile more often for better performance.
-- Order pseudo-classes and `stylex.when` selectors according to priorities in `sort-keys.
+- Order pseudo-classes and `stylex.when` selectors according to priorities in
+  `sort-keys.
 - Add support for ternary and logical expressions in `valid-styles`.
 - Bump specificity of `stylex.when` selectors over defaults.
 - Add polyfill for logical float values in legacy mode.

--- a/examples/example-cli/package.json
+++ b/examples/example-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-cli",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "scripts": {
     "example:build": "stylex --config .stylex.json5"
   },
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.25.7",
     "@babel/preset-typescript": "^7.25.7",
-    "@stylexjs/cli": "0.17.2",
+    "@stylexjs/cli": "0.17.3",
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.3",
     "typescript": "^5.9.3"

--- a/examples/example-esbuild/package.json
+++ b/examples/example-esbuild/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-esbuild",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Simple esbuild example for @stylexjs/unplugin",
   "main": "src/App.jsx",
   "scripts": {
@@ -10,13 +10,13 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/stylex": "0.17.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.17.2",
-    "@stylexjs/eslint-plugin": "0.17.2",
+    "@stylexjs/unplugin": "0.17.3",
+    "@stylexjs/eslint-plugin": "0.17.3",
     "esbuild": "^0.27.0",
     "eslint": "^8.57.1"
   }

--- a/examples/example-nextjs/package.json
+++ b/examples/example-nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-nextjs",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "scripts": {
     "clean": "rimraf .next",
     "example:build": "next build",
@@ -10,14 +10,14 @@
     "example:start": "next start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/stylex": "0.17.3",
     "next": "^16.0.7",
     "react": "^19.0.0-rc-de68d2f4-20241204",
     "react-dom": "^19.0.0-rc-de68d2f4-20241204"
   },
   "devDependencies": {
-    "@stylexjs/eslint-plugin": "0.17.2",
-    "@stylexjs/postcss-plugin": "0.17.2",
+    "@stylexjs/eslint-plugin": "0.17.3",
+    "@stylexjs/postcss-plugin": "0.17.3",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^22.7.6",
     "@types/react": "^18.3.0",

--- a/examples/example-react-router/package.json
+++ b/examples/example-react-router/package.json
@@ -9,8 +9,8 @@
     "example:typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.17.2",
-    "@stylexjs/shared-ui": "0.17.2",
+    "@stylexjs/stylex": "0.17.3",
+    "@stylexjs/shared-ui": "0.17.3",
     "@remix-run/node-fetch-server": "0.12.0",
     "compression": "^1.8.0",
     "express": "^5.1.0",
@@ -19,7 +19,7 @@
     "react-router": "7.9.2"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.17.2",
+    "@stylexjs/unplugin": "0.17.3",
     "@types/compression": "^1.8.1",
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.3",
@@ -32,5 +32,5 @@
     "vite": "^7.2.4",
     "vite-plugin-devtools-json": "0.2.0"
   },
-  "version": "0.17.2"
+  "version": "0.17.3"
 }

--- a/examples/example-redwoodsdk/package.json
+++ b/examples/example-redwoodsdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/starter",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "A bare-bones RedwoodSDK starter",
   "main": "index.js",
   "type": "module",
@@ -22,15 +22,15 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/stylex": "0.17.3",
     "react": "19.3.0-canary-561ee24d-20251101",
     "react-dom": "19.3.0-canary-561ee24d-20251101",
     "react-server-dom-webpack": "19.2.1",
     "rwsdk": "1.0.0-beta.31",
-    "@stylexjs/shared-ui": "0.17.2"
+    "@stylexjs/shared-ui": "0.17.3"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.17.2",
+    "@stylexjs/unplugin": "0.17.3",
     "@cloudflare/vite-plugin": "^1.15.2",
     "@cloudflare/workers-types": "4.20251121.0",
     "@types/node": "^24.10.1",

--- a/examples/example-rollup/package.json
+++ b/examples/example-rollup/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-rollup",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "A simple rollup example to test stylexjs/rollup-plugin",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/stylex": "0.17.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },
@@ -23,7 +23,7 @@
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.7",
-    "@stylexjs/rollup-plugin": "0.17.2",
+    "@stylexjs/rollup-plugin": "0.17.3",
     "rollup": "^4.24.0",
     "serve": "^14.2.4"
   }

--- a/examples/example-rspack/package.json
+++ b/examples/example-rspack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-rspack",
   "private": true,
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Example: StyleX with Rspack via @stylexjs/unplugin",
   "scripts": {
     "example:build": "rspack build --config ./rspack.config.js",
@@ -10,12 +10,12 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.17.2"
+    "@stylexjs/stylex": "0.17.3"
   },
   "devDependencies": {
     "@rspack/cli": "^1.6.4",
     "@rspack/core": "^1.6.4",
     "css-loader": "^7.1.2",
-    "@stylexjs/unplugin": "0.17.2"
+    "@stylexjs/unplugin": "0.17.3"
   }
 }

--- a/examples/example-storybook/package.json
+++ b/examples/example-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-storybook",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "scripts": {
     "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build",
@@ -15,10 +15,10 @@
     "@storybook/addon-links": "^9.1.7",
     "@storybook/addon-vitest": "^9.1.7",
     "@storybook/react-vite": "^9.1.7",
-    "@stylexjs/babel-plugin": "0.17.2",
-    "@stylexjs/eslint-plugin": "0.17.2",
-    "@stylexjs/postcss-plugin": "0.17.2",
-    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/babel-plugin": "0.17.3",
+    "@stylexjs/eslint-plugin": "0.17.3",
+    "@stylexjs/postcss-plugin": "0.17.3",
+    "@stylexjs/stylex": "0.17.3",
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.44.0",
     "@vitejs/plugin-react": "^5.0.3",

--- a/examples/example-vite-react/package.json
+++ b/examples/example-vite-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vite-react",
   "private": true,
-  "version": "0.17.2",
+  "version": "0.17.3",
   "type": "module",
   "scripts": {
     "example:dev": "vite",
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.17.2",
-    "@stylexjs/shared-ui": "0.17.2"
+    "@stylexjs/stylex": "0.17.3",
+    "@stylexjs/shared-ui": "0.17.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
@@ -21,7 +21,7 @@
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.0.4",
-    "@stylexjs/unplugin": "0.17.2",
+    "@stylexjs/unplugin": "0.17.3",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/examples/example-vite-rsc/package.json
+++ b/examples/example-vite-rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitejs/plugin-rsc-examples-starter",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "private": true,
   "license": "MIT",
   "type": "module",
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.17.2",
-    "@stylexjs/shared-ui": "0.17.2"
+    "@stylexjs/stylex": "0.17.3",
+    "@stylexjs/shared-ui": "0.17.3"
   },
   "devDependencies": {
     "@types/react": "^19.2.6",
@@ -22,6 +22,6 @@
     "@vitejs/plugin-rsc": "latest",
     "rsc-html-stream": "^0.0.7",
     "vite": "^7.1.12",
-    "@stylexjs/unplugin": "0.17.2"
+    "@stylexjs/unplugin": "0.17.3"
   }
 }

--- a/examples/example-vite/package.json
+++ b/examples/example-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vite",
   "private": true,
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Example: StyleX with Vite via @stylexjs/unplugin",
   "scripts": {
     "example:dev": "vite",
@@ -11,12 +11,12 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.17.2",
-    "@stylexjs/shared-ui": "0.17.2"
+    "@stylexjs/stylex": "0.17.3",
+    "@stylexjs/shared-ui": "0.17.3"
   },
   "devDependencies": {
     "vite": "^7.2.4",
-    "@stylexjs/unplugin": "0.17.2",
+    "@stylexjs/unplugin": "0.17.3",
     "@vitejs/plugin-react": "latest"
   }
 }

--- a/examples/example-waku/package.json
+++ b/examples/example-waku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-waku",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "type": "module",
   "private": true,
   "scripts": {
@@ -9,15 +9,15 @@
     "example:serve": "waku start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/stylex": "0.17.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-server-dom-webpack": "19.2.1",
     "waku": "0.27.1",
-    "@stylexjs/shared-ui": "0.17.2"
+    "@stylexjs/shared-ui": "0.17.3"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.17.2",
+    "@stylexjs/unplugin": "0.17.3",
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "5.1.0",

--- a/examples/example-webpack/package.json
+++ b/examples/example-webpack/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-webpack",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Example: StyleX with Webpack via @stylexjs/unplugin",
   "main": "index.js",
   "scripts": {
@@ -15,8 +15,8 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.1",
-    "@stylexjs/eslint-plugin": "0.17.2",
-    "@stylexjs/unplugin": "0.17.2",
+    "@stylexjs/eslint-plugin": "0.17.3",
+    "@stylexjs/unplugin": "0.17.3",
     "babel-loader": "^10.0.0",
     "css-loader": "^7.1.2",
     "file-loader": "^6.2.0",
@@ -29,7 +29,7 @@
     "webpack-dev-server": "^5.2.2"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/stylex": "0.17.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       }
     },
     "examples/example-cli": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -48,7 +48,7 @@
       "devDependencies": {
         "@babel/preset-react": "^7.25.7",
         "@babel/preset-typescript": "^7.25.7",
-        "@stylexjs/cli": "0.17.2",
+        "@stylexjs/cli": "0.17.3",
         "@types/react": "^19.2.6",
         "@types/react-dom": "^19.2.3",
         "typescript": "^5.9.3"
@@ -104,16 +104,16 @@
       "license": "MIT"
     },
     "examples/example-esbuild": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/stylex": "0.17.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
-        "@stylexjs/eslint-plugin": "0.17.2",
-        "@stylexjs/unplugin": "0.17.2",
+        "@stylexjs/eslint-plugin": "0.17.3",
+        "@stylexjs/unplugin": "0.17.3",
         "esbuild": "^0.27.0",
         "eslint": "^8.57.1"
       }
@@ -612,16 +612,16 @@
       "license": "MIT"
     },
     "examples/example-nextjs": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/stylex": "0.17.3",
         "next": "^16.0.7",
         "react": "^19.0.0-rc-de68d2f4-20241204",
         "react-dom": "^19.0.0-rc-de68d2f4-20241204"
       },
       "devDependencies": {
-        "@stylexjs/eslint-plugin": "0.17.2",
-        "@stylexjs/postcss-plugin": "0.17.2",
+        "@stylexjs/eslint-plugin": "0.17.3",
+        "@stylexjs/postcss-plugin": "0.17.3",
         "@types/json-schema": "^7.0.15",
         "@types/node": "^22.7.6",
         "@types/react": "^18.3.0",
@@ -1237,11 +1237,11 @@
       }
     },
     "examples/example-react-router": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
         "@remix-run/node-fetch-server": "0.12.0",
-        "@stylexjs/shared-ui": "0.17.2",
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/shared-ui": "0.17.3",
+        "@stylexjs/stylex": "0.17.3",
         "compression": "^1.8.0",
         "express": "^5.1.0",
         "react": "^19.2.0",
@@ -1249,7 +1249,7 @@
         "react-router": "7.9.2"
       },
       "devDependencies": {
-        "@stylexjs/unplugin": "0.17.2",
+        "@stylexjs/unplugin": "0.17.3",
         "@types/compression": "^1.8.1",
         "@types/express": "^5.0.3",
         "@types/node": "^24.0.3",
@@ -1721,11 +1721,11 @@
     },
     "examples/example-redwoodsdk": {
       "name": "@redwoodjs/starter",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/shared-ui": "0.17.2",
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/shared-ui": "0.17.3",
+        "@stylexjs/stylex": "0.17.3",
         "react": "19.3.0-canary-561ee24d-20251101",
         "react-dom": "19.3.0-canary-561ee24d-20251101",
         "react-server-dom-webpack": "19.2.1",
@@ -1734,7 +1734,7 @@
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.15.2",
         "@cloudflare/workers-types": "4.20251121.0",
-        "@stylexjs/unplugin": "0.17.2",
+        "@stylexjs/unplugin": "0.17.3",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.6",
         "@types/react-dom": "^19.2.3",
@@ -2516,10 +2516,10 @@
       }
     },
     "examples/example-rollup": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/stylex": "0.17.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -2531,7 +2531,7 @@
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-replace": "^5.0.7",
-        "@stylexjs/rollup-plugin": "0.17.2",
+        "@stylexjs/rollup-plugin": "0.17.3",
         "rollup": "^4.24.0",
         "serve": "^14.2.4"
       }
@@ -2559,16 +2559,16 @@
       "license": "MIT"
     },
     "examples/example-rspack": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/stylex": "0.17.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
         "@rspack/cli": "^1.6.4",
         "@rspack/core": "^1.6.4",
-        "@stylexjs/unplugin": "0.17.2",
+        "@stylexjs/unplugin": "0.17.3",
         "css-loader": "^7.1.2"
       }
     },
@@ -2640,7 +2640,7 @@
       }
     },
     "examples/example-storybook": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.1",
         "@storybook/addon-a11y": "^9.1.7",
@@ -2648,10 +2648,10 @@
         "@storybook/addon-links": "^9.1.7",
         "@storybook/addon-vitest": "^9.1.7",
         "@storybook/react-vite": "^9.1.7",
-        "@stylexjs/babel-plugin": "0.17.2",
-        "@stylexjs/eslint-plugin": "0.17.2",
-        "@stylexjs/postcss-plugin": "0.17.2",
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/babel-plugin": "0.17.3",
+        "@stylexjs/eslint-plugin": "0.17.3",
+        "@stylexjs/postcss-plugin": "0.17.3",
+        "@stylexjs/stylex": "0.17.3",
         "@typescript-eslint/eslint-plugin": "^8.44.0",
         "@typescript-eslint/parser": "^8.44.0",
         "@vitejs/plugin-react": "^5.0.3",
@@ -3555,30 +3555,30 @@
       }
     },
     "examples/example-vite": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
-        "@stylexjs/shared-ui": "0.17.2",
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/shared-ui": "0.17.3",
+        "@stylexjs/stylex": "0.17.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
-        "@stylexjs/unplugin": "0.17.2",
+        "@stylexjs/unplugin": "0.17.3",
         "@vitejs/plugin-react": "latest",
         "vite": "^7.2.4"
       }
     },
     "examples/example-vite-react": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
-        "@stylexjs/shared-ui": "0.17.2",
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/shared-ui": "0.17.3",
+        "@stylexjs/stylex": "0.17.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
-        "@stylexjs/unplugin": "0.17.2",
+        "@stylexjs/unplugin": "0.17.3",
         "@types/node": "^24.6.0",
         "@types/react": "^19.2.6",
         "@types/react-dom": "^19.2.3",
@@ -3967,16 +3967,16 @@
     },
     "examples/example-vite-rsc": {
       "name": "@vitejs/plugin-rsc-examples-starter",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/shared-ui": "0.17.2",
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/shared-ui": "0.17.3",
+        "@stylexjs/stylex": "0.17.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
-        "@stylexjs/unplugin": "0.17.2",
+        "@stylexjs/unplugin": "0.17.3",
         "@types/react": "^19.2.6",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "latest",
@@ -4327,17 +4327,17 @@
       }
     },
     "examples/example-waku": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
-        "@stylexjs/shared-ui": "0.17.2",
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/shared-ui": "0.17.3",
+        "@stylexjs/stylex": "0.17.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-server-dom-webpack": "19.2.1",
         "waku": "0.27.1"
       },
       "devDependencies": {
-        "@stylexjs/unplugin": "0.17.2",
+        "@stylexjs/unplugin": "0.17.3",
         "@types/react": "^19.2.6",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "5.1.0",
@@ -4581,10 +4581,10 @@
       }
     },
     "examples/example-webpack": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/stylex": "0.17.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -4593,8 +4593,8 @@
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.6.1",
-        "@stylexjs/eslint-plugin": "0.17.2",
-        "@stylexjs/unplugin": "0.17.2",
+        "@stylexjs/eslint-plugin": "0.17.3",
+        "@stylexjs/unplugin": "0.17.3",
         "babel-loader": "^10.0.0",
         "css-loader": "^7.1.2",
         "file-loader": "^6.2.0",
@@ -37408,7 +37408,7 @@
       }
     },
     "packages/@stylexjs/babel-plugin": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
@@ -37416,8 +37416,8 @@
         "@babel/traverse": "^7.26.8",
         "@babel/types": "^7.26.8",
         "@dual-bundle/import-meta-resolve": "^4.1.0",
-        "@stylexjs/shared": "0.17.2",
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/shared": "0.17.3",
+        "@stylexjs/stylex": "0.17.3",
         "postcss-value-parser": "^4.1.0"
       },
       "devDependencies": {
@@ -37430,7 +37430,7 @@
         "babel-plugin-syntax-hermes-parser": "^0.32.1",
         "path-browserify": "^1.0.1",
         "rollup": "^4.24.0",
-        "scripts": "0.17.2"
+        "scripts": "0.17.3"
       }
     },
     "packages/@stylexjs/babel-plugin/node_modules/@rollup/plugin-commonjs": {
@@ -37504,14 +37504,14 @@
       }
     },
     "packages/@stylexjs/cli": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.5",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
         "@babel/types": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.17.2",
+        "@stylexjs/babel-plugin": "0.17.3",
         "ansis": "^3.3.2",
         "fb-watchman": "^2.0.2",
         "json5": "^2.2.3",
@@ -37522,25 +37522,25 @@
         "stylex": "lib/index.js"
       },
       "devDependencies": {
-        "scripts": "0.17.2"
+        "scripts": "0.17.3"
       }
     },
     "packages/@stylexjs/eslint-plugin": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/shared": "0.17.2",
+        "@stylexjs/shared": "0.17.3",
         "css-shorthand-expand": "^1.2.0",
         "micromatch": "^4.0.5",
         "postcss-value-parser": "^4.2.0"
       }
     },
     "packages/@stylexjs/postcss-plugin": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.17.2",
+        "@stylexjs/babel-plugin": "0.17.3",
         "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
@@ -37548,14 +37548,14 @@
       }
     },
     "packages/@stylexjs/rollup-plugin": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
         "@babel/plugin-syntax-flow": "^7.26.0",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
-        "@stylexjs/babel-plugin": "0.17.2",
+        "@stylexjs/babel-plugin": "0.17.3",
         "lightningcss": "^1.29.1"
       },
       "devDependencies": {
@@ -37616,7 +37616,7 @@
       }
     },
     "packages/@stylexjs/shared": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.23.9",
@@ -37624,7 +37624,7 @@
       }
     },
     "packages/@stylexjs/stylex": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
         "css-mediaquery": "^0.1.2",
@@ -37651,7 +37651,7 @@
         "cross-env": "^10.1.0",
         "rimraf": "^6.1.2",
         "rollup": "^4.24.0",
-        "scripts": "0.17.2"
+        "scripts": "0.17.3"
       }
     },
     "packages/@stylexjs/stylex/node_modules/@rollup/plugin-commonjs": {
@@ -37725,14 +37725,14 @@
       }
     },
     "packages/@stylexjs/unplugin": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
         "@babel/plugin-syntax-flow": "^7.26.0",
         "@babel/plugin-syntax-jsx": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9",
-        "@stylexjs/babel-plugin": "0.17.2",
+        "@stylexjs/babel-plugin": "0.17.3",
         "browserslist": "^4.24.0",
         "lightningcss": "^1.29.1"
       },
@@ -37741,11 +37741,11 @@
       }
     },
     "packages/benchmarks": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/babel-plugin": "0.17.2",
-        "@stylexjs/rollup-plugin": "0.17.2",
+        "@stylexjs/babel-plugin": "0.17.3",
+        "@stylexjs/rollup-plugin": "0.17.3",
         "benchmark": "^2.1.4",
         "brotli-size": "^4.0.0",
         "clean-css": "^5.3.3",
@@ -37758,7 +37758,7 @@
       }
     },
     "packages/docs": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
         "@docusaurus/core": "2.4.1",
         "@docusaurus/preset-classic": "2.4.1",
@@ -37767,7 +37767,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.1",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@mdx-js/react": "^1.6.22",
-        "@stylexjs/stylex": "0.17.2",
+        "@stylexjs/stylex": "0.17.3",
         "@webcontainer/api": "^1.3.0",
         "clsx": "^1.2.1",
         "codemirror": "^5.65.16",
@@ -37778,9 +37778,9 @@
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.26.8",
-        "@stylexjs/babel-plugin": "0.17.2",
-        "@stylexjs/eslint-plugin": "0.17.2",
-        "@stylexjs/unplugin": "0.17.2",
+        "@stylexjs/babel-plugin": "0.17.3",
+        "@stylexjs/eslint-plugin": "0.17.3",
+        "@stylexjs/unplugin": "0.17.3",
         "clean-css": "^5.3.2",
         "eslint": "^8.57.1",
         "eslint-config-airbnb": "^19.0.4",
@@ -37792,7 +37792,7 @@
       }
     },
     "packages/scripts": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
         "flow-api-translator": "^0.32.1",
@@ -37805,7 +37805,7 @@
     },
     "packages/shared-ui": {
       "name": "@stylexjs/shared-ui",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "peerDependencies": {
         "@stylexjs/stylex": "*",
         "react": ">=18"
@@ -37822,7 +37822,7 @@
       }
     },
     "packages/style-value-parser": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
         "@csstools/css-tokenizer": "^3.0.3"
@@ -37835,10 +37835,11 @@
       }
     },
     "packages/typescript-tests": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
-        "@stylexjs/stylex": "0.17.2"
+        "@stylexjs/babel-plugin": "0.17.3",
+        "@stylexjs/stylex": "0.17.3"
       },
       "devDependencies": {
         "@types/react": "^19.2.3",

--- a/packages/@stylexjs/babel-plugin/package.json
+++ b/packages/@stylexjs/babel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/babel-plugin",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "StyleX babel plugin.",
   "main": "lib/index.js",
   "browser": "lib/index.browser.js",
@@ -23,8 +23,8 @@
     "@babel/traverse": "^7.26.8",
     "@babel/types": "^7.26.8",
     "@dual-bundle/import-meta-resolve": "^4.1.0",
-    "@stylexjs/shared": "0.17.2",
-    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/shared": "0.17.3",
+    "@stylexjs/stylex": "0.17.3",
     "postcss-value-parser": "^4.1.0"
   },
   "devDependencies": {
@@ -37,7 +37,7 @@
     "babel-plugin-syntax-hermes-parser": "^0.32.1",
     "path-browserify": "^1.0.1",
     "rollup": "^4.24.0",
-    "scripts": "0.17.2"
+    "scripts": "0.17.3"
   },
   "files": [
     "flow_modules/*",

--- a/packages/@stylexjs/cli/package.json
+++ b/packages/@stylexjs/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/cli",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "A cli to compile a folder with StyleX",
   "main": "./lib/transform.js",
   "repository": "https://www.github.com/facebook/stylex",
@@ -19,7 +19,7 @@
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
     "@babel/types": "^7.26.8",
-    "@stylexjs/babel-plugin": "0.17.2",
+    "@stylexjs/babel-plugin": "0.17.3",
     "ansis": "^3.3.2",
     "fb-watchman": "^2.0.2",
     "json5": "^2.2.3",
@@ -27,7 +27,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "scripts": "0.17.2"
+    "scripts": "0.17.3"
   },
   "bin": {
     "stylex": "./lib/index.js"

--- a/packages/@stylexjs/eslint-plugin/package.json
+++ b/packages/@stylexjs/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/eslint-plugin",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "StyleX eslint plugin.",
   "main": "lib/index.js",
   "repository": {
@@ -16,7 +16,7 @@
     "test": "jest --detectOpenHandles --coverage"
   },
   "dependencies": {
-    "@stylexjs/shared": "0.17.2",
+    "@stylexjs/shared": "0.17.3",
     "css-shorthand-expand": "^1.2.0",
     "micromatch": "^4.0.5",
     "postcss-value-parser": "^4.2.0"

--- a/packages/@stylexjs/postcss-plugin/package.json
+++ b/packages/@stylexjs/postcss-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/postcss-plugin",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "PostCSS plugin for StyleX",
   "main": "src/index.js",
   "repository": {
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.26.8",
-    "@stylexjs/babel-plugin": "0.17.2",
+    "@stylexjs/babel-plugin": "0.17.3",
     "postcss": "^8.4.49",
     "fast-glob": "^3.3.2",
     "glob-parent": "^6.0.2",

--- a/packages/@stylexjs/rollup-plugin/package.json
+++ b/packages/@stylexjs/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/rollup-plugin",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Rollup plugin for StyleX",
   "main": "./lib/index.js",
   "module": "./lib/es/index.mjs",
@@ -35,7 +35,7 @@
     "@babel/plugin-syntax-flow": "^7.26.0",
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
-    "@stylexjs/babel-plugin": "0.17.2",
+    "@stylexjs/babel-plugin": "0.17.3",
     "lightningcss": "^1.29.1"
   },
   "devDependencies": {

--- a/packages/@stylexjs/shared/package.json
+++ b/packages/@stylexjs/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/shared",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "main": "lib/index.js",
   "repository": {
     "type": "git",

--- a/packages/@stylexjs/stylex/package.json
+++ b/packages/@stylexjs/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/stylex",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "A library for defining styles for optimized user interfaces.",
   "main": "./lib/cjs/stylex.js",
   "module": "./lib/es/stylex.mjs",
@@ -61,7 +61,7 @@
     "cross-env": "^10.1.0",
     "rimraf": "^6.1.2",
     "rollup": "^4.24.0",
-    "scripts": "0.17.2"
+    "scripts": "0.17.3"
   },
   "files": [
     "lib/*"

--- a/packages/@stylexjs/unplugin/package.json
+++ b/packages/@stylexjs/unplugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/unplugin",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "private": false,
   "description": "Universal bundler plugin for StyleX using unplugin",
   "license": "MIT",
@@ -35,7 +35,7 @@
     "@babel/plugin-syntax-flow": "^7.26.0",
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
-    "@stylexjs/babel-plugin": "0.17.2",
+    "@stylexjs/babel-plugin": "0.17.3",
     "browserslist": "^4.24.0",
     "lightningcss": "^1.29.1"
   },

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "benchmarks",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "scripts": {
     "perf": "node ./perf/run.js",
     "size": "NODE_ENV=production rollup --config ./size/rollup.config.mjs && node ./size/run.js",
@@ -9,8 +9,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/babel-plugin": "0.17.2",
-    "@stylexjs/rollup-plugin": "0.17.2",
+    "@stylexjs/babel-plugin": "0.17.3",
+    "@stylexjs/rollup-plugin": "0.17.3",
     "benchmark": "^2.1.4",
     "brotli-size": "^4.0.0",
     "clean-css": "^5.3.3",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "docs",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "scripts": {
     "build": "rimraf ./build ./docusaurus && npm run clear && cross-env NODE_ENV=production docusaurus build",
     "clear": "docusaurus clear",
@@ -17,7 +17,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.1",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mdx-js/react": "^1.6.22",
-    "@stylexjs/stylex": "0.17.2",
+    "@stylexjs/stylex": "0.17.3",
     "@webcontainer/api": "^1.3.0",
     "clsx": "^1.2.1",
     "codemirror": "^5.65.16",
@@ -28,9 +28,9 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.26.8",
-    "@stylexjs/unplugin": "0.17.2",
-    "@stylexjs/eslint-plugin": "0.17.2",
-    "@stylexjs/babel-plugin": "0.17.2",
+    "@stylexjs/unplugin": "0.17.3",
+    "@stylexjs/eslint-plugin": "0.17.3",
+    "@stylexjs/babel-plugin": "0.17.3",
     "clean-css": "^5.3.2",
     "eslint": "^8.57.1",
     "eslint-config-airbnb": "^19.0.4",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "scripts",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Helper scripts for stylex monorepo.",
   "license": "MIT",
   "bin": {

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/shared-ui",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "private": true,
   "main": "src/index.tsx",
   "exports": {

--- a/packages/style-value-parser/package.json
+++ b/packages/style-value-parser/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "style-value-parser",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "type": "module",
   "main": "lib/index.js",
   "license": "MIT",

--- a/packages/typescript-tests/package.json
+++ b/packages/typescript-tests/package.json
@@ -1,15 +1,15 @@
 {
   "private": true,
   "name": "typescript-tests",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "type": "module",
   "scripts": {
     "test": "tsc --noEmit"
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.17.2",
-    "@stylexjs/babel-plugin": "0.17.2"
+    "@stylexjs/stylex": "0.17.3",
+    "@stylexjs/babel-plugin": "0.17.3"
   },
   "devDependencies": {
     "typescript": "^5.8.3",

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,7 +4,9 @@ Tools used to manage monorepo tasks like pre-commit hooks and npm releases.
 
 ## How to create a release
 
-The release script (run from the monorepo root) must be used to create and publish releases. All releases must follow semver versioning standards, e.g., `0.20.1`.
+The release script (run from the monorepo root) must be used to create and
+publish releases. All releases must follow semver versioning standards, e.g.,
+`0.20.1`.
 
 Checkout a release branch from latest `main`:
 
@@ -20,7 +22,7 @@ You can perform a dry run by only specifying the new version for a release:
 npm run release -- --pkg-version <version>
 ```
 
-To commit the release:
+Modify the CHANGELOG.md with new changes. Then commit the release:
 
 ```shell
 npm run release -- --pkg-version <version> --commit


### PR DESCRIPTION
Patch to unblock unplugin users and internal bundling issues.

## 0.17.3 (Dec 1, 2025)

- Add docs for setup instructions.
- Improve AST detection for `.stylex` named exports
- Add browser rollup bundle.
- Fix unplugin file suffix parsing.