### PR TITLE
[playground] add @stylexjs/stylex types to editor

### DIFF
--- a/packages/docs/components/PlaygroundNew.js
+++ b/packages/docs/components/PlaygroundNew.js
@@ -360,6 +360,24 @@ export const vars = stylex.defineVars({
                 key={activeInputFile}
                 onChange={handleEditorChange}
                 onMount={(editor) => {
+                  monaco.languages.typescript.javascriptDefaults.setCompilerOptions(
+                    {
+                      ...monaco.languages.typescript.javascriptDefaults.getCompilerOptions(),
+                      paths: {
+                        '@stylexjs/stylex': [
+                          'file:///node_modules/@stylexjs/stylex/stylex.d.ts',
+                        ],
+                      },
+                    },
+                  );
+
+                  for (const [file, content] of Object.entries(STYLEX_TYPES)) {
+                    monaco.languages.typescript.javascriptDefaults.addExtraLib(
+                      content,
+                      file,
+                    );
+                  }
+
                   editor.getDomNode()?.addEventListener('keydown', (e) => {
                     if (e.key === '/') {
                       // prevent docusaurus's search from opening

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -30,6 +30,22 @@ const config = {
     function () {
       const webpack = require('webpack');
       const fs = require('fs');
+      const path = require('path');
+
+      const stylexFilename = require.resolve('@stylexjs/stylex');
+      const stylexSource = fs.readFileSync(stylexFilename, 'utf8');
+      const stylexTypes = {};
+      for (const file of fs.readdirSync(path.dirname(stylexFilename), {
+        recursive: true,
+      })) {
+        if (file.endsWith('.d.ts')) {
+          stylexTypes[`file:///node_modules/@stylexjs/stylex/${file}`] =
+            fs.readFileSync(
+              path.join(path.dirname(stylexFilename), file),
+              'utf8',
+            );
+        }
+      }
 
       return {
         name: 'playground-webpack-config',
@@ -37,9 +53,8 @@ const config = {
           return {
             plugins: [
               new webpack.DefinePlugin({
-                STYLEX_SOURCE: JSON.stringify(
-                  fs.readFileSync(require.resolve('@stylexjs/stylex'), 'utf8'),
-                ),
+                STYLEX_SOURCE: JSON.stringify(stylexSource),
+                STYLEX_TYPES: JSON.stringify(stylexTypes),
               }),
             ],
           };


### PR DESCRIPTION
## What changed / motivation ?

This PR adds the `@stylexjs/stylex` types to the playground editor so we can have intellisense when using StyleX APIs.

## Additional Context

<img width="826" height="467" alt="Screenshot 2025-12-16 at 7 50 41 PM" src="https://github.com/user-attachments/assets/e5eee650-9d3c-46be-bcaf-6d430f37f91e" />


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code