### PR TITLE
[docs] add missing StaticStylesWithout docs

### DIFF
--- a/packages/docs/content/docs/api/index.mdx
+++ b/packages/docs/content/docs/api/index.mdx
@@ -34,5 +34,6 @@ sidebar_position: 2
 - [`type StyleXStyles`](/docs/api/types/StyleXStyles)
 - [`type StyleXStylesWithout`](/docs/api/types/StyleXStylesWithout)
 - [`type StaticStyles`](/docs/api/types/StaticStyles)
+- [`type StaticStylesWithout`](/docs/api/types/StaticStylesWithout)
 - [`type Theme`](/docs/api/types/Theme)
 - [`type VarGroup`](/docs/api/types/VarGroup)

--- a/packages/docs/content/docs/api/types/StaticStylesWithout.mdx
+++ b/packages/docs/content/docs/api/types/StaticStylesWithout.mdx
@@ -1,0 +1,47 @@
+---
+title: 'StaticStylesWithout<>'
+---
+
+Allow any static styles except for keys defined in the provided object type. It
+works similarly to the `Omit<>` utility type.
+
+```tsx
+import type { StaticStylesWithout } from '@stylexjs/stylex';
+
+type Props = {
+  // ...
+  style?: StaticStylesWithout<{
+    position: unknown;
+    display: unknown;
+    top: unknown;
+    start: unknown;
+    end: unknown;
+    bottom: unknown;
+    border: unknown;
+    borderWidth: unknown;
+    borderBottomWidth: unknown;
+    borderEndWidth: unknown;
+    borderStartWidth: unknown;
+    borderTopWidth: unknown;
+    margin: unknown;
+    marginBottom: unknown;
+    marginEnd: unknown;
+    marginStart: unknown;
+    marginTop: unknown;
+    padding: unknown;
+    paddingBottom: unknown;
+    paddingEnd: unknown;
+    paddingStart: unknown;
+    paddingTop: unknown;
+    width: unknown;
+    height: unknown;
+    flexBasis: unknown;
+    overflow: unknown;
+    overflowX: unknown;
+    overflowY: unknown;
+  }>;
+};
+```
+
+This type will disallow all the keys which are known to cause layout changes,
+but will continue to allow all other static style properties.

--- a/packages/docs/content/docs/api/types/meta.json
+++ b/packages/docs/content/docs/api/types/meta.json
@@ -4,6 +4,7 @@
         "./StyleXStyles.mdx",
         "./StyleXStylesWithout.mdx",
         "./StaticStyles.mdx",
+        "./StaticStylesWithout.mdx",
         "./Theme.mdx",
         "./VarGroup.mdx"
     ]


### PR DESCRIPTION
## What changed / motivation ?

I noticed that the docs for `StaticStylesWithout<T> were missing and this PR add them. 

OOC Was it ever considered to just make it more like `Omit<T>` (e.g `StaticStylesWithout<'position' | 'display'>`). Do people actually use it to omit specific values like `StaticStylesWithout<{ position: 'relative' }>`?

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code