### PR TITLE
[eslint-plugin] allows CSS variables for cursor property

### DIFF
--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -226,6 +226,7 @@ const brStyle: RuleCheck = makeUnionRule(
   makeLiteralRule('outset'),
 );
 const CSSCursor: RuleCheck = makeUnionRule(
+  isCSSVariable,
   makeLiteralRule('auto'),
   makeLiteralRule('default'),
   makeLiteralRule('none'),


### PR DESCRIPTION
## What changed / motivation ?

Add isCSSVariable to the CSSCursor union rule, matching the existing pattern used by `fontWeight`, so that values like `"var(--pointer)"` are accepted.

## Linked PR/Issues

n/a

## Additional Context

n/a

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code