### PR TITLE
0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.18.1 (Mar 5, 2026)
+- Add simple `sx={}` JSX prop syntax as an alternative to `stylex.props`.
+- Fix `unplugin` `generateBundle` hook to use `emitFile` instead of direct bundle assignment.
+
 ## 0.18.0 (Mar 3, 2026)
 - Add `stylex.env` API for compile-time constants and shareable design tokens.
 - New `create-stylex-app` CLI for scaffolding projects with `npx create-stylex-app`.

--- a/examples/example-bun/package.json
+++ b/examples/example-bun/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-bun",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Example: StyleX with Bun via @stylexjs/unplugin",
   "main": "src/App.jsx",
   "scripts": {
@@ -12,13 +12,13 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.18.0",
+    "@stylexjs/stylex": "0.18.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.18.0",
-    "@stylexjs/eslint-plugin": "0.18.0",
+    "@stylexjs/unplugin": "0.18.1",
+    "@stylexjs/eslint-plugin": "0.18.1",
     "eslint": "^8.57.1"
   }
 }

--- a/examples/example-cli/package.json
+++ b/examples/example-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-cli",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "scripts": {
     "example:build": "stylex --config .stylex.json5"
   },
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.25.7",
     "@babel/preset-typescript": "^7.25.7",
-    "@stylexjs/cli": "0.18.0",
+    "@stylexjs/cli": "0.18.1",
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.3",
     "typescript": "^5.9.3"

--- a/examples/example-esbuild/package.json
+++ b/examples/example-esbuild/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-esbuild",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Simple esbuild example for @stylexjs/unplugin",
   "main": "src/App.jsx",
   "scripts": {
@@ -10,13 +10,13 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.18.0",
+    "@stylexjs/stylex": "0.18.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.18.0",
-    "@stylexjs/eslint-plugin": "0.18.0",
+    "@stylexjs/unplugin": "0.18.1",
+    "@stylexjs/eslint-plugin": "0.18.1",
     "esbuild": "^0.27.0",
     "eslint": "^8.57.1"
   }

--- a/examples/example-nextjs/package.json
+++ b/examples/example-nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-nextjs",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "scripts": {
     "clean": "shx rm -rf .next",
     "example:build": "next build",
@@ -10,15 +10,15 @@
     "example:start": "next start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.18.0",
+    "@stylexjs/stylex": "0.18.1",
     "next": "^16.0.7",
     "react": "^19.0.0-rc-de68d2f4-20241204",
     "react-dom": "^19.0.0-rc-de68d2f4-20241204"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",
-    "@stylexjs/eslint-plugin": "0.18.0",
-    "@stylexjs/postcss-plugin": "0.18.0",
+    "@stylexjs/eslint-plugin": "0.18.1",
+    "@stylexjs/postcss-plugin": "0.18.1",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^22.7.6",
     "@types/react": "^18.3.0",

--- a/examples/example-react-router/package.json
+++ b/examples/example-react-router/package.json
@@ -9,8 +9,8 @@
     "example:typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.18.0",
-    "@stylexjs/shared-ui": "0.18.0",
+    "@stylexjs/stylex": "0.18.1",
+    "@stylexjs/shared-ui": "0.18.1",
     "@remix-run/node-fetch-server": "0.12.0",
     "compression": "^1.8.0",
     "express": "^5.1.0",
@@ -19,7 +19,7 @@
     "react-router": "7.9.6"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.18.0",
+    "@stylexjs/unplugin": "0.18.1",
     "@types/compression": "^1.8.1",
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.3",
@@ -31,5 +31,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.2.4"
   },
-  "version": "0.18.0"
+  "version": "0.18.1"
 }

--- a/examples/example-redwoodsdk/package.json
+++ b/examples/example-redwoodsdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redwoodjs/starter",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A bare-bones RedwoodSDK starter",
   "main": "index.js",
   "type": "module",
@@ -22,16 +22,16 @@
     "types": "tsc"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.18.0",
+    "@stylexjs/stylex": "0.18.1",
     "capnweb": "~0.2.0",
     "react": "19.3.0-canary-561ee24d-20251101",
     "react-dom": "19.3.0-canary-561ee24d-20251101",
     "react-server-dom-webpack": "19.3.0-canary-561ee24d-20251101",
     "rwsdk": "1.0.0-beta.31",
-    "@stylexjs/shared-ui": "0.18.0"
+    "@stylexjs/shared-ui": "0.18.1"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.18.0",
+    "@stylexjs/unplugin": "0.18.1",
     "@cloudflare/vite-plugin": "^1.15.2",
     "@cloudflare/workers-types": "^4.20260120.0",
     "@types/node": "^24.10.1",

--- a/examples/example-rollup/package.json
+++ b/examples/example-rollup/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-rollup",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A simple rollup example to test stylexjs/rollup-plugin",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.18.0",
+    "@stylexjs/stylex": "0.18.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },
@@ -24,7 +24,7 @@
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.7",
-    "@stylexjs/rollup-plugin": "0.18.0",
+    "@stylexjs/rollup-plugin": "0.18.1",
     "rollup": "^4.59.0",
     "serve": "^14.2.4"
   }

--- a/examples/example-rspack/package.json
+++ b/examples/example-rspack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-rspack",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Example: StyleX with Rspack via @stylexjs/unplugin",
   "scripts": {
     "example:build": "rspack build --config ./rspack.config.js",
@@ -10,12 +10,12 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.18.0"
+    "@stylexjs/stylex": "0.18.1"
   },
   "devDependencies": {
     "@rspack/cli": "^1.6.4",
     "@rspack/core": "^1.6.4",
     "css-loader": "^7.1.2",
-    "@stylexjs/unplugin": "0.18.0"
+    "@stylexjs/unplugin": "0.18.1"
   }
 }

--- a/examples/example-storybook/package.json
+++ b/examples/example-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-storybook",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "scripts": {
     "example:dev": "storybook dev -p 6006 --no-open",
     "storybook": "storybook dev -p 6006 --no-open",
@@ -16,10 +16,10 @@
     "@storybook/addon-links": "^9.1.7",
     "@storybook/addon-vitest": "^9.1.7",
     "@storybook/react-vite": "^9.1.7",
-    "@stylexjs/babel-plugin": "0.18.0",
-    "@stylexjs/eslint-plugin": "0.18.0",
-    "@stylexjs/postcss-plugin": "0.18.0",
-    "@stylexjs/stylex": "0.18.0",
+    "@stylexjs/babel-plugin": "0.18.1",
+    "@stylexjs/eslint-plugin": "0.18.1",
+    "@stylexjs/postcss-plugin": "0.18.1",
+    "@stylexjs/stylex": "0.18.1",
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.44.0",
     "@vitejs/plugin-react": "^5.0.3",

--- a/examples/example-vite-react/package.json
+++ b/examples/example-vite-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vite-react",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "scripts": {
     "example:dev": "vite",
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.18.0",
-    "@stylexjs/shared-ui": "0.18.0"
+    "@stylexjs/stylex": "0.18.1",
+    "@stylexjs/shared-ui": "0.18.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
@@ -21,7 +21,7 @@
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.0.4",
-    "@stylexjs/unplugin": "0.18.0",
+    "@stylexjs/unplugin": "0.18.1",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/examples/example-vite-rsc/package.json
+++ b/examples/example-vite-rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitejs/plugin-rsc-examples-starter",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "license": "MIT",
   "type": "module",
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.18.0",
-    "@stylexjs/shared-ui": "0.18.0"
+    "@stylexjs/stylex": "0.18.1",
+    "@stylexjs/shared-ui": "0.18.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.6",
@@ -22,6 +22,6 @@
     "@vitejs/plugin-rsc": "latest",
     "rsc-html-stream": "^0.0.7",
     "vite": "^7.1.12",
-    "@stylexjs/unplugin": "0.18.0"
+    "@stylexjs/unplugin": "0.18.1"
   }
 }

--- a/examples/example-vite/package.json
+++ b/examples/example-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vite",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Example: StyleX with Vite via @stylexjs/unplugin",
   "scripts": {
     "example:dev": "vite",
@@ -11,12 +11,12 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@stylexjs/stylex": "0.18.0",
-    "@stylexjs/shared-ui": "0.18.0"
+    "@stylexjs/stylex": "0.18.1",
+    "@stylexjs/shared-ui": "0.18.1"
   },
   "devDependencies": {
     "vite": "^7.2.4",
-    "@stylexjs/unplugin": "0.18.0",
+    "@stylexjs/unplugin": "0.18.1",
     "@vitejs/plugin-react": "latest"
   }
 }

--- a/examples/example-waku/package.json
+++ b/examples/example-waku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-waku",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "private": true,
   "scripts": {
@@ -9,15 +9,15 @@
     "example:serve": "waku start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.18.0",
+    "@stylexjs/stylex": "0.18.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-server-dom-webpack": "19.2.1",
     "waku": "1.0.0-alpha.0",
-    "@stylexjs/shared-ui": "0.18.0"
+    "@stylexjs/shared-ui": "0.18.1"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.18.0",
+    "@stylexjs/unplugin": "0.18.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "5.1.0",

--- a/examples/example-webpack/package.json
+++ b/examples/example-webpack/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "example-webpack",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Example: StyleX with Webpack via @stylexjs/unplugin",
   "main": "index.js",
   "scripts": {
@@ -15,8 +15,8 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.1",
-    "@stylexjs/eslint-plugin": "0.18.0",
-    "@stylexjs/unplugin": "0.18.0",
+    "@stylexjs/eslint-plugin": "0.18.1",
+    "@stylexjs/unplugin": "0.18.1",
     "babel-loader": "^10.0.0",
     "css-loader": "^7.1.2",
     "file-loader": "^6.2.0",
@@ -29,7 +29,7 @@
     "webpack-dev-server": "^5.2.2"
   },
   "dependencies": {
-    "@stylexjs/stylex": "0.18.0",
+    "@stylexjs/stylex": "0.18.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   }

--- a/packages/@stylexjs/babel-plugin/package.json
+++ b/packages/@stylexjs/babel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/babel-plugin",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "StyleX babel plugin.",
   "main": "lib/index.js",
   "browser": "lib/index.browser.js",
@@ -23,8 +23,8 @@
     "@babel/traverse": "^7.26.8",
     "@babel/types": "^7.26.8",
     "@dual-bundle/import-meta-resolve": "^4.1.0",
-    "@stylexjs/shared": "0.18.0",
-    "@stylexjs/stylex": "0.18.0",
+    "@stylexjs/shared": "0.18.1",
+    "@stylexjs/stylex": "0.18.1",
     "postcss-value-parser": "^4.1.0"
   },
   "devDependencies": {
@@ -37,7 +37,7 @@
     "babel-plugin-syntax-hermes-parser": "^0.32.1",
     "path-browserify": "^1.0.1",
     "rollup": "^4.59.0",
-    "scripts": "0.18.0"
+    "scripts": "0.18.1"
   },
   "files": [
     "flow_modules/*",

--- a/packages/@stylexjs/cli/package.json
+++ b/packages/@stylexjs/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/cli",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A cli to compile a folder with StyleX",
   "main": "./lib/transform.js",
   "repository": "https://www.github.com/facebook/stylex",
@@ -19,7 +19,7 @@
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
     "@babel/types": "^7.26.8",
-    "@stylexjs/babel-plugin": "0.18.0",
+    "@stylexjs/babel-plugin": "0.18.1",
     "ansis": "^3.3.2",
     "fb-watchman": "^2.0.2",
     "json5": "^2.2.3",
@@ -27,7 +27,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "scripts": "0.18.0"
+    "scripts": "0.18.1"
   },
   "bin": {
     "stylex": "./lib/index.js"

--- a/packages/@stylexjs/create-stylex-app/package.json
+++ b/packages/@stylexjs/create-stylex-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-stylex-app",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Scaffold a new StyleX project from official templates",
   "repository": "https://www.github.com/facebook/stylex",
   "license": "MIT",
@@ -33,6 +33,6 @@
     "@babel/core": "^7.26.8",
     "@babel/preset-env": "^7.26.8",
     "cross-env": "^10.1.0",
-    "scripts": "0.18.0"
+    "scripts": "0.18.1"
   }
 }

--- a/packages/@stylexjs/eslint-plugin/package.json
+++ b/packages/@stylexjs/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/eslint-plugin",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "StyleX eslint plugin.",
   "main": "lib/index.js",
   "repository": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@csstools/css-tokenizer": "^3.0.3",
-    "@stylexjs/shared": "0.18.0",
+    "@stylexjs/shared": "0.18.1",
     "micromatch": "^4.0.5",
     "postcss-value-parser": "^4.2.0"
   },

--- a/packages/@stylexjs/postcss-plugin/package.json
+++ b/packages/@stylexjs/postcss-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/postcss-plugin",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "PostCSS plugin for StyleX",
   "main": "src/index.js",
   "repository": {
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.26.8",
-    "@stylexjs/babel-plugin": "0.18.0",
+    "@stylexjs/babel-plugin": "0.18.1",
     "postcss": "^8.4.49",
     "fast-glob": "^3.3.2",
     "glob-parent": "^6.0.2",

--- a/packages/@stylexjs/rollup-plugin/package.json
+++ b/packages/@stylexjs/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/rollup-plugin",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Rollup plugin for StyleX",
   "main": "./lib/index.js",
   "module": "./lib/es/index.mjs",
@@ -35,7 +35,7 @@
     "@babel/plugin-syntax-flow": "^7.26.0",
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
-    "@stylexjs/babel-plugin": "0.18.0",
+    "@stylexjs/babel-plugin": "0.18.1",
     "lightningcss": "^1.29.1"
   },
   "devDependencies": {

--- a/packages/@stylexjs/shared/package.json
+++ b/packages/@stylexjs/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/shared",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "main": "lib/index.js",
   "repository": {
     "type": "git",

--- a/packages/@stylexjs/stylex/package.json
+++ b/packages/@stylexjs/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/stylex",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A library for defining styles for optimized user interfaces.",
   "main": "./lib/cjs/stylex.js",
   "module": "./lib/es/stylex.mjs",
@@ -60,7 +60,7 @@
     "babel-plugin-syntax-hermes-parser": "^0.32.1",
     "cross-env": "^10.1.0",
     "rollup": "^4.59.0",
-    "scripts": "0.18.0"
+    "scripts": "0.18.1"
   },
   "files": [
     "lib/*"

--- a/packages/@stylexjs/unplugin/package.json
+++ b/packages/@stylexjs/unplugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/unplugin",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": false,
   "description": "Universal bundler plugin for StyleX using unplugin",
   "license": "MIT",
@@ -82,7 +82,7 @@
     "@babel/plugin-syntax-flow": "^7.26.0",
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-syntax-typescript": "^7.25.9",
-    "@stylexjs/babel-plugin": "0.18.0",
+    "@stylexjs/babel-plugin": "0.18.1",
     "browserslist": "^4.24.0",
     "lightningcss": "^1.29.1"
   },

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "benchmarks",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "scripts": {
     "perf": "node ./perf/run.js",
     "size": "NODE_ENV=production rollup --config ./size/rollup.config.mjs && node ./size/run.js",
@@ -9,8 +9,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/babel-plugin": "0.18.0",
-    "@stylexjs/rollup-plugin": "0.18.0",
+    "@stylexjs/babel-plugin": "0.18.1",
+    "@stylexjs/rollup-plugin": "0.18.1",
     "benchmark": "^2.1.4",
     "brotli-size": "^4.0.0",
     "clean-css": "^5.3.3",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-new",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "sideEffects": false,
   "type": "module",
@@ -16,8 +16,8 @@
     "algoliasearch": "^5.46.2",
     "@codesandbox/sandpack-client": "^2.19.8",
     "@codesandbox/sandpack-react": "^2.20.0",
-    "@stylexjs/stylex": "0.18.0",
-    "@stylexjs/babel-plugin": "0.18.0",
+    "@stylexjs/stylex": "0.18.1",
+    "@stylexjs/babel-plugin": "0.18.1",
     "@monaco-editor/react": "^4.7.0",
     "marked": "^17.0.1",
     "lz-string": "^1.5.0",
@@ -41,7 +41,7 @@
     "use-query-params": "^2.2.2"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "0.18.0",
+    "@stylexjs/unplugin": "0.18.1",
     "@types/mdx": "^2.0.13",
     "@types/node": "^24.10.4",
     "@types/react": "^19.2.7",

--- a/packages/old-docs/package.json
+++ b/packages/old-docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "docs",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "scripts": {
     "old:build": "shx rm -rf ./build ./docusaurus && cross-env NODE_ENV=production docusaurus build && node ./scripts/make-stylex-sheet.js",
     "clear": "docusaurus clear",
@@ -17,7 +17,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.1",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mdx-js/react": "^1.6.22",
-    "@stylexjs/stylex": "0.18.0",
+    "@stylexjs/stylex": "0.18.1",
     "@webcontainer/api": "^1.3.0",
     "clsx": "^1.2.1",
     "codemirror": "^5.65.16",
@@ -28,8 +28,8 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.26.8",
-    "@stylexjs/eslint-plugin": "0.18.0",
-    "@stylexjs/babel-plugin": "0.18.0",
+    "@stylexjs/eslint-plugin": "0.18.1",
+    "@stylexjs/babel-plugin": "0.18.1",
     "clean-css": "^5.3.2",
     "eslint": "^8.57.1",
     "eslint-config-airbnb": "^19.0.4",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "scripts",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Helper scripts for stylex monorepo.",
   "license": "MIT",
   "bin": {

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexjs/shared-ui",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "main": "src/index.tsx",
   "exports": {

--- a/packages/style-value-parser/package.json
+++ b/packages/style-value-parser/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "style-value-parser",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "main": "lib/index.js",
   "license": "MIT",

--- a/packages/typescript-tests/package.json
+++ b/packages/typescript-tests/package.json
@@ -1,15 +1,15 @@
 {
   "private": true,
   "name": "typescript-tests",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "scripts": {
     "test": "tsc --noEmit"
   },
   "license": "MIT",
   "dependencies": {
-    "@stylexjs/stylex": "0.18.0",
-    "@stylexjs/babel-plugin": "0.18.0"
+    "@stylexjs/stylex": "0.18.1",
+    "@stylexjs/babel-plugin": "0.18.1"
   },
   "devDependencies": {
     "typescript": "^5.8.3",


### PR DESCRIPTION
## 0.18.1

### Changes
- Add simple `sx={}` JSX prop syntax as an alternative to `stylex.props`.
- Fix `unplugin` `generateBundle` hook to use `emitFile` instead of direct bundle assignment.

---
*Crafted with care by Navi*