### PR TITLE
[chore] bump react-router version in example app

### DIFF
--- a/examples/example-react-router/package.json
+++ b/examples/example-react-router/package.json
@@ -16,7 +16,7 @@
     "express": "^5.1.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router": "7.9.2"
+    "react-router": "7.9.6"
   },
   "devDependencies": {
     "@stylexjs/unplugin": "0.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16645,10 +16645,10 @@ react-router@5.3.4, react-router@^5.3.3:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@7.9.2:
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.9.2.tgz#f424a14f87e4d7b5b268ce3647876e9504e4fca6"
-  integrity sha512-i2TPp4dgaqrOqiRGLZmqh2WXmbdFknUyiCRmSKs0hf6fWXkTKg5h56b+9F22NbGRAMxjYfqQnpi63egzD2SuZA==
+react-router@7.9.6:
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.9.6.tgz#003c8de335fdd7390286a478dcfd9579c1826137"
+  integrity sha512-Y1tUp8clYRXpfPITyuifmSoE2vncSME18uVLgaqyxh9H35JWpIfzHo+9y3Fzh5odk/jxPW29IgLgzcdwxGqyNA==
   dependencies:
     cookie "^1.0.1"
     set-cookie-parser "^2.6.0"


### PR DESCRIPTION

We got notificaiton of a react-router vulnerability that was fixed in 7.9.6 so this diff bumps that version
