### PR TITLE
[eslint-plugin] Add overflow/overscrollBehavior shorthand expansion to stylex-valid-shorthands

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -531,6 +531,26 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       })
     `,
     },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          overflow: 'hidden',
+        },
+      })
+    `,
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          overscrollBehavior: 'contain',
+        },
+      })
+    `,
+    },
   ],
   invalid: [
     {
@@ -3267,6 +3287,111 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         {
           message:
             'Property shorthands using multiple values like "border: 1px solid red !important" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // overflow: 2 values split to overflowX + overflowY
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            overflow: 'hidden scroll',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            overflowX: 'hidden',
+            overflowY: 'scroll',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "overflow: hidden scroll" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // overflow: two identical values still split
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            overflow: 'auto auto',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            overflowX: 'auto',
+            overflowY: 'auto',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "overflow: auto auto" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // overscrollBehavior: 2 values split to overscrollBehaviorX + overscrollBehaviorY
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            overscrollBehavior: 'contain auto',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            overscrollBehaviorX: 'contain',
+            overscrollBehaviorY: 'auto',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "overscrollBehavior: contain auto" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // overflow: with !important (allowImportant)
+    {
+      options: [{ allowImportant: true }],
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            overflow: 'hidden scroll !important',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            overflowX: 'hidden !important',
+            overflowY: 'scroll !important',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "overflow: hidden scroll !important" are not supported in StyleX. Separate into individual properties.',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
@@ -79,6 +79,8 @@ const shorthandAliases: $ReadOnly<{
   flex: createSpecificTransformer('flex'),
   gap: createSpecificTransformer('gap'),
   gridGap: createSpecificTransformer('gap'),
+  overflow: createSpecificTransformer('overflow'),
+  overscrollBehavior: createSpecificTransformer('overscroll-behavior'),
   margin: createDirectionalTransformer('margin', 'Block', 'Inline'),
   padding: createDirectionalTransformer('padding', 'Block', 'Inline'),
   marginBlock: createBlockInlineTransformer('margin', 'Block'),

--- a/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
@@ -1095,6 +1095,25 @@ export function splitSpecificShorthands(
     return expanded.length > 0 ? expanded : [['gridArea', CANNOT_FIX]];
   }
 
+  if (property === 'overflow' || property === 'overscroll-behavior') {
+    const split = splitTopLevelValueTokens(baseValue);
+    if (split.hasTopLevelComma || split.hasTopLevelSlash) {
+      return [[toCamelCase(property), CANNOT_FIX]];
+    }
+    const vals = split.parts.map((part) => part.text);
+    if (vals.length <= 1) {
+      return [[toCamelCase(property), isNumber ? Number(rawValue) : rawValue]];
+    }
+    if (vals.length === 2) {
+      const baseKey = toCamelCase(property);
+      return [
+        [`${baseKey}X`, applyImportant(vals[0], importantSuffix)],
+        [`${baseKey}Y`, applyImportant(vals[1], importantSuffix)],
+      ];
+    }
+    return [[toCamelCase(property), CANNOT_FIX]];
+  }
+
   if (property === 'flex') {
     const flexSplit = splitTopLevelValueTokens(baseValue);
     if (flexSplit.hasTopLevelComma || flexSplit.hasTopLevelSlash) {


### PR DESCRIPTION
Expand `overflow` and `overscrollBehavior` two-value shorthands into X/Y longhands.

**Stack: 2/7** — depends on #1585

## What changed / motivation ?

- `overflow: 'hidden scroll'` → `overflowX: 'hidden'` + `overflowY: 'scroll'`
- `overscrollBehavior: 'contain auto'` → `overscrollBehaviorX: 'contain'` + `overscrollBehaviorY: 'auto'`
- Single values pass through unchanged

## Linked PR/Issues

Follow-up to #1553, #1552

## Additional Context

Added tests covering: single-value passthrough, 2-value X/Y expansion, identical values,
!important propagation.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code