### PR TITLE
[eslint-plugin] Add textDecoration shorthand expansion to stylex-valid-shorthands

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -4002,11 +4002,14 @@ insetTester.run('stylex-valid-shorthands (inset)', rule.default, {
 });
 
 // columnRule, columns, listStyle, caret shorthand expansion tests
-eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)', rule.default, {
-  valid: [
-    // columnRule single value
-    {
-      code: `
+eslintTester.run(
+  'stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
+  rule.default,
+  {
+    valid: [
+      // columnRule single value
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4014,10 +4017,10 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-    },
-    // columns single value
-    {
-      code: `
+      },
+      // columns single value
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4025,10 +4028,10 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-    },
-    // listStyle single value
-    {
-      code: `
+      },
+      // listStyle single value
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4036,10 +4039,10 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-    },
-    // caret single value
-    {
-      code: `
+      },
+      // caret single value
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4047,12 +4050,12 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-    },
-  ],
-  invalid: [
-    // columnRule: '1px solid red' → columnRuleWidth + columnRuleStyle + columnRuleColor
-    {
-      code: `
+      },
+    ],
+    invalid: [
+      // columnRule: '1px solid red' → columnRuleWidth + columnRuleStyle + columnRuleColor
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4060,7 +4063,7 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      output: `
+        output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4070,16 +4073,16 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "columnRule: 1px solid red" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // columns: '200px 3' → columnWidth + columnCount
-    {
-      code: `
+        errors: [
+          {
+            message:
+              'Property shorthands using multiple values like "columnRule: 1px solid red" are not supported in StyleX. Separate into individual properties.',
+          },
+        ],
+      },
+      // columns: '200px 3' → columnWidth + columnCount
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4087,7 +4090,7 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      output: `
+        output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4096,16 +4099,16 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "columns: 200px 3" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // columns: 'auto 200px' → columnWidth + columnCount
-    {
-      code: `
+        errors: [
+          {
+            message:
+              'Property shorthands using multiple values like "columns: 200px 3" are not supported in StyleX. Separate into individual properties.',
+          },
+        ],
+      },
+      // columns: 'auto 200px' → columnWidth + columnCount
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4113,7 +4116,7 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      output: `
+        output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4122,16 +4125,16 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "columns: auto 200px" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // listStyle: 'square inside' → listStyleType + listStylePosition
-    {
-      code: `
+        errors: [
+          {
+            message:
+              'Property shorthands using multiple values like "columns: auto 200px" are not supported in StyleX. Separate into individual properties.',
+          },
+        ],
+      },
+      // listStyle: 'square inside' → listStyleType + listStylePosition
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4139,7 +4142,7 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      output: `
+        output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4148,16 +4151,16 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "listStyle: square inside" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // listStyle: 'disc inside url(bullet.png)' → type + position + image
-    {
-      code: `
+        errors: [
+          {
+            message:
+              'Property shorthands using multiple values like "listStyle: square inside" are not supported in StyleX. Separate into individual properties.',
+          },
+        ],
+      },
+      // listStyle: 'disc inside url(bullet.png)' → type + position + image
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4165,7 +4168,7 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      output: `
+        output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4175,16 +4178,16 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "listStyle: disc inside url(bullet.png)" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // listStyle: 'none inside' → type + position + image
-    {
-      code: `
+        errors: [
+          {
+            message:
+              'Property shorthands using multiple values like "listStyle: disc inside url(bullet.png)" are not supported in StyleX. Separate into individual properties.',
+          },
+        ],
+      },
+      // listStyle: 'none inside' → type + position + image
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4192,7 +4195,7 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      output: `
+        output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4202,16 +4205,16 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "listStyle: none inside" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // listStyle: 'none url(bullet.png)' → type + image
-    {
-      code: `
+        errors: [
+          {
+            message:
+              'Property shorthands using multiple values like "listStyle: none inside" are not supported in StyleX. Separate into individual properties.',
+          },
+        ],
+      },
+      // listStyle: 'none url(bullet.png)' → type + image
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4219,7 +4222,7 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      output: `
+        output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4228,16 +4231,16 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "listStyle: none url(bullet.png)" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // listStyle: 'url(bullet.png) none' → type + image
-    {
-      code: `
+        errors: [
+          {
+            message:
+              'Property shorthands using multiple values like "listStyle: none url(bullet.png)" are not supported in StyleX. Separate into individual properties.',
+          },
+        ],
+      },
+      // listStyle: 'url(bullet.png) none' → type + image
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4245,7 +4248,7 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      output: `
+        output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4254,16 +4257,16 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "listStyle: url(bullet.png) none" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // caret: 'red bar' → caretColor + caretShape
-    {
-      code: `
+        errors: [
+          {
+            message:
+              'Property shorthands using multiple values like "listStyle: url(bullet.png) none" are not supported in StyleX. Separate into individual properties.',
+          },
+        ],
+      },
+      // caret: 'red bar' → caretColor + caretShape
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4271,7 +4274,7 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      output: `
+        output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4280,16 +4283,16 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "caret: red bar" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // caret: 'block blue' → caretColor + caretShape (reversed order)
-    {
-      code: `
+        errors: [
+          {
+            message:
+              'Property shorthands using multiple values like "caret: red bar" are not supported in StyleX. Separate into individual properties.',
+          },
+        ],
+      },
+      // caret: 'block blue' → caretColor + caretShape (reversed order)
+      {
+        code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4297,7 +4300,7 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      output: `
+        output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           main: {
@@ -4306,12 +4309,13 @@ eslintTester.run('stylex-valid-shorthands (columnRule/columns/listStyle/caret)',
           },
         });
       `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "caret: block blue" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-  ],
-});
+        errors: [
+          {
+            message:
+              'Property shorthands using multiple values like "caret: block blue" are not supported in StyleX. Separate into individual properties.',
+          },
+        ],
+      },
+    ],
+  },
+);

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -606,6 +606,27 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       })
     `,
     },
+    // textDecoration: single value (valid, no expansion needed)
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          textDecoration: 'underline',
+        },
+      })
+    `,
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          textDecoration: 'none',
+        },
+      })
+    `,
+    },
   ],
   invalid: [
     {
@@ -3655,6 +3676,114 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         {
           message:
             'Property shorthands using multiple values like "flexFlow: column-reverse nowrap" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // textDecoration: line + style
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            textDecoration: 'underline solid',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            textDecorationLine: 'underline',
+            textDecorationStyle: 'solid',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "textDecoration: underline solid" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // textDecoration: line + style + color
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            textDecoration: 'underline solid red',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            textDecorationLine: 'underline',
+            textDecorationStyle: 'solid',
+            textDecorationColor: 'red',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "textDecoration: underline solid red" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // textDecoration: line + style + hex color
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            textDecoration: 'underline wavy #ff0000',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            textDecorationLine: 'underline',
+            textDecorationStyle: 'wavy',
+            textDecorationColor: '#ff0000',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "textDecoration: underline wavy #ff0000" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    // textDecoration: line + style + color + thickness
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            textDecoration: 'line-through double blue 2px',
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            textDecorationLine: 'line-through',
+            textDecorationStyle: 'double',
+            textDecorationColor: 'blue',
+            textDecorationThickness: '2px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "textDecoration: line-through double blue 2px" are not supported in StyleX. Separate into individual properties.',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
@@ -75,6 +75,7 @@ const shorthandAliases: $ReadOnly<{
   gridRow: createSpecificTransformer('grid-row'),
   gridTemplate: createSpecificTransformer('grid-template'),
   outline: createSpecificTransformer('outline'),
+  textDecoration: createSpecificTransformer('text-decoration'),
   animation: createSpecificTransformer('animation'),
   flex: createSpecificTransformer('flex'),
   flexFlow: createSpecificTransformer('flex-flow'),

--- a/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
@@ -1159,8 +1159,14 @@ export function splitSpecificShorthands(
     if (vals.length === 2) {
       const suffix = property.replace('place-', '');
       return [
-        [toCamelCase(`align-${suffix}`), applyImportant(vals[0], importantSuffix)],
-        [toCamelCase(`justify-${suffix}`), applyImportant(vals[1], importantSuffix)],
+        [
+          toCamelCase(`align-${suffix}`),
+          applyImportant(vals[0], importantSuffix),
+        ],
+        [
+          toCamelCase(`justify-${suffix}`),
+          applyImportant(vals[1], importantSuffix),
+        ],
       ];
     }
     return [[toCamelCase(property), CANNOT_FIX]];
@@ -1713,7 +1719,10 @@ export function splitSpecificShorthands(
 
     const entries: Array<[string, string]> = [];
     if (line != null)
-      entries.push(['textDecorationLine', applyImportant(line, importantSuffix)]);
+      entries.push([
+        'textDecorationLine',
+        applyImportant(line, importantSuffix),
+      ]);
     if (style != null)
       entries.push([
         'textDecorationStyle',

--- a/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
@@ -160,6 +160,21 @@ const FONT_SIZE_KEYWORDS = new Set([
   'smaller',
   'larger',
 ]);
+const TEXT_DECORATION_LINE_KEYWORDS = new Set([
+  'none',
+  'underline',
+  'overline',
+  'line-through',
+  'blink',
+]);
+const TEXT_DECORATION_STYLE_KEYWORDS = new Set([
+  'solid',
+  'double',
+  'dotted',
+  'dashed',
+  'wavy',
+]);
+const TEXT_DECORATION_THICKNESS_KEYWORDS = new Set(['auto', 'from-font']);
 const COLOR_KEYWORDS = new Set(['transparent', 'currentcolor']);
 const COLOR_FUNCTION_REGEX =
   /^(?:rgb|rgba|hsl|hsla|hwb|hsb|lab|lch|oklab|oklch|color)\(/i;
@@ -1658,6 +1673,65 @@ export function splitSpecificShorthands(
       importantSuffix,
     );
     return expandedOutline ?? [[toCamelCase(property), CANNOT_FIX]];
+  }
+
+  if (property === 'text-decoration') {
+    if (splitValues.hasTopLevelComma || splitValues.hasTopLevelSlash) {
+      return [['textDecoration', CANNOT_FIX]];
+    }
+
+    let line = null;
+    let style = null;
+    let color = null;
+    let thickness = null;
+
+    for (const val of values) {
+      const lower = val.toLowerCase();
+      if (TEXT_DECORATION_LINE_KEYWORDS.has(lower)) {
+        if (line != null) return [['textDecoration', CANNOT_FIX]];
+        line = val;
+        continue;
+      }
+      if (TEXT_DECORATION_STYLE_KEYWORDS.has(lower)) {
+        if (style != null) return [['textDecoration', CANNOT_FIX]];
+        style = val;
+        continue;
+      }
+      if (
+        TEXT_DECORATION_THICKNESS_KEYWORDS.has(lower) ||
+        LENGTH_REGEX.test(lower) ||
+        LENGTH_FUNCTION_REGEX.test(lower)
+      ) {
+        if (thickness != null) return [['textDecoration', CANNOT_FIX]];
+        thickness = val;
+        continue;
+      }
+      // Assume it's a color
+      if (color != null) return [['textDecoration', CANNOT_FIX]];
+      color = val;
+    }
+
+    const entries: Array<[string, string]> = [];
+    if (line != null)
+      entries.push(['textDecorationLine', applyImportant(line, importantSuffix)]);
+    if (style != null)
+      entries.push([
+        'textDecorationStyle',
+        applyImportant(style, importantSuffix),
+      ]);
+    if (color != null)
+      entries.push([
+        'textDecorationColor',
+        applyImportant(color, importantSuffix),
+      ]);
+    if (thickness != null)
+      entries.push([
+        'textDecorationThickness',
+        applyImportant(thickness, importantSuffix),
+      ]);
+
+    if (entries.length === 0) return [['textDecoration', CANNOT_FIX]];
+    return entries;
   }
 
   return [[toCamelCase(property), CANNOT_FIX]];


### PR DESCRIPTION
Expand `textDecoration` shorthand into up to 4 longhands: `textDecorationLine`,
`textDecorationStyle`, `textDecorationColor`, and `textDecorationThickness`. Token
classification follows CSS spec order: line keywords → style keywords → thickness
(length/keyword) → color (fallback).

**Stack: 7/7** — depends on #1590

## What changed / motivation ?

- `textDecoration: 'underline solid red'` → `textDecorationLine` + `textDecorationStyle` + `textDecorationColor`
- `textDecoration: 'line-through double blue 2px'` → all 4 longhands including thickness
- Single values like `textDecoration: 'underline'` pass through unchanged
- Ambiguous values return CANNOT_FIX (no autofix)

## Linked PR/Issues

Follow-up to #1553, #1552

## Additional Context

Added tests covering: single-value passthrough, 2/3/4-value expansion, hex colors,
thickness values (length and keyword).

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code