### PR TITLE
[babel-plugin] Add missing jsxSpreadAttribute export to browser bundle stub

### DIFF
--- a/packages/@stylexjs/babel-plugin/rollup.config.mjs
+++ b/packages/@stylexjs/babel-plugin/rollup.config.mjs
@@ -109,7 +109,7 @@ export const {
   isNumericLiteral, isObjectExpression, isObjectProperty, isPrivateName,
   isSpreadElement, isStringLiteral, isTemplateLiteral, isUnaryExpression,
   isUpdateExpression, isValidIdentifier, isVariableDeclaration, jsxAttribute,
-  jsxIdentifier, memberExpression, nullLiteral, numericLiteral, objectExpression,
+  jsxIdentifier, jsxSpreadAttribute, memberExpression, nullLiteral, numericLiteral, objectExpression,
   objectProperty, stringLiteral, unaryExpression, variableDeclaration, variableDeclarator
 } = packages.types;`;
           default:


### PR DESCRIPTION
## What changed / motivation ?
The browser build's `@babel/types` stub was missing the `jsxSpreadAttribute` export, which is used by the plugin when transforming JSX spread attributes. 

When the browser build uses rollup to bundle the plugin for browser environments, @babel/types gets replaced with @babel/standalone's packages.types via @rollup/plugin-alias. The bundled browser build destructures a curated allowlist of type helpers which was missing `jsxSpreadAttribute`.

This caused a runtime error in the browser/playground environment: `jsxSpreadAttribute is not a function`. 

The breaking changes was introduced with the addition of `sx` feature PR #1218. To perform that transformation, the new visitor calls t.jsxSpreadAttribute() to construct the {...expr} AST node. This function comes from @babel/types.

The fix: Added jsxSpreadAttribute to the destructured exports in the @babel/types browser stub.

## Additional Context
Testing was done:
1. Run `npm run build` in packages/@stylexjs/babel-plugin — both CJS (lib/index.js) and browser ESM (lib/index.browser.js) bundles build successfully
2. Verified the built lib/index.browser.js destructures `jsxSpreadAttribute` from packages.types 
3. Existing `npm test` passes

### _**Before fix:**_
npm run build --prefix packages/@stylexjs/babel-plugin
node -e "
  const code = require('fs').readFileSync('packages/@stylexjs/babel-plugin/lib/index.browser.js','utf8');
  const m = code.match(/const \{([^}]+)\} = packages\.types/s);
  console.log('stub has jsxSpreadAttribute:', m && m[1].includes('jsxSpreadAttribute'));
"

> @stylexjs/babel-plugin@0.18.1 build
> rollup --config ./rollup.config.mjs

./src/index.js → ./lib/index.js...
created ./lib/index.js in 1.2s

./src/index.js → ./lib/index.browser.js...
**(!) Missing exports**
https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module
src/index.js
jsxSpreadAttribute is not exported by @babel/types
315:           }
316:           attr.replaceWith(
317:             t.jsxSpreadAttribute(
                   ^
318:               t.callExpression(
319:                 t.memberExpression(
created ./lib/index.browser.js in 734ms
stub has jsxSpreadAttribute: **false**


### _**After fix:**_
npm run build --prefix packages/@stylexjs/babel-plugin
node -e "
  const code = require('fs').readFileSync('packages/@stylexjs/babel-plugin/lib/index.browser.js','utf8');
  const m = code.match(/const \{([^}]+)\} = packages\.types/s);
  console.log('stub has jsxSpreadAttribute:', m && m[1].includes('jsxSpreadAttribute'));
"

> @stylexjs/babel-plugin@0.18.1 prebuild
> gen-types -i src/ -o lib/

**Successfully generated type definitions**

> @stylexjs/babel-plugin@0.18.1 build
> rollup --config ./rollup.config.mjs


./src/index.js → ./lib/index.js...
created ./lib/index.js in 1.3s

./src/index.js → ./lib/index.browser.js...
created ./lib/index.browser.js in 790ms
stub has jsxSpreadAttribute: **true**

----------
**`npm test`**
Test Suites: 1 skipped, 37 passed, 37 of 38 total
Tests:       64 skipped, 803 passed, 867 total
Snapshots:   770 passed, 770 total
Time:        14.372 s

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code