### PR TITLE
[eslint-plugin] Add flex shorthand expansion to stylex-valid-shorthands

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -1752,5 +1752,303 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         },
       ],
     },
+    // flex: single number expands to grow/shrink/basis
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flex: 1,
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexGrow: '1',
+            flexShrink: '1',
+            flexBasis: '0%',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flex: 1" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flex: string single number
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flex: '2',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexGrow: '2',
+            flexShrink: '1',
+            flexBasis: '0%',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flex: 2" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flex: auto keyword
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flex: 'auto',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexGrow: '1',
+            flexShrink: '1',
+            flexBasis: 'auto',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flex: auto" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flex: none keyword
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flex: 'none',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexGrow: '0',
+            flexShrink: '0',
+            flexBasis: 'auto',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flex: none" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flex: initial keyword
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flex: 'initial',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexGrow: '0',
+            flexShrink: '1',
+            flexBasis: 'auto',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flex: initial" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flex: single basis value (with unit)
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flex: '100px',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexGrow: '1',
+            flexShrink: '1',
+            flexBasis: '100px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flex: 100px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flex: two numbers (grow shrink)
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flex: '1 0',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexGrow: '1',
+            flexShrink: '0',
+            flexBasis: '0%',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flex: 1 0" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flex: number + basis
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flex: '1 30px',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexGrow: '1',
+            flexShrink: '1',
+            flexBasis: '30px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flex: 1 30px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flex: three values (grow shrink basis)
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flex: '2 2 10%',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexGrow: '2',
+            flexShrink: '2',
+            flexBasis: '10%',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flex: 2 2 10%" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flex: with !important (allowImportant)
+    {
+      options: [{ allowImportant: true }],
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flex: '1 0 auto !important',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexGrow: '1 !important',
+            flexShrink: '0 !important',
+            flexBasis: 'auto !important',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flex: 1 0 auto !important" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flex: calc() basis
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flex: '1 1 calc(100% - 20px)',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexGrow: '1',
+            flexShrink: '1',
+            flexBasis: 'calc(100% - 20px)',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flex: 1 1 calc(100% - 20px)" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
   ],
 });

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
@@ -58,6 +58,7 @@ const shorthandAliases: $ReadOnly<{
   gridRow: createSpecificTransformer('grid-row'),
   gridTemplate: createSpecificTransformer('grid-template'),
   outline: createSpecificTransformer('outline'),
+  flex: createSpecificTransformer('flex'),
   margin: createDirectionalTransformer('margin', 'Block', 'Inline'),
   padding: createDirectionalTransformer('padding', 'Block', 'Inline'),
   marginBlock: createBlockInlineTransformer('margin', 'Block'),

--- a/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
@@ -546,6 +546,126 @@ function parseBorderParts(values: Array<string>): ?{
   return { width, style, color };
 }
 
+const FLEX_BASIS_KEYWORDS = new Set([
+  'auto',
+  'content',
+  'min-content',
+  'max-content',
+  'fit-content',
+]);
+const FLEX_BASIS_FUNCTION_REGEX = /^(?:calc|min|max|clamp|fit-content)\(/i;
+const FLEX_NUMBER_REGEX = /^-?(?:\d+|\d*\.\d+)$/;
+const FLEX_UNITLESS_ZERO_REGEX = /^-?(?:0|0\.0+)$/;
+
+function isFlexNumberValue(value: string): boolean {
+  return FLEX_NUMBER_REGEX.test(value);
+}
+
+function isFlexBasisValue(
+  value: string,
+  options: { allowUnitlessZero?: boolean } = {},
+): boolean {
+  const lower = value.toLowerCase();
+  if (options.allowUnitlessZero && FLEX_UNITLESS_ZERO_REGEX.test(lower)) {
+    return true;
+  }
+  return (
+    FLEX_BASIS_KEYWORDS.has(lower) ||
+    FLEX_BASIS_FUNCTION_REGEX.test(lower) ||
+    lower.startsWith('var(') ||
+    /^-?(?:\d+|\d*\.\d+)(?:[a-z%]+)$/i.test(lower)
+  );
+}
+
+function expandFlexShorthand(
+  values: Array<string>,
+  importantSuffix: string,
+): ?$ReadOnlyArray<$ReadOnly<[string, string]>> {
+  if (values.length === 1) {
+    const val = values[0];
+    const lower = val.toLowerCase();
+    if (lower === 'auto') {
+      return [
+        ['flexGrow', applyImportant('1', importantSuffix)],
+        ['flexShrink', applyImportant('1', importantSuffix)],
+        ['flexBasis', applyImportant('auto', importantSuffix)],
+      ];
+    }
+    if (lower === 'none') {
+      return [
+        ['flexGrow', applyImportant('0', importantSuffix)],
+        ['flexShrink', applyImportant('0', importantSuffix)],
+        ['flexBasis', applyImportant('auto', importantSuffix)],
+      ];
+    }
+    if (lower === 'initial') {
+      return [
+        ['flexGrow', applyImportant('0', importantSuffix)],
+        ['flexShrink', applyImportant('1', importantSuffix)],
+        ['flexBasis', applyImportant('auto', importantSuffix)],
+      ];
+    }
+    if (isFlexNumberValue(val)) {
+      // Single unitless number = flex-grow
+      return [
+        ['flexGrow', applyImportant(val, importantSuffix)],
+        ['flexShrink', applyImportant('1', importantSuffix)],
+        ['flexBasis', applyImportant('0%', importantSuffix)],
+      ];
+    }
+    if (isFlexBasisValue(val)) {
+      return [
+        ['flexGrow', applyImportant('1', importantSuffix)],
+        ['flexShrink', applyImportant('1', importantSuffix)],
+        ['flexBasis', applyImportant(val, importantSuffix)],
+      ];
+    }
+    return null;
+  }
+
+  if (values.length === 2) {
+    const [first, second] = values;
+    if (!isFlexNumberValue(first)) {
+      return null;
+    }
+    if (isFlexNumberValue(second)) {
+      // <number> <number>
+      return [
+        ['flexGrow', applyImportant(first, importantSuffix)],
+        ['flexShrink', applyImportant(second, importantSuffix)],
+        ['flexBasis', applyImportant('0%', importantSuffix)],
+      ];
+    }
+    if (isFlexBasisValue(second)) {
+      // <number> <basis>
+      return [
+        ['flexGrow', applyImportant(first, importantSuffix)],
+        ['flexShrink', applyImportant('1', importantSuffix)],
+        ['flexBasis', applyImportant(second, importantSuffix)],
+      ];
+    }
+    return null;
+  }
+
+  if (values.length === 3) {
+    const [grow, shrink, basis] = values;
+    if (
+      !isFlexNumberValue(grow) ||
+      !isFlexNumberValue(shrink) ||
+      !isFlexBasisValue(basis, { allowUnitlessZero: true })
+    ) {
+      return null;
+    }
+    return [
+      ['flexGrow', applyImportant(grow, importantSuffix)],
+      ['flexShrink', applyImportant(shrink, importantSuffix)],
+      ['flexBasis', applyImportant(basis, importantSuffix)],
+    ];
+  }
+
+  return null;
+}
+
 function expandBorderSideShorthand(
   property: string,
   values: Array<string>,
@@ -805,6 +925,16 @@ export function splitSpecificShorthands(
     }
     const expanded = expandGridAreaShorthand(groups, importantSuffix);
     return expanded.length > 0 ? expanded : [['gridArea', CANNOT_FIX]];
+  }
+
+  if (property === 'flex') {
+    const flexSplit = splitTopLevelValueTokens(baseValue);
+    if (flexSplit.hasTopLevelComma || flexSplit.hasTopLevelSlash) {
+      return [['flex', CANNOT_FIX]];
+    }
+    const flexValues = flexSplit.parts.map((part) => part.text);
+    const expandedFlex = expandFlexShorthand(flexValues, importantSuffix);
+    return expandedFlex ?? [['flex', CANNOT_FIX]];
   }
 
   const splitValues = splitTopLevelValueTokens(baseValue);


### PR DESCRIPTION
## What changed / motivation ?

Added flex shorthand expansion to `stylex-valid-shorthands` using the same `createSpecificTransformer` pattern already used for `background`, `font`, `border`, `grid`, and `outline`.

Changes:
- Added `flex: createSpecificTransformer('flex')` to shorthand aliases.
- Added `expandFlexShorthand()` in `splitShorthands.js` plus helper classifiers for:
  - unitless flex numbers (`flex-grow` / `flex-shrink`)
  - valid basis values (`auto`, `content`, `min-content`, `max-content`, `fit-content`, `calc()/min()/max()/clamp()/fit-content()`, `var()`, unit/percent values)
- Added `property === 'flex'` dispatch in `splitSpecificShorthands` before generic single-value passthrough so cases like `flex: 1` still expand.
- Added/updated tests covering:
  - keywords: `auto`, `none`, `initial`
  - single number
  - single basis
  - two-value forms (`grow shrink`, `grow basis`)
  - three-value form (`grow shrink basis`)
  - `calc()` basis
  - `!important` propagation

Behavior:
- `flex: '1 0 auto'` now reports and autofixes to:
  - `flexGrow: '1'`
  - `flexShrink: '0'`
  - `flexBasis: 'auto'`

Motivation:
- `flex` shorthand is common in StyleX authoring and migration paths.
- Previously this pattern was flagged but not expanded as a first-class shorthand.
- This brings `flex` in line with existing shorthand autofix behavior while keeping fixes safe and deterministic.

## Linked PR/Issues

N/A

## Additional Context

Example autofix:
- Input: `flex: '1 0 auto'`
- Output: `flexGrow: '1', flexShrink: '0', flexBasis: 'auto'`

Tests:
- `npx jest --watchman=false --coverage=false stylex-valid-shorthands-test.js`
- Result: `PASS` (`94 passed`, `0 failed`)

Screenshots:
- N/A (ESLint rule + autofix behavior change)

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
