### PR TITLE
[chore] bump storybook version

### DIFF
--- a/examples/example-storybook/package.json
+++ b/examples/example-storybook/package.json
@@ -33,7 +33,7 @@
     "prop-types": "^15.8.1",
     "rollup-plugin-jsx-remove-attributes": "^3.1.1",
     "rollup-plugin-node-externals": "^8.1.1",
-    "storybook": "^9.1.7",
+    "storybook": "^9.1.17",
     "typescript-eslint": "^8.44.0",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.0.13"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2666,7 +2666,7 @@
         "prop-types": "^15.8.1",
         "rollup-plugin-jsx-remove-attributes": "^3.1.1",
         "rollup-plugin-node-externals": "^8.1.1",
-        "storybook": "^9.1.7",
+        "storybook": "^9.1.17",
         "typescript-eslint": "^8.44.0",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.0.13"
@@ -33213,7 +33213,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.1.7",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.17.tgz",
+      "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
       "license": "MIT",
       "peer": true,


### PR DESCRIPTION

T249104775

Github raised a vulnerability report with Storybook (https://github.com/storybookjs/storybook/security/advisories/GHSA-8452-54wp-rmv6?fbclid=IwY2xjawOxMO9leHRuA2FlbQIxMQBicmlkETEwck95M0FsN2VxdWVBSzNDc3J0YwZhcHBfaWQBMAABHkHhuQM_6vNxzKYsV_CVBjOC0wHqmLghVSaexl-oBAgq535ATufRGS3KpdiG_aem_vaXSd5G_ejnB5pXO-Ky3sg) and this diff updates the dependency version to one that has the issue fixed
