### PR TITLE
ci: add pull request permissions to benchmarks workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,6 +2,10 @@ name: benchmarks
 
 on: [pull_request]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   perf:
     runs-on: ubuntu-latest


### PR DESCRIPTION
ci: add pull request permissions to benchmarks workflow

It appears there's recently been a regression wrt the permissions attached to the Github actions token, probably due to the recent supply chain attacks, so this diff is an attempt to resolve the failing benchmark ci workflows that are currently failing.
