### PR TITLE
[eslint-plugin] fix stylex/valid-styles false positives for member expressions 

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -672,6 +672,28 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       })
     })
     `,
+    // test using member expressions on function params in dynamic styles
+    `
+    import * as stylex from 'stylex';
+    stylex.create({
+      badge: (props) => ({
+        backgroundColor: props.badgeColor,
+        color: props.color,
+      })
+    })
+    `,
+    // test member expressions on function params with pseudo-classes
+    `
+    import * as stylex from 'stylex';
+    stylex.create({
+      root: (props) => ({
+        color: {
+          default: props.textColor,
+          ':hover': props.hoverColor,
+        },
+      })
+    })
+    `,
     // test importing vars from paths including theme file extension
     `
     import * as stylex from '@stylexjs/stylex';
@@ -878,6 +900,26 @@ eslintTester.run('stylex-valid-styles', rule.default, {
             zIndex: zIndexConst ?? 10,
             width: isMobile ? (widthConst || "100%") : (widthConst2 ?? "200%"),
           }
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          foo: {
+            outlineOffset: 2,
+          },
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          foo: {
+            strokeDasharray: 100,
+          },
         });
       `,
     },

--- a/packages/@stylexjs/eslint-plugin/src/utils/makeVariableCheckingRule.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/makeVariableCheckingRule.js
@@ -39,6 +39,18 @@ export default function makeVariableCheckingRule(rule: RuleCheck): RuleCheck {
         return varCheckingRule(existingVar, variables, prop, context);
       }
     }
+    if (node.type === 'MemberExpression' && variables != null) {
+      let obj = node.object;
+      while (obj.type === 'MemberExpression') {
+        obj = obj.object;
+      }
+      if (obj.type === 'Identifier') {
+        const existingVar = variables.get(obj.name);
+        if (existingVar === 'ARG') {
+          return undefined;
+        }
+      }
+    }
     return rule(node, variables, prop, context);
   };
 


### PR DESCRIPTION
## What changed / motivation ?

The valid-styles rule only checked for Identifier nodes when skipping validation of arrow function parameters. MemberExpression nodes like props.badgeColor were not recognized, causing false positives. This adds a check that walks up the object chain of MemberExpressions to find the root identifier and skips validation when it maps to a function argument.

## Linked PR/Issues

Fixes #1520

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code