### PR TITLE
[playground] fix FileNameDialog not resetting between uses

### DIFF
--- a/packages/docs/components/playground-components/Dialogs.js
+++ b/packages/docs/components/playground-components/Dialogs.js
@@ -26,6 +26,9 @@ export const FileNameDialog = forwardRef(function FileNameDialog(
 
   return (
     <dialog
+      onClose={() => {
+        inputRef.current.value = defaultValue;
+      }}
       ref={ref}
       style={{ backdropFilter: 'blur(2px)' }}
       {...stylex.props(styles.dialog)}


### PR DESCRIPTION
## What changed / motivation ?

I noticed a couple small bugs in the Create/Rename file dialog: 

1) If you create a component file and then another it uses the same name
2) If you open a dialog, modify value, cancel, re-open it would have the modified value

My fix in this PR is to imperatively reset the input value when the dialog closes. I don't love this solution because it is relying on the fact that `defaultValue` is updated before `onClose` when the form is submitted but it seems to work and fits in with the uncontrolled input usage. My initial thought was to use a `key` prop on `<FileNameDialog>` element to force a remount when the `defaultValue` changes.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code