### PR TITLE
[unplugin] Stop assigning to bundle object in unplugin generateBundle hook

### DIFF
--- a/packages/@stylexjs/unplugin/src/core.js
+++ b/packages/@stylexjs/unplugin/src/core.js
@@ -109,16 +109,7 @@ export function replaceCssAssetWithHashedCopy(ctx, bundle, asset, nextSource) {
     return;
   }
   replaceBundleReferences(bundle, oldFileName, nextFileName);
-  const emitted = bundle[nextFileName];
-  if (emitted && emitted !== asset) {
-    delete bundle[nextFileName];
-  }
-  asset.fileName = nextFileName;
-  asset.source = nextSource;
-  if (bundle[oldFileName] === asset) {
-    delete bundle[oldFileName];
-  }
-  bundle[nextFileName] = asset;
+  delete bundle[oldFileName];
 }
 
 function readJSON(file) {


### PR DESCRIPTION
## What changed / motivation ?

Vite build warns due to a stylex unplugin and vite incompatibility.

`[plugin @stylexjs/unplugin] Error: This plugin assigns to bundle variable. This is discouraged by Rollup and is not supported by Rolldown. This will be ignored.`

The `replaceCssAssetWithHashedCopy` function was directly assigning to the Rollup `bundle` object (`bundle[key] = asset`), which is [discouraged](https://rollupjs.org/plugin-development/#generatebundle) by Rollup and unsupported by Rolldown. This also caused stale content hashes in CSS filenames since the hash was computed before StyleX CSS was appended.

The function already calls `this.emitFile()` which properly adds the new asset to the bundle with a correctly-hashed filename. Remove the redundant manual bundle manipulation and rely solely on `emitFile` for adding entries and `delete bundle[key]` for removing the old asset, both of which are supported by the Rollup plugin API.

Chatted with @sapphi-red and he pointed me in the right direction.

## Linked PR/Issues

Fixes #1387

## Additional Context

<img width="1454" height="534" alt="CleanShot 2026-03-03 at 21 49 09@2x" src="https://github.com/user-attachments/assets/7c9f5655-6b82-4ad0-bf12-ace870af130f" />

See https://rollupjs.org/plugin-development/#generatebundle


## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code