### PR TITLE
[eslint-plugin] Add flexFlow shorthand expansion to stylex-valid-shorthands

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -584,6 +584,28 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       })
     `,
     },
+    // flexFlow: single value (direction only)
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          flexFlow: 'row',
+        },
+      })
+    `,
+    },
+    // flexFlow: single value (wrap only)
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          flexFlow: 'wrap',
+        },
+      })
+    `,
+    },
   ],
   invalid: [
     {
@@ -3530,6 +3552,84 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         {
           message:
             'Property shorthands using multiple values like "placeContent: center space-between !important" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flexFlow: 'row wrap' → flexDirection + flexWrap
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexFlow: 'row wrap',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flexFlow: row wrap" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flexFlow: reversed order 'wrap column'
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexFlow: 'wrap column',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexDirection: 'column',
+            flexWrap: 'wrap',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flexFlow: wrap column" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // flexFlow: 'column-reverse nowrap'
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexFlow: 'column-reverse nowrap',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexDirection: 'column-reverse',
+            flexWrap: 'nowrap',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flexFlow: column-reverse nowrap" are not supported in StyleX. Separate into individual properties.',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -3607,6 +3607,31 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         },
       ],
     },
+    // flexFlow: invalid wrap value should not autofix
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexFlow: 'row banana',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            flexFlow: 'row banana',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "flexFlow: row banana" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
     // flexFlow: 'column-reverse nowrap'
     {
       code: `

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
@@ -77,6 +77,7 @@ const shorthandAliases: $ReadOnly<{
   outline: createSpecificTransformer('outline'),
   animation: createSpecificTransformer('animation'),
   flex: createSpecificTransformer('flex'),
+  flexFlow: createSpecificTransformer('flex-flow'),
   gap: createSpecificTransformer('gap'),
   gridGap: createSpecificTransformer('gap'),
   overflow: createSpecificTransformer('overflow'),

--- a/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
@@ -1138,8 +1138,14 @@ export function splitSpecificShorthands(
     if (vals.length === 2) {
       const suffix = property.replace('place-', '');
       return [
-        [toCamelCase(`align-${suffix}`), applyImportant(vals[0], importantSuffix)],
-        [toCamelCase(`justify-${suffix}`), applyImportant(vals[1], importantSuffix)],
+        [
+          toCamelCase(`align-${suffix}`),
+          applyImportant(vals[0], importantSuffix),
+        ],
+        [
+          toCamelCase(`justify-${suffix}`),
+          applyImportant(vals[1], importantSuffix),
+        ],
       ];
     }
     return [[toCamelCase(property), CANNOT_FIX]];

--- a/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
@@ -672,6 +672,7 @@ const FLEX_DIRECTION_KEYWORDS = new Set([
   'column',
   'column-reverse',
 ]);
+const FLEX_WRAP_KEYWORDS = new Set(['nowrap', 'wrap', 'wrap-reverse']);
 
 const ANIMATION_DIRECTION_KEYWORDS = new Set([
   'normal',
@@ -1218,13 +1219,18 @@ export function splitSpecificShorthands(
       let direction = null;
       let wrap = null;
       for (const val of vals) {
-        if (FLEX_DIRECTION_KEYWORDS.has(val.toLowerCase())) {
+        const lower = val.toLowerCase();
+        if (FLEX_DIRECTION_KEYWORDS.has(lower)) {
           if (direction != null) return [['flexFlow', CANNOT_FIX]];
           direction = val;
-        } else {
+          continue;
+        }
+        if (FLEX_WRAP_KEYWORDS.has(lower)) {
           if (wrap != null) return [['flexFlow', CANNOT_FIX]];
           wrap = val;
+          continue;
         }
+        return [['flexFlow', CANNOT_FIX]];
       }
       if (direction == null || wrap == null) {
         return [['flexFlow', CANNOT_FIX]];

--- a/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
@@ -666,6 +666,13 @@ function expandFlexShorthand(
   return null;
 }
 
+const FLEX_DIRECTION_KEYWORDS = new Set([
+  'row',
+  'row-reverse',
+  'column',
+  'column-reverse',
+]);
+
 const ANIMATION_DIRECTION_KEYWORDS = new Set([
   'normal',
   'reverse',
@@ -1196,6 +1203,38 @@ export function splitSpecificShorthands(
       ['bottom', applyImportant(bottom, importantSuffix)],
       ['left', applyImportant(left, importantSuffix)],
     ];
+  }
+
+  if (property === 'flex-flow') {
+    const split = splitTopLevelValueTokens(baseValue);
+    if (split.hasTopLevelComma || split.hasTopLevelSlash) {
+      return [['flexFlow', CANNOT_FIX]];
+    }
+    const vals = split.parts.map((part) => part.text);
+    if (vals.length <= 1) {
+      return [['flexFlow', isNumber ? Number(rawValue) : rawValue]];
+    }
+    if (vals.length === 2) {
+      let direction = null;
+      let wrap = null;
+      for (const val of vals) {
+        if (FLEX_DIRECTION_KEYWORDS.has(val.toLowerCase())) {
+          if (direction != null) return [['flexFlow', CANNOT_FIX]];
+          direction = val;
+        } else {
+          if (wrap != null) return [['flexFlow', CANNOT_FIX]];
+          wrap = val;
+        }
+      }
+      if (direction == null || wrap == null) {
+        return [['flexFlow', CANNOT_FIX]];
+      }
+      return [
+        ['flexDirection', applyImportant(direction, importantSuffix)],
+        ['flexWrap', applyImportant(wrap, importantSuffix)],
+      ];
+    }
+    return [['flexFlow', CANNOT_FIX]];
   }
 
   const splitValues = splitTopLevelValueTokens(baseValue);


### PR DESCRIPTION
Expand `flexFlow` shorthand into `flexDirection` + `flexWrap` longhands. Both tokens are
validated against keyword sets before applying the fix, preventing incorrect expansions
for invalid values.

**Stack: 5/7** — depends on #1588

## What changed / motivation ?

- `flexFlow: 'row wrap'` → `flexDirection: 'row'` + `flexWrap: 'wrap'`
- `flexFlow: 'wrap column'` → `flexDirection: 'column'` + `flexWrap: 'wrap'` (order-independent)
- `flexFlow: 'row banana'` → error with no autofix (invalid wrap token)
- Single values pass through unchanged

## Linked PR/Issues

Follow-up to #1537

## Additional Context

Added tests covering: single-value passthrough, direction+wrap expansion, reversed token order,
invalid tokens (CANNOT_FIX), column-reverse/nowrap.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code