### PR TITLE
(babel-plugin): Unify CSS layers config and add prefix option

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -385,12 +385,13 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
-    test('useLayers with layersBefore', () => {
+    test('useLayers with before option', () => {
       const { metadata } = transform(fixture);
       expect(
         stylexPlugin.processStylexRules(metadata, {
-          useLayers: true,
-          layersBefore: ['reset', 'typography'],
+          useLayers: {
+            before: ['reset', 'typography'],
+          },
           enableLTRRTLComments: false,
         }),
       ).toMatchInlineSnapshot(`
@@ -433,12 +434,13 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
-    test('useLayers with layersAfter', () => {
+    test('useLayers with after option', () => {
       const { metadata } = transform(fixture);
       expect(
         stylexPlugin.processStylexRules(metadata, {
-          useLayers: true,
-          layersAfter: ['overrides', 'xds.theme'],
+          useLayers: {
+            after: ['overrides', 'xds.theme'],
+          },
           enableLTRRTLComments: false,
         }),
       ).toMatchInlineSnapshot(`
@@ -481,13 +483,14 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
-    test('useLayers with both layersBefore and layersAfter', () => {
+    test('useLayers with both before and after', () => {
       const { metadata } = transform(fixture);
       expect(
         stylexPlugin.processStylexRules(metadata, {
-          useLayers: true,
-          layersBefore: ['reset'],
-          layersAfter: ['xds.theme'],
+          useLayers: {
+            before: ['reset'],
+            after: ['xds.theme'],
+          },
           enableLTRRTLComments: false,
         }),
       ).toMatchInlineSnapshot(`
@@ -530,18 +533,19 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
-    test('layersBefore/layersAfter are ignored when useLayers is false', () => {
+    test('useLayers with prefix option', () => {
       const { metadata } = transform(fixture);
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       expect(
         stylexPlugin.processStylexRules(metadata, {
-          useLayers: false,
-          layersBefore: ['reset'],
-          layersAfter: ['overrides'],
+          useLayers: {
+            prefix: 'stylex',
+          },
           enableLTRRTLComments: false,
         }),
       ).toMatchInlineSnapshot(`
-        "@property --x-color { syntax: "*"; inherits: false;}
+        "
+        @layer stylex.priority1, stylex.priority2, stylex.priority3, stylex.priority4;
+        @property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
         :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
         :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
@@ -551,38 +555,143 @@ describe('@stylexjs/babel-plugin', () => {
         .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
         .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
         .--orange-theme-color-xufgesz{--orange-theme-color:red}
-        .margin-xymmreb:not(#\\#){margin:10px 20px}
-        .padding-xss17vw:not(#\\#){padding:var(--large-x1ec7iuc)}
-        .borderColor-x1bg2uv5:not(#\\#):not(#\\#){border-color:green}
-        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c:not(#\\#):not(#\\#){border-color:var(--blue-xpqh4lw)}}
-        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys:not(#\\#):not(#\\#){border-color:yellow}}}
-        .animationName-x13ah0pd:not(#\\#):not(#\\#):not(#\\#){animation-name:x35atj5-B}
-        .backgroundColor-xrkmrrc:not(#\\#):not(#\\#):not(#\\#){background-color:red}
-        .color-x14rh7hd:not(#\\#):not(#\\#):not(#\\#){color:var(--x-color)}
-        html:not([dir='rtl']) .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:left}
-        html[dir='rtl'] .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:right}
-        .outlineColor-x184ctg8:not(#\\#):not(#\\#):not(#\\#){outline-color:var(--colorTokens-xkxfyv)}
-        .textShadow-x1skrh0i:not(#\\#):not(#\\#):not(#\\#){text-shadow:1px 2px 3px 4px red}
-        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *):not(#\\#):not(#\\#):not(#\\#){background-color:green}
-        .backgroundColor-xbrh7vm:hover:not(#\\#):not(#\\#):not(#\\#){background-color:blue}
-        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn:not(#\\#):not(#\\#):not(#\\#){background-color:yellow}}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id:not(#\\#):not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}
-        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)):not(#\\#):not(#\\#):not(#\\#){background-color:purple}}
-        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)):not(#\\#):not(#\\#):not(#\\#){background-color:orange}}"
+        @layer stylex.priority2{
+        .margin-xymmreb{margin:10px 20px}
+        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        }
+        @layer stylex.priority3{
+        .borderColor-x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        }
+        @layer stylex.priority4{
+        .animationName-x13ah0pd{animation-name:x35atj5-B}
+        .backgroundColor-xrkmrrc{background-color:red}
+        .color-x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .float-x1kmio9f{float:left}
+        html[dir='rtl'] .float-x1kmio9f{float:right}
+        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
+        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .backgroundColor-xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        }"
       `);
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[@stylexjs/babel-plugin] `layersBefore` and `layersAfter` options are ignored when `useCSSLayers` is not enabled.',
-      );
-      warnSpy.mockRestore();
     });
 
-    test('empty layersBefore/layersAfter produce standard layer declaration', () => {
+    test('useLayers with prefix, before, and after combined', () => {
       const { metadata } = transform(fixture);
       expect(
         stylexPlugin.processStylexRules(metadata, {
-          useLayers: true,
-          layersBefore: [],
-          layersAfter: [],
+          useLayers: {
+            prefix: 'stylex',
+            before: ['reset', 'typography'],
+            after: ['xds.theme'],
+          },
+          enableLTRRTLComments: false,
+        }),
+      ).toMatchInlineSnapshot(`
+        "
+        @layer reset, typography, stylex.priority1, stylex.priority2, stylex.priority3, stylex.priority4, xds.theme;
+        @property --x-color { syntax: "*"; inherits: false;}
+        @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
+        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
+        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
+        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        @layer stylex.priority2{
+        .margin-xymmreb{margin:10px 20px}
+        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        }
+        @layer stylex.priority3{
+        .borderColor-x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        }
+        @layer stylex.priority4{
+        .animationName-x13ah0pd{animation-name:x35atj5-B}
+        .backgroundColor-xrkmrrc{background-color:red}
+        .color-x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .float-x1kmio9f{float:left}
+        html[dir='rtl'] .float-x1kmio9f{float:right}
+        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
+        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .backgroundColor-xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        }"
+      `);
+    });
+
+    test('useLayers with multi-segment dot-notated prefix (XDS use case)', () => {
+      const { metadata } = transform(fixture);
+      expect(
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: {
+            prefix: 'xds.base',
+            before: ['xds.reset', 'xds.typography'],
+            after: ['xds.theme'],
+          },
+          enableLTRRTLComments: false,
+        }),
+      ).toMatchInlineSnapshot(`
+        "
+        @layer xds.reset, xds.typography, xds.base.priority1, xds.base.priority2, xds.base.priority3, xds.base.priority4, xds.theme;
+        @property --x-color { syntax: "*"; inherits: false;}
+        @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
+        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
+        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
+        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
+        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
+        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        @layer xds.base.priority2{
+        .margin-xymmreb{margin:10px 20px}
+        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        }
+        @layer xds.base.priority3{
+        .borderColor-x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        }
+        @layer xds.base.priority4{
+        .animationName-x13ah0pd{animation-name:x35atj5-B}
+        .backgroundColor-xrkmrrc{background-color:red}
+        .color-x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .float-x1kmio9f{float:left}
+        html[dir='rtl'] .float-x1kmio9f{float:right}
+        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
+        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .backgroundColor-xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        }"
+      `);
+    });
+
+    test('empty before/after produce standard layer declaration', () => {
+      const { metadata } = transform(fixture);
+      expect(
+        stylexPlugin.processStylexRules(metadata, {
+          useLayers: {
+            before: [],
+            after: [],
+          },
           enableLTRRTLComments: false,
         }),
       ).toMatchInlineSnapshot(`

--- a/packages/@stylexjs/babel-plugin/src/index.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/index.d.ts
@@ -44,9 +44,13 @@ declare function processStylexRules(
   config?:
     | boolean
     | {
-        useLayers?: boolean;
-        layersBefore?: ReadonlyArray<string>;
-        layersAfter?: ReadonlyArray<string>;
+        useLayers?:
+          | boolean
+          | {
+              before?: ReadonlyArray<string>;
+              after?: ReadonlyArray<string>;
+              prefix?: string;
+            };
         enableLTRRTLComments?: boolean;
         legacyDisableLayers?: boolean;
       },

--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -438,29 +438,35 @@ function processStylexRules(
   config?:
     | boolean
     | {
-        useLayers?: boolean,
-        layersBefore?: $ReadOnlyArray<string>,
-        layersAfter?: $ReadOnlyArray<string>,
+        useLayers?:
+          | boolean
+          | $ReadOnly<{
+              before?: $ReadOnlyArray<string>,
+              after?: $ReadOnlyArray<string>,
+              prefix?: string,
+            }>,
         enableLTRRTLComments?: boolean,
         legacyDisableLayers?: boolean,
         useLegacyClassnamesSort?: boolean,
         ...
       },
 ): string {
+  const rawConfig =
+    typeof config === 'boolean' ? { useLayers: config } : (config ?? {});
   const {
-    useLayers = false,
-    layersBefore = [],
-    layersAfter = [],
     enableLTRRTLComments = false,
     legacyDisableLayers = false,
     useLegacyClassnamesSort = false,
-  } = typeof config === 'boolean' ? { useLayers: config } : (config ?? {});
+  } = rawConfig;
 
-  if (!useLayers && (layersBefore.length > 0 || layersAfter.length > 0)) {
-    console.warn(
-      '[@stylexjs/babel-plugin] `layersBefore` and `layersAfter` options are ignored when `useCSSLayers` is not enabled.',
-    );
-  }
+  const rawUseLayers = rawConfig.useLayers ?? false;
+  const useLayers = rawUseLayers !== false;
+  const layersBefore =
+    typeof rawUseLayers === 'object' ? (rawUseLayers.before ?? []) : [];
+  const layersAfter =
+    typeof rawUseLayers === 'object' ? (rawUseLayers.after ?? []) : [];
+  const layerPrefix =
+    typeof rawUseLayers === 'object' ? (rawUseLayers.prefix ?? '') : '';
 
   if (rules.length === 0) {
     return '';
@@ -575,11 +581,16 @@ function processStylexRules(
 
   const logicalFloatVars = getLogicalFloatVars(nonConstantRules);
 
+  const layerName = (index: number): string =>
+    layerPrefix
+      ? `${layerPrefix}.priority${index + 1}`
+      : `priority${index + 1}`;
+
   const header = useLayers
     ? '\n@layer ' +
       [
         ...layersBefore,
-        ...grouped.map((_, index) => `priority${index + 1}`),
+        ...grouped.map((_, index) => layerName(index)),
         ...layersAfter,
       ].join(', ') +
       ';\n'
@@ -632,7 +643,7 @@ function processStylexRules(
 
       // Don't put @property, @keyframe, @position-try in layers
       return useLayers && pri > 0
-        ? `@layer priority${index + 1}{\n${collectedCSS}\n}`
+        ? `@layer ${layerName(index)}{\n${collectedCSS}\n}`
         : collectedCSS;
     })
     .join('\n');

--- a/packages/@stylexjs/postcss-plugin/src/builder.js
+++ b/packages/@stylexjs/postcss-plugin/src/builder.js
@@ -157,8 +157,6 @@ function createBuilder() {
       cwd,
       babelConfig,
       useCSSLayers,
-      layersBefore,
-      layersAfter,
       enableLTRRTLComments,
       importSources,
       isDev,
@@ -210,8 +208,6 @@ function createBuilder() {
 
     const css = bundler.bundle({
       useCSSLayers,
-      layersBefore,
-      layersAfter,
       enableLTRRTLComments,
     });
     return css;

--- a/packages/@stylexjs/postcss-plugin/src/bundler.js
+++ b/packages/@stylexjs/postcss-plugin/src/bundler.js
@@ -62,18 +62,11 @@ module.exports = function createBundler() {
   }
 
   //  Bundles all collected StyleX rules into a single CSS string.
-  function bundle({
-    useCSSLayers,
-    layersBefore,
-    layersAfter,
-    enableLTRRTLComments,
-  }) {
+  function bundle({ useCSSLayers, enableLTRRTLComments }) {
     const rules = Array.from(styleXRulesMap.values()).flat();
 
     const css = stylexBabelPlugin.processStylexRules(rules, {
       useLayers: useCSSLayers,
-      layersBefore,
-      layersAfter,
       enableLTRRTLComments,
     });
 

--- a/packages/@stylexjs/postcss-plugin/src/plugin.js
+++ b/packages/@stylexjs/postcss-plugin/src/plugin.js
@@ -33,8 +33,6 @@ module.exports = function createPlugin() {
     include,
     exclude,
     useCSSLayers = false,
-    layersBefore,
-    layersAfter,
     styleResolution = 'property-specificity',
     importSources,
   }) => {
@@ -107,8 +105,6 @@ module.exports = function createPlugin() {
             cwd,
             babelConfig: effectiveBabelConfig,
             useCSSLayers,
-            layersBefore,
-            layersAfter,
             styleResolution,
             importSources: effectiveImportSources,
             isDev,

--- a/packages/@stylexjs/rollup-plugin/src/index.js
+++ b/packages/@stylexjs/rollup-plugin/src/index.js
@@ -37,9 +37,13 @@ export type PluginOptions = $ReadOnly<{
     plugins?: $ReadOnlyArray<PluginItem>,
     presets?: $ReadOnlyArray<PluginItem>,
   }>,
-  useCSSLayers?: boolean,
-  layersBefore?: $ReadOnlyArray<string>,
-  layersAfter?: $ReadOnlyArray<string>,
+  useCSSLayers?:
+    | boolean
+    | $ReadOnly<{
+        before?: $ReadOnlyArray<string>,
+        after?: $ReadOnlyArray<string>,
+        prefix?: string,
+      }>,
   lightningcssOptions?: Omit<
     TransformOptions<{}>,
     'code' | 'filename' | 'visitor',
@@ -66,8 +70,6 @@ export default function stylexPlugin({
   babelConfig: { plugins = [], presets = [] } = {},
   importSources = ['stylex', '@stylexjs/stylex'],
   useCSSLayers = false,
-  layersBefore,
-  layersAfter,
   lightningcssOptions,
   ...options
 }: PluginOptions = {}): Plugin<> {
@@ -82,8 +84,6 @@ export default function stylexPlugin({
       if (rules.length > 0) {
         const collectedCSS = stylexBabelPlugin.processStylexRules(rules, {
           useLayers: useCSSLayers,
-          layersBefore,
-          layersAfter,
           enableLTRRTLComments: options?.enableLTRRTLComments,
         });
 

--- a/packages/@stylexjs/unplugin/src/core.d.ts
+++ b/packages/@stylexjs/unplugin/src/core.d.ts
@@ -10,8 +10,16 @@ import type { TransformOptions } from 'lightningcss';
 
 type LightningcssOptions = Omit<TransformOptions<any>, 'filename' | 'code'>;
 
+export type CSSLayersConfig =
+  | boolean
+  | {
+      before?: ReadonlyArray<string>;
+      after?: ReadonlyArray<string>;
+      prefix?: string;
+    };
+
 export type UserOptions = StyleXOptions & {
-  useCSSLayers?: boolean;
+  useCSSLayers?: CSSLayersConfig;
   enableLTRRTLComments?: boolean;
   legacyDisableLayers?: boolean;
   lightningcssOptions?: LightningcssOptions;

--- a/packages/@stylexjs/unplugin/src/core.js
+++ b/packages/@stylexjs/unplugin/src/core.js
@@ -48,9 +48,7 @@ export function pickCssAssetFromRollupBundle(bundle, choose) {
 function processCollectedRulesToCSS(rules, options) {
   if (!rules || rules.length === 0) return '';
   const collectedCSS = stylexBabelPlugin.processStylexRules(rules, {
-    useLayers: !!options.useCSSLayers,
-    layersBefore: options?.layersBefore,
-    layersAfter: options?.layersAfter,
+    useLayers: options.useCSSLayers ?? false,
     enableLTRRTLComments: options?.enableLTRRTLComments,
   });
   const { code } = lightningTransform({
@@ -359,8 +357,6 @@ export const unpluginFactory = (userOptions = {}, metaOptions) => {
     const allRules = Array.from(merged.values()).flat();
     return processCollectedRulesToCSS(allRules, {
       useCSSLayers,
-      layersBefore: userOptions.layersBefore,
-      layersAfter: userOptions.layersAfter,
       lightningcssOptions,
       enableLTRRTLComments: stylexOptions?.enableLTRRTLComments,
     });


### PR DESCRIPTION
## What changed / motivation?

This PR consolidates the three separate CSS layer config options (`useLayers`, `layersBefore`, `layersAfter`) introduced in #1529 into a single unified `useLayers` config, and adds a new `prefix` option for namespacing layer names.

**Before (3 separate options):**
```js
processStylexRules(rules, {
  useLayers: true,
  layersBefore: ['reset'],
  layersAfter: ['xds.theme'],
});
```

**After (single unified config):**
```js
processStylexRules(rules, {
  useLayers: {
    before: ['reset'],
    after: ['xds.theme'],
    prefix: 'stylex',
  },
});
```

`useLayers` now accepts `boolean | { before?, after?, prefix? }`:
- `false` / omitted — no layers (default)
- `true` — layers enabled with defaults (backward compatible with existing usage)
- `{ before?, after?, prefix? }` — layers enabled with full customization

The `prefix` option namespaces StyleX's generated layer names to avoid collisions when multiple design systems or StyleX instances coexist. For example, `prefix: 'xds.base'` produces `xds.base.priority1` instead of `priority1`. This directly enables the XDS use case described in https://github.com/facebookexperimental/xds/pull/794:

> *Once that ships, we can rename `priority1-9` to `xds.base.priority1-9`.*

The same unified config is available at the bundler plugin level via `useCSSLayers`:

```js
// Bundler plugins (rollup, postcss, unplugin)
stylexPlugin({
  useCSSLayers: {
    before: ['xds.reset', 'xds.typography'],
    after: ['xds.theme'],
    prefix: 'xds.base',
  },
});
```

Generated CSS:
```css
@layer xds.reset, xds.typography, xds.base.priority1, xds.base.priority2, xds.base.priority3, xds.base.priority4, xds.theme;

@layer xds.base.priority2{
.margin-xymmreb{margin:10px 20px}
}
@layer xds.base.priority3{
.borderColor-x1bg2uv5{border-color:green}
}
@layer xds.base.priority4{
.backgroundColor-xrkmrrc{background-color:red}
}
```

`useCSSLayers: true` works fine on its own — it enables CSS layers with sensible defaults (no prefix, no extra layers before/after), producing simple priority1 through priorityN layer names. The before, after, and prefix properties are purely optional customization hooks.

### Breaking change note

This removes the top-level `layersBefore` and `layersAfter` options introduced in #1529. Since #1529 has not been included in any npm release yet, there are no external consumers to break.

## Changes

- **`@stylexjs/babel-plugin`** — Replaced `useLayers` (boolean) + `layersBefore` + `layersAfter` with a unified `useLayers` that accepts `boolean | { before?, after?, prefix? }`. Added `layerName()` helper for prefixed layer name generation in both the `@layer` declaration header and individual layer wrapping blocks.
- **`@stylexjs/babel-plugin` (types)** — Updated `processStylexRules` config type in both Flow (`index.js`) and TypeScript (`index.d.ts`) declarations.
- **`@stylexjs/rollup-plugin`** — Replaced `useCSSLayers` (boolean) + `layersBefore` + `layersAfter` with unified `useCSSLayers` that accepts `boolean | object`. Passes through directly as `useLayers`.
- **`@stylexjs/postcss-plugin`** — Removed `layersBefore`/`layersAfter` threading from `plugin.js` → `builder.js` → `bundler.js`. The unified `useCSSLayers` value flows through the entire chain.
- **`@stylexjs/unplugin`** — Removed `layersBefore`/`layersAfter` from `processCollectedRulesToCSS` and `collectCss`. Added `CSSLayersConfig` type to `core.d.ts`.

## Linked PR/Issues

Builds on #1529
Addresses https://github.com/facebookexperimental/xds/issues/646
Enables https://github.com/facebookexperimental/xds/pull/794

## Additional Context

`npx jest`:

3 new test cases added, 5 existing layer tests migrated to the new unified API:

```
PASS __tests__/transform-process-test.js
  @stylexjs/babel-plugin
    [transform] stylexPlugin.processStylexRules
      ✓ no rules (52 ms)
      ✓ all rules (useLayers:false) (43 ms)
      ✓ all rules (useLayers:true) (45 ms)
      ✓ useLayers with before option (45 ms)
      ✓ useLayers with after option (48 ms)
      ✓ useLayers with both before and after (49 ms)
      ✓ useLayers with prefix option (49 ms)
      ✓ useLayers with prefix, before, and after combined (52 ms)
      ✓ useLayers with multi-segment dot-notated prefix (XDS use case) (48 ms)
      ✓ empty before/after produce standard layer declaration (50 ms)
      ✓ all rules (legacyDisableLayers:true) (51 ms)
      ✓ legacy-expand-shorthands with logical styles polyfill (4 ms)
      ✓ legacy-expand-shorthands duplicates theme selectors for higher precedence (3 ms)
      ✓ no mutation of rules (52 ms)
      ✓ useLegacyClassnamesSort: false (default behavior) (52 ms)
      ✓ useLegacyClassnamesSort: true (legacy behavior) (51 ms)
      ✓ sort is deterministic regardless of input order (1 ms)
      ✓ sort is deterministic with duplicate rules in different input orders

Test Suites: 1 passed, 1 total
Tests:       18 passed, 18 total
Snapshots:   26 passed, 26 total
Time:        1.4 s
```

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code