### PR TITLE
[playground] set page title

### DIFF
--- a/packages/docs/src/pages/playground.js
+++ b/packages/docs/src/pages/playground.js
@@ -13,7 +13,7 @@ import { WindowHistoryAdapter } from 'use-query-params/adapters/window';
 
 export default function PlaygroundNewPage() {
   return (
-    <Layout>
+    <Layout title="Playground">
       <BrowserOnly>
         {() => {
           const PlaygroundNew =


### PR DESCRIPTION
## What changed / motivation ?

I realized that the page title for the playground page was just "StyleX". This PR updates it so that it is "Playground | StyleX", following the pattern used by other pages. I'm not too familiar with docusaurus but I think this is related to this being a standalone non-MDX "page"   

## Additional Context

After:
<img width="300" height="133" alt="Screenshot 2025-12-17 at 9 27 02 AM" src="https://github.com/user-attachments/assets/c630f14c-41fd-4e34-b0ee-445e6cdec6d6" />


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code