### PR TITLE
[eslint-plugin] accept bare numbers for time-related properties

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -923,6 +923,20 @@ eslintTester.run('stylex-valid-styles', rule.default, {
         });
       `,
     },
+    // bare numbers for time-based properties
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          foo: {
+            animationDelay: 200,
+            animationDuration: 300,
+            transitionDelay: 100,
+            transitionDuration: 500,
+          },
+        });
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -104,7 +104,7 @@ const borderImageSource: RuleCheck = makeUnionRule(
   makeLiteralRule('none'),
   isString,
 );
-const time: RuleCheck = isString;
+const time: RuleCheck = makeUnionRule(isNumber, isString);
 const animationDirection: RuleCheck = makeUnionRule(
   makeLiteralRule('normal'),
   makeLiteralRule('reverse'),
@@ -1430,6 +1430,7 @@ const speakAs: RuleCheck = makeUnionRule(
 const stroke: RuleCheck = paint;
 const strokeDasharray: RuleCheck = makeUnionRule(
   makeLiteralRule('none'),
+  isNumber,
   isString,
 );
 const strokeDashoffset: RuleCheck = svgLength;
@@ -1987,7 +1988,7 @@ const CSSProperties = {
   orphans: orphans,
   outline: outline,
   outlineColor: color,
-  outlineOffset: isLength,
+  outlineOffset: makeUnionRule(isNumber, isLength) as RuleCheck,
   outlineStyle: makeUnionRule(
     'auto',
     'none',


### PR DESCRIPTION
## What changed / motivation ?

Allow bare numbers for time-based properties (animationDelay, animationDuration, transitionDelay, transitionDuration, voiceDuration), outlineOffset, and strokeDasharray to match the babel plugin behavior.

Also fixes `strokeDasharray` and `outlineOffset` that didn't accept numbers (and broke CI in https://github.com/facebook/stylex/pull/1521, as the tests were added by mistake)

Similar to https://github.com/facebook/stylex/pull/1522

## Linked PR/Issues

n/a

## Additional Context

n/a

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code