### PR TITLE
[docs] fix callout icon alignment

### DIFF
--- a/packages/docs/src/components/mdx/Callout.tsx
+++ b/packages/docs/src/components/mdx/Callout.tsx
@@ -40,10 +40,11 @@ export function Callout({ children, title, ...props }: CalloutProps) {
   );
 }
 
-export interface CalloutContainerProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  'className' | 'style' | 'title'
-> {
+export interface CalloutContainerProps
+  extends Omit<
+    HTMLAttributes<HTMLDivElement>,
+    'className' | 'style' | 'title'
+  > {
   /**
    * @defaultValue info
    */
@@ -93,10 +94,8 @@ export function CalloutContainer({
   );
 }
 
-export interface CalloutTitleProps extends Omit<
-  HTMLAttributes<HTMLParagraphElement>,
-  'className' | 'style'
-> {
+export interface CalloutTitleProps
+  extends Omit<HTMLAttributes<HTMLParagraphElement>, 'className' | 'style'> {
   children: ReactNode;
 }
 
@@ -108,10 +107,8 @@ export function CalloutTitle({ children, ...props }: CalloutTitleProps) {
   );
 }
 
-export interface CalloutDescriptionProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  'className' | 'style'
-> {
+export interface CalloutDescriptionProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'style'> {
   children: ReactNode;
 }
 


### PR DESCRIPTION
## What changed / motivation ?

The docs `<Callout />` icon alignment was not aligned to the first line of text.

<img width="610" height="363" alt="Screenshot 2026-01-04 at 10 17 14 AM" src="https://github.com/user-attachments/assets/7f40dd84-5b43-44fa-bcbb-21c1e83ac7ef" />

> [!NOTE]
> Looks like title usage within Callouts is roughly aligned, but not when titles are omitted. But unclear why the titles are 14px when the text within the callouts are rendering at 16px. We could conditionally apply the height based on whether a title is used or not.

## Linked PR/Issues

Fixes # (issue)

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

| BEFORE | AFTER |
|--------|--------|
| <img width="610" height="363" alt="Screenshot 2026-01-04 at 10 17 14 AM" src="https://github.com/user-attachments/assets/8741ec16-118f-49fd-a72f-3847699fabac" /> | <img width="648" height="352" alt="Screenshot 2026-01-04 at 10 16 59 AM" src="https://github.com/user-attachments/assets/d5875d55-7a55-4878-88e0-19d4b3717bbf" /> | 

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code