### PR TITLE
[babel-plugin] fix invalid @ rule body when using dynamic styles in pseudo elements

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -4448,7 +4448,7 @@ describe('@stylexjs/babel-plugin', () => {
                 [
                   "--x-1g451k2",
                   {
-                    "ltr": "@property --x-1g451k2 { syntax: "*";}",
+                    "ltr": "@property --x-1g451k2 { syntax: "*"; inherits: true;}",
                     "rtl": null,
                   },
                   0,
@@ -4456,7 +4456,7 @@ describe('@stylexjs/babel-plugin', () => {
                 [
                   "--x-19erzii",
                   {
-                    "ltr": "@property --x-19erzii { syntax: "*";}",
+                    "ltr": "@property --x-19erzii { syntax: "*"; inherits: true;}",
                     "rtl": null,
                   },
                   0,
@@ -4502,7 +4502,7 @@ describe('@stylexjs/babel-plugin', () => {
                 [
                   "--x-163tekb",
                   {
-                    "ltr": "@property --x-163tekb { syntax: "*";}",
+                    "ltr": "@property --x-163tekb { syntax: "*"; inherits: true;}",
                     "rtl": null,
                   },
                   0,
@@ -4548,7 +4548,7 @@ describe('@stylexjs/babel-plugin', () => {
                 [
                   "--x-msahdu",
                   {
-                    "ltr": "@property --x-msahdu { syntax: "*";}",
+                    "ltr": "@property --x-msahdu { syntax: "*"; inherits: true;}",
                     "rtl": null,
                   },
                   0,
@@ -4606,7 +4606,53 @@ describe('@stylexjs/babel-plugin', () => {
                 [
                   "--x-6bge3v",
                   {
-                    "ltr": "@property --x-6bge3v { syntax: "*";}",
+                    "ltr": "@property --x-6bge3v { syntax: "*"; inherits: true;}",
+                    "rtl": null,
+                  },
+                  0,
+                ],
+              ],
+            }
+          `);
+        });
+
+        test('dynamic style in "::after" generates valid @property with inherits', () => {
+          const { code, metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              repro: (color) => ({
+                '::after': {
+                  color,
+                },
+              }),
+            });
+          `);
+          expect(code).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            export const styles = {
+              repro: color => [{
+                kB1Fuz: color != null ? "x1p1099i" : color,
+                $$css: true
+              }, {
+                "--x-19erzii": color != null ? color : undefined
+              }]
+            };"
+          `);
+          expect(metadata).toMatchInlineSnapshot(`
+            {
+              "stylex": [
+                [
+                  "x1p1099i",
+                  {
+                    "ltr": ".x1p1099i::after{color:var(--x-19erzii)}",
+                    "rtl": null,
+                  },
+                  8000,
+                ],
+                [
+                  "--x-19erzii",
+                  {
+                    "ltr": "@property --x-19erzii { syntax: "*"; inherits: true;}",
                     "rtl": null,
                   },
                   0,

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
@@ -240,7 +240,7 @@ export default function transformStyleXCreate(
         const isPseudoElement = path.some((p) => p.startsWith('::'));
         injectedInheritStyles[variableName] = {
           priority: 0,
-          ltr: `@property ${variableName} { syntax: "*";${isPseudoElement ? '' : ' inherits: false;'}}`,
+          ltr: `@property ${variableName} { syntax: "*"; inherits: ${isPseudoElement ? 'true' : 'false'};}`,
           rtl: null,
         };
       });


### PR DESCRIPTION
## What changed / motivation ?

Fix runtime error `Invalid @ rule body` when using dynamic styles in pseudo elements, such as:

```jsx
const styles = stylex.create({
  repro: (var: string) => ({
    '::after': {
      color: var, // FAILS
    },
  }),
});
```

## Linked PR/Issues

Fixes https://github.com/facebook/stylex/issues/1396 

## Additional Context

Steps to reproduce

1. In this repository, use the examples/example-vite-react project.
2. Add the following style:
```jsx
const styles = stylex.create({
  repro: (color: string) => ({
    '::after': {
      color,
    },
  }),
});
```

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code