### PR TITLE
[eslint-plugin] fix WebkitAppearance to accept all valid appearance values

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -392,6 +392,13 @@ eslintTester.run('stylex-valid-styles', rule.default, {
          paddingInlineEnd: Math.round(x / 2),
        },
      })`,
+    // test for WebkitAppearance with 'none'
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
+       default: {
+         'WebkitAppearance': 'none',
+       },
+     })`,
     // test for Search
     `import * as stylex from '@stylexjs/stylex';
      stylex.create({

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -1491,7 +1491,7 @@ const maskImage: RuleCheck = maskReference;
 const SupportedVendorSpecificCSSProperties = {
   MozOsxFontSmoothing: makeLiteralRule('grayscale') as RuleCheck,
   WebkitFontSmoothing: makeLiteralRule('antialiased') as RuleCheck,
-  WebkitAppearance: makeLiteralRule('textfield') as RuleCheck,
+  WebkitAppearance: appearance,
   WebkitTapHighlightColor: color,
   WebkitOverflowScrolling: makeLiteralRule('touch') as RuleCheck,
 


### PR DESCRIPTION
## What changed / motivation ?

WebkitAppearance was restricted to only 'textfield' while the standard appearance property accepts 'auto', 'none', and 'textfield'. Reuse the existing appearance rule so the vendor-prefixed variant allows the same values.

Seen like a copy-paste?

## Linked PR/Issues

n/a

## Additional Context

n/a

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code