### PR TITLE
[unplugin] Omit filename & code from lightningcssOptions

### DIFF
--- a/packages/@stylexjs/unplugin/src/core.d.ts
+++ b/packages/@stylexjs/unplugin/src/core.d.ts
@@ -8,7 +8,7 @@ import { type UnpluginFactory, type UnpluginInstance } from 'unplugin';
 import type { Options as StyleXOptions } from '@stylexjs/babel-plugin';
 import type { TransformOptions } from 'lightningcss';
 
-type LightningcssOptions = TransformOptions<any>;
+type LightningcssOptions = Omit<TransformOptions<any>, 'filename' | 'code'>;
 
 export type UserOptions = StyleXOptions & {
   useCSSLayers?: boolean;


### PR DESCRIPTION
## What changed / motivation ?

Type checking on ` vite.config.ts` can fail on custom `lightningcssOptions` if `filename` & `code` are not passed to it (I use `csslightningOptions` to force the minification of the css output)

Those options are un-necessary to pass as someone configuring StyleX, as they are provided by StyleX itself here:

https://github.com/facebook/stylex/blob/945f0f39bb59fc7fa15e12dd67fd6eb7f794abde/packages/%40stylexjs/unplugin/src/core.js#L56-L58

## Linked PR/Issues

n/a

## Additional Context

<img width="900" height="275" alt="Screenshot 2026-03-17 at 14 49 40" src="https://github.com/user-attachments/assets/5887103d-595b-43be-83f5-415a87448636" />

Before:

```
martpie@martpie museeks % vp check
VITE+ - The Unified Toolchain for the Web

pass: All 140 files are correctly formatted (498ms, 12 threads)
error: Lint or type issues found
× typescript(TS2739): Type '{ minify: true; targets: Targets; }' is missing the following properties from type 'TransformOptions<any>': filename, code
    ╭─[vite.config.ts:37:5]
 36 │     // https://github.com/facebook/stylex/issues/1378
 37 │     lightningcssOptions: {
    ·     ───────────────────
 38 │       minify: true,
    ╰────

Found 1 error and 0 warnings in 121 files (2.4s, 12 threads)
```
This can be reproduced on a StyleX example vite config: 

<img width="946" height="280" alt="Screenshot 2026-03-17 at 15 03 46" src="https://github.com/user-attachments/assets/385cbd4d-21f1-429b-8b79-809d69544a33" />

I am not 100% sure how to test that, as examples are using `@stylexjs/unplugin` and I'm not sure how to use the local version of unplugin.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code