### PR TITLE
fix(types): deprecate shorthand properties rejected by default compiler mode

### DIFF
--- a/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.js
@@ -1017,6 +1017,7 @@ export type CSSProperties = Readonly<{
 
   // Not Allowed:
   // all?: all | all,
+  /** @deprecated Use individual animation properties (animationName, animationDuration, etc.) instead. Not supported in property-specificity mode (the default). */
   animation?: all | string,
   animationComposition?: all | string,
   animationDelay?: all | OptionalArray<animationDelay>,
@@ -1036,6 +1037,7 @@ export type CSSProperties = Readonly<{
 
   backdropFilter?: all | backdropFilter,
   backfaceVisibility?: all | backfaceVisibility,
+  /** @deprecated Use backgroundColor, backgroundImage, etc. instead. Not supported in property-specificity mode (the default). */
   background?: all | string,
   backgroundAttachment?: all | OptionalArray<backgroundAttachment>,
   backgroundBlendMode?: all | OptionalArray<backgroundBlendMode>,
@@ -1051,7 +1053,9 @@ export type CSSProperties = Readonly<{
   baselineShift?: all | baselineShift,
   behavior?: all | behavior,
   blockSize?: all | blockSize,
+  /** @deprecated Use borderWidth, borderStyle, and borderColor instead. Not supported in property-specificity mode (the default). */
   border?: all | border,
+  /** @deprecated Use borderBlockWidth, borderBlockStyle, and borderBlockColor instead. Not supported in property-specificity mode (the default). */
   borderBlock?: all | borderBlockEnd,
   borderBlockColor?: all | borderBlockEndColor,
   borderBlockStyle?: all | borderBlockEndStyle,
@@ -1064,6 +1068,7 @@ export type CSSProperties = Readonly<{
   borderBlockStartColor?: all | borderBlockStartColor,
   borderBlockStartStyle?: all | borderBlockStartStyle,
   borderBlockStartWidth?: all | borderBlockStartWidth,
+  /** @deprecated Use borderBottomWidth, borderBottomStyle, and borderBottomColor instead. Not supported in property-specificity mode (the default). */
   borderBottom?: all | border,
   borderBottomColor?: all | color,
   borderBottomStyle?: all | borderBottomStyle,
@@ -1076,28 +1081,34 @@ export type CSSProperties = Readonly<{
   borderImageSlice?: all | borderImageSlice,
   borderImageSource?: all | borderImageSource,
   borderImageWidth?: all | borderImageWidth,
+  /** @deprecated Use borderInlineWidth, borderInlineStyle, and borderInlineColor instead. Not supported in property-specificity mode (the default). */
   borderInline?: all | borderInlineEnd,
   borderInlineColor?: all | borderInlineEndColor,
   borderInlineStyle?: all | borderInlineEndStyle,
   borderInlineWidth?: all | borderInlineEndWidth,
+  /** @deprecated Use borderInlineEndWidth, borderInlineEndStyle, and borderInlineEndColor instead. Not supported in property-specificity mode (the default). */
   borderInlineEnd?: all | borderInlineEnd,
   borderInlineEndColor?: all | borderInlineEndColor,
   borderInlineEndStyle?: all | borderInlineEndStyle,
   borderInlineEndWidth?: all | borderInlineEndWidth,
+  /** @deprecated Use borderInlineStartWidth, borderInlineStartStyle, and borderInlineStartColor instead. Not supported in property-specificity mode (the default). */
   borderInlineStart?: all | borderInlineStart,
   borderInlineStartColor?: all | borderInlineStartColor,
   borderInlineStartStyle?: all | borderInlineStartStyle,
   borderInlineStartWidth?: all | borderInlineStartWidth,
+  /** @deprecated Use borderLeftWidth, borderLeftStyle, and borderLeftColor instead (or preferably borderInlineStart* equivalents). Not supported in property-specificity mode (the default). */
   borderLeft?: all | border,
   borderLeftColor?: all | borderLeftColor,
   borderLeftStyle?: all | borderLeftStyle,
   borderLeftWidth?: all | borderLeftWidth,
+  /** @deprecated Use borderRightWidth, borderRightStyle, and borderRightColor instead (or preferably borderInlineEnd* equivalents). Not supported in property-specificity mode (the default). */
   borderRight?: all | border,
   borderRightColor?: all | borderRightColor,
   borderRightStyle?: all | borderRightStyle,
   borderRightWidth?: all | borderRightWidth,
   borderSpacing?: all | borderSpacing,
   borderStyle?: all | borderStyle,
+  /** @deprecated Use borderTopWidth, borderTopStyle, and borderTopColor instead. Not supported in property-specificity mode (the default). */
   borderTop?: all | border,
   borderTopColor?: all | color,
 


### PR DESCRIPTION
## Summary

Adds `@deprecated` JSDoc annotations to the 11 CSS shorthand properties in `StyleXCSSTypes.js` that throw errors in the default `property-specificity` styleResolution mode.

This bridges the gap where TypeScript types accept these properties but the compiler rejects them at build time. With this change, IDEs show a strikethrough warning before the user hits a build error.

**Properties annotated:** `animation`, `background`, `border`, `borderBlock`, `borderBottom`, `borderInline`, `borderInlineEnd`, `borderInlineStart`, `borderLeft`, `borderRight`, `borderTop`

Each annotation includes:
- The recommended longhand alternatives (matching the compiler's error messages)
- A note that the property is not supported in the default `property-specificity` mode

## Context

- The default `styleResolution` is `property-specificity` (set in `default-options.js`)
- In this mode, `preprocess-rules/property-specificity.js` throws for these 11 shorthands
- In `application-order` mode, these properties *are* accepted — `@deprecated` is appropriate because it's a soft warning, not a type error
- `@deprecated` aligns with the [authoring guide](https://stylexjs.com/docs/learn/styling-ui/defining-styles/#use-longhand-properties): "Use longhand properties and single-value shorthands over multi-value shorthands"
- The `gen-types` pipeline (`flow-api-translator`) generates `.d.ts` files from this Flow source — JSDoc annotations should propagate to TypeScript consumers

## Test plan

- [ ] Verify `gen-types` preserves `@deprecated` annotations in the generated `.d.ts` output
- [ ] Confirm IDE (VS Code, WebStorm) shows strikethrough on deprecated properties
- [ ] Confirm no behavioral change — types still accept the properties (just with a warning)

Fixes #1542