### PR TITLE
(babel-plugin): Add layersBefore/layersAfter config to processStylexR…

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -385,6 +385,246 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
+    test('useLayers with layersBefore', () => {
+      const { metadata } = transform(fixture);
+      expect(
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: true,
+          layersBefore: ['reset', 'typography'],
+          enableLTRRTLComments: false,
+        }),
+      ).toMatchInlineSnapshot(`
+        "
+        @layer reset, typography, priority1, priority2, priority3, priority4;
+        @property --x-color { syntax: "*"; inherits: false;}
+        @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
+        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
+        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
+        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        @layer priority2{
+        .margin-xymmreb{margin:10px 20px}
+        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        }
+        @layer priority3{
+        .borderColor-x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        }
+        @layer priority4{
+        .animationName-x13ah0pd{animation-name:x35atj5-B}
+        .backgroundColor-xrkmrrc{background-color:red}
+        .color-x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .float-x1kmio9f{float:left}
+        html[dir='rtl'] .float-x1kmio9f{float:right}
+        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
+        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .backgroundColor-xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        }"
+      `);
+    });
+
+    test('useLayers with layersAfter', () => {
+      const { metadata } = transform(fixture);
+      expect(
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: true,
+          layersAfter: ['overrides', 'xds.theme'],
+          enableLTRRTLComments: false,
+        }),
+      ).toMatchInlineSnapshot(`
+        "
+        @layer priority1, priority2, priority3, priority4, overrides, xds.theme;
+        @property --x-color { syntax: "*"; inherits: false;}
+        @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
+        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
+        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
+        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        @layer priority2{
+        .margin-xymmreb{margin:10px 20px}
+        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        }
+        @layer priority3{
+        .borderColor-x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        }
+        @layer priority4{
+        .animationName-x13ah0pd{animation-name:x35atj5-B}
+        .backgroundColor-xrkmrrc{background-color:red}
+        .color-x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .float-x1kmio9f{float:left}
+        html[dir='rtl'] .float-x1kmio9f{float:right}
+        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
+        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .backgroundColor-xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        }"
+      `);
+    });
+
+    test('useLayers with both layersBefore and layersAfter', () => {
+      const { metadata } = transform(fixture);
+      expect(
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: true,
+          layersBefore: ['reset'],
+          layersAfter: ['xds.theme'],
+          enableLTRRTLComments: false,
+        }),
+      ).toMatchInlineSnapshot(`
+        "
+        @layer reset, priority1, priority2, priority3, priority4, xds.theme;
+        @property --x-color { syntax: "*"; inherits: false;}
+        @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
+        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
+        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
+        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        @layer priority2{
+        .margin-xymmreb{margin:10px 20px}
+        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        }
+        @layer priority3{
+        .borderColor-x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        }
+        @layer priority4{
+        .animationName-x13ah0pd{animation-name:x35atj5-B}
+        .backgroundColor-xrkmrrc{background-color:red}
+        .color-x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .float-x1kmio9f{float:left}
+        html[dir='rtl'] .float-x1kmio9f{float:right}
+        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
+        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .backgroundColor-xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        }"
+      `);
+    });
+
+    test('layersBefore/layersAfter are ignored when useLayers is false', () => {
+      const { metadata } = transform(fixture);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: false,
+          layersBefore: ['reset'],
+          layersAfter: ['overrides'],
+          enableLTRRTLComments: false,
+        }),
+      ).toMatchInlineSnapshot(`
+        "@property --x-color { syntax: "*"; inherits: false;}
+        @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
+        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
+        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
+        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        .margin-xymmreb:not(#\\#){margin:10px 20px}
+        .padding-xss17vw:not(#\\#){padding:var(--large-x1ec7iuc)}
+        .borderColor-x1bg2uv5:not(#\\#):not(#\\#){border-color:green}
+        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c:not(#\\#):not(#\\#){border-color:var(--blue-xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys:not(#\\#):not(#\\#){border-color:yellow}}}
+        .animationName-x13ah0pd:not(#\\#):not(#\\#):not(#\\#){animation-name:x35atj5-B}
+        .backgroundColor-xrkmrrc:not(#\\#):not(#\\#):not(#\\#){background-color:red}
+        .color-x14rh7hd:not(#\\#):not(#\\#):not(#\\#){color:var(--x-color)}
+        html:not([dir='rtl']) .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:left}
+        html[dir='rtl'] .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:right}
+        .outlineColor-x184ctg8:not(#\\#):not(#\\#):not(#\\#){outline-color:var(--colorTokens-xkxfyv)}
+        .textShadow-x1skrh0i:not(#\\#):not(#\\#):not(#\\#){text-shadow:1px 2px 3px 4px red}
+        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *):not(#\\#):not(#\\#):not(#\\#){background-color:green}
+        .backgroundColor-xbrh7vm:hover:not(#\\#):not(#\\#):not(#\\#){background-color:blue}
+        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn:not(#\\#):not(#\\#):not(#\\#){background-color:yellow}}
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id:not(#\\#):not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)):not(#\\#):not(#\\#):not(#\\#){background-color:purple}}
+        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)):not(#\\#):not(#\\#):not(#\\#){background-color:orange}}"
+      `);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[@stylexjs/babel-plugin] `layersBefore` and `layersAfter` options are ignored when `useCSSLayers` is not enabled.',
+      );
+      warnSpy.mockRestore();
+    });
+
+    test('empty layersBefore/layersAfter produce standard layer declaration', () => {
+      const { metadata } = transform(fixture);
+      expect(
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: true,
+          layersBefore: [],
+          layersAfter: [],
+          enableLTRRTLComments: false,
+        }),
+      ).toMatchInlineSnapshot(`
+        "
+        @layer priority1, priority2, priority3, priority4;
+        @property --x-color { syntax: "*"; inherits: false;}
+        @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
+        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
+        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
+        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        @layer priority2{
+        .margin-xymmreb{margin:10px 20px}
+        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        }
+        @layer priority3{
+        .borderColor-x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        }
+        @layer priority4{
+        .animationName-x13ah0pd{animation-name:x35atj5-B}
+        .backgroundColor-xrkmrrc{background-color:red}
+        .color-x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .float-x1kmio9f{float:left}
+        html[dir='rtl'] .float-x1kmio9f{float:right}
+        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
+        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .backgroundColor-xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        }"
+      `);
+    });
+
     test('all rules (legacyDisableLayers:true)', () => {
       const { code, metadata } = transform(fixture);
       expect(code).toMatchInlineSnapshot(`

--- a/packages/@stylexjs/babel-plugin/src/index.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/index.d.ts
@@ -45,6 +45,8 @@ declare function processStylexRules(
     | boolean
     | {
         useLayers?: boolean;
+        layersBefore?: ReadonlyArray<string>;
+        layersAfter?: ReadonlyArray<string>;
         enableLTRRTLComments?: boolean;
         legacyDisableLayers?: boolean;
       },

--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -439,6 +439,8 @@ function processStylexRules(
     | boolean
     | {
         useLayers?: boolean,
+        layersBefore?: $ReadOnlyArray<string>,
+        layersAfter?: $ReadOnlyArray<string>,
         enableLTRRTLComments?: boolean,
         legacyDisableLayers?: boolean,
         useLegacyClassnamesSort?: boolean,
@@ -447,10 +449,19 @@ function processStylexRules(
 ): string {
   const {
     useLayers = false,
+    layersBefore = [],
+    layersAfter = [],
     enableLTRRTLComments = false,
     legacyDisableLayers = false,
     useLegacyClassnamesSort = false,
   } = typeof config === 'boolean' ? { useLayers: config } : (config ?? {});
+
+  if (!useLayers && (layersBefore.length > 0 || layersAfter.length > 0)) {
+    console.warn(
+      '[@stylexjs/babel-plugin] `layersBefore` and `layersAfter` options are ignored when `useCSSLayers` is not enabled.',
+    );
+  }
+
   if (rules.length === 0) {
     return '';
   }
@@ -566,7 +577,11 @@ function processStylexRules(
 
   const header = useLayers
     ? '\n@layer ' +
-      grouped.map((_, index) => `priority${index + 1}`).join(', ') +
+      [
+        ...layersBefore,
+        ...grouped.map((_, index) => `priority${index + 1}`),
+        ...layersAfter,
+      ].join(', ') +
       ';\n'
     : '';
 

--- a/packages/@stylexjs/postcss-plugin/src/builder.js
+++ b/packages/@stylexjs/postcss-plugin/src/builder.js
@@ -157,6 +157,8 @@ function createBuilder() {
       cwd,
       babelConfig,
       useCSSLayers,
+      layersBefore,
+      layersAfter,
       enableLTRRTLComments,
       importSources,
       isDev,
@@ -206,7 +208,12 @@ function createBuilder() {
       }),
     );
 
-    const css = bundler.bundle({ useCSSLayers, enableLTRRTLComments });
+    const css = bundler.bundle({
+      useCSSLayers,
+      layersBefore,
+      layersAfter,
+      enableLTRRTLComments,
+    });
     return css;
   }
 

--- a/packages/@stylexjs/postcss-plugin/src/bundler.js
+++ b/packages/@stylexjs/postcss-plugin/src/bundler.js
@@ -62,11 +62,18 @@ module.exports = function createBundler() {
   }
 
   //  Bundles all collected StyleX rules into a single CSS string.
-  function bundle({ useCSSLayers, enableLTRRTLComments }) {
+  function bundle({
+    useCSSLayers,
+    layersBefore,
+    layersAfter,
+    enableLTRRTLComments,
+  }) {
     const rules = Array.from(styleXRulesMap.values()).flat();
 
     const css = stylexBabelPlugin.processStylexRules(rules, {
       useLayers: useCSSLayers,
+      layersBefore,
+      layersAfter,
       enableLTRRTLComments,
     });
 

--- a/packages/@stylexjs/postcss-plugin/src/plugin.js
+++ b/packages/@stylexjs/postcss-plugin/src/plugin.js
@@ -33,6 +33,8 @@ module.exports = function createPlugin() {
     include,
     exclude,
     useCSSLayers = false,
+    layersBefore,
+    layersAfter,
     styleResolution = 'property-specificity',
     importSources,
   }) => {
@@ -105,6 +107,8 @@ module.exports = function createPlugin() {
             cwd,
             babelConfig: effectiveBabelConfig,
             useCSSLayers,
+            layersBefore,
+            layersAfter,
             styleResolution,
             importSources: effectiveImportSources,
             isDev,

--- a/packages/@stylexjs/rollup-plugin/src/index.js
+++ b/packages/@stylexjs/rollup-plugin/src/index.js
@@ -38,6 +38,8 @@ export type PluginOptions = $ReadOnly<{
     presets?: $ReadOnlyArray<PluginItem>,
   }>,
   useCSSLayers?: boolean,
+  layersBefore?: $ReadOnlyArray<string>,
+  layersAfter?: $ReadOnlyArray<string>,
   lightningcssOptions?: Omit<
     TransformOptions<{}>,
     'code' | 'filename' | 'visitor',
@@ -64,6 +66,8 @@ export default function stylexPlugin({
   babelConfig: { plugins = [], presets = [] } = {},
   importSources = ['stylex', '@stylexjs/stylex'],
   useCSSLayers = false,
+  layersBefore,
+  layersAfter,
   lightningcssOptions,
   ...options
 }: PluginOptions = {}): Plugin<> {
@@ -78,6 +82,8 @@ export default function stylexPlugin({
       if (rules.length > 0) {
         const collectedCSS = stylexBabelPlugin.processStylexRules(rules, {
           useLayers: useCSSLayers,
+          layersBefore,
+          layersAfter,
           enableLTRRTLComments: options?.enableLTRRTLComments,
         });
 

--- a/packages/@stylexjs/unplugin/src/core.js
+++ b/packages/@stylexjs/unplugin/src/core.js
@@ -49,6 +49,8 @@ function processCollectedRulesToCSS(rules, options) {
   if (!rules || rules.length === 0) return '';
   const collectedCSS = stylexBabelPlugin.processStylexRules(rules, {
     useLayers: !!options.useCSSLayers,
+    layersBefore: options?.layersBefore,
+    layersAfter: options?.layersAfter,
     enableLTRRTLComments: options?.enableLTRRTLComments,
   });
   const { code } = lightningTransform({
@@ -357,6 +359,8 @@ export const unpluginFactory = (userOptions = {}, metaOptions) => {
     const allRules = Array.from(merged.values()).flat();
     return processCollectedRulesToCSS(allRules, {
       useCSSLayers,
+      layersBefore: userOptions.layersBefore,
+      layersAfter: userOptions.layersAfter,
       lightningcssOptions,
       enableLTRRTLComments: stylexOptions?.enableLTRRTLComments,
     });


### PR DESCRIPTION
## What changed / motivation?

When useCSSLayers is enabled, StyleX generates a layer order declaration:

`@layer priority1, priority2, ..., priorityN;`

Users often need to insert custom CSS layers before or after StyleX's priority layers — for example, reset layers that should have lower precedence, or theme override layers that should sit between base component styles and prop-level overrides. Previously this required fragile workarounds like injecting a hardcoded @layer declaration via a separate build plugin, which could break if StyleX generated a different number of priority layers.

This PR adds two new config options to processStylexRules: layersBefore and layersAfter. These prepend/append user-defined layer names to the generated @layer declaration:

`@layer reset, typography, priority1, ..., priorityN, xds.theme;`

This enables the three-level specificity hierarchy described in the issue:

Base component styles (StyleX priority layers) — lowest
Theme overrides (custom layer via layersAfter) — middle
Prop overrides (StyleX higher priority layers) — highest


Usage
```
// Babel plugin
stylexPlugin.processStylexRules(rules, {
  useLayers: true,
  layersBefore: ['reset', 'typography'],
  layersAfter: ['xds.theme'],
});

// Bundler plugins (rollup, postcss, unplugin)
stylexPlugin({
  useCSSLayers: true,
  layersBefore: ['reset', 'typography'],
  layersAfter: ['xds.theme'],
});
```

Changes
@stylexjs/babel-plugin — Added layersBefore/layersAfter to the processStylexRules config type and header generation logic
@stylexjs/rollup-plugin — Thread new options through to processStylexRules
@stylexjs/postcss-plugin — Thread new options through plugin → builder → bundler
@stylexjs/unplugin — Thread new options through to processCollectedRulesToCSS
When useLayers is false, both options are ignored. When omitted or empty, output is unchanged (fully backward compatible).

## Linked PR/Issues

Fixes #1526

## Additional Context
`npx jest`:
5 new test cases added to transform-process-test.js 
```
 PASS  __tests__/transform-process-test.js
  @stylexjs/babel-plugin
    [transform] stylexPlugin.processStylexRules
      ✓ no rules (66 ms)
      ✓ all rules (useLayers:false) (46 ms)
      ✓ all rules (useLayers:true) (45 ms)
      ✓ useLayers with layersBefore (46 ms)
      ✓ useLayers with layersAfter (57 ms)
      ✓ useLayers with both layersBefore and layersAfter (46 ms)
      ✓ layersBefore/layersAfter are ignored when useLayers is false (47 ms)
      ✓ empty layersBefore/layersAfter produce standard layer declaration (46 ms)
      ✓ all rules (legacyDisableLayers:true) (49 ms)
      ✓ legacy-expand-shorthands with logical styles polyfill (4 ms)
      ✓ legacy-expand-shorthands duplicates theme selectors for higher precedence (3 ms)
      ✓ no mutation of rules (48 ms)
      ✓ useLegacyClassnamesSort: false (default behavior) (50 ms)
      ✓ useLegacyClassnamesSort: true (legacy behavior) (50 ms)
      ✓ sort is deterministic regardless of input order
      ✓ sort is deterministic with duplicate rules in different input orders

Test Suites: 1 passed, 1 total
Tests:       16 passed, 16 total
Snapshots:   19 passed, 19 total
Time:        1.344 s, estimated 2 s
```
and `npm run test:packages `

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code