### PR TITLE
fix: preserve units in zero values CSS variables

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/shared/utils/__tests__/transform-value-test.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/__tests__/transform-value-test.js
@@ -74,4 +74,20 @@ describe('transformValue content property tests', () => {
       expect(transformValue('content', input, {})).toBe(expected);
     });
   });
+
+  test('preserve units in zero values CSS variables', () => {
+    const variables = [
+      ['--test', '0px', '0px'],
+      ['--test', '0vdh', '0vdh'],
+      ['transform', '0rad', '0deg'],
+      ['animation-duration', '0ms', '0s'],
+      ['grid-template-rows', '0fr', '0fr'],
+      ['width', '0%', '0%'],
+      ['margin', '0px', '0'],
+    ];
+
+    variables.forEach(([key, value, expected]) => {
+      expect(transformValue(key, value, {})).toBe(expected);
+    });
+  });
 });

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/normalizers/zero-dimensions.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/normalizers/zero-dimensions.js
@@ -23,8 +23,12 @@ const percentage = '%';
 
 export default function normalizeZeroDimensions(
   ast: PostCSSValueAST,
-  _: mixed,
+  key: mixed,
 ): PostCSSValueAST {
+  if (typeof key === 'string' && key.startsWith('--')) {
+    return ast;
+  }
+
   let endFunction = 0;
 
   ast.walk((node) => {


### PR DESCRIPTION
## What changed / motivation ?

When zero value variables change js to css, units are removed in the code. It makes incorrect value in calculation. so, preserve units in zero values css variables.

## Linked PR/Issues

- https://github.com/facebook/stylex/issues/1411

## Additional Context

build and test is successful!
<img width="248" height="85" alt="image" src="https://github.com/user-attachments/assets/62bae045-9a8b-4a1e-bc32-36af6d10b942" />

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code