### PR TITLE
[stylex] fix defineMarker "inaccessible 'unique symbol' type error"

### DIFF
--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
@@ -306,8 +306,10 @@ export type StyleX$CreateTheme = <
   overrides: OverridesForTokenType<TokensFromVarGroup<TVars>>,
 ) => Theme<TVars, ThemeID>;
 
+declare const StyleXMarkerTag: unique symbol;
+
 export type StyleX$DefineMarker = () => MapNamespace<{
-  readonly marker: unique symbol;
+  readonly marker: typeof StyleXMarkerTag;
 }>;
 
 export type StyleX$When = {

--- a/packages/typescript-tests/src/exports.ts
+++ b/packages/typescript-tests/src/exports.ts
@@ -136,3 +136,5 @@ export const withFirstThatWorks = stylex.create({
     width: stylex.firstThatWorks('50%', '100%'),
   },
 });
+
+export const customMarker = stylex.defineMarker();


### PR DESCRIPTION
## What changed / motivation ?

We upgraded to `v0.17.3` and had reports (from @j-malt) of TypeScript errors with the new `defineMarker()` API:

```ts 
// markers.stylex.ts
export const customMarker = stylex.defineMarker();
```
> The inferred type of 'customMarker' references an inaccessible 'unique symbol' type. A type annotation is necessary.ts(2527)



This is a bit outside of my TypeScript knowledge but my understanding is that the generated `.d.ts` file needs to be able to reference the `unique symbol` but it is inaccessible. My fix in this PR is to just extract a `StyleXMarkerTag` declaration which can be accessed in the generated `.d.ts` file. We don't run into this error in the `defineMarker()` usage in the docs apps because `"declaration": true` is not set in the `tsconfig.json`. 

```ts
// markers.stylex.d.ts
export declare const customMarker: Readonly<{
    readonly marker: stylex.StyleXClassNameFor<"marker", typeof import("@stylexjs/stylex/lib/types/StyleXTypes").StyleXMarkerTag>;
}>;
```

### Workaround

Right now our workaround is to annotate the export:

```ts
 export const customMarker = ReturnType<typeof stylex.defineMarker> = stylex.defineMarker();
```

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code