### PR TITLE
[playground] use JsonParam serialization

### DIFF
--- a/packages/docs/components/PlaygroundNew.js
+++ b/packages/docs/components/PlaygroundNew.js
@@ -14,7 +14,7 @@ import { loadSandpackClient } from '@codesandbox/sandpack-client';
 import Editor from '@monaco-editor/react';
 import path from 'path-browserify';
 import { useColorMode } from '@docusaurus/theme-common';
-import { useQueryParam, ObjectParam, withDefault } from 'use-query-params';
+import { useQueryParam, JsonParam, withDefault } from 'use-query-params';
 import { Tabs } from './playground-components/Tabs';
 import prettier from 'prettier';
 import * as babelPlugin from 'prettier/plugins/babel.js';
@@ -98,7 +98,7 @@ const decodeObjKeys = (obj) => {
 export default function PlaygroundNew() {
   const [_inputFiles, _setInputFiles] = useQueryParam(
     'inputFiles',
-    withDefault(ObjectParam, encodeObjKeys(INITIAL_INPUT_FILES)),
+    withDefault(JsonParam, encodeObjKeys(INITIAL_INPUT_FILES)),
   );
   const [activeInputFile, setActiveInputFile] = useState('App.js');
   const [transformedFiles, setTransformedFiles] = useState([]);
@@ -154,7 +154,7 @@ export default function PlaygroundNew() {
 
 const styles = stylex.create({
   root: {
-   
+
   },
 });
 


### PR DESCRIPTION
## What changed / motivation ?

I ran into an issue with the new playground. If you add a new file called `tokens-2.stylex.js` there ends up being an issue where the filename is truncated and the rest of it ends up in the file source.

<img width="562" height="432" alt="Screenshot 2025-12-15 at 1 45 15 PM" src="https://github.com/user-attachments/assets/f0d57c7f-9151-48ee-8a13-b03b6f712f95" />

It looks like `ObjectParam` serialization in `use-query-params` [uses `'-'` as a kev-val separator
](https://github.com/pbeshai/use-query-params/blob/f887e72fad1e28532421bf8bf0e34fb8e4b9745c/packages/serialize-query-params/src/serialize.ts#L508) and is not configurable. 

My fix in this PR is to use `JsonParam` serialization but I think we have other options:

- Disallow using `'-'` in filenames
- Encode filenames ourselves like we do for the file source
- Provide our own "custom param" (see "Example with Custom Param" in their [README](https://github.com/pbeshai/use-query-params/blob/f887e72fad1e28532421bf8bf0e34fb8e4b9745c/packages/serialize-query-params/README.md))

The downside of `JsonParam` is that it is less readable and would not be backwards compatible with existing links to the playground. Do we need to build in backwards compat?

## Linked PR/Issues

Sorry for not creating an issue. I found it easier to create a PR in this case

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code