### PR TITLE
feat(babel-plugin): add disallowedPropertiesValidation option

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
@@ -1372,6 +1372,7 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
             },
           });
         `,
+          { propertyValidationMode: 'throw' },
         ),
       ).toThrow();
       expect(() =>
@@ -1384,6 +1385,7 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
             },
           });
         `,
+          { propertyValidationMode: 'throw' },
         ),
       ).toThrow();
     });

--- a/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-create-test.js
@@ -847,8 +847,12 @@ describe('@stylexjs/babel-plugin', () => {
     });
   });
 
-  describe('[validation] disallowedPropertiesValidation config', () => {
-    test('throws error by default for disallowed properties', () => {
+  describe('[validation] propertyValidationMode config', () => {
+    test('does not throw by default for disallowed properties (silent mode)', () => {
+      const consoleSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
       expect(() => {
         transform(`
           import * as stylex from '@stylexjs/stylex';
@@ -858,10 +862,15 @@ describe('@stylexjs/babel-plugin', () => {
             },
           });
         `);
-      }).toThrow('border is not supported');
+      }).not.toThrow();
+
+      // Should not log any warning in silent mode (default)
+      expect(consoleSpy).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
     });
 
-    test('throws error when disallowedPropertiesValidation is "throw"', () => {
+    test('throws error when propertyValidationMode is "throw"', () => {
       expect(() => {
         transform(
           `
@@ -872,12 +881,12 @@ describe('@stylexjs/babel-plugin', () => {
             },
           });
         `,
-          { disallowedPropertiesValidation: 'throw' },
+          { propertyValidationMode: 'throw' },
         );
       }).toThrow('border is not supported');
     });
 
-    test('does not throw when disallowedPropertiesValidation is "warn"', () => {
+    test('does not throw when propertyValidationMode is "warn"', () => {
       const consoleSpy = jest
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
@@ -892,7 +901,7 @@ describe('@stylexjs/babel-plugin', () => {
             },
           });
         `,
-          { disallowedPropertiesValidation: 'warn' },
+          { propertyValidationMode: 'warn' },
         );
       }).not.toThrow();
 
@@ -903,7 +912,7 @@ describe('@stylexjs/babel-plugin', () => {
       consoleSpy.mockRestore();
     });
 
-    test('does not throw when disallowedPropertiesValidation is "silent"', () => {
+    test('does not throw when propertyValidationMode is "silent"', () => {
       const consoleSpy = jest
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
@@ -918,7 +927,7 @@ describe('@stylexjs/babel-plugin', () => {
             },
           });
         `,
-          { disallowedPropertiesValidation: 'silent' },
+          { propertyValidationMode: 'silent' },
         );
       }).not.toThrow();
 
@@ -939,7 +948,7 @@ describe('@stylexjs/babel-plugin', () => {
             },
           });
         `,
-          { disallowedPropertiesValidation: 'silent' },
+          { propertyValidationMode: 'silent' },
         );
       }).not.toThrow();
     });
@@ -955,7 +964,7 @@ describe('@stylexjs/babel-plugin', () => {
             },
           });
         `,
-          { disallowedPropertiesValidation: 'silent' },
+          { propertyValidationMode: 'silent' },
         );
       }).not.toThrow();
     });

--- a/packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts
@@ -41,7 +41,7 @@ export type StyleXOptions = Readonly<{
   debug: null | undefined | boolean;
   definedStylexCSSVariables?: { [key: string]: unknown };
   dev: boolean;
-  disallowedPropertiesValidation?: 'throw' | 'warn' | 'silent';
+  propertyValidationMode?: 'throw' | 'warn' | 'silent';
   enableDebugClassNames?: null | undefined | boolean;
   enableDebugDataProp?: null | undefined | boolean;
   enableDevClassNames?: null | undefined | boolean;

--- a/packages/@stylexjs/babel-plugin/src/shared/common-types.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/common-types.js
@@ -48,7 +48,7 @@ export type StyleXOptions = $ReadOnly<{
   debug: ?boolean,
   definedStylexCSSVariables?: { [key: string]: mixed },
   dev: boolean,
-  disallowedPropertiesValidation?: 'throw' | 'warn' | 'silent',
+  propertyValidationMode?: 'throw' | 'warn' | 'silent',
   enableDebugClassNames?: ?boolean,
   enableDebugDataProp?: ?boolean,
   enableDevClassNames?: ?boolean,

--- a/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/index.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/preprocess-rules/index.js
@@ -31,7 +31,7 @@ export default function flatMapExpandedShorthands(
   objEntry: $ReadOnly<[string, TStyleValue]>,
   options: $ReadOnly<{
     styleResolution: StyleXOptions['styleResolution'],
-    disallowedPropertiesValidation?: StyleXOptions['disallowedPropertiesValidation'],
+    propertyValidationMode?: StyleXOptions['propertyValidationMode'],
     ...
   }>,
 ): $ReadOnlyArray<[string, TStyleValue]> {
@@ -54,13 +54,11 @@ export default function flatMapExpandedShorthands(
     try {
       return expansion(value);
     } catch (error) {
-      const validationMode = options.disallowedPropertiesValidation ?? 'throw';
+      const validationMode = options.propertyValidationMode ?? 'silent';
       if (validationMode === 'throw') {
         throw error;
       } else if (validationMode === 'warn') {
-        console.warn(
-          `[stylex] ${error.message} Property "${key}" will be skipped.`,
-        );
+        console.warn(`[stylex] ${error.message}`);
         return [];
       } else {
         // silent mode - skip the property without any output

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/default-options.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/default-options.js
@@ -13,7 +13,7 @@ export const defaultOptions: StyleXOptions = {
   classNamePrefix: 'x',
   dev: false,
   debug: false,
-  disallowedPropertiesValidation: 'throw',
+  propertyValidationMode: 'silent',
   enableDebugClassNames: false,
   enableDevClassNames: false,
   enableDebugDataProp: true,

--- a/packages/@stylexjs/babel-plugin/src/utils/__tests__/state-manager-test.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/__tests__/state-manager-test.js
@@ -599,17 +599,17 @@ describe('StateManager config parsing', () => {
     });
   });
 
-  describe('"disallowedPropertiesValidation" option', () => {
+  describe('"propertyValidationMode" option', () => {
     test('logs errors if invalid', () => {
       const stateManager = makeState({
-        disallowedPropertiesValidation: 'something-else',
+        propertyValidationMode: 'something-else',
       });
-      expect(stateManager.options.disallowedPropertiesValidation).toBe('throw');
+      expect(stateManager.options.propertyValidationMode).toBe('silent');
       expect(warnings).toMatchInlineSnapshot(`
         [
           [
             "[@stylexjs/babel-plugin]",
-            "Expected (options.disallowedPropertiesValidation) to be one of
+            "Expected (options.propertyValidationMode) to be one of
         	- the literal "throw"
         	- the literal "warn"
         	- the literal "silent"
@@ -621,21 +621,19 @@ describe('StateManager config parsing', () => {
 
     test('default value', () => {
       const stateManager = makeState();
-      expect(stateManager.options.disallowedPropertiesValidation).toBe('throw');
+      expect(stateManager.options.propertyValidationMode).toBe('silent');
       expect(warnings).toEqual([]);
     });
 
     test('valid values', () => {
-      let stateManager = makeState({ disallowedPropertiesValidation: 'throw' });
-      expect(stateManager.options.disallowedPropertiesValidation).toBe('throw');
+      let stateManager = makeState({ propertyValidationMode: 'throw' });
+      expect(stateManager.options.propertyValidationMode).toBe('throw');
 
-      stateManager = makeState({ disallowedPropertiesValidation: 'warn' });
-      expect(stateManager.options.disallowedPropertiesValidation).toBe('warn');
+      stateManager = makeState({ propertyValidationMode: 'warn' });
+      expect(stateManager.options.propertyValidationMode).toBe('warn');
 
-      stateManager = makeState({ disallowedPropertiesValidation: 'silent' });
-      expect(stateManager.options.disallowedPropertiesValidation).toBe(
-        'silent',
-      );
+      stateManager = makeState({ propertyValidationMode: 'silent' });
+      expect(stateManager.options.propertyValidationMode).toBe('silent');
 
       expect(warnings).toEqual([]);
     });

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -93,7 +93,7 @@ const CheckModuleResolution: Check<ModuleResolution> = z.unionOf4(
 export type StyleXOptions = $ReadOnly<{
   ...RuntimeOptions,
   aliases?: ?$ReadOnly<{ [string]: string | $ReadOnlyArray<string> }>,
-  disallowedPropertiesValidation?: 'throw' | 'warn' | 'silent',
+  propertyValidationMode?: 'throw' | 'warn' | 'silent',
   enableDebugClassNames?: boolean,
   enableDebugDataProp?: boolean,
   enableDevClassNames?: boolean,
@@ -340,13 +340,12 @@ export default class StateManager {
         'options.styleResolution',
       );
 
-    const disallowedPropertiesValidation: StyleXStateOptions['disallowedPropertiesValidation'] =
+    const propertyValidationMode: StyleXStateOptions['propertyValidationMode'] =
       z.logAndDefault(
         z.unionOf3(z.literal('throw'), z.literal('warn'), z.literal('silent')),
-        options.disallowedPropertiesValidation ??
-          defaultOptions.disallowedPropertiesValidation,
-        'throw',
-        'options.disallowedPropertiesValidation',
+        options.propertyValidationMode ?? defaultOptions.propertyValidationMode,
+        'silent',
+        'options.propertyValidationMode',
       );
 
     const unstable_moduleResolution: StyleXStateOptions['unstable_moduleResolution'] =
@@ -400,7 +399,7 @@ export default class StateManager {
       debug,
       definedStylexCSSVariables: {},
       dev,
-      disallowedPropertiesValidation,
+      propertyValidationMode,
       enableDebugClassNames,
       enableDebugDataProp,
       enableDevClassNames,


### PR DESCRIPTION
Add config option to control validation behavior for disallowed shorthand properties (border, background, animation, etc).

## Changes
- Added `disallowedPropertiesValidation` option with three modes:
  - `'throw'` (default): Throws error for disallowed properties
  - `'warn'`: Logs warning and skips property
  - `'silent'`: Silently skips property

## Use case
Allows gradual migration of existing codebases that use disallowed shorthand properties without breaking the build.

Fixes #1423