### PR TITLE
Fix/cli external modules watch

### DIFF
--- a/packages/@stylexjs/cli/__tests__/compile-stylex-folder-test.js
+++ b/packages/@stylexjs/cli/__tests__/compile-stylex-folder-test.js
@@ -14,7 +14,11 @@ import type { CliConfig, TransformConfig } from '../src/config';
 import { compileDirectory } from '../src/transform';
 import * as cacheModule from '../src/cache';
 import { getDefaultCachePath, findProjectRoot } from '../src/cache';
-import { copyNodeModules, clearInputModuleDir } from '../src/modules';
+import {
+  copyNodeModules,
+  clearInputModuleDir,
+  COMPILED_MODULES_DIR_NAME,
+} from '../src/modules';
 import * as modulesModule from '../src/modules';
 
 const fs = require('node:fs').promises;
@@ -605,7 +609,7 @@ describe('copyNodeModules preserves all configured modules', () => {
     const result = copyNodeModules(config);
     expect(result).toBe(true);
 
-    const compiledDir = path.join(inputDir, 'stylex_compiled_modules');
+    const compiledDir = path.join(inputDir, COMPILED_MODULES_DIR_NAME);
     expect(
       await fs
         .access(path.join(compiledDir, 'module-a'))
@@ -674,7 +678,7 @@ describe('copyNodeModules preserves all configured modules', () => {
     const result = copyNodeModules(config);
     expect(result).toBe(true);
 
-    const compiledDir = path.join(inputDir, 'stylex_compiled_modules');
+    const compiledDir = path.join(inputDir, COMPILED_MODULES_DIR_NAME);
     expect(
       await fs
         .access(path.join(compiledDir, 'module-a'))

--- a/packages/@stylexjs/cli/src/modules.js
+++ b/packages/@stylexjs/cli/src/modules.js
@@ -14,7 +14,7 @@ import fs from 'node:fs';
 import { createRequire } from 'module';
 import path from 'node:path';
 
-const COMPILED_MODULES_DIR_NAME = 'stylex_compiled_modules';
+export const COMPILED_MODULES_DIR_NAME = 'stylex_compiled_modules';
 
 export function copyNodeModules(config: TransformConfig): boolean {
   if (config.modules_EXPERIMENTAL === undefined) {

--- a/packages/@stylexjs/cli/src/plugins.js
+++ b/packages/@stylexjs/cli/src/plugins.js
@@ -10,7 +10,7 @@
 import type { ModuleType, TransformConfig } from './config';
 import type { NodePath } from '@babel/traverse';
 import { getRelativePath } from './files';
-import { findModuleDir } from './modules';
+import { findModuleDir, COMPILED_MODULES_DIR_NAME } from './modules';
 import * as t from '@babel/types';
 
 import * as nodePath from 'node:path';
@@ -100,7 +100,7 @@ export const createModuleImportModifierPlugin = (
                     )
                   : nodePath.join(
                       config.output,
-                      'stylex_compiled_modules',
+                      COMPILED_MODULES_DIR_NAME,
                       module,
                       source.split(module).pop() ?? '',
                     );

--- a/packages/@stylexjs/cli/src/watcher.js
+++ b/packages/@stylexjs/cli/src/watcher.js
@@ -9,7 +9,12 @@
 
 import type { ModuleType, TransformConfig } from './config';
 
-import { clearInputModuleDir, fetchModule, findModuleDir } from './modules';
+import {
+  clearInputModuleDir,
+  fetchModule,
+  findModuleDir,
+  COMPILED_MODULES_DIR_NAME,
+} from './modules';
 import { compileDirectory } from './transform';
 
 import ansis from 'ansis';
@@ -197,7 +202,7 @@ function subscribeInput(
   registerSubscription(client, watcher, relative_path, 'jsFileChanged');
 
   const isNotCompiledModule = (file: $ReadOnly<Object>) =>
-    !file.name.startsWith('stylex_compiled_modules');
+    !file.name.startsWith(COMPILED_MODULES_DIR_NAME);
 
   client.on('subscription', function (resp: OnEvent) {
     if (resp.subscription !== 'jsFileChanged') return;
@@ -231,7 +236,7 @@ function subscribeModule(
 
     fetchModule(moduleConfig, config);
 
-    const prefix = 'stylex_compiled_modules/' + moduleName + '/';
+    const prefix = COMPILED_MODULES_DIR_NAME + '/' + moduleName + '/';
 
     compileAndCleanup(
       config,


### PR DESCRIPTION
## What changed / motivation ?

The StyleX CLI had two issues related to `modules_EXPERIMENTAL` support:

### 1. Bug in `fetchModule`

`fetchModule` was calling `fs.rmSync` on the entire `stylex_compiled_modules` directory before copying each module.

When multiple external modules were configured, this caused destructive overwrite behavior:

- Each module copy deleted previously compiled modules.
- Only the last configured module remained in the output.

### 2. No watch mode support for external modules

The CLI’s `--watch` mode only tracked changes inside the input source directory.

Changes inside external modules (`modules_EXPERIMENTAL`) were **not detected**, requiring a manual restart to re-fetch and recompile them.


## Linked PR/Issues

Fixes #731

## Additional Context

Added tests in `compile-stylex-folder-test.js` to verify that `copyNodeModules` correctly preserves:

- Multiple configured modules
- A single module
- The empty-module case

No breaking changes — the fix and added functionality are additive and only affect `modules_EXPERIMENTAL` behavior.

## Pre-flight checklist

- [x] I have read the contributing guidelines  
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code