### PR TITLE
[playground] improvements to output tab

### DIFF
--- a/packages/docs/src/components/Playground/Tabs.tsx
+++ b/packages/docs/src/components/Playground/Tabs.tsx
@@ -577,7 +577,7 @@ const styles = stylex.create({
   },
 
   chevronCollapsed: {
-    transform: 'rotate(-90deg)',
+    transform: 'rotate(180deg)',
   },
 });
 

--- a/packages/docs/src/components/Playground/index.tsx
+++ b/packages/docs/src/components/Playground/index.tsx
@@ -746,7 +746,10 @@ export const vars = stylex.defineVars({
                   isCollapsed={outputCollapsed}
                   onSelectFile={(label) => {
                     const found = OUTPUT_TABS.find((t) => t.label === label);
-                    if (found) setActiveOutputTab(found.key);
+                    if (found) {
+                      setActiveOutputTab(found.key);
+                      setOutputCollapsed(false);
+                    }
                   }}
                   onToggleCollapse={() => setOutputCollapsed((c) => !c)}
                   readOnly


### PR DESCRIPTION
## What changed / motivation ?

Small tweaks to output menu based on feedback from @ezzak 
- Chevron direction more clear
- Output panel opens on JS/CSS output


https://github.com/user-attachments/assets/cda09923-13d2-497b-91f9-9c713da9d709

