### PR TITLE
Add AI context generation system for multi-tool agent routing

### DIFF
--- a/.cursor/rules/stylex-authoring.mdc
+++ b/.cursor/rules/stylex-authoring.mdc
@@ -1,0 +1,18 @@
+---
+description: "WF-AUTHOR workflow routing and constraints"
+globs:
+  - "**/*.{js,jsx,ts,tsx}"
+---
+
+Workflow: `WF-AUTHOR` (P0)
+Author valid, idiomatic StyleX styles in apps
+
+Load sources first:
+- `packages/docs/static/llm/stylex-authoring.md`
+- `packages/@stylexjs/eslint-plugin/README.md`
+
+Hard constraints:
+- Use stylex.create() for definitions and stylex.props() for application.
+- Prefer longhands over disallowed multivalue shorthand patterns.
+- Avoid mixing className/style with stylex.props() on the same element.
+- Use modern nested syntax for media queries and pseudo-classes.

--- a/.cursor/rules/stylex-global.mdc
+++ b/.cursor/rules/stylex-global.mdc
@@ -1,0 +1,12 @@
+---
+description: "StyleX global router: default setup/authoring workflows and canonical source files."
+alwaysApply: true
+---
+
+Use `WF-SETUP` and `WF-AUTHOR` by default.
+Use `WF-MAINTAIN` only for StyleX internals under `packages/@stylexjs/*` and `packages/style-value-parser/*`.
+Load canonical sources first:
+- `packages/docs/static/llm/stylex-installation.md`
+- `packages/docs/static/llm/stylex-authoring.md`
+- `packages/@stylexjs/eslint-plugin/README.md`
+Keep this rule short and route to canonical docs instead of duplicating long explanations.

--- a/.cursor/rules/stylex-maintainers.mdc
+++ b/.cursor/rules/stylex-maintainers.mdc
@@ -1,0 +1,20 @@
+---
+description: "WF-MAINTAIN workflow routing and constraints"
+globs:
+  - "packages/@stylexjs/**/*.{js,jsx,ts,tsx,mjs,flow}"
+  - "packages/style-value-parser/**/*.{js,ts,mjs}"
+---
+
+Workflow: `WF-MAINTAIN` (P1)
+Modify StyleX OSS internals safely
+
+Load sources first:
+- `packages/@stylexjs/eslint-plugin/README.md`
+- `packages/@stylexjs/babel-plugin/__tests__/evaluation-import-test.js`
+- `packages/@stylexjs/shared/src/utils/property-priorities.js`
+- `packages/style-value-parser/src/index.js`
+
+Hard constraints:
+- Preserve behavior unless semantic change is explicitly requested.
+- Reference package-local tests and snapshots for behavior validation.
+- Call out user-visible impact on setup and authoring docs when applicable.

--- a/.cursor/rules/stylex-setup.mdc
+++ b/.cursor/rules/stylex-setup.mdc
@@ -1,0 +1,20 @@
+---
+description: "WF-SETUP workflow routing and constraints"
+globs:
+  - "**/{vite.config,webpack.config,rspack.config,rollup.config,esbuild.config,next.config,babel.config,postcss.config}.{js,cjs,mjs,ts}"
+  - "**/package.json"
+  - "**/*.css"
+---
+
+Workflow: `WF-SETUP` (P0)
+Install and configure StyleX in app projects
+
+Load sources first:
+- `packages/docs/static/llm/stylex-installation.md`
+- `packages/docs/static/llm/stylex-authoring.md`
+
+Hard constraints:
+- Provide minimal, working config for the user's exact stack.
+- Keep StyleX plugin ordering constraints where required (for example, before React in Vite).
+- Include @stylex stylesheet directive guidance where needed.
+- Mention .stylex extension and module-resolution caveats when relevant.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,59 @@
+# StyleX Copilot Repository Instructions
+
+_Generated file. Do not edit directly._
+_Source: `ai-dev/plugins/index.json` and `ai-dev/plugins/*.json`._
+
+Keep this file global and orthogonal. Put workflow-specific guidance in
+`.github/instructions/*.instructions.md`.
+
+## Global behavior
+
+- Default to `WF-SETUP` and `WF-AUTHOR`.
+- Use `WF-MAINTAIN` only for StyleX internals.
+- Load canonical docs before giving setup or authoring advice.
+- Align suggestions with StyleX lint rules.
+- Avoid duplicating long setup/authoring explanations; reference canonical files.
+
+## Canonical Sources
+
+- `packages/docs/static/llm/stylex-installation.md`
+- `packages/docs/static/llm/stylex-authoring.md`
+- `packages/@stylexjs/eslint-plugin/README.md`
+
+## Rule Alignment
+
+- `@stylexjs/valid-styles`
+- `@stylexjs/sort-keys`
+- `@stylexjs/valid-shorthands`
+- `@stylexjs/no-unused`
+- `@stylexjs/no-legacy-contextual-styles`
+- `@stylexjs/no-lookahead-selectors`
+- `@stylexjs/no-nonstandard-styles`
+- `@stylexjs/no-conflicting-props`
+- `@stylexjs/enforce-extension`
+
+## Validation Commands
+
+Always run these commands before finalizing changes:
+
+- **Build:** `npm run build`
+- **Test Packages:** `npm run test:packages`
+- **Lint:** `npm run lint:report`
+- **Typecheck:** `npm run flow`
+- **Check Context Drift:** `npm run ai:check-context`
+
+## Do Not
+
+- Do not mix className or inline style with stylex.props() on the same element.
+- Do not use legacy contextual syntax for media or pseudo styles.
+- Do not use disallowed multivalue shorthand patterns where longhands are required.
+- Do not write TypeScript syntax in Flow-typed internal .js files.
+
+## Conventions
+
+- Internal packages use Flow-typed .js files. Do not write TypeScript syntax in these files.
+
+## Generation and Integrity
+
+- Generate: `node tools/ai-context/generate-agents.js`
+- Check drift: `node tools/ai-context/generate-agents.js --check`

--- a/.github/instructions/stylex-authoring.instructions.md
+++ b/.github/instructions/stylex-authoring.instructions.md
@@ -1,0 +1,24 @@
+---
+applyTo: "**/*.{js,jsx,ts,tsx}"
+---
+# WF-AUTHOR (P0)
+
+Author valid, idiomatic StyleX styles in apps
+
+When to use:
+
+- User asks how to write or refactor StyleX styles
+- User asks about pseudo/media rules, dynamic styles, vars/themes, or style merges
+- User is fixing lint violations in app-level StyleX code
+
+Load sources first:
+
+- `packages/docs/static/llm/stylex-authoring.md`
+- `packages/@stylexjs/eslint-plugin/README.md`
+
+Hard constraints:
+
+- Use stylex.create() for definitions and stylex.props() for application.
+- Prefer longhands over disallowed multivalue shorthand patterns.
+- Avoid mixing className/style with stylex.props() on the same element.
+- Use modern nested syntax for media queries and pseudo-classes.

--- a/.github/instructions/stylex-maintainers.instructions.md
+++ b/.github/instructions/stylex-maintainers.instructions.md
@@ -1,0 +1,25 @@
+---
+applyTo: "packages/{@stylexjs,style-value-parser}/**/*.{js,jsx,ts,tsx,mjs,flow}"
+---
+# WF-MAINTAIN (P1)
+
+Modify StyleX OSS internals safely
+
+When to use:
+
+- User edits packages/@stylexjs/* or packages/style-value-parser/*
+- Task changes compiler, parser, lint rule internals, or shared utilities
+- Task modifies tests, transforms, or behavior snapshots
+
+Load sources first:
+
+- `packages/@stylexjs/eslint-plugin/README.md`
+- `packages/@stylexjs/babel-plugin/__tests__/evaluation-import-test.js`
+- `packages/@stylexjs/shared/src/utils/property-priorities.js`
+- `packages/style-value-parser/src/index.js`
+
+Hard constraints:
+
+- Preserve behavior unless semantic change is explicitly requested.
+- Reference package-local tests and snapshots for behavior validation.
+- Call out user-visible impact on setup and authoring docs when applicable.

--- a/.github/instructions/stylex-setup.instructions.md
+++ b/.github/instructions/stylex-setup.instructions.md
@@ -1,0 +1,26 @@
+---
+applyTo: "**/{vite.config,webpack.config,rspack.config,rollup.config,esbuild.config,next.config,babel.config,postcss.config}.{js,cjs,mjs,ts}"
+---
+# WF-SETUP (P0)
+
+Install and configure StyleX in app projects
+
+When to use:
+
+- User asks to install StyleX or integrate it with a bundler/framework
+- User asks for plugin config, CSS entrypoint setup, or compile setup
+- User is troubleshooting setup or module resolution
+- User is creating .stylex.ts/.stylex.js files for defineVars or defineConsts
+- User is setting up theming, variables, or constants infrastructure
+
+Load sources first:
+
+- `packages/docs/static/llm/stylex-installation.md`
+- `packages/docs/static/llm/stylex-authoring.md`
+
+Hard constraints:
+
+- Provide minimal, working config for the user's exact stack.
+- Keep StyleX plugin ordering constraints where required (for example, before React in Vite).
+- Include @stylex stylesheet directive guidance where needed.
+- Mention .stylex extension and module-resolution caveats when relevant.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,137 @@
+# StyleX Agent Context
+
+_Generated file. Do not edit directly._
+_Source: `ai-dev/plugins/index.json` and `ai-dev/plugins/*.json`._
+
+This file is a context router. Keep detailed setup/authoring guidance in canonical static docs.
+
+## Default Workflow Selection
+
+Default workflows: WF-SETUP, WF-AUTHOR
+
+Use maintainer workflow only when the task clearly edits StyleX internals.
+
+## Canonical Sources
+
+- `packages/docs/static/llm/stylex-installation.md`
+- `packages/docs/static/llm/stylex-authoring.md`
+- `packages/@stylexjs/eslint-plugin/README.md`
+
+## Workflow Plugins
+
+- `WF-SETUP` (P0): Install and configure StyleX in app projects
+- `WF-AUTHOR` (P0): Author valid, idiomatic StyleX styles in apps
+- `WF-MAINTAIN` (P1): Modify StyleX OSS internals safely
+
+### WF-SETUP (P0)
+
+Install and configure StyleX in app projects
+
+When to use:
+
+- User asks to install StyleX or integrate it with a bundler/framework
+- User asks for plugin config, CSS entrypoint setup, or compile setup
+- User is troubleshooting setup or module resolution
+- User is creating .stylex.ts/.stylex.js files for defineVars or defineConsts
+- User is setting up theming, variables, or constants infrastructure
+
+Load sources first:
+
+- `packages/docs/static/llm/stylex-installation.md`
+- `packages/docs/static/llm/stylex-authoring.md`
+
+Hard constraints:
+
+- Provide minimal, working config for the user's exact stack.
+- Keep StyleX plugin ordering constraints where required (for example, before React in Vite).
+- Include @stylex stylesheet directive guidance where needed.
+- Mention .stylex extension and module-resolution caveats when relevant.
+
+### WF-AUTHOR (P0)
+
+Author valid, idiomatic StyleX styles in apps
+
+When to use:
+
+- User asks how to write or refactor StyleX styles
+- User asks about pseudo/media rules, dynamic styles, vars/themes, or style merges
+- User is fixing lint violations in app-level StyleX code
+
+Load sources first:
+
+- `packages/docs/static/llm/stylex-authoring.md`
+- `packages/@stylexjs/eslint-plugin/README.md`
+
+Hard constraints:
+
+- Use stylex.create() for definitions and stylex.props() for application.
+- Prefer longhands over disallowed multivalue shorthand patterns.
+- Avoid mixing className/style with stylex.props() on the same element.
+- Use modern nested syntax for media queries and pseudo-classes.
+
+## Non-default Workflows
+
+- `WF-MAINTAIN` (P1): Modify StyleX OSS internals safely
+
+Use scoped maintainer files for deep maintainer guidance:
+- `.github/instructions/stylex-maintainers.instructions.md`
+- `.cursor/rules/stylex-maintainers.mdc`
+
+## Rule Alignment Targets
+
+- `@stylexjs/valid-styles`
+- `@stylexjs/sort-keys`
+- `@stylexjs/valid-shorthands`
+- `@stylexjs/no-unused`
+- `@stylexjs/no-legacy-contextual-styles`
+- `@stylexjs/no-lookahead-selectors`
+- `@stylexjs/no-nonstandard-styles`
+- `@stylexjs/no-conflicting-props`
+- `@stylexjs/enforce-extension`
+
+## Validation Commands
+
+Always run these commands before finalizing changes:
+
+- **Build:** `npm run build`
+- **Test Packages:** `npm run test:packages`
+- **Lint:** `npm run lint:report`
+- **Typecheck:** `npm run flow`
+- **Check Context Drift:** `npm run ai:check-context`
+
+## Do Not
+
+- Do not mix className or inline style with stylex.props() on the same element.
+- Do not use legacy contextual syntax for media or pseudo styles.
+- Do not use disallowed multivalue shorthand patterns where longhands are required.
+- Do not write TypeScript syntax in Flow-typed internal .js files.
+
+## Conventions
+
+- Internal packages use Flow-typed .js files. Do not write TypeScript syntax in these files.
+
+## Package Map
+
+- `packages/@stylexjs/stylex` - Public API and runtime
+- `packages/@stylexjs/babel-plugin` - Compiler (style extraction and code transforms)
+- `packages/@stylexjs/shared` - Shared utilities (property priorities, naming)
+- `packages/@stylexjs/eslint-plugin` - Lint rules for style validation
+- `packages/style-value-parser` - CSS value parser and normalizer
+- `packages/@stylexjs/unplugin` - Bundler integrations (Vite, Webpack, Rspack, esbuild, Rollup)
+- `packages/@stylexjs/postcss-plugin` - PostCSS integration (Next.js)
+- `packages/@stylexjs/cli` - CLI for standalone file processing
+
+## Local Override
+
+For machine-local customizations, use `AGENTS.override.md` (not committed).
+
+## Maintainer Trigger Paths
+
+- `packages/@stylexjs/*`
+- `packages/style-value-parser/*`
+
+## Generation and Integrity
+
+- Generate: `node tools/ai-context/generate-agents.js`
+- Check drift: `node tools/ai-context/generate-agents.js --check`
+- Never edit generated context files manually; update plugin source files instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE Context
+
+_Generated file. Do not edit directly._
+_Source: `ai-dev/plugins/index.json` and `ai-dev/plugins/*.json`._
+
+Use `AGENTS.md` as the primary context router.
+
+## Defaults
+
+- Default workflows: WF-SETUP, WF-AUTHOR
+- Use maintainer workflow only for StyleX internals.
+
+## Canonical Sources
+
+- `packages/docs/static/llm/stylex-installation.md`
+- `packages/docs/static/llm/stylex-authoring.md`
+- `packages/@stylexjs/eslint-plugin/README.md`
+
+## Workflow Summary
+
+- `WF-SETUP` (P0): Install and configure StyleX in app projects
+- `WF-AUTHOR` (P0): Author valid, idiomatic StyleX styles in apps
+- `WF-MAINTAIN` (P1): Modify StyleX OSS internals safely
+
+## Rule Alignment
+
+- `@stylexjs/valid-styles`
+- `@stylexjs/sort-keys`
+- `@stylexjs/valid-shorthands`
+- `@stylexjs/no-unused`
+- `@stylexjs/no-legacy-contextual-styles`
+- `@stylexjs/no-lookahead-selectors`
+- `@stylexjs/no-nonstandard-styles`
+- `@stylexjs/no-conflicting-props`
+- `@stylexjs/enforce-extension`
+
+## Validation Commands
+
+Always run these commands before finalizing changes:
+
+- **Build:** `npm run build`
+- **Test Packages:** `npm run test:packages`
+- **Lint:** `npm run lint:report`
+- **Typecheck:** `npm run flow`
+- **Check Context Drift:** `npm run ai:check-context`
+
+## Do Not
+
+- Do not mix className or inline style with stylex.props() on the same element.
+- Do not use legacy contextual syntax for media or pseudo styles.
+- Do not use disallowed multivalue shorthand patterns where longhands are required.
+- Do not write TypeScript syntax in Flow-typed internal .js files.
+
+## Conventions
+
+- Internal packages use Flow-typed .js files. Do not write TypeScript syntax in these files.
+
+## Package Map
+
+- `packages/@stylexjs/stylex` - Public API and runtime
+- `packages/@stylexjs/babel-plugin` - Compiler (style extraction and code transforms)
+- `packages/@stylexjs/shared` - Shared utilities (property priorities, naming)
+- `packages/@stylexjs/eslint-plugin` - Lint rules for style validation
+- `packages/style-value-parser` - CSS value parser and normalizer
+- `packages/@stylexjs/unplugin` - Bundler integrations (Vite, Webpack, Rspack, esbuild, Rollup)
+- `packages/@stylexjs/postcss-plugin` - PostCSS integration (Next.js)
+- `packages/@stylexjs/cli` - CLI for standalone file processing
+
+## Local Override
+
+For machine-local customizations, use `AGENTS.override.md` (not committed).
+
+## Generation and Integrity
+
+- Generate: `node tools/ai-context/generate-agents.js`
+- Check drift: `node tools/ai-context/generate-agents.js --check`
+- Never edit generated context files manually; update plugin source files instead.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,77 @@
+# GEMINI Context
+
+_Generated file. Do not edit directly._
+_Source: `ai-dev/plugins/index.json` and `ai-dev/plugins/*.json`._
+
+Use `AGENTS.md` as the primary context router.
+
+## Defaults
+
+- Default workflows: WF-SETUP, WF-AUTHOR
+- Use maintainer workflow only for StyleX internals.
+
+## Canonical Sources
+
+- `packages/docs/static/llm/stylex-installation.md`
+- `packages/docs/static/llm/stylex-authoring.md`
+- `packages/@stylexjs/eslint-plugin/README.md`
+
+## Workflow Summary
+
+- `WF-SETUP` (P0): Install and configure StyleX in app projects
+- `WF-AUTHOR` (P0): Author valid, idiomatic StyleX styles in apps
+- `WF-MAINTAIN` (P1): Modify StyleX OSS internals safely
+
+## Rule Alignment
+
+- `@stylexjs/valid-styles`
+- `@stylexjs/sort-keys`
+- `@stylexjs/valid-shorthands`
+- `@stylexjs/no-unused`
+- `@stylexjs/no-legacy-contextual-styles`
+- `@stylexjs/no-lookahead-selectors`
+- `@stylexjs/no-nonstandard-styles`
+- `@stylexjs/no-conflicting-props`
+- `@stylexjs/enforce-extension`
+
+## Validation Commands
+
+Always run these commands before finalizing changes:
+
+- **Build:** `npm run build`
+- **Test Packages:** `npm run test:packages`
+- **Lint:** `npm run lint:report`
+- **Typecheck:** `npm run flow`
+- **Check Context Drift:** `npm run ai:check-context`
+
+## Do Not
+
+- Do not mix className or inline style with stylex.props() on the same element.
+- Do not use legacy contextual syntax for media or pseudo styles.
+- Do not use disallowed multivalue shorthand patterns where longhands are required.
+- Do not write TypeScript syntax in Flow-typed internal .js files.
+
+## Conventions
+
+- Internal packages use Flow-typed .js files. Do not write TypeScript syntax in these files.
+
+## Package Map
+
+- `packages/@stylexjs/stylex` - Public API and runtime
+- `packages/@stylexjs/babel-plugin` - Compiler (style extraction and code transforms)
+- `packages/@stylexjs/shared` - Shared utilities (property priorities, naming)
+- `packages/@stylexjs/eslint-plugin` - Lint rules for style validation
+- `packages/style-value-parser` - CSS value parser and normalizer
+- `packages/@stylexjs/unplugin` - Bundler integrations (Vite, Webpack, Rspack, esbuild, Rollup)
+- `packages/@stylexjs/postcss-plugin` - PostCSS integration (Next.js)
+- `packages/@stylexjs/cli` - CLI for standalone file processing
+
+## Local Override
+
+For machine-local customizations, use `AGENTS.override.md` (not committed).
+
+## Generation and Integrity
+
+- Generate: `node tools/ai-context/generate-agents.js`
+- Check drift: `node tools/ai-context/generate-agents.js --check`
+- Never edit generated context files manually; update plugin source files instead.

--- a/ai-dev/plugins/authoring.json
+++ b/ai-dev/plugins/authoring.json
@@ -1,0 +1,22 @@
+{
+  "id": "WF-AUTHOR",
+  "priority": "P0",
+  "title": "Author valid, idiomatic StyleX styles in apps",
+  "copilot_apply_to": "**/*.{js,jsx,ts,tsx}",
+  "cursor_globs": ["**/*.{js,jsx,ts,tsx}"],
+  "when_to_use": [
+    "User asks how to write or refactor StyleX styles",
+    "User asks about pseudo/media rules, dynamic styles, vars/themes, or style merges",
+    "User is fixing lint violations in app-level StyleX code"
+  ],
+  "sources": [
+    "packages/docs/static/llm/stylex-authoring.md",
+    "packages/@stylexjs/eslint-plugin/README.md"
+  ],
+  "hard_constraints": [
+    "Use stylex.create() for definitions and stylex.props() for application.",
+    "Prefer longhands over disallowed multivalue shorthand patterns.",
+    "Avoid mixing className/style with stylex.props() on the same element.",
+    "Use modern nested syntax for media queries and pseudo-classes."
+  ]
+}

--- a/ai-dev/plugins/index.json
+++ b/ai-dev/plugins/index.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "description": "Canonical workflow plugin registry for StyleX agent context routing.",
+  "default_workflows": ["WF-SETUP", "WF-AUTHOR"],
+  "workflows": ["setup", "authoring", "maintainers"],
+  "global_sources": [
+    "packages/docs/static/llm/stylex-installation.md",
+    "packages/docs/static/llm/stylex-authoring.md",
+    "packages/@stylexjs/eslint-plugin/README.md"
+  ],
+  "rule_alignment_targets": [
+    "@stylexjs/valid-styles",
+    "@stylexjs/sort-keys",
+    "@stylexjs/valid-shorthands",
+    "@stylexjs/no-unused",
+    "@stylexjs/no-legacy-contextual-styles",
+    "@stylexjs/no-lookahead-selectors",
+    "@stylexjs/no-nonstandard-styles",
+    "@stylexjs/no-conflicting-props",
+    "@stylexjs/enforce-extension"
+  ],
+  "verification_commands": [
+    { "name": "Build", "command": "npm run build" },
+    { "name": "Test Packages", "command": "npm run test:packages" },
+    { "name": "Lint", "command": "npm run lint:report" },
+    { "name": "Typecheck", "command": "npm run flow" },
+    { "name": "Check Context Drift", "command": "npm run ai:check-context" }
+  ],
+  "repo_structure": [
+    {
+      "path": "packages/@stylexjs/stylex",
+      "role": "Public API and runtime"
+    },
+    {
+      "path": "packages/@stylexjs/babel-plugin",
+      "role": "Compiler (style extraction and code transforms)"
+    },
+    {
+      "path": "packages/@stylexjs/shared",
+      "role": "Shared utilities (property priorities, naming)"
+    },
+    {
+      "path": "packages/@stylexjs/eslint-plugin",
+      "role": "Lint rules for style validation"
+    },
+    {
+      "path": "packages/style-value-parser",
+      "role": "CSS value parser and normalizer"
+    },
+    {
+      "path": "packages/@stylexjs/unplugin",
+      "role": "Bundler integrations (Vite, Webpack, Rspack, esbuild, Rollup)"
+    },
+    {
+      "path": "packages/@stylexjs/postcss-plugin",
+      "role": "PostCSS integration (Next.js)"
+    },
+    {
+      "path": "packages/@stylexjs/cli",
+      "role": "CLI for standalone file processing"
+    }
+  ],
+  "conventions": {
+    "internal_type_system": "flow",
+    "note": "Internal packages use Flow-typed .js files. Do not write TypeScript syntax in these files."
+  },
+  "do_not_rules": [
+    "Do not mix className or inline style with stylex.props() on the same element.",
+    "Do not use legacy contextual syntax for media or pseudo styles.",
+    "Do not use disallowed multivalue shorthand patterns where longhands are required.",
+    "Do not write TypeScript syntax in Flow-typed internal .js files."
+  ],
+  "local_override": {
+    "path": "AGENTS.override.md",
+    "note": "Use for machine-local customizations. Do not commit."
+  }
+}

--- a/ai-dev/plugins/maintainers.json
+++ b/ai-dev/plugins/maintainers.json
@@ -1,0 +1,26 @@
+{
+  "id": "WF-MAINTAIN",
+  "priority": "P1",
+  "title": "Modify StyleX OSS internals safely",
+  "copilot_apply_to": "packages/{@stylexjs,style-value-parser}/**/*.{js,jsx,ts,tsx,mjs,flow}",
+  "cursor_globs": [
+    "packages/@stylexjs/**/*.{js,jsx,ts,tsx,mjs,flow}",
+    "packages/style-value-parser/**/*.{js,ts,mjs}"
+  ],
+  "when_to_use": [
+    "User edits packages/@stylexjs/* or packages/style-value-parser/*",
+    "Task changes compiler, parser, lint rule internals, or shared utilities",
+    "Task modifies tests, transforms, or behavior snapshots"
+  ],
+  "sources": [
+    "packages/@stylexjs/eslint-plugin/README.md",
+    "packages/@stylexjs/babel-plugin/__tests__/evaluation-import-test.js",
+    "packages/@stylexjs/shared/src/utils/property-priorities.js",
+    "packages/style-value-parser/src/index.js"
+  ],
+  "hard_constraints": [
+    "Preserve behavior unless semantic change is explicitly requested.",
+    "Reference package-local tests and snapshots for behavior validation.",
+    "Call out user-visible impact on setup and authoring docs when applicable."
+  ]
+}

--- a/ai-dev/plugins/setup.json
+++ b/ai-dev/plugins/setup.json
@@ -1,0 +1,28 @@
+{
+  "id": "WF-SETUP",
+  "priority": "P0",
+  "title": "Install and configure StyleX in app projects",
+  "copilot_apply_to": "**/{vite.config,webpack.config,rspack.config,rollup.config,esbuild.config,next.config,babel.config,postcss.config}.{js,cjs,mjs,ts}",
+  "cursor_globs": [
+    "**/{vite.config,webpack.config,rspack.config,rollup.config,esbuild.config,next.config,babel.config,postcss.config}.{js,cjs,mjs,ts}",
+    "**/package.json",
+    "**/*.css"
+  ],
+  "when_to_use": [
+    "User asks to install StyleX or integrate it with a bundler/framework",
+    "User asks for plugin config, CSS entrypoint setup, or compile setup",
+    "User is troubleshooting setup or module resolution",
+    "User is creating .stylex.ts/.stylex.js files for defineVars or defineConsts",
+    "User is setting up theming, variables, or constants infrastructure"
+  ],
+  "sources": [
+    "packages/docs/static/llm/stylex-installation.md",
+    "packages/docs/static/llm/stylex-authoring.md"
+  ],
+  "hard_constraints": [
+    "Provide minimal, working config for the user's exact stack.",
+    "Keep StyleX plugin ordering constraints where required (for example, before React in Vite).",
+    "Include @stylex stylesheet directive guidance where needed.",
+    "Mention .stylex extension and module-resolution caveats when relevant."
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     "lint": "npm run lint:report -- --fix",
     "lint:report": "eslint . --ext .flow,.js,.jsx,.mjs,.ts,.tsx",
     "release": "tools/npm/release.js",
+    "ai:generate-context": "node tools/ai-context/generate-agents.js",
+    "ai:check-context": "node tools/ai-context/generate-agents.js --check",
     "test:packages": "npm run test --workspaces --if-present",
-    "test": "npm run build && npm run flow && npm run test:packages && npm run prettier:report && npm run lint:report"
+    "test": "npm run build && npm run flow && npm run test:packages && npm run prettier:report && npm run lint:report && npm run ai:check-context"
   },
   "workspaces": [
     "packages/style-value-parser",

--- a/packages/docs/content/docs/llm-resources.mdx
+++ b/packages/docs/content/docs/llm-resources.mdx
@@ -8,6 +8,15 @@ These files are intended to give LLM agents clear context on StyleX setup and us
 You can also download these files directly on
 [GitHub](https://github.com/facebook/stylex/tree/main/packages/docs/static/llm).
 
+## Agent entrypoint
+
+Start with the shared agent context file, then load setup/authoring files as needed.
+The file is generated from workflow plugins under `ai-dev/plugins/`.
+
+<a href="/llm/AGENTS.md" target="_blank" rel="noreferrer">
+  AGENTS.md
+</a>
+
 ## Installation guide
 
 Steps to install or integrate StyleX across Vite, Next.js, Webpack, Rspack, and Esbuild apps.

--- a/packages/docs/static/llm/AGENTS.md
+++ b/packages/docs/static/llm/AGENTS.md
@@ -1,0 +1,137 @@
+# StyleX Agent Context
+
+_Generated file. Do not edit directly._
+_Source: `ai-dev/plugins/index.json` and `ai-dev/plugins/*.json`._
+
+This file is a context router. Keep detailed setup/authoring guidance in canonical static docs.
+
+## Default Workflow Selection
+
+Default workflows: WF-SETUP, WF-AUTHOR
+
+Use maintainer workflow only when the task clearly edits StyleX internals.
+
+## Canonical Sources
+
+- `packages/docs/static/llm/stylex-installation.md`
+- `packages/docs/static/llm/stylex-authoring.md`
+- `packages/@stylexjs/eslint-plugin/README.md`
+
+## Workflow Plugins
+
+- `WF-SETUP` (P0): Install and configure StyleX in app projects
+- `WF-AUTHOR` (P0): Author valid, idiomatic StyleX styles in apps
+- `WF-MAINTAIN` (P1): Modify StyleX OSS internals safely
+
+### WF-SETUP (P0)
+
+Install and configure StyleX in app projects
+
+When to use:
+
+- User asks to install StyleX or integrate it with a bundler/framework
+- User asks for plugin config, CSS entrypoint setup, or compile setup
+- User is troubleshooting setup or module resolution
+- User is creating .stylex.ts/.stylex.js files for defineVars or defineConsts
+- User is setting up theming, variables, or constants infrastructure
+
+Load sources first:
+
+- `packages/docs/static/llm/stylex-installation.md`
+- `packages/docs/static/llm/stylex-authoring.md`
+
+Hard constraints:
+
+- Provide minimal, working config for the user's exact stack.
+- Keep StyleX plugin ordering constraints where required (for example, before React in Vite).
+- Include @stylex stylesheet directive guidance where needed.
+- Mention .stylex extension and module-resolution caveats when relevant.
+
+### WF-AUTHOR (P0)
+
+Author valid, idiomatic StyleX styles in apps
+
+When to use:
+
+- User asks how to write or refactor StyleX styles
+- User asks about pseudo/media rules, dynamic styles, vars/themes, or style merges
+- User is fixing lint violations in app-level StyleX code
+
+Load sources first:
+
+- `packages/docs/static/llm/stylex-authoring.md`
+- `packages/@stylexjs/eslint-plugin/README.md`
+
+Hard constraints:
+
+- Use stylex.create() for definitions and stylex.props() for application.
+- Prefer longhands over disallowed multivalue shorthand patterns.
+- Avoid mixing className/style with stylex.props() on the same element.
+- Use modern nested syntax for media queries and pseudo-classes.
+
+## Non-default Workflows
+
+- `WF-MAINTAIN` (P1): Modify StyleX OSS internals safely
+
+Use scoped maintainer files for deep maintainer guidance:
+- `.github/instructions/stylex-maintainers.instructions.md`
+- `.cursor/rules/stylex-maintainers.mdc`
+
+## Rule Alignment Targets
+
+- `@stylexjs/valid-styles`
+- `@stylexjs/sort-keys`
+- `@stylexjs/valid-shorthands`
+- `@stylexjs/no-unused`
+- `@stylexjs/no-legacy-contextual-styles`
+- `@stylexjs/no-lookahead-selectors`
+- `@stylexjs/no-nonstandard-styles`
+- `@stylexjs/no-conflicting-props`
+- `@stylexjs/enforce-extension`
+
+## Validation Commands
+
+Always run these commands before finalizing changes:
+
+- **Build:** `npm run build`
+- **Test Packages:** `npm run test:packages`
+- **Lint:** `npm run lint:report`
+- **Typecheck:** `npm run flow`
+- **Check Context Drift:** `npm run ai:check-context`
+
+## Do Not
+
+- Do not mix className or inline style with stylex.props() on the same element.
+- Do not use legacy contextual syntax for media or pseudo styles.
+- Do not use disallowed multivalue shorthand patterns where longhands are required.
+- Do not write TypeScript syntax in Flow-typed internal .js files.
+
+## Conventions
+
+- Internal packages use Flow-typed .js files. Do not write TypeScript syntax in these files.
+
+## Package Map
+
+- `packages/@stylexjs/stylex` - Public API and runtime
+- `packages/@stylexjs/babel-plugin` - Compiler (style extraction and code transforms)
+- `packages/@stylexjs/shared` - Shared utilities (property priorities, naming)
+- `packages/@stylexjs/eslint-plugin` - Lint rules for style validation
+- `packages/style-value-parser` - CSS value parser and normalizer
+- `packages/@stylexjs/unplugin` - Bundler integrations (Vite, Webpack, Rspack, esbuild, Rollup)
+- `packages/@stylexjs/postcss-plugin` - PostCSS integration (Next.js)
+- `packages/@stylexjs/cli` - CLI for standalone file processing
+
+## Local Override
+
+For machine-local customizations, use `AGENTS.override.md` (not committed).
+
+## Maintainer Trigger Paths
+
+- `packages/@stylexjs/*`
+- `packages/style-value-parser/*`
+
+## Generation and Integrity
+
+- Generate: `node tools/ai-context/generate-agents.js`
+- Check drift: `node tools/ai-context/generate-agents.js --check`
+- Never edit generated context files manually; update plugin source files instead.

--- a/packages/docs/static/llm/stylex-authoring.md
+++ b/packages/docs/static/llm/stylex-authoring.md
@@ -278,7 +278,8 @@ const styles = stylex.create({
 ```
 
 **IMPORTANT: For `defineConsts` and `defineVars`:**
-- Must be in `.stylex.ts` or `.stylex.js` files
+- Must be in `.stylex.ts` or `.stylex.js` files by default
+- If `@stylexjs/enforce-extension` is configured with `enforceDefineConstsExtension: true`, use `.stylex.const.ts` / `.stylex.const.js` for `defineConsts` exports
 - Must be named exports (not default exports)
 - No other exports allowed in the file
 

--- a/packages/docs/static/llms.txt
+++ b/packages/docs/static/llms.txt
@@ -1,0 +1,17 @@
+# StyleX
+
+> StyleX is a build-time CSS-in-JS library for defining and applying optimized atomic styles.
+
+## Documentation
+
+- [Installation Guide](/llm/stylex-installation.md): Build-time setup for Vite, Next.js, Webpack, Rspack, esbuild, and Rollup
+- [Authoring Guide](/llm/stylex-authoring.md): Writing styles, pseudo-classes, media queries, dynamic styles, variables, themes, and TypeScript types
+- [ESLint Plugin](https://raw.githubusercontent.com/facebook/stylex/main/packages/@stylexjs/eslint-plugin/README.md): Lint rules for valid styles, shorthands, unused styles, and naming conventions
+- [Agent Context](/llm/AGENTS.md): Workflow routing for AI coding agents
+
+## Links
+
+- Website: https://stylexjs.com
+- API Reference: https://stylexjs.com/docs/api
+- GitHub: https://github.com/facebook/stylex
+- Examples: https://github.com/facebook/stylex/tree/main/examples

--- a/tools/ai-context/generate-agents.js
+++ b/tools/ai-context/generate-agents.js
@@ -1,0 +1,452 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const PLUGIN_ROOT = path.join(REPO_ROOT, 'ai-dev', 'plugins');
+const INDEX_PATH = path.join(PLUGIN_ROOT, 'index.json');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function formatBulletList(items) {
+  return items.map((item) => `- \`${item}\``).join('\n');
+}
+
+function formatCommandList(commands) {
+  return commands
+    .map((entry) => `- **${entry.name}:** \`${entry.command}\``)
+    .join('\n');
+}
+
+function renderVerificationCommands(index) {
+  if (
+    !index.verification_commands ||
+    index.verification_commands.length === 0
+  ) {
+    return '';
+  }
+  return `## Validation Commands
+
+Always run these commands before finalizing changes:
+
+${formatCommandList(index.verification_commands)}
+`;
+}
+
+function renderRepoStructure(index) {
+  if (!index.repo_structure || index.repo_structure.length === 0) {
+    return '';
+  }
+  return `## Package Map
+
+${index.repo_structure
+  .map((entry) => `- \`${entry.path}\` - ${entry.role}`)
+  .join('\n')}
+`;
+}
+
+function renderConventions(index) {
+  if (!index.conventions) {
+    return '';
+  }
+  return `## Conventions
+
+- ${index.conventions.note}
+`;
+}
+
+function renderDoNotRules(index) {
+  if (!index.do_not_rules || index.do_not_rules.length === 0) {
+    return '';
+  }
+  return `## Do Not
+
+${index.do_not_rules.map((rule) => `- ${rule}`).join('\n')}
+`;
+}
+
+function renderLocalOverride(index) {
+  if (!index.local_override || !index.local_override.path) {
+    return '';
+  }
+  return `## Local Override
+
+For machine-local customizations, use \`${index.local_override.path}\` (not committed).
+`;
+}
+
+function formatWorkflowSection(workflow) {
+  const lines = [];
+  lines.push(`### ${workflow.id} (${workflow.priority})`);
+  lines.push('');
+  lines.push(workflow.title);
+  lines.push('');
+  lines.push('When to use:');
+  lines.push('');
+  for (const entry of workflow.when_to_use) {
+    lines.push(`- ${entry}`);
+  }
+  lines.push('');
+  lines.push('Load sources first:');
+  lines.push('');
+  for (const source of workflow.sources) {
+    lines.push(`- \`${source}\``);
+  }
+  lines.push('');
+  lines.push('Hard constraints:');
+  lines.push('');
+  for (const item of workflow.hard_constraints) {
+    lines.push(`- ${item}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function renderAgentsMarkdown(index, workflows) {
+  const defaultWorkflows = index.default_workflows.join(', ');
+  const defaultWorkflowSet = new Set(index.default_workflows);
+  const defaultWorkflowDetails = workflows.filter((wf) =>
+    defaultWorkflowSet.has(wf.id),
+  );
+  const nonDefaultWorkflows = workflows.filter(
+    (wf) => !defaultWorkflowSet.has(wf.id),
+  );
+  const workflowSummary = workflows
+    .map((wf) => `- \`${wf.id}\` (${wf.priority}): ${wf.title}`)
+    .join('\n');
+
+  const sections = defaultWorkflowDetails.map(formatWorkflowSection).join('\n');
+  const nonDefaultSummary =
+    nonDefaultWorkflows.length === 0
+      ? ''
+      : `## Non-default Workflows
+
+${nonDefaultWorkflows
+  .map((wf) => `- \`${wf.id}\` (${wf.priority}): ${wf.title}`)
+  .join('\n')}
+
+Use scoped maintainer files for deep maintainer guidance:
+- \`.github/instructions/stylex-maintainers.instructions.md\`
+- \`.cursor/rules/stylex-maintainers.mdc\`
+`;
+
+  return `# StyleX Agent Context
+
+_Generated file. Do not edit directly._
+_Source: \`ai-dev/plugins/index.json\` and \`ai-dev/plugins/*.json\`._
+
+This file is a context router. Keep detailed setup/authoring guidance in canonical static docs.
+
+## Default Workflow Selection
+
+Default workflows: ${defaultWorkflows}
+
+Use maintainer workflow only when the task clearly edits StyleX internals.
+
+## Canonical Sources
+
+${formatBulletList(index.global_sources)}
+
+## Workflow Plugins
+
+${workflowSummary}
+
+${sections}
+${nonDefaultSummary}
+## Rule Alignment Targets
+
+${formatBulletList(index.rule_alignment_targets)}
+
+${renderVerificationCommands(index)}
+${renderDoNotRules(index)}
+${renderConventions(index)}
+${renderRepoStructure(index)}
+${renderLocalOverride(index)}
+## Maintainer Trigger Paths
+
+- \`packages/@stylexjs/*\`
+- \`packages/style-value-parser/*\`
+
+## Generation and Integrity
+
+- Generate: \`node tools/ai-context/generate-agents.js\`
+- Check drift: \`node tools/ai-context/generate-agents.js --check\`
+- Never edit generated context files manually; update plugin source files instead.
+`;
+}
+
+function renderToolRouterMarkdown(toolName, index, workflows) {
+  const defaultWorkflows = index.default_workflows.join(', ');
+  return `# ${toolName} Context
+
+_Generated file. Do not edit directly._
+_Source: \`ai-dev/plugins/index.json\` and \`ai-dev/plugins/*.json\`._
+
+Use \`AGENTS.md\` as the primary context router.
+
+## Defaults
+
+- Default workflows: ${defaultWorkflows}
+- Use maintainer workflow only for StyleX internals.
+
+## Canonical Sources
+
+${formatBulletList(index.global_sources)}
+
+## Workflow Summary
+
+${workflows
+  .map((wf) => `- \`${wf.id}\` (${wf.priority}): ${wf.title}`)
+  .join('\n')}
+
+## Rule Alignment
+
+${formatBulletList(index.rule_alignment_targets)}
+
+${renderVerificationCommands(index)}
+${renderDoNotRules(index)}
+${renderConventions(index)}
+${renderRepoStructure(index)}
+${renderLocalOverride(index)}
+## Generation and Integrity
+
+- Generate: \`node tools/ai-context/generate-agents.js\`
+- Check drift: \`node tools/ai-context/generate-agents.js --check\`
+- Never edit generated context files manually; update plugin source files instead.
+`;
+}
+
+function renderCopilotRepoInstructions(index) {
+  return `# StyleX Copilot Repository Instructions
+
+_Generated file. Do not edit directly._
+_Source: \`ai-dev/plugins/index.json\` and \`ai-dev/plugins/*.json\`._
+
+Keep this file global and orthogonal. Put workflow-specific guidance in
+\`.github/instructions/*.instructions.md\`.
+
+## Global behavior
+
+- Default to \`WF-SETUP\` and \`WF-AUTHOR\`.
+- Use \`WF-MAINTAIN\` only for StyleX internals.
+- Load canonical docs before giving setup or authoring advice.
+- Align suggestions with StyleX lint rules.
+- Avoid duplicating long setup/authoring explanations; reference canonical files.
+
+## Canonical Sources
+
+${formatBulletList(index.global_sources)}
+
+## Rule Alignment
+
+${formatBulletList(index.rule_alignment_targets)}
+
+${renderVerificationCommands(index)}
+${renderDoNotRules(index)}
+${renderConventions(index)}
+## Generation and Integrity
+
+- Generate: \`node tools/ai-context/generate-agents.js\`
+- Check drift: \`node tools/ai-context/generate-agents.js --check\`
+`;
+}
+
+function renderCopilotScopedInstruction(workflow) {
+  return `---
+applyTo: ${JSON.stringify(workflow.copilot_apply_to)}
+---
+# ${workflow.id} (${workflow.priority})
+
+${workflow.title}
+
+When to use:
+
+${workflow.when_to_use.map((entry) => `- ${entry}`).join('\n')}
+
+Load sources first:
+
+${workflow.sources.map((source) => `- \`${source}\``).join('\n')}
+
+Hard constraints:
+
+${workflow.hard_constraints.map((item) => `- ${item}`).join('\n')}
+`;
+}
+
+function renderCursorRuleFrontmatter(options) {
+  const lines = ['---'];
+  lines.push(`description: ${JSON.stringify(options.description)}`);
+  if (options.alwaysApply != null) {
+    lines.push(`alwaysApply: ${options.alwaysApply ? 'true' : 'false'}`);
+  }
+  if (options.globs && options.globs.length > 0) {
+    lines.push('globs:');
+    for (const glob of options.globs) {
+      lines.push(`  - ${JSON.stringify(glob)}`);
+    }
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function renderCursorGlobalRule(index) {
+  const frontmatter = renderCursorRuleFrontmatter({
+    description:
+      'StyleX global router: default setup/authoring workflows and canonical source files.',
+    alwaysApply: true,
+  });
+
+  const body = `Use \`WF-SETUP\` and \`WF-AUTHOR\` by default.
+Use \`WF-MAINTAIN\` only for StyleX internals under \`packages/@stylexjs/*\` and \`packages/style-value-parser/*\`.
+Load canonical sources first:
+${formatBulletList(index.global_sources)}
+Keep this rule short and route to canonical docs instead of duplicating long explanations.`;
+
+  return `${frontmatter}
+
+${body}
+`;
+}
+
+function renderCursorWorkflowRule(workflow) {
+  const frontmatter = renderCursorRuleFrontmatter({
+    description: `${workflow.id} workflow routing and constraints`,
+    globs: workflow.cursor_globs,
+  });
+  const body = `Workflow: \`${workflow.id}\` (${workflow.priority})
+${workflow.title}
+
+Load sources first:
+${workflow.sources.map((source) => `- \`${source}\``).join('\n')}
+
+Hard constraints:
+${workflow.hard_constraints.map((item) => `- ${item}`).join('\n')}
+`;
+  return `${frontmatter}
+
+${body}`;
+}
+
+function buildOutputs(index, workflows) {
+  const byId = new Map(workflows.map((workflow) => [workflow.id, workflow]));
+  return [
+    {
+      path: path.join(REPO_ROOT, 'AGENTS.md'),
+      content: renderAgentsMarkdown(index, workflows),
+    },
+    {
+      path: path.join(
+        REPO_ROOT,
+        'packages',
+        'docs',
+        'static',
+        'llm',
+        'AGENTS.md',
+      ),
+      content: renderAgentsMarkdown(index, workflows),
+    },
+    {
+      path: path.join(REPO_ROOT, 'CLAUDE.md'),
+      content: renderToolRouterMarkdown('CLAUDE', index, workflows),
+    },
+    {
+      path: path.join(REPO_ROOT, 'GEMINI.md'),
+      content: renderToolRouterMarkdown('GEMINI', index, workflows),
+    },
+    {
+      path: path.join(REPO_ROOT, '.github', 'copilot-instructions.md'),
+      content: renderCopilotRepoInstructions(index),
+    },
+    {
+      path: path.join(
+        REPO_ROOT,
+        '.github',
+        'instructions',
+        'stylex-setup.instructions.md',
+      ),
+      content: renderCopilotScopedInstruction(byId.get('WF-SETUP')),
+    },
+    {
+      path: path.join(
+        REPO_ROOT,
+        '.github',
+        'instructions',
+        'stylex-authoring.instructions.md',
+      ),
+      content: renderCopilotScopedInstruction(byId.get('WF-AUTHOR')),
+    },
+    {
+      path: path.join(
+        REPO_ROOT,
+        '.github',
+        'instructions',
+        'stylex-maintainers.instructions.md',
+      ),
+      content: renderCopilotScopedInstruction(byId.get('WF-MAINTAIN')),
+    },
+    {
+      path: path.join(REPO_ROOT, '.cursor', 'rules', 'stylex-global.mdc'),
+      content: renderCursorGlobalRule(index),
+    },
+    {
+      path: path.join(REPO_ROOT, '.cursor', 'rules', 'stylex-setup.mdc'),
+      content: renderCursorWorkflowRule(byId.get('WF-SETUP')),
+    },
+    {
+      path: path.join(REPO_ROOT, '.cursor', 'rules', 'stylex-authoring.mdc'),
+      content: renderCursorWorkflowRule(byId.get('WF-AUTHOR')),
+    },
+    {
+      path: path.join(REPO_ROOT, '.cursor', 'rules', 'stylex-maintainers.mdc'),
+      content: renderCursorWorkflowRule(byId.get('WF-MAINTAIN')),
+    },
+  ];
+}
+
+function main() {
+  const isCheck = process.argv.includes('--check');
+  const index = readJson(INDEX_PATH);
+  const workflows = index.workflows.map((name) =>
+    readJson(path.join(PLUGIN_ROOT, `${name}.json`)),
+  );
+  const outputs = buildOutputs(index, workflows);
+
+  let hasDiff = false;
+  for (const output of outputs) {
+    const filePath = output.path;
+    const desired = output.content;
+    const current = fs.existsSync(filePath)
+      ? fs.readFileSync(filePath, 'utf8')
+      : null;
+    if (current !== desired) {
+      hasDiff = true;
+      if (!isCheck) {
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, desired, 'utf8');
+        // eslint-disable-next-line no-console
+        console.log(`updated ${path.relative(REPO_ROOT, filePath)}`);
+      }
+    }
+  }
+
+  if (isCheck && hasDiff) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'Generated context files are out of date. Run: node tools/ai-context/generate-agents.js',
+    );
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## What changed / motivation?

AI agents (Cursor, Copilot, Claude Code, Gemini, Codex) need StyleX-specific context to avoid common mistakes like using legacy contextual syntax, writing disallowed shorthands, or misconfiguring bundler plugins. This PR adds a codegen system that produces tool-native context files from a single source of truth.

**What's included:**

- `ai-dev/plugins/` — canonical workflow plugins (setup, authoring, maintainers) as JSON, plus `index.json` registry with validation commands, package map, conventions, and do-not rules
- `tools/ai-context/generate-agents.js` — generator that reads plugins and produces all tool-specific outputs below
- Generated outputs (root): `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
- Generated outputs (Copilot): `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`
- Generated outputs (Cursor): `.cursor/rules/*.mdc`
- Generated outputs (docs): `packages/docs/static/llm/AGENTS.md`, `packages/docs/static/llms.txt`
- `defineConsts` extension nuance added to `packages/docs/static/llm/stylex-authoring.md`
- `ai:check-context` drift detection wired into `npm test`

**Design principles:**

- One fact, one home — canonical content stays in `packages/docs/static/llm/`, metadata in `ai-dev/plugins/`, generated files are read-only routers
- Tool-native formats — Cursor gets `.mdc` with `globs` frontmatter, Copilot gets `applyTo` scoped instructions, Claude/Gemini get markdown routers
- Maintainer context is scoped — `WF-MAINTAIN` details only appear in scoped files, not global routers

## Linked PR/Issues

Closes #1450
Closes #1256

## Additional Context

`node tools/ai-context/generate-agents.js --check` passes.
`npx eslint tools/ai-context/generate-agents.js` passes.

Generated files are intentionally thin — they route to existing canonical docs (`stylex-installation.md`, `stylex-authoring.md`, `eslint-plugin/README.md`) rather than duplicating content.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code