### PR TITLE
[stylex] enable disableMix for styleq instance

### DIFF
--- a/packages/@stylexjs/stylex/src/stylex.js
+++ b/packages/@stylexjs/stylex/src/stylex.js
@@ -56,6 +56,10 @@ export type {
 
 import { styleq } from 'styleq';
 
+const optimizedStyleq = styleq.factory({
+  disableMix: true,
+});
+
 const errorForFn = (name: string) =>
   new Error(
     `Unexpected 'stylex.${name}' call at runtime. Styles must be compiled by '@stylexjs/babel-plugin'.`,
@@ -114,7 +118,7 @@ export function props(
   'data-style-src'?: string,
   style?: $ReadOnly<{ [string]: string | number }>,
 }> {
-  const [className, style, dataStyleSrc] = styleq(styles);
+  const [className, style, dataStyleSrc] = optimizedStyleq(styles);
   const result: {
     className?: string,
     'data-style-src'?: string,


### PR DESCRIPTION
## What changed / motivation ?

I was reading the `react-strict-dom` codebase and noticed that they set `disableMix: true` on their styleq instance: https://github.com/facebook/react-strict-dom/blob/a5cbf07a03cff88dac6682b4409c1ad49e723d65/packages/react-strict-dom/src/web/css/merge.js#L32-L38

I have no real concerns about the runtime performance of `stylex.props()` but, unless I'm missing something obvious, this seems like an easy win. By default, styleq removes CSS classes for any properties that are also set by inline styles, but StyleX hashes the property keys so the comparisons are pointless. Setting `disableMix: true` will just bypass this logic. 


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code