### PR TITLE
[eslint-plugin] Add inset shorthand expansion to stylex-valid-shorthands

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -3471,6 +3471,33 @@ insetTester.run('stylex-valid-shorthands (inset)', rule.default, {
         },
       ],
     },
+    // inset: 2-value expansion with preferInline
+    {
+      options: [{ preferInline: true }],
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            inset: '0 10px',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            insetBlock: '0',
+            insetInline: '10px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "inset: 0 10px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
     // inset: 3-value expansion
     {
       code: `

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -3397,3 +3397,187 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
     },
   ],
 });
+
+// --- inset, insetBlock, insetInline tests ---
+
+const insetTester = new ESLintTester({
+  parser: require.resolve('hermes-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+insetTester.run('stylex-valid-shorthands (inset)', rule.default, {
+  valid: [
+    // inset: single numeric value
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            inset: 0,
+          },
+        });
+      `,
+    },
+    // insetBlock: single string value
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            insetBlock: '10px',
+          },
+        });
+      `,
+    },
+    // insetInline: single string value
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            insetInline: '10px',
+          },
+        });
+      `,
+    },
+  ],
+  invalid: [
+    // inset: 2-value expansion
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            inset: '0 10px',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            insetBlock: '0',
+            insetInline: '10px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "inset: 0 10px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // inset: 3-value expansion
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            inset: '0 10px 20px',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            top: '0',
+            right: '10px',
+            bottom: '20px',
+            left: '10px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "inset: 0 10px 20px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // inset: 4-value expansion
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            inset: '0 10px 20px 30px',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            top: '0',
+            right: '10px',
+            bottom: '20px',
+            left: '30px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "inset: 0 10px 20px 30px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // insetBlock: 2-value expansion
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            insetBlock: '0 10px',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            insetBlockStart: '0',
+            insetBlockEnd: '10px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "insetBlock: 0 10px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // insetInline: 2-value expansion
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            insetInline: '0 10px',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            insetInlineStart: '0',
+            insetInlineEnd: '10px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "insetInline: 0 10px" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
@@ -87,6 +87,9 @@ const shorthandAliases: $ReadOnly<{
   marginInline: createBlockInlineTransformer('margin', 'Inline'),
   paddingBlock: createBlockInlineTransformer('padding', 'Block'),
   paddingInline: createBlockInlineTransformer('padding', 'Inline'),
+  inset: createSpecificTransformer('inset'),
+  insetBlock: createBlockInlineTransformer('inset', 'Block'),
+  insetInline: createBlockInlineTransformer('inset', 'Inline'),
 };
 
 const stylexValidShorthands = {

--- a/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
@@ -1148,6 +1148,33 @@ export function splitSpecificShorthands(
     return [['gap', CANNOT_FIX]];
   }
 
+  if (property === 'inset') {
+    const split = splitTopLevelValueTokens(baseValue);
+    if (split.hasTopLevelComma || split.hasTopLevelSlash) {
+      return [['inset', CANNOT_FIX]];
+    }
+    const vals = split.parts.map((part) => part.text);
+    if (vals.length <= 1) {
+      return [['inset', isNumber ? Number(rawValue) : rawValue]];
+    }
+    if (vals.length === 2) {
+      return [
+        ['insetBlock', applyImportant(vals[0], importantSuffix)],
+        ['insetInline', applyImportant(vals[1], importantSuffix)],
+      ];
+    }
+    if (vals.length > 4) {
+      return [['inset', CANNOT_FIX]];
+    }
+    const [top, right = top, bottom = top, left = right] = vals;
+    return [
+      ['top', applyImportant(top, importantSuffix)],
+      ['right', applyImportant(right, importantSuffix)],
+      ['bottom', applyImportant(bottom, importantSuffix)],
+      ['left', applyImportant(left, importantSuffix)],
+    ];
+  }
+
   const splitValues = splitTopLevelValueTokens(baseValue);
   if (splitValues.parts.length <= 1 && !splitValues.hasTopLevelSlash) {
     return [[toCamelCase(property), isNumber ? Number(rawValue) : rawValue]];


### PR DESCRIPTION
Expand `inset`, `insetBlock`, and `insetInline` shorthands into longhands. Uses logical
properties for 2-value expansion and physical properties for 3-4 values per CSS spec.

**Stack: 3/7** — depends on #1586

## What changed / motivation ?

- `inset: '0 10px'` → `insetBlock: '0'` + `insetInline: '10px'` (2-value, logical)
- `inset: '0 10px 20px'` → `top` + `right` + `bottom` + `left` (3-4 value, physical per CSS spec)
- `insetBlock: '0 10px'` → `insetBlockStart` + `insetBlockEnd`
- `insetInline: '0 10px'` → `insetInlineStart` + `insetInlineEnd`
- Single values pass through unchanged

## Linked PR/Issues

Follow-up to #1553, #1552

## Additional Context

Added tests covering: single-value passthrough, 2/3/4-value expansion, preferInline option,
insetBlock/insetInline axis expansion.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code