### PR TITLE
[shared] rework compound pseudos priority logic

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -1979,6 +1979,7 @@ describe('@stylexjs/babel-plugin', () => {
           `);
         });
 
+        // Generates invalid CSS, need to revisit this API
         test('"::before" containing pseudo-classes', () => {
           const { code, metadata } = transform(`
             import * as stylex from '@stylexjs/stylex';
@@ -2017,6 +2018,78 @@ describe('@stylexjs/babel-plugin', () => {
                   "xeb2lg0",
                   {
                     "ltr": ".xeb2lg0::before:hover{color:blue}",
+                    "rtl": null,
+                  },
+                  8130,
+                ],
+              ],
+            }
+          `);
+        });
+
+        test('legacy compound ":hover::after" selector as single key', () => {
+          const { code, metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              foo: {
+                ':hover::after': {
+                  color: 'red',
+                },
+              },
+            });
+          `);
+          expect(code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              foo: {
+                kF1atM: "x1gfyp89",
+                $$css: true
+              }
+            };"
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x1gfyp89",
+                  {
+                    "ltr": ".x1gfyp89:hover::after{color:red}",
+                    "rtl": null,
+                  },
+                  8130,
+                ],
+              ],
+            }
+          `);
+        });
+
+        test('compound ":hover::after" selector as single key', () => {
+          const { metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              foo: {
+                color: {
+                  default: 'red',
+                  ':hover::after': 'blue',
+                },
+              },
+            });
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x1e2nbdu",
+                  {
+                    "ltr": ".x1e2nbdu{color:red}",
+                    "rtl": null,
+                  },
+                  3000,
+                ],
+                [
+                  "x6wc952",
+                  {
+                    "ltr": ".x6wc952:hover::after{color:blue}",
                     "rtl": null,
                   },
                   8130,


### PR DESCRIPTION
## Context

This is an interim fix for https://github.com/facebook/stylex/issues/1473 to unblock some internal experiments. The larger bug requires a better solution at the API design level.

We currently enforce outer-key pseudo-elements, which by our sorting logic outputs 

```
.x1qdmp1q::before:hover{color:red}
```

In the meantime, let's allow for compound selectors like `:hover::after` and sum up the priorities. We'll opt out of handling functional pseudo-classes (eg. :where(), :is(), :has()), as those don't follow additive specificities.

This PR is a follow up to https://github.com/facebook/stylex/commit/ca12618c19244308f3488b2206e04782f2bfce9e to clean up failing signals and refine logic