### PR TITLE
RFC: `stylex.namedVar` for ergonomic custom property names in `defineVars`

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-defineVars-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-defineVars-test.js
@@ -223,5 +223,62 @@ describe('@stylexjs/babel-plugin', () => {
         `);
       }).not.toThrow();
     });
+
+    test('invalid namedVar: missing leading "--"', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          export const vars = stylex.defineVars({
+            background: stylex.namedVar('surface-bg', 'black'),
+          });
+        `);
+      }).toThrow('Expected a CSS custom property name starting with "--"');
+    });
+
+    test('invalid namedVar: invalid custom property syntax', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          export const vars = stylex.defineVars({
+            background: stylex.namedVar('--surface bg', 'black'),
+          });
+        `);
+      }).toThrow('is not a valid CSS custom property name');
+    });
+
+    test('invalid namedVar: dynamic name', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          export const vars = stylex.defineVars({
+            background: stylex.namedVar(getName(), 'black'),
+          });
+        `);
+      }).toThrow(messages.namedVarNameMustBeStatic());
+    });
+
+    test('invalid namedVar: duplicate custom property names', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          export const vars = stylex.defineVars({
+            background: stylex.namedVar('--surface-bg', 'black'),
+            accent: stylex.namedVar('--surface-bg', 'blue'),
+          });
+        `);
+      }).toThrow('Duplicate custom property name "--surface-bg"');
+    });
+
+    test('invalid namedVar: collides with literal -- key', () => {
+      expect(() => {
+        transform(`
+          import * as stylex from '@stylexjs/stylex';
+          export const vars = stylex.defineVars({
+            '--surface-bg': 'black',
+            accent: stylex.namedVar('--surface-bg', 'blue'),
+          });
+        `);
+      }).toThrow('Duplicate custom property name "--surface-bg"');
+    });
   });
 });

--- a/packages/@stylexjs/babel-plugin/src/shared/index.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/index.js
@@ -34,6 +34,7 @@ import styleXCreateTheme from './stylex-create-theme';
 import stylexKeyframes from './stylex-keyframes';
 import stylexPositionTry from './stylex-position-try';
 import stylexFirstThatWorks from './stylex-first-that-works';
+import stylexNamedVar from './stylex-named-var';
 import hash from './hash';
 import genFileBasedIdentifier from './utils/file-based-identifier';
 import * as m from './messages';
@@ -50,6 +51,7 @@ export const create: typeof styleXCreateSet = styleXCreateSet;
 export const defineVars: typeof styleXDefineVars = styleXDefineVars;
 export const defineConsts: typeof styleXDefineConsts = styleXDefineConsts;
 export const createTheme: typeof styleXCreateTheme = styleXCreateTheme;
+export const namedVar: typeof stylexNamedVar = stylexNamedVar;
 export const keyframes: typeof stylexKeyframes = stylexKeyframes;
 export const positionTry: typeof stylexPositionTry = stylexPositionTry;
 export const utils: {

--- a/packages/@stylexjs/babel-plugin/src/shared/messages.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/messages.js
@@ -24,6 +24,26 @@ export const unboundCallValue = (fn: string): string =>
   `${fn}() calls must be bound to a bare variable.`;
 export const cannotGenerateHash = (fn: string): string =>
   `Unable to generate hash for ${fn}(). Check that the file has a valid extension and that unstable_moduleResolution is configured.`;
+export const namedVarIllegalArgumentLength = (): string =>
+  'namedVar() should have 2 arguments.';
+export const namedVarNameMustBeStatic = (): string =>
+  'namedVar() name must be a static string literal.';
+export const namedVarNameMustStartWithDashes = (
+  key: string,
+  name: string,
+): string =>
+  `Invalid namedVar() name for "${key}". Expected a CSS custom property name starting with "--", but received "${name}".`;
+export const namedVarInvalidCustomPropertyName = (
+  key: string,
+  name: string,
+): string =>
+  `Invalid namedVar() name for "${key}". "${name}" is not a valid CSS custom property name.`;
+export const duplicateCustomPropertyName = (
+  customPropertyName: string,
+  keyA: string,
+  keyB: string,
+): string =>
+  `Duplicate custom property name "${customPropertyName}" for defineVars() keys "${keyA}" and "${keyB}". Choose a unique custom property name for each key.`;
 
 export const DUPLICATE_CONDITIONAL =
   'The same pseudo selector or at-rule cannot be used more than once.';

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-define-vars.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-define-vars.js
@@ -8,12 +8,15 @@
  */
 
 import type { InjectableStyle, StyleXOptions } from './common-types';
-import type { VarsConfig, VarsConfigValue } from './stylex-vars-utils';
+import type { VarsConfig, ResolvedVarsConfigValue } from './stylex-vars-utils';
+import type { NamedVarSpec } from './stylex-named-var';
 import { type CSSType, isCSSType } from './types';
 
 import createHash from './hash';
+import * as messages from './messages';
 import { objMap } from './utils/object-utils';
 import { defaultOptions } from './utils/default-options';
+import { isNamedVarSpec, isValidCustomPropertyName } from './stylex-named-var';
 import {
   collectVarsByAtRule,
   getDefaultValue,
@@ -49,28 +52,62 @@ export default function styleXDefineVars<Vars: VarsConfig>(
       syntax: string,
     }>,
   } = {};
+  const customPropertyKeysByName: Map<string, string> = new Map();
 
   const variablesMap: {
-    +[string]: { +nameHash: string, +value: VarsConfigValue },
+    +[string]: { +nameHash: string, +value: ResolvedVarsConfigValue },
   } = objMap(variables, (value, key) => {
+    let resolvedValue: any = value;
+    let explicitCustomPropertyName: null | string = null;
+    if (isNamedVarSpec(value)) {
+      const namedVarSpec: NamedVarSpec<mixed> = value as any;
+      const customPropertyName = namedVarSpec.name;
+      if (!customPropertyName.startsWith('--')) {
+        throw new Error(
+          messages.namedVarNameMustStartWithDashes(key, customPropertyName),
+        );
+      }
+      if (!isValidCustomPropertyName(customPropertyName)) {
+        throw new Error(
+          messages.namedVarInvalidCustomPropertyName(key, customPropertyName),
+        );
+      }
+      explicitCustomPropertyName = customPropertyName;
+      resolvedValue = namedVarSpec.value;
+    }
+
     const varSafeKey = (
       key[0] >= '0' && key[0] <= '9' ? `_${key}` : key
     ).replace(/[^a-zA-Z0-9]/g, '_');
-    const nameHash = key.startsWith('--')
-      ? key.slice(2)
-      : debug && enableDebugClassNames
-        ? varSafeKey + '-' + classNamePrefix + createHash(`${exportId}.${key}`)
-        : classNamePrefix + createHash(`${exportId}.${key}`);
+    const nameHash =
+      explicitCustomPropertyName != null
+        ? explicitCustomPropertyName.slice(2)
+        : key.startsWith('--')
+          ? key.slice(2)
+          : debug && enableDebugClassNames
+            ? varSafeKey +
+              '-' +
+              classNamePrefix +
+              createHash(`${exportId}.${key}`)
+            : classNamePrefix + createHash(`${exportId}.${key}`);
 
-    if (isCSSType(value)) {
-      const v: CSSType<> = value;
+    const existingKey = customPropertyKeysByName.get(nameHash);
+    if (existingKey != null && existingKey !== key) {
+      throw new Error(
+        messages.duplicateCustomPropertyName(`--${nameHash}`, existingKey, key),
+      );
+    }
+    customPropertyKeysByName.set(nameHash, key);
+
+    if (isCSSType(resolvedValue)) {
+      const v: CSSType<> = resolvedValue;
       typedVariables[nameHash] = {
         initialValue: getDefaultValue(v.value),
         syntax: v.syntax,
       };
       return { nameHash, value: v.value };
     }
-    return { nameHash, value: value as $FlowFixMe };
+    return { nameHash, value: resolvedValue as $FlowFixMe };
   });
 
   const themeVariablesObject = objMap(
@@ -102,7 +139,9 @@ export default function styleXDefineVars<Vars: VarsConfig>(
 }
 
 function constructCssVariablesString(
-  variables: { +[string]: { +nameHash: string, +value: VarsConfigValue } },
+  variables: {
+    +[string]: { +nameHash: string, +value: ResolvedVarsConfigValue },
+  },
   varGroupHash: string,
 ): { [string]: InjectableStyle } {
   const rulesByAtRule: { [string]: Array<string> } = {};

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-named-var.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-named-var.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+export declare const NAMED_VAR_SENTINEL = '__stylexNamedVar';
+
+export type NamedVarSpec<T> = Readonly<{
+  __stylexNamedVar: true;
+  name: string;
+  value: T;
+}>;
+
+export declare function isNamedVarSpec(
+  value: unknown,
+): value is NamedVarSpec<unknown>;
+export declare function isValidCustomPropertyName(name: string): boolean;
+declare function stylexNamedVar<T>(name: string, value: T): NamedVarSpec<T>;
+export default stylexNamedVar;

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-named-var.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-named-var.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+export const NAMED_VAR_SENTINEL = '__stylexNamedVar';
+
+export type NamedVarSpec<+T> = $ReadOnly<{
+  +__stylexNamedVar: true,
+  +name: string,
+  +value: T,
+}>;
+
+// Enforce simple dashed identifier syntax for custom properties.
+// We intentionally require the leading "--" to keep the API explicit.
+const CUSTOM_PROPERTY_NAME_REGEX = /^--[A-Za-z_][A-Za-z0-9_-]*$/;
+
+export function isNamedVarSpec(value: mixed): boolean {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const candidate: any = value;
+  return (
+    candidate[NAMED_VAR_SENTINEL] === true &&
+    typeof candidate.name === 'string' &&
+    'value' in candidate
+  );
+}
+
+export function isValidCustomPropertyName(name: string): boolean {
+  return CUSTOM_PROPERTY_NAME_REGEX.test(name);
+}
+
+export default function stylexNamedVar<T>(
+  name: string,
+  value: T,
+): NamedVarSpec<T> {
+  return {
+    [NAMED_VAR_SENTINEL]: true,
+    name,
+    value,
+  };
+}

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-vars-utils.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-vars-utils.js
@@ -8,10 +8,30 @@
  */
 
 import type { CSSType } from './types';
+import type { NamedVarSpec } from './stylex-named-var';
+
+type VarsConfigPrimitive = string | number;
+
+export interface VarsConfigConditional {
+  +default: VarsConfigValue;
+  +[string]: VarsConfigValue;
+}
+
+export type VarsConfigNamedVarValue =
+  | VarsConfigPrimitive
+  | VarsConfigConditional;
 
 export type VarsConfigValue =
-  | string
-  | $ReadOnly<{ default: VarsConfigValue, [string]: VarsConfigValue }>;
+  | VarsConfigPrimitive
+  | NamedVarSpec<VarsConfigNamedVarValue>
+  | VarsConfigConditional;
+
+export type ResolvedVarsConfigValue =
+  | VarsConfigPrimitive
+  | $ReadOnly<{
+      default: ResolvedVarsConfigValue,
+      [string]: ResolvedVarsConfigValue,
+    }>;
 
 export type VarsConfig = $ReadOnly<{
   [string]: VarsConfigValue | CSSType<>,
@@ -21,7 +41,13 @@ const SPLIT_TOKEN = '__$$__';
 
 export function collectVarsByAtRule(
   key: string,
-  { nameHash, value }: { +nameHash: string, +value: VarsConfigValue },
+  {
+    nameHash,
+    value,
+  }: {
+    +nameHash: string,
+    +value: ResolvedVarsConfigValue,
+  },
   collection: { [string]: Array<string> } = {},
   atRules: Array<string> = [],
 ): void {
@@ -69,7 +95,7 @@ export function priorityForAtRule(atRule: string): number {
   return 1 + atRule.split(SPLIT_TOKEN).length;
 }
 
-export function getDefaultValue(value: VarsConfigValue): ?string {
+export function getDefaultValue(value: ResolvedVarsConfigValue): ?string {
   if (typeof value === 'string' || typeof value === 'number') {
     return value.toString();
   }

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -158,6 +158,7 @@ export default class StateManager {
   +stylexKeyframesImport: Set<string> = new Set();
   +stylexPositionTryImport: Set<string> = new Set();
   +stylexDefineVarsImport: Set<string> = new Set();
+  +stylexNamedVarImport: Set<string> = new Set();
   +stylexDefineMarkerImport: Set<string> = new Set();
   +stylexDefineConstsImport: Set<string> = new Set();
   +stylexCreateThemeImport: Set<string> = new Set();

--- a/packages/@stylexjs/babel-plugin/src/visitors/imports.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/imports.js
@@ -79,6 +79,9 @@ export function readImportDeclarations(
             if (importedName === 'defineVars') {
               state.stylexDefineVarsImport.add(localName);
             }
+            if (importedName === 'namedVar') {
+              state.stylexNamedVarImport.add(localName);
+            }
             if (importedName === 'defineMarker') {
               state.stylexDefineMarkerImport.add(localName);
             }
@@ -160,6 +163,9 @@ export function readRequires(
           }
           if (prop.key.name === 'defineVars') {
             state.stylexDefineVarsImport.add(value.name);
+          }
+          if (prop.key.name === 'namedVar') {
+            state.stylexNamedVarImport.add(value.name);
           }
           if (prop.key.name === 'defineMarker') {
             state.stylexDefineMarkerImport.add(value.name);

--- a/packages/@stylexjs/stylex/__tests__/stylex-test.js
+++ b/packages/@stylexjs/stylex/__tests__/stylex-test.js
@@ -18,6 +18,7 @@ describe('stylex', () => {
       'createTheme',
       'defineConsts',
       'defineVars',
+      'namedVar',
       'firstThatWorks',
       'keyframes',
       'positionTry',

--- a/packages/@stylexjs/stylex/src/stylex.js
+++ b/packages/@stylexjs/stylex/src/stylex.js
@@ -19,6 +19,7 @@ import type {
   StyleX$Create,
   StyleX$CreateTheme,
   StyleX$DefineVars,
+  StyleX$NamedVar,
   StyleX$DefineConsts,
   StyleXArray,
   StyleXClassNameFor,
@@ -82,6 +83,13 @@ export const defineVars: StyleX$DefineVars = function stylexDefineVars(
   _styles: $FlowFixMe,
 ) {
   throw errorForFn('defineVars');
+};
+
+export const namedVar: StyleX$NamedVar = function stylexNamedVar(
+  _name: string,
+  _value: $FlowFixMe,
+) {
+  throw errorForFn('namedVar');
 };
 
 export const defineMarker: StyleX$DefineMarker = () => {
@@ -232,6 +240,7 @@ type IStyleX = {
   createTheme: StyleX$CreateTheme,
   defineConsts: StyleX$DefineConsts,
   defineVars: StyleX$DefineVars,
+  namedVar: StyleX$NamedVar,
   defaultMarker: () => MapNamespace<
     $ReadOnly<{
       marker: 'default-marker',
@@ -274,6 +283,7 @@ _legacyMerge.createTheme = createTheme;
 _legacyMerge.defineConsts = defineConsts;
 _legacyMerge.defineMarker = defineMarker;
 _legacyMerge.defineVars = defineVars;
+_legacyMerge.namedVar = namedVar;
 _legacyMerge.defaultMarker = defaultMarker;
 _legacyMerge.firstThatWorks = firstThatWorks;
 _legacyMerge.keyframes = keyframes;

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
@@ -251,17 +251,27 @@ export type TokensFromVarGroup<T extends VarGroup<{}>> = T['__tokens'];
 export type IDFromVarGroup<T extends VarGroup<{}>> = T['__opaqueId'];
 
 type TTokens = Readonly<{
-  [key: string]:
-    | NestedVarObject<null | string | number>
-    | StyleXVar<null | string | number>
-    | CSSType<null | string | number>;
+  [key: string]: TTokenValue | NamedVarSpec<TTokenValue>;
 }>;
 
 type UnwrapVars<T> = T extends StyleXVar<infer U> ? U : T;
+export type NamedVarSpec<T> = Readonly<{
+  __stylexNamedVar: true;
+  name: string;
+  value: T;
+}>;
+type TTokenValue =
+  | NestedVarObject<null | string | number>
+  | StyleXVar<null | string | number>
+  | CSSType<null | string | number>;
+type FlattenTokenValue<T> =
+  T extends NamedVarSpec<infer V>
+    ? FlattenTokenValue<V>
+    : T extends { [key: string]: infer X }
+      ? UnwrapVars<X>
+      : UnwrapVars<T>;
 export type FlattenTokens<T extends TTokens> = Readonly<{
-  [Key in keyof T]: T[Key] extends { [key: string]: infer X }
-    ? UnwrapVars<X>
-    : UnwrapVars<T[Key]>;
+  [Key in keyof T]: FlattenTokenValue<T[Key]>;
 }>;
 
 type NestedVarObject<T> =
@@ -285,6 +295,10 @@ export type StyleX$DefineVars = <
 >(
   tokens: DefaultTokens,
 ) => VarGroup<FlattenTokens<DefaultTokens>, ID>;
+export type StyleX$NamedVar = <T extends TTokenValue>(
+  name: string,
+  value: T,
+) => NamedVarSpec<T>;
 
 declare class ThemeKey<out VG extends VarGroup<{}>> extends String {
   private varGroup: VG;

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.js
@@ -205,25 +205,43 @@ type NestedVarObject<+T> =
       [string]: NestedVarObject<T>,
     }>;
 
+export type NamedVarSpec<+T> = $ReadOnly<{
+  +__stylexNamedVar: true,
+  +name: string,
+  +value: T,
+}>;
+
+type TTokenValue =
+  | NestedVarObject<null | string | number>
+  | StyleXVar<null | string | number>
+  | CSSType<null | string | number>;
+
 type TTokens = $ReadOnly<{
-  [string]:
-    | NestedVarObject<null | string | number>
-    | StyleXVar<null | string | number>
-    | CSSType<null | string | number>,
+  [string]: TTokenValue | NamedVarSpec<TTokenValue>,
 }>;
 
 type UnwrapVar<+T> = T extends StyleXVar<infer U> ? U : T;
+type FlattenTokenValue<+T> =
+  T extends NamedVarSpec<infer Value>
+    ? FlattenTokenValue<Value>
+    : T extends CSSType<string | number>
+      ? UnwrapVar<T>
+      : T extends { +default: infer X, +[string]: infer Y }
+        ? UnwrapVar<X | Y>
+        : UnwrapVar<T>;
+
 export type FlattenTokens<+T: TTokens> = {
-  +[Key in keyof T]: T[Key] extends CSSType<string | number>
-    ? UnwrapVar<T[Key]>
-    : T[Key] extends { +default: infer X, +[string]: infer Y }
-      ? UnwrapVar<X | Y>
-      : UnwrapVar<T[Key]>,
+  +[Key in keyof T]: FlattenTokenValue<T[Key]>,
 };
 
 export type StyleX$DefineVars = <DefaultTokens: TTokens, ID: string = string>(
   tokens: DefaultTokens,
 ) => VarGroup<FlattenTokens<DefaultTokens>, ID>;
+
+export type StyleX$NamedVar = <T: TTokenValue>(
+  name: string,
+  value: T,
+) => NamedVarSpec<T>;
 
 export type StyleX$DefineConsts = <
   const DefaultTokens: { +[string]: number | string },

--- a/packages/docs/content/docs/api/javascript/defineVars.mdx
+++ b/packages/docs/content/docs/api/javascript/defineVars.mdx
@@ -16,6 +16,25 @@ variables with custom names use a key that starts with `--`. These will generate
 CSS custom properties with the provided name instead of generating a globally
 unique name.
 
+If you want to keep dot-notation ergonomics while assigning a custom CSS custom
+property name, use `stylex.namedVar('--name', value)`:
+
+```tsx title="vars.stylex.js"
+import * as stylex from '@stylexjs/stylex';
+
+export const colors = stylex.defineVars({
+  background: stylex.namedVar('--surface-background', 'black'),
+  accent: stylex.namedVar('--brand-accent', {
+    default: 'blue',
+    '@media (prefers-color-scheme: dark)': 'lightblue',
+  }),
+});
+```
+
+`namedVar()` requires a static string that starts with `--` and matches valid
+CSS custom property naming rules. Invalid names, non-static names, or duplicate
+custom property names fail compilation.
+
 ### Example use:
 
 You must define your variables as named exports in a `.stylex.js` (or

--- a/packages/docs/src/components/Playground/index.tsx
+++ b/packages/docs/src/components/Playground/index.tsx
@@ -41,9 +41,10 @@ import {
 import * as stylexPluginModule from '@stylexjs/babel-plugin';
 import { vars, playgroundVars } from '@/theming/vars.stylex';
 import { ChevronDown } from 'lucide-react';
-const stylexPlugin: typeof import('@stylexjs/babel-plugin').default =
+const stylexPluginDefaultExportKey = 'default';
+const stylexPlugin: any =
   // @ts-ignore - handle CJS default export
-  stylexPluginModule.default ?? stylexPluginModule;
+  stylexPluginModule[stylexPluginDefaultExportKey] ?? stylexPluginModule;
 
 declare const STYLEX_TYPES: Record<string, string>;
 declare const REACT_TYPES: string;


### PR DESCRIPTION
RFC: `stylex.namedVar` for ergonomic custom property names in `defineVars`

### Summary
This RFC introduces a new compile-time helper:

```ts
stylex.namedVar(name: string, value: DefineVarValue)
```

It lets developers keep ergonomic dot-notation keys in `defineVars` while explicitly choosing the emitted CSS custom property name.

Example:

```ts
export const vars = stylex.defineVars({
  surfaceBg: stylex.namedVar('--surface-bg', 'black'),
  textPrimary: stylex.namedVar('--text-primary', 'white'),
});
```

This preserves usage ergonomics (`vars.surfaceBg`) and emits explicit custom property names (`--surface-bg`, `--text-primary`).

### Motivation
Current `defineVars` patterns force a tradeoff:

1. Hash-based var names are ergonomic but not explicit.
2. Legacy explicit custom names via `'--foo'` keys are explicit but less ergonomic for dot-notation authoring.

We want both explicit naming and ergonomic authoring, with hard-fail diagnostics when misconfigured.

### Goals
1. Keep dot-notation variable references ergonomic.
2. Allow explicit custom property names in `defineVars`.
3. Fail loudly and actionably on invalid declarations.
4. Preserve cross-file correctness for imported theme references.
5. Keep legacy `'--foo'` behavior fully supported.

### Non-goals
1. No runtime execution semantics for `namedVar`.
2. No auto-prefixing missing `--`.
3. No relaxation of static-analysis constraints.

---

## API Design

### New API
```ts
stylex.namedVar(name, value)
```

`name` must be:

1. A static string literal at compile time.
2. Prefixed with `--` (mandatory).
3. A valid CSS custom property name under strict validation.

`value` supports existing `defineVars` value shapes, including conditional objects and typed values.

### Validation contract (hard-fail)
Compilation fails with actionable errors when:

1. `name` is missing the `--` prefix.
2. `name` is dynamic/non-static.
3. `name` violates syntax validation (`/^--[A-Za-z_][A-Za-z0-9_-]*$/`).
4. Multiple declarations resolve to the same custom property name.
5. `namedVar` collides with legacy `'--foo'` declarations.

### Runtime behavior
`stylex.namedVar` is compile-time-only. If uncompiled code reaches runtime, it throws a clear error instructing users to ensure StyleX compilation is correctly configured.

---

## Detailed Behavior

### Transform semantics
1. If a `defineVars` value uses `stylex.namedVar('--x', value)`, `--x` is used as the emitted property name instead of hash generation.
2. The wrapped `value` is unwrapped and processed through existing logic, including conditional and typed variable handling.
3. Mixed declarations are supported: regular hashed variables and explicitly named variables can coexist in the same object.

### Cross-file theme reference semantics
Imported `defineVars` references preserve explicit names from both:

1. `stylex.namedVar('--x', value)`, and
2. legacy `'--x': value` keys.

If imported declarations are invalid, compilation fails deterministically with cause-preserving diagnostics.

---

## Diagnostics
This RFC adds specific error modes for `defineVars` + `namedVar`:

1. Missing required `--` prefix.
2. Invalid custom property syntax.
3. Dynamic/non-static name argument.
4. Duplicate custom property name collisions.
5. Invalid `namedVar` call shape (argument count, etc.).

All failures are hard errors with code-frame context and remediation guidance.

---

## Backward Compatibility
1. Existing `defineVars` usage remains valid.
2. Existing legacy explicit custom property keys (`'--foo'`) remain valid.
3. This change is additive for valid programs and stricter for invalid ones.

---

## Alternatives Considered

### 1) Auto-prefix missing `--`
Rejected. Auto-prefixing hides mistakes and reduces predictability. Mandatory prefixing creates explicit intent and better diagnostics.

### 2) Object wrapper syntax
Example: `{ name: '--surface-bg', value: 'black' }`.
Rejected due to weaker ergonomics, easier accidental misuse, and less clear compile-time intent than a dedicated helper call.

### 3) Keep only legacy `'--foo'` keys
Rejected because it does not preserve ergonomic dot-notation authoring patterns.

---

## Test Plan
1. Transform tests validate explicit-name emission, conditional values, typed values, and mixed named/hashed usage.
2. Validation tests cover missing prefix, invalid syntax, dynamic names, and duplicate/collision errors.
3. Evaluate-path tests verify imported refs resolve explicit names and invalid imported declarations fail deterministically.
4. Runtime API tests verify the uncompiled runtime stub throws with actionable guidance.
