### PR TITLE
fix: handle peerDependencies in release script 

### DIFF
--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -8,7 +8,7 @@
     "./tokens.stylex": "./src/tokens.stylex.ts"
   },
   "peerDependencies": {
-    "@stylexjs/stylex": "0.18.0",
+    "@stylexjs/stylex": "*",
     "react": ">=18"
   }
 }

--- a/tools/npm/release.js
+++ b/tools/npm/release.js
@@ -87,6 +87,13 @@ workspaces.forEach(({ packageJson, packageJsonPath }) => {
     if (packageJson.devDependencies && packageJson.devDependencies[name]) {
       packageJson.devDependencies[name] = pkgVersion;
     }
+    if (
+      packageJson.peerDependencies &&
+      packageJson.peerDependencies[name] &&
+      packageJson.peerDependencies[name] !== '*'
+    ) {
+      packageJson.peerDependencies[name] = pkgVersion;
+    }
   });
 
   fs.writeFileSync(


### PR DESCRIPTION
## Summary

1. **`packages/shared-ui/package.json`** — Revert `@stylexjs/stylex` peerDep back to `"*"`. `shared-ui` is `private: true` (never published), so the pinned peerDep just caused `npm ERESOLVE` errors. It was `"*"` for every release from 0.17.1 through 0.17.5.

2. **`tools/npm/release.js`** — Add `peerDependencies` handling for workspace packages. The script already bumped `dependencies` and `devDependencies` but missed `peerDependencies`. Skips wildcard (`"*"`) entries. No published package needs this today, but it prevents the same class of bug if a pinned peerDep is added in the future.

---
*Crafted with care by Navi*