### PR TITLE
[eslint-plugin] Add auto-fixers and suggest-fixes to stylex-valid-styles

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -1264,8 +1264,8 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: 'blue',
+            borderStyle: 'solid',
+            borderColor: 'blue',
           }
         });
       `,
@@ -1281,8 +1281,8 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: 'blue',
+            borderStyle: 'solid',
+            borderColor: 'blue',
           }
         });
       `,
@@ -1306,8 +1306,8 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: 'rgba(var(--black), 0.0975)',
+            borderStyle: 'solid',
+            borderColor: 'rgba(var(--black), 0.0975)',
           }
         });
       `,
@@ -1323,8 +1323,8 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: 'rgba(var(--black), 0.0975)',
+            borderStyle: 'solid',
+            borderColor: 'rgba(var(--black), 0.0975)',
           }
         });
       `,
@@ -1348,8 +1348,8 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: 'blue',
+            borderStyle: 'solid',
+            borderColor: 'blue',
           }
         });
       `,
@@ -1365,8 +1365,8 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: 'blue',
+            borderStyle: 'solid',
+            borderColor: 'blue',
           }
         });
       `,
@@ -1390,8 +1390,8 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: 'blue',
+            borderStyle: 'solid',
+            borderColor: 'blue',
           }
         });
       `,
@@ -1407,8 +1407,8 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: 'blue',
+            borderStyle: 'solid',
+            borderColor: 'blue',
           }
         });
       `,
@@ -1432,8 +1432,8 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: 'blue',
+            borderStyle: 'solid',
+            borderColor: 'blue',
           }
         });
       `,
@@ -1449,8 +1449,8 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: 'blue',
+            borderStyle: 'solid',
+            borderColor: 'blue',
           }
         });
       `,
@@ -1474,7 +1474,7 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
+            borderStyle: 'solid',
           }
         });
       `,
@@ -1490,7 +1490,7 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
+            borderStyle: 'solid',
           }
         });
       `,
@@ -1514,7 +1514,7 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderColor: 'var(--foo)',
+            borderColor: 'var(--foo)',
           }
         });
       `,
@@ -1530,7 +1530,7 @@ revert`,
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderColor: 'var(--foo)',
+            borderColor: 'var(--foo)',
           }
         });
       `,
@@ -2816,9 +2816,9 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             gridColumnEnd: '4',
-    gridColumnStart: '2',
-    gridRowEnd: '3',
-    gridRowStart: '1',
+            gridColumnStart: '2',
+            gridRowEnd: '3',
+            gridRowStart: '1',
           }
         });
       `,
@@ -2834,9 +2834,9 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             gridColumnEnd: '4',
-    gridColumnStart: '2',
-    gridRowEnd: '3',
-    gridRowStart: '1',
+            gridColumnStart: '2',
+            gridRowEnd: '3',
+            gridRowStart: '1',
           }
         });
       `,
@@ -2861,7 +2861,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             gridColumnEnd: '3',
-    gridColumnStart: '1',
+            gridColumnStart: '1',
           }
         });
       `,
@@ -2888,7 +2888,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             gridRowEnd: '3',
-    gridRowStart: '1',
+            gridRowStart: '1',
           }
         });
       `,
@@ -2915,7 +2915,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             gridTemplateColumns: '120px 1fr',
-    gridTemplateRows: 'auto 1fr',
+            gridTemplateRows: 'auto 1fr',
           }
         });
       `,
@@ -2942,7 +2942,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             rowGap: '10px',
-    columnGap: '20px',
+            columnGap: '20px',
           }
         });
       `,
@@ -2969,7 +2969,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             rowGap: 10,
-    columnGap: 10,
+            columnGap: 10,
           }
         });
       `,
@@ -3014,9 +3014,9 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             gridColumnEnd: 'header',
-    gridColumnStart: 'header',
-    gridRowEnd: 'header',
-    gridRowStart: 'header',
+            gridColumnStart: 'header',
+            gridRowEnd: 'header',
+            gridRowStart: 'header',
           }
         });
       `,
@@ -3051,8 +3051,8 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             animationDuration: '1s',
-    animationTimingFunction: 'ease-in',
-    animationName: 'fadeIn',
+            animationTimingFunction: 'ease-in',
+            animationName: 'fadeIn',
           }
         });
       `,
@@ -3077,9 +3077,9 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             fontFamily: 'Arial',
-    fontWeight: 'bold',
-    fontSize: '16px',
-    lineHeight: 1.5,
+            fontWeight: 'bold',
+            fontSize: '16px',
+            lineHeight: 1.5,
           }
         });
       `,
@@ -3105,8 +3105,8 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             fontFamily: 'Arial',
-    fontWeight: 700,
-    fontSize: '16px',
+            fontWeight: 700,
+            fontSize: '16px',
           }
         });
       `,
@@ -3195,8 +3195,8 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: 'blue',
+            borderStyle: 'solid',
+            borderColor: 'blue',
           }
         });
       `,
@@ -3277,7 +3277,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         const styles = stylex.create({
           default: {
             gridColumnStart: '2',
-    gridRowStart: '1',
+            gridRowStart: '1',
           }
         });
       `,

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -1258,6 +1258,7 @@ revert`,
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -1299,6 +1300,7 @@ revert`,
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -1340,6 +1342,7 @@ revert`,
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -1381,6 +1384,7 @@ revert`,
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -1422,6 +1426,7 @@ revert`,
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -1463,6 +1468,7 @@ revert`,
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -1502,6 +1508,7 @@ revert`,
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -1541,6 +1548,7 @@ revert`,
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -1578,6 +1586,7 @@ revert`,
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -1615,6 +1624,7 @@ revert`,
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -1652,6 +1662,7 @@ revert`,
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -1697,7 +1708,12 @@ revert`,
           }
         });
       `,
-      options: [{ validImports: ['custom-import'] }],
+      options: [
+        {
+          validImports: ['custom-import'],
+          styleResolution: 'legacy-expand-shorthands',
+        },
+      ],
       errors: [
         {
           message:
@@ -3022,6 +3038,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       errors: [
         {
           message:
@@ -3054,6 +3071,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -3081,6 +3099,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
           }
         });
       `,
+      options: [{ styleResolution: 'legacy-expand-shorthands' }],
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
@@ -3094,6 +3113,95 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       errors: [
         {
           message: /^font value must be one of:\n`font` is not recommended/,
+        },
+      ],
+    },
+    // animation/font/border autofixes are only enabled in legacy-expand-shorthands mode
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            animation: 'fadeIn 1s ease-in',
+          }
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            animation: 'fadeIn 1s ease-in',
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            /^animation value must be one of:\n`animation` is not recommended/,
+          suggestions: [],
+        },
+      ],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            font: 'bold 16px/1.5 Arial',
+          }
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            font: 'bold 16px/1.5 Arial',
+          }
+        });
+      `,
+      errors: [
+        {
+          message: /^font value must be one of:\n`font` is not recommended/,
+          suggestions: [],
+        },
+      ],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            border: '1px solid blue',
+          }
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            border: '1px solid blue',
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            "The 'border' property is not supported. Use the 'borderWidth', 'borderStyle' and 'borderColor' properties instead.",
+          suggestions: [
+            {
+              desc: "Replace 'border' with 'borderWidth', 'borderStyle' and 'borderColor' instead?",
+              output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'blue',
+          }
+        });
+      `,
+            },
+          ],
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -1258,6 +1258,16 @@ revert`,
           }
         });
       `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'blue',
+          }
+        });
+      `,
       errors: [
         {
           message:
@@ -1286,6 +1296,16 @@ revert`,
         const styles = stylex.create({
           default: {
             border: '1px solid rgba(var(--black), 0.0975)',
+          }
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'rgba(var(--black), 0.0975)',
           }
         });
       `,
@@ -1320,6 +1340,16 @@ revert`,
           }
         });
       `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'blue',
+          }
+        });
+      `,
       errors: [
         {
           message:
@@ -1348,6 +1378,16 @@ revert`,
         const styles = stylex.create({
           default: {
             border: "blue 1px solid",
+          }
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'blue',
           }
         });
       `,
@@ -1382,6 +1422,16 @@ revert`,
           }
         });
       `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'blue',
+          }
+        });
+      `,
       errors: [
         {
           message:
@@ -1410,6 +1460,15 @@ revert`,
         const styles = stylex.create({
           default: {
             border: "1px solid",
+          }
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            borderWidth: '1px',
+    borderStyle: 'solid',
           }
         });
       `,
@@ -1443,6 +1502,15 @@ revert`,
           }
         });
       `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            borderWidth: '1px',
+    borderColor: 'var(--foo)',
+          }
+        });
+      `,
       errors: [
         {
           message:
@@ -1470,6 +1538,14 @@ revert`,
         const styles = stylex.create({
           default: {
             border: "1px",
+          }
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            borderWidth: '1px',
           }
         });
       `,
@@ -1502,6 +1578,14 @@ revert`,
           }
         });
       `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            borderStyle: 'none',
+          }
+        });
+      `,
       errors: [
         {
           message:
@@ -1528,6 +1612,14 @@ revert`,
         const styles = stylex.create({
           default: {
             border: 0,
+          }
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            borderWidth: 0,
           }
         });
       `,
@@ -1560,6 +1652,14 @@ revert`,
           }
         });
       `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            borderWidth: 4,
+          }
+        });
+      `,
       errors: [
         {
           message:
@@ -1586,6 +1686,14 @@ revert`,
         const styles = stylex.create({
           default: {
             border: 4,
+          }
+        });
+      `,
+      output: `
+        import * as stylex from 'custom-import';
+        const styles = stylex.create({
+          default: {
+            borderWidth: 4,
           }
         });
       `,
@@ -1853,7 +1961,8 @@ revert`,
           message: /^fontSize value must be one of:\n/,
         },
         {
-          message: 'The empty string is not allowed by Stylex.',
+          message:
+            'The empty string is not allowed by Stylex. Use `null` to reset a style.',
         },
         {
           message: /^zIndex value must be one of:\n/,
@@ -2209,7 +2318,8 @@ This property is not supported in legacy StyleX resolution.`,
     `,
       errors: [
         {
-          message: 'The empty string is not allowed by Stylex.',
+          message:
+            'The empty string is not allowed by Stylex. Use `null` to reset a style.',
         },
       ],
     },
@@ -2250,7 +2360,8 @@ revert`,
       options: [{ validImports: [{ from: 'a', as: 'css' }] }],
       errors: [
         {
-          message: 'The empty string is not allowed by Stylex.',
+          message:
+            'The empty string is not allowed by Stylex. Use `null` to reset a style.',
         },
       ],
     },
@@ -2641,6 +2752,441 @@ revert`,
         },
         {
           message: 'Keys must be strings',
+        },
+      ],
+    },
+  ],
+});
+
+eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
+  valid: [
+    // Grid longhands should be allowed under banPropsForLegacy
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            display: 'grid',
+            gridTemplateColumns: 'repeat(3, 1fr)',
+            gridTemplateRows: 'auto',
+            gridRowStart: '1',
+            gridRowEnd: '3',
+            gridColumnStart: '1',
+            gridColumnEnd: '3',
+            gridAutoFlow: 'row',
+            gridAutoColumns: 'auto',
+            gridAutoRows: 'minmax(100px, auto)',
+            gridTemplateAreas: '"header header" "sidebar main"',
+          }
+        });
+      `,
+      options: [{ banPropsForLegacy: true }],
+    },
+  ],
+  invalid: [
+    // gridArea auto-fix under banPropsForLegacy
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridArea: '1 / 2 / 3 / 4',
+          }
+        });
+      `,
+      options: [{ banPropsForLegacy: true }],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridColumnEnd: '4',
+    gridColumnStart: '2',
+    gridRowEnd: '3',
+    gridRowStart: '1',
+          }
+        });
+      `,
+      errors: [
+        {
+          message: `gridArea value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+          suggestions: [
+            {
+              desc: "Split 'gridArea' shorthand into individual longhand properties?",
+              output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridColumnEnd: '4',
+    gridColumnStart: '2',
+    gridRowEnd: '3',
+    gridRowStart: '1',
+          }
+        });
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    // gridColumn auto-fix under banPropsForLegacy
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridColumn: '1 / 3',
+          }
+        });
+      `,
+      options: [{ banPropsForLegacy: true }],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridColumnEnd: '3',
+    gridColumnStart: '1',
+          }
+        });
+      `,
+      errors: [
+        {
+          message: `gridColumn value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+        },
+      ],
+    },
+    // gridRow auto-fix under banPropsForLegacy
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridRow: '1 / 3',
+          }
+        });
+      `,
+      options: [{ banPropsForLegacy: true }],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridRowEnd: '3',
+    gridRowStart: '1',
+          }
+        });
+      `,
+      errors: [
+        {
+          message: `gridRow value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+        },
+      ],
+    },
+    // gridTemplate auto-fix under banPropsForLegacy
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridTemplate: 'auto 1fr / 120px 1fr',
+          }
+        });
+      `,
+      options: [{ banPropsForLegacy: true }],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridTemplateColumns: '120px 1fr',
+    gridTemplateRows: 'auto 1fr',
+          }
+        });
+      `,
+      errors: [
+        {
+          message: `gridTemplate value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+        },
+      ],
+    },
+    // gridGap auto-fix under banPropsForLegacy
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridGap: '10px 20px',
+          }
+        });
+      `,
+      options: [{ banPropsForLegacy: true }],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            rowGap: '10px',
+    columnGap: '20px',
+          }
+        });
+      `,
+      errors: [
+        {
+          message: `gridGap value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+        },
+      ],
+    },
+    // gridGap numeric value auto-fix under banPropsForLegacy
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridGap: '10',
+          }
+        });
+      `,
+      options: [{ banPropsForLegacy: true }],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            rowGap: 10,
+    columnGap: 10,
+          }
+        });
+      `,
+      errors: [
+        {
+          message: `gridGap value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+        },
+      ],
+    },
+    // grid shorthand without fix (too complex for deterministic expansion)
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            grid: 'repeat(3, 80px) / auto-flow',
+          }
+        });
+      `,
+      options: [{ banPropsForLegacy: true }],
+      errors: [
+        {
+          message: `grid value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+        },
+      ],
+    },
+    // gridArea with single ident (custom ident expansion)
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridArea: 'header',
+          }
+        });
+      `,
+      options: [{ banPropsForLegacy: true }],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridColumnEnd: 'header',
+    gridColumnStart: 'header',
+    gridRowEnd: 'header',
+    gridRowStart: 'header',
+          }
+        });
+      `,
+      errors: [
+        {
+          message: `gridArea value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+        },
+      ],
+    },
+    // animation suggest-fix via CSSPropertyReplacements (suggest-only because
+    // animationName needs a keyframes() reference, not a string literal)
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            animation: 'fadeIn 1s ease-in',
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            "`animation` is not supported. Use `animationName`, `animationDuration`, `animationTimingFunction`, etc. instead.",
+          suggestions: [
+            {
+              desc: "Split 'animation' shorthand into individual longhand properties?",
+              output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            animationDuration: '1s',
+    animationTimingFunction: 'ease-in',
+    animationName: 'fadeIn',
+          }
+        });
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    // font auto-fix via CSSPropertyReplacements
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            font: 'bold 16px/1.5 Arial',
+          }
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            fontFamily: 'Arial',
+    fontWeight: 'bold',
+    fontSize: '16px',
+    lineHeight: 1.5,
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            "`font` is not supported. Use `fontSize`, `fontFamily`, `fontStyle`, `fontWeight`, etc. instead.",
+        },
+      ],
+    },
+    // font auto-fix emits numeric fontWeight as a number literal
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            font: '700 16px Arial',
+          }
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            fontFamily: 'Arial',
+    fontWeight: 700,
+    fontSize: '16px',
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            "`font` is not supported. Use `fontSize`, `fontFamily`, `fontStyle`, `fontWeight`, etc. instead.",
+        },
+      ],
+    },
+    // animation with no expansion (single value)
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            animation: 'none',
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            "`animation` is not supported. Use `animationName`, `animationDuration`, `animationTimingFunction`, etc. instead.",
+        },
+      ],
+    },
+    // font with no expansion (single value)
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            font: 'inherit',
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            "`font` is not supported. Use `fontSize`, `fontFamily`, `fontStyle`, `fontWeight`, etc. instead.",
+        },
+      ],
+    },
+    // empty string suggest-fix
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            color: '',
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            'The empty string is not allowed by Stylex. Use `null` to reset a style.',
+          suggestions: [
+            {
+              desc: 'Replace empty string with `null`?',
+              output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            color: null,
+          }
+        });
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    // grid shorthand with propLimits (user-defined, not banPropsForLegacy)
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridArea: '1 / 2',
+          }
+        });
+      `,
+      options: [
+        {
+          propLimits: {
+            gridArea: {
+              limit: null,
+              reason: 'gridArea shorthand is banned',
+            },
+          },
+        },
+      ],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          default: {
+            gridColumnStart: '2',
+    gridRowStart: '1',
+          }
+        });
+      `,
+      errors: [
+        {
+          message: `gridArea value must be one of:\ngridArea shorthand is banned`,
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -2808,7 +2808,8 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       `,
       errors: [
         {
-          message: `gridArea value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+          message:
+            'gridArea value must be one of:\nThis property is not supported in legacy StyleX resolution.',
           suggestions: [
             {
               desc: "Split 'gridArea' shorthand into individual longhand properties?",
@@ -2850,7 +2851,8 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       `,
       errors: [
         {
-          message: `gridColumn value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+          message:
+            'gridColumn value must be one of:\nThis property is not supported in legacy StyleX resolution.',
         },
       ],
     },
@@ -2876,7 +2878,8 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       `,
       errors: [
         {
-          message: `gridRow value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+          message:
+            'gridRow value must be one of:\nThis property is not supported in legacy StyleX resolution.',
         },
       ],
     },
@@ -2902,7 +2905,8 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       `,
       errors: [
         {
-          message: `gridTemplate value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+          message:
+            'gridTemplate value must be one of:\nThis property is not supported in legacy StyleX resolution.',
         },
       ],
     },
@@ -2928,7 +2932,8 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       `,
       errors: [
         {
-          message: `gridGap value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+          message:
+            'gridGap value must be one of:\nThis property is not supported in legacy StyleX resolution.',
         },
       ],
     },
@@ -2954,7 +2959,8 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       `,
       errors: [
         {
-          message: `gridGap value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+          message:
+            'gridGap value must be one of:\nThis property is not supported in legacy StyleX resolution.',
         },
       ],
     },
@@ -2971,7 +2977,8 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       options: [{ banPropsForLegacy: true }],
       errors: [
         {
-          message: `grid value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+          message:
+            'grid value must be one of:\nThis property is not supported in legacy StyleX resolution.',
         },
       ],
     },
@@ -2999,12 +3006,13 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       `,
       errors: [
         {
-          message: `gridArea value must be one of:\nThis property is not supported in legacy StyleX resolution.`,
+          message:
+            'gridArea value must be one of:\nThis property is not supported in legacy StyleX resolution.',
         },
       ],
     },
-    // animation suggest-fix via CSSPropertyReplacements (suggest-only because
-    // animationName needs a keyframes() reference, not a string literal)
+    // animation suggest-fix (suggest-only because animationName needs
+    // a keyframes() reference, not a string literal)
     {
       code: `
         import * as stylex from '@stylexjs/stylex';
@@ -3017,7 +3025,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       errors: [
         {
           message:
-            "`animation` is not supported. Use `animationName`, `animationDuration`, `animationTimingFunction`, etc. instead.",
+            /^animation value must be one of:\n`animation` is not recommended/,
           suggestions: [
             {
               desc: "Split 'animation' shorthand into individual longhand properties?",
@@ -3036,7 +3044,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
         },
       ],
     },
-    // font auto-fix via CSSPropertyReplacements
+    // font auto-fix
     {
       code: `
         import * as stylex from '@stylexjs/stylex';
@@ -3059,8 +3067,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       `,
       errors: [
         {
-          message:
-            "`font` is not supported. Use `fontSize`, `fontFamily`, `fontStyle`, `fontWeight`, etc. instead.",
+          message: /^font value must be one of:\n`font` is not recommended/,
         },
       ],
     },
@@ -3086,8 +3093,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       `,
       errors: [
         {
-          message:
-            "`font` is not supported. Use `fontSize`, `fontFamily`, `fontStyle`, `fontWeight`, etc. instead.",
+          message: /^font value must be one of:\n`font` is not recommended/,
         },
       ],
     },
@@ -3104,24 +3110,7 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       errors: [
         {
           message:
-            "`animation` is not supported. Use `animationName`, `animationDuration`, `animationTimingFunction`, etc. instead.",
-        },
-      ],
-    },
-    // font with no expansion (single value)
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          default: {
-            font: 'inherit',
-          }
-        });
-      `,
-      errors: [
-        {
-          message:
-            "`font` is not supported. Use `fontSize`, `fontFamily`, `fontStyle`, `fontWeight`, etc. instead.",
+            /^animation value must be one of:\n`animation` is not recommended/,
         },
       ],
     },
@@ -3186,7 +3175,8 @@ eslintTester.run('stylex-valid-styles [autofixers]', rule.default, {
       `,
       errors: [
         {
-          message: `gridArea value must be one of:\ngridArea shorthand is banned`,
+          message:
+            'gridArea value must be one of:\ngridArea shorthand is banned',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -23,10 +23,6 @@ import isPercentage from '../rules/isPercentage';
 import isAbsoluteLength from '../rules/isAbsoluteLength';
 import isRelativeLength from '../rules/isRelativeLength';
 import { borderSplitter } from '../utils/split-css-value';
-import {
-  splitSpecificShorthands,
-  CANNOT_FIX,
-} from '../utils/splitShorthands';
 
 export type RuleResponse = void | {
   message: string,
@@ -531,52 +527,6 @@ const serializeValue = (propertyKey: string, val: number | string): string => {
   return `'${escaped}'`;
 };
 
-const createShorthandFixer =
-  (
-    property: string,
-    errorMessage: string,
-    suggestOnly?: boolean,
-  ): RuleCheck =>
-  (
-    node: Expression | Pattern,
-    _variables?: Variables,
-    prop?: Property,
-  ): RuleResponse => {
-    const response: $NonMaybeType<RuleResponse> = {
-      message: errorMessage,
-    };
-    if (node.type !== 'Literal' || prop == null) {
-      return response;
-    }
-    const val = node.value;
-    if (typeof val !== 'string' && typeof val !== 'number') {
-      return response;
-    }
-    const expanded = splitSpecificShorthands(property, String(val));
-    if (
-      expanded.length <= 1 &&
-      expanded[0]?.[1] !== CANNOT_FIX
-    ) {
-      return response;
-    }
-    if (expanded.length === 1 && expanded[0]?.[1] === CANNOT_FIX) {
-      return response;
-    }
-    const newPropertiesText = expanded
-      .map(([key, value]) => `${key}: ${serializeValue(key, value)}`)
-      .join(',\n    ');
-    const fixFn = (fixer: Rule.RuleFixer): Rule.Fix | null => {
-      return fixer.replaceText(prop, newPropertiesText);
-    };
-    if (!suggestOnly) {
-      response.fix = fixFn;
-    }
-    response.suggest = {
-      desc: `Split '${property}' shorthand into individual longhand properties?`,
-      fix: fixFn,
-    };
-    return response;
-  };
 const border =
   (suffix: string = ''): RuleCheck =>
   (node: Expression | Pattern, _variables?: Variables, prop?: Property) => {
@@ -2319,15 +2269,6 @@ export const CSSPropertyReplacements: { [key: string]: RuleCheck | void } = {
   borderStart: border('InlineStart'),
   borderInlineStart: border('InlineStart'),
   borderLeft: border('Left'),
-  animation: createShorthandFixer(
-    'animation',
-    '`animation` is not supported. Use `animationName`, `animationDuration`, `animationTimingFunction`, etc. instead.',
-    true, // suggest-only: animationName needs a keyframes() reference, not a string
-  ),
-  font: createShorthandFixer(
-    'font',
-    '`font` is not supported. Use `fontSize`, `fontFamily`, `fontStyle`, `fontWeight`, etc. instead.',
-  ),
 };
 
 export const pseudoElements: RuleCheck = makeUnionRule(

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -23,6 +23,8 @@ import isPercentage from '../rules/isPercentage';
 import isAbsoluteLength from '../rules/isAbsoluteLength';
 import isRelativeLength from '../rules/isRelativeLength';
 import { borderSplitter } from '../utils/split-css-value';
+import formatPropertiesWithNodeIndentation from '../utils/formatPropertiesWithNodeIndentation';
+import getSourceCode from '../utils/getSourceCode';
 
 export type RuleResponse = void | {
   message: string,
@@ -37,6 +39,7 @@ export type RuleCheck = (
   node: $ReadOnly<Expression | Pattern>,
   variables?: Variables,
   prop?: $ReadOnly<Property>,
+  context?: Rule.RuleContext,
 ) => RuleResponse;
 
 export type Variables = $ReadOnlyMap<string, Expression | 'ARG'>;
@@ -527,9 +530,23 @@ const serializeValue = (propertyKey: string, val: number | string): string => {
   return `'${escaped}'`;
 };
 
+const formatReplacementProperties = (
+  prop: $ReadOnly<Property>,
+  properties: $ReadOnlyArray<string>,
+  context?: Rule.RuleContext,
+): string => {
+  const sourceCode = context != null ? getSourceCode(context) : undefined;
+  return formatPropertiesWithNodeIndentation(prop, properties, sourceCode);
+};
+
 const border =
   (suffix: string = ''): RuleCheck =>
-  (node: Expression | Pattern, _variables?: Variables, prop?: Property) => {
+  (
+    node: Expression | Pattern,
+    _variables?: Variables,
+    prop?: Property,
+    context?: Rule.RuleContext,
+  ) => {
     const response: $NonMaybeType<RuleResponse> = {
       message: `The 'border${suffix}' property is not supported. Use the 'border${suffix}Width', 'border${suffix}Style' and 'border${suffix}Color' properties instead.`,
     };
@@ -569,7 +586,10 @@ const border =
               `border${suffix}Color: ${serializeValue(`border${suffix}Color`, color)}`,
             );
           }
-          return fixer.replaceText(prop, newRules.join(',\n    '));
+          return fixer.replaceText(
+            prop,
+            formatReplacementProperties(prop, newRules, context),
+          );
         };
         response.fix = fixFn;
         response.suggest = {

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -23,10 +23,15 @@ import isPercentage from '../rules/isPercentage';
 import isAbsoluteLength from '../rules/isAbsoluteLength';
 import isRelativeLength from '../rules/isRelativeLength';
 import { borderSplitter } from '../utils/split-css-value';
+import {
+  splitSpecificShorthands,
+  CANNOT_FIX,
+} from '../utils/splitShorthands';
 
 export type RuleResponse = void | {
   message: string,
   distance?: number,
+  fix?: Rule.ReportFixer,
   suggest?: {
     fix: Rule.ReportFixer,
     desc: string,
@@ -52,16 +57,27 @@ const isNamedColor: RuleCheck = makeUnionRule(
 
 const isLength: RuleCheck = makeUnionRule(isAbsoluteLength, isRelativeLength);
 
-const isNonNumericString: RuleCheck = (node: Node): RuleResponse => {
+const isNonNumericString: RuleCheck = (
+  node: Node,
+  _variables?: Variables,
+  _prop?: Property,
+): RuleResponse => {
   if (node.type === 'Literal' && typeof node.value === 'string') {
     if (/^[-+]?(?:\d+|\d*\.\d+)$/.test(node.value)) {
       if (node.value === '0') {
         return undefined;
       }
 
-      return {
+      const response: $NonMaybeType<RuleResponse> = {
         message: 'a non-numeric string',
       };
+      response.suggest = {
+        desc: `Replace string '${node.value}' with number ${Number(node.value)}?`,
+        fix: (fixer: Rule.RuleFixer): Rule.Fix | null => {
+          return fixer.replaceText(node, String(Number(node.value)));
+        },
+      };
+      return response;
     }
   }
   return undefined;
@@ -483,8 +499,84 @@ const backgroundOrigin: RuleCheck = box;
 const backgroundRepeat: RuleCheck = repeatStyle;
 const backgroundSize: RuleCheck = bgSize;
 const blockSize: RuleCheck = width;
-const quotedString = (val: number | string) =>
-  typeof val === 'string' ? `'${val}'` : val;
+const NUMERIC_LITERAL_VALUE_REGEX = /^[-+]?(?:\d+|\d*\.\d+)$/;
+
+const NUMERIC_LITERAL_PROPERTIES = new Set([
+  'lineHeight',
+  'fontWeight',
+  'animationIterationCount',
+  'borderWidth',
+  'borderTopWidth',
+  'borderRightWidth',
+  'borderBottomWidth',
+  'borderLeftWidth',
+  'borderInlineStartWidth',
+  'borderInlineEndWidth',
+  'borderBlockStartWidth',
+  'borderBlockEndWidth',
+]);
+
+const serializeValue = (propertyKey: string, val: number | string): string => {
+  if (typeof val === 'number') {
+    return String(val);
+  }
+  if (
+    NUMERIC_LITERAL_PROPERTIES.has(propertyKey) &&
+    NUMERIC_LITERAL_VALUE_REGEX.test(val)
+  ) {
+    return String(Number(val));
+  }
+  // Escape single quotes within the string
+  const escaped = val.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  return `'${escaped}'`;
+};
+
+const createShorthandFixer =
+  (
+    property: string,
+    errorMessage: string,
+    suggestOnly?: boolean,
+  ): RuleCheck =>
+  (
+    node: Expression | Pattern,
+    _variables?: Variables,
+    prop?: Property,
+  ): RuleResponse => {
+    const response: $NonMaybeType<RuleResponse> = {
+      message: errorMessage,
+    };
+    if (node.type !== 'Literal' || prop == null) {
+      return response;
+    }
+    const val = node.value;
+    if (typeof val !== 'string' && typeof val !== 'number') {
+      return response;
+    }
+    const expanded = splitSpecificShorthands(property, String(val));
+    if (
+      expanded.length <= 1 &&
+      expanded[0]?.[1] !== CANNOT_FIX
+    ) {
+      return response;
+    }
+    if (expanded.length === 1 && expanded[0]?.[1] === CANNOT_FIX) {
+      return response;
+    }
+    const newPropertiesText = expanded
+      .map(([key, value]) => `${key}: ${serializeValue(key, value)}`)
+      .join(',\n    ');
+    const fixFn = (fixer: Rule.RuleFixer): Rule.Fix | null => {
+      return fixer.replaceText(prop, newPropertiesText);
+    };
+    if (!suggestOnly) {
+      response.fix = fixFn;
+    }
+    response.suggest = {
+      desc: `Split '${property}' shorthand into individual longhand properties?`,
+      fix: fixFn,
+    };
+    return response;
+  };
 const border =
   (suffix: string = ''): RuleCheck =>
   (node: Expression | Pattern, _variables?: Variables, prop?: Property) => {
@@ -495,34 +587,44 @@ const border =
       return response;
     }
     if (typeof node.value === 'number') {
+      const fixFn = (fixer: Rule.RuleFixer): Rule.Fix | null => {
+        return fixer.replaceText(
+          prop,
+          `border${suffix}Width: ${String(node.value)}`,
+        );
+      };
+      response.fix = fixFn;
       response.suggest = {
         desc: `Replace 'border${suffix}' set to a number with 'border${suffix}Width' instead?`,
-        fix: (fixer: Rule.RuleFixer): Rule.Fix | null => {
-          return fixer.replaceText(
-            prop,
-            `border${suffix}Width: ${String(node.value)}`,
-          );
-        },
+        fix: fixFn,
       };
     }
     if (typeof node.value === 'string') {
       const [width, style, color] = borderSplitter(node.value);
       if (width != null || style != null || color != null) {
+        const fixFn = (fixer: Rule.RuleFixer): Rule.Fix | null => {
+          const newRules = [];
+          if (width != null) {
+            newRules.push(
+              `border${suffix}Width: ${serializeValue(`border${suffix}Width`, width)}`,
+            );
+          }
+          if (style != null) {
+            newRules.push(
+              `border${suffix}Style: ${serializeValue(`border${suffix}Style`, style)}`,
+            );
+          }
+          if (color != null) {
+            newRules.push(
+              `border${suffix}Color: ${serializeValue(`border${suffix}Color`, color)}`,
+            );
+          }
+          return fixer.replaceText(prop, newRules.join(',\n    '));
+        };
+        response.fix = fixFn;
         response.suggest = {
           desc: `Replace 'border${suffix}' with 'border${suffix}Width', 'border${suffix}Style' and 'border${suffix}Color' instead?`,
-          fix: (fixer: Rule.RuleFixer): Rule.Fix | null => {
-            const newRules = [];
-            if (width != null) {
-              newRules.push(`border${suffix}Width: ${quotedString(width)}`);
-            }
-            if (style != null) {
-              newRules.push(`border${suffix}Style: ${quotedString(style)}`);
-            }
-            if (color != null) {
-              newRules.push(`border${suffix}Color: ${quotedString(color)}`);
-            }
-            return fixer.replaceText(prop, newRules.join(',\n    '));
-          },
+          fix: fixFn,
         };
       }
     }
@@ -2217,6 +2319,15 @@ export const CSSPropertyReplacements: { [key: string]: RuleCheck | void } = {
   borderStart: border('InlineStart'),
   borderInlineStart: border('InlineStart'),
   borderLeft: border('Left'),
+  animation: createShorthandFixer(
+    'animation',
+    '`animation` is not supported. Use `animationName`, `animationDuration`, `animationTimingFunction`, etc. instead.',
+    true, // suggest-only: animationName needs a keyframes() reference, not a string
+  ),
+  font: createShorthandFixer(
+    'font',
+    '`font` is not supported. Use `fontSize`, `fontFamily`, `fontStyle`, `fontWeight`, etc. instead.',
+  ),
 };
 
 export const pseudoElements: RuleCheck = makeUnionRule(

--- a/packages/@stylexjs/eslint-plugin/src/rules/makeUnionRule.js
+++ b/packages/@stylexjs/eslint-plugin/src/rules/makeUnionRule.js
@@ -40,11 +40,14 @@ export default function makeUnionRule(
       }
       failedRules.push(check);
     }
-    const fixable = failedRules.filter((a) => a.suggest != null);
+    const fixable = failedRules.filter(
+      (a) => a.suggest != null || a.fix != null,
+    );
     fixable.sort((a, b) => (a.distance || Infinity) - (b.distance || Infinity));
 
     return {
       message: failedRules.map((a) => a.message).join('\n'),
+      fix: fixable[0] != null ? fixable[0].fix : undefined,
       suggest: fixable[0] != null ? fixable[0].suggest : undefined,
     };
   };

--- a/packages/@stylexjs/eslint-plugin/src/rules/makeUnionRule.js
+++ b/packages/@stylexjs/eslint-plugin/src/rules/makeUnionRule.js
@@ -13,6 +13,7 @@ import type {
   RuleCheck,
 } from '../stylex-valid-styles';
 import type { Expression, Pattern, Property } from 'estree';
+/*:: import { Rule } from 'eslint'; */
 
 import makeLiteralRule from './makeLiteralRule';
 
@@ -23,6 +24,7 @@ export default function makeUnionRule(
     node: Expression | Pattern,
     variables?: Variables,
     prop?: Property,
+    context?: Rule.RuleContext,
   ): RuleResponse => {
     const failedRules = [];
     for (const _rule of rules) {
@@ -33,7 +35,7 @@ export default function makeUnionRule(
             ? makeLiteralRule(_rule)
             : _rule;
 
-      const check = rule(node, variables, prop);
+      const check = rule(node, variables, prop, context);
       if (check === undefined) {
         // passes, that means we pass.
         return undefined;

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
@@ -14,10 +14,7 @@ import type {
   Node,
   Property,
   ObjectExpression,
-  Comment,
 } from 'estree';
-import type { SourceCode } from 'eslint/eslint-rule';
-import type { Token } from 'eslint/eslint-ast';
 import {
   createBlockInlineTransformer,
   createSpecificTransformer,
@@ -25,6 +22,7 @@ import {
 } from './utils/splitShorthands.js';
 import { CANNOT_FIX } from './utils/splitShorthands.js';
 import getSourceCode from './utils/getSourceCode';
+import getNodeIndentation from './utils/getNodeIndentation';
 import createImportTracker from './utils/createImportTracker';
 /*:: import { Rule } from 'eslint'; */
 
@@ -272,38 +270,5 @@ const stylexValidShorthands = {
     };
   },
 };
-
-function isSameLine(
-  aNode: Property | Comment | Token,
-  bNode: Property | Comment | Token,
-): boolean {
-  return Boolean(
-    aNode.loc && bNode.loc && aNode.loc?.start.line === bNode.loc?.start.line,
-  );
-}
-
-function getNodeIndentation(
-  sourceCode: SourceCode,
-  node: Property | Comment,
-): string {
-  const tokenBefore = sourceCode.getTokenBefore(node, {
-    includeComments: false,
-  });
-
-  const isTokenBeforeSameLineAsNode =
-    !!tokenBefore && isSameLine(tokenBefore, node);
-
-  const sliceStart =
-    isTokenBeforeSameLineAsNode && tokenBefore?.loc
-      ? tokenBefore.loc.end.column
-      : 0;
-
-  return node?.loc
-    ? sourceCode.lines[node.loc.start.line - 1].slice(
-        sliceStart,
-        node.loc.start.column,
-      )
-    : '';
-}
 
 export default stylexValidShorthands as typeof stylexValidShorthands;

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
@@ -9,12 +9,7 @@
 
 'use strict';
 
-import type {
-  CallExpression,
-  Node,
-  Property,
-  ObjectExpression,
-} from 'estree';
+import type { CallExpression, Node, Property, ObjectExpression } from 'estree';
 import {
   createBlockInlineTransformer,
   createSpecificTransformer,

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -41,6 +41,8 @@ import isStylexResolvedVarsToken from './rules/isStylexResolvedVarsToken';
 import isCSSVariable from './rules/isCSSVariable';
 import evaluate from './utils/evaluate';
 import resolveKey from './utils/resolveKey';
+import formatPropertiesWithNodeIndentation from './utils/formatPropertiesWithNodeIndentation';
+import getSourceCode from './utils/getSourceCode';
 import {
   CSSPropertyKeys,
   CSSProperties,
@@ -132,12 +134,25 @@ const serializeValue = (propertyKey: string, val: number | string): string => {
   return `'${escaped}'`;
 };
 
+const formatExpandedProperties = (
+  prop: $ReadOnly<Property>,
+  expanded: $ReadOnlyArray<$ReadOnly<[string, number | string]>>,
+  context?: Rule.RuleContext,
+): string => {
+  const sourceCode = context != null ? getSourceCode(context) : undefined;
+  const properties = expanded.map(
+    ([key, value]) => `${key}: ${serializeValue(key, value)}`,
+  );
+  return formatPropertiesWithNodeIndentation(prop, properties, sourceCode);
+};
+
 const showErrorWithFix =
   (message: string, propertyKey: string): RuleCheck =>
   (
     node: $ReadOnly<Expression | Pattern>,
     _variables?: Variables,
     prop?: $ReadOnly<Property>,
+    context?: Rule.RuleContext,
   ): RuleResponse => {
     const response: $NonMaybeType<RuleResponse> = { message };
     const shorthandProp = shorthandExpansionMap[propertyKey];
@@ -157,9 +172,7 @@ const showErrorWithFix =
       // Cannot be auto-fixed
       return response;
     }
-    const newPropertiesText = expanded
-      .map(([key, value]) => `${key}: ${serializeValue(key, value)}`)
-      .join(',\n    ');
+    const newPropertiesText = formatExpandedProperties(prop, expanded, context);
     const fixFn = (fixer: Rule.RuleFixer) => {
       return fixer.replaceText(prop, newPropertiesText);
     };
@@ -767,7 +780,7 @@ const stylexValidStyles = {
           const propCheck: RuleCheck = CSSPropertyReplacements[key];
           // eslint-disable-next-line no-unused-vars
           const val: Property = style;
-          const check = propCheck(style.value, variables, style);
+          const check = propCheck(style.value, variables, style, context);
           if (check != null) {
             const { message } = check;
             const { suggest } = check;
@@ -902,9 +915,11 @@ const stylexValidStyles = {
                   canFix &&
                   !(expanded.length === 1 && expanded[0]?.[1] === CANNOT_FIX);
                 if (isFixable) {
-                  const newPropertiesText = expanded
-                    .map(([k, v]) => `${k}: ${serializeValue(k, v)}`)
-                    .join(',\n    ');
+                  const newPropertiesText = formatExpandedProperties(
+                    style,
+                    expanded,
+                    context,
+                  );
                   const fixFn = (fixer: Rule.RuleFixer) =>
                     fixer.replaceText(style, newPropertiesText);
                   // animation is suggest-only since animationName needs keyframes()

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -50,10 +50,7 @@ import {
   allModifiers,
   all,
 } from './reference/cssProperties';
-import {
-  splitSpecificShorthands,
-  CANNOT_FIX,
-} from './utils/splitShorthands';
+import { splitSpecificShorthands, CANNOT_FIX } from './utils/splitShorthands';
 
 export type Variables = $ReadOnlyMap<string, Expression | 'ARG'>;
 export type RuleCheck = (
@@ -85,6 +82,8 @@ const showError =
 // Maps camelCase CSS shorthand property names to the hyphenated names
 // used by splitSpecificShorthands
 const shorthandExpansionMap: { [string]: string } = {
+  animation: 'animation',
+  font: 'font',
   gridArea: 'grid-area',
   gridColumn: 'grid-column',
   gridRow: 'grid-row',
@@ -94,7 +93,13 @@ const shorthandExpansionMap: { [string]: string } = {
 
 const NUMERIC_LITERAL_VALUE_REGEX = /^[-+]?(?:\d+|\d*\.\d+)$/;
 
-const NUMERIC_LITERAL_PROPERTIES = new Set(['rowGap', 'columnGap']);
+const NUMERIC_LITERAL_PROPERTIES = new Set([
+  'rowGap',
+  'columnGap',
+  'lineHeight',
+  'fontWeight',
+  'animationIterationCount',
+]);
 
 const serializeValue = (propertyKey: string, val: number | string): string => {
   if (typeof val === 'number') {
@@ -128,10 +133,7 @@ const showErrorWithFix =
       return response;
     }
     const expanded = splitSpecificShorthands(shorthandProp, String(val));
-    if (
-      expanded.length <= 1 &&
-      expanded[0]?.[1] !== CANNOT_FIX
-    ) {
+    if (expanded.length <= 1 && expanded[0]?.[1] !== CANNOT_FIX) {
       // Single value that's unchanged — no expansion available
       return response;
     }
@@ -819,7 +821,48 @@ const stylexValidStyles = {
               });
             }
 
-            const { message, fix, suggest } = check;
+            const { message } = check;
+            let { fix, suggest } = check;
+
+            // If the property has a known shorthand expansion and no fix yet,
+            // try to attach one
+            if (
+              fix == null &&
+              suggest == null &&
+              shorthandExpansionMap[key] != null &&
+              style.value.type === 'Literal'
+            ) {
+              const val = style.value.value;
+              if (typeof val === 'string' || typeof val === 'number') {
+                const shorthandProp = shorthandExpansionMap[key];
+                const expanded = splitSpecificShorthands(
+                  shorthandProp,
+                  String(val),
+                );
+                const canFix =
+                  expanded.length > 1 ||
+                  (expanded.length === 1 && expanded[0]?.[1] === CANNOT_FIX);
+                const isFixable =
+                  canFix &&
+                  !(expanded.length === 1 && expanded[0]?.[1] === CANNOT_FIX);
+                if (isFixable) {
+                  const newPropertiesText = expanded
+                    .map(([k, v]) => `${k}: ${serializeValue(k, v)}`)
+                    .join(',\n    ');
+                  const fixFn = (fixer: Rule.RuleFixer) =>
+                    fixer.replaceText(style, newPropertiesText);
+                  // animation is suggest-only since animationName needs keyframes()
+                  if (key !== 'animation') {
+                    fix = fixFn;
+                  }
+                  suggest = {
+                    desc: `Split '${key}' shorthand into individual longhand properties?`,
+                    fix: fixFn,
+                  };
+                }
+              }
+            }
+
             const isBackgroundBlendModeFormatError =
               key === 'backgroundBlendMode' &&
               typeof message === 'string' &&

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -50,6 +50,10 @@ import {
   allModifiers,
   all,
 } from './reference/cssProperties';
+import {
+  splitSpecificShorthands,
+  CANNOT_FIX,
+} from './utils/splitShorthands';
 
 export type Variables = $ReadOnlyMap<string, Expression | 'ARG'>;
 export type RuleCheck = (
@@ -61,6 +65,7 @@ export type RuleCheck = (
 export type RuleResponse = void | {
   message: string,
   distance?: number,
+  fix?: Rule.ReportFixer,
   suggest?: {
     fix: Rule.ReportFixer,
     desc: string,
@@ -76,6 +81,77 @@ type ValidationResult =
 const showError =
   (message: string): RuleCheck =>
   () => ({ message });
+
+// Maps camelCase CSS shorthand property names to the hyphenated names
+// used by splitSpecificShorthands
+const shorthandExpansionMap: { [string]: string } = {
+  gridArea: 'grid-area',
+  gridColumn: 'grid-column',
+  gridRow: 'grid-row',
+  gridTemplate: 'grid-template',
+  gridGap: 'gap',
+};
+
+const NUMERIC_LITERAL_VALUE_REGEX = /^[-+]?(?:\d+|\d*\.\d+)$/;
+
+const NUMERIC_LITERAL_PROPERTIES = new Set(['rowGap', 'columnGap']);
+
+const serializeValue = (propertyKey: string, val: number | string): string => {
+  if (typeof val === 'number') {
+    return String(val);
+  }
+  if (
+    NUMERIC_LITERAL_PROPERTIES.has(propertyKey) &&
+    NUMERIC_LITERAL_VALUE_REGEX.test(val)
+  ) {
+    return String(Number(val));
+  }
+  // Escape single quotes within the string
+  const escaped = val.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  return `'${escaped}'`;
+};
+
+const showErrorWithFix =
+  (message: string, propertyKey: string): RuleCheck =>
+  (
+    node: $ReadOnly<Expression | Pattern>,
+    _variables?: Variables,
+    prop?: $ReadOnly<Property>,
+  ): RuleResponse => {
+    const response: $NonMaybeType<RuleResponse> = { message };
+    const shorthandProp = shorthandExpansionMap[propertyKey];
+    if (shorthandProp == null || node.type !== 'Literal' || prop == null) {
+      return response;
+    }
+    const val = node.value;
+    if (typeof val !== 'string' && typeof val !== 'number') {
+      return response;
+    }
+    const expanded = splitSpecificShorthands(shorthandProp, String(val));
+    if (
+      expanded.length <= 1 &&
+      expanded[0]?.[1] !== CANNOT_FIX
+    ) {
+      // Single value that's unchanged — no expansion available
+      return response;
+    }
+    if (expanded.length === 1 && expanded[0]?.[1] === CANNOT_FIX) {
+      // Cannot be auto-fixed
+      return response;
+    }
+    const newPropertiesText = expanded
+      .map(([key, value]) => `${key}: ${serializeValue(key, value)}`)
+      .join(',\n    ');
+    const fixFn = (fixer: Rule.RuleFixer) => {
+      return fixer.replaceText(prop, newPropertiesText);
+    };
+    response.fix = fixFn;
+    response.suggest = {
+      desc: `Split '${propertyKey}' shorthand into individual longhand properties?`,
+      fix: fixFn,
+    };
+    return response;
+  };
 
 const stylexValidStyles = {
   meta: {
@@ -180,7 +256,14 @@ const stylexValidStyles = {
     };
 
     const legacyProps: PropLimits = {
-      'grid*': { limit: null, reason: legacyReason },
+      grid: { limit: null, reason: legacyReason },
+      gridArea: { limit: null, reason: legacyReason },
+      gridColumn: { limit: null, reason: legacyReason },
+      gridRow: { limit: null, reason: legacyReason },
+      gridTemplate: { limit: null, reason: legacyReason },
+      gridGap: { limit: null, reason: legacyReason },
+      gridColumnGap: { limit: null, reason: legacyReason },
+      gridRowGap: { limit: null, reason: legacyReason },
       'mask+([a-zA-Z])': { limit: null, reason: legacyReason },
       blockOverflow: { limit: null, reason: legacyReason },
       inlineOverflow: { limit: null, reason: legacyReason },
@@ -256,34 +339,51 @@ const stylexValidStyles = {
     };
     for (const overrideKey in overrides) {
       const { limit, reason } = overrides[overrideKey];
+      if (limit === null) {
+        // For properties with known shorthand expansions, provide auto-fixers
+        if (overrideKey.includes('*') || overrideKey.includes('+')) {
+          for (const key in CSSPropertiesWithOverrides) {
+            if (micromatch.isMatch(key, overrideKey)) {
+              CSSPropertiesWithOverrides[key] =
+                shorthandExpansionMap[key] != null
+                  ? showErrorWithFix(reason, key)
+                  : showError(reason);
+            }
+          }
+        } else {
+          CSSPropertiesWithOverrides[overrideKey] =
+            shorthandExpansionMap[overrideKey] != null
+              ? showErrorWithFix(reason, overrideKey)
+              : showError(reason);
+        }
+        continue;
+      }
       const overrideValue =
-        limit === null
-          ? showError(reason)
-          : limit === '*'
-            ? makeUnionRule(isString, isNumber, all)
-            : limit === 'string'
-              ? makeUnionRule(isString, all)
-              : limit === 'number'
-                ? makeUnionRule(isNumber, all)
-                : typeof limit === 'string' || typeof limit === 'number'
-                  ? makeUnionRule(limit, all)
-                  : Array.isArray(limit)
-                    ? makeUnionRule(
-                        ...limit.map((l) => {
-                          if (l === '*') {
-                            return makeUnionRule(isString, isNumber);
-                          }
-                          if (l === 'string') {
-                            return isString;
-                          }
-                          if (l === 'number') {
-                            return isNumber;
-                          }
-                          return l;
-                        }),
-                        all,
-                      )
-                    : undefined;
+        limit === '*'
+          ? makeUnionRule(isString, isNumber, all)
+          : limit === 'string'
+            ? makeUnionRule(isString, all)
+            : limit === 'number'
+              ? makeUnionRule(isNumber, all)
+              : typeof limit === 'string' || typeof limit === 'number'
+                ? makeUnionRule(limit, all)
+                : Array.isArray(limit)
+                  ? makeUnionRule(
+                      ...limit.map((l) => {
+                        if (l === '*') {
+                          return makeUnionRule(isString, isNumber);
+                        }
+                        if (l === 'string') {
+                          return isString;
+                        }
+                        if (l === 'number') {
+                          return isNumber;
+                        }
+                        return l;
+                      }),
+                      all,
+                    )
+                  : undefined;
       if (overrideValue === undefined) {
         // skip
         continue;
@@ -420,7 +520,14 @@ const stylexValidStyles = {
         return {
           node: valueNode,
           loc: valueNode.loc,
-          message: 'The empty string is not allowed by Stylex.',
+          message:
+            'The empty string is not allowed by Stylex. Use `null` to reset a style.',
+          suggest: [
+            {
+              desc: 'Replace empty string with `null`?',
+              fix: (fixer) => fixer.replaceText(valueNode, 'null'),
+            },
+          ],
           isSpecialCase: true,
         };
       }
@@ -613,11 +720,12 @@ const stylexValidStyles = {
           const val: Property = style;
           const check = propCheck(style.value, variables, style);
           if (check != null) {
-            const { message, suggest } = check;
+            const { message, fix, suggest } = check;
             const diagnostic: Rule.ReportDescriptor = {
               node: style,
               loc: style.loc,
               message,
+              fix: fix != null ? fix : undefined,
               suggest: suggest != null ? [suggest] : undefined,
             };
             return context.report(diagnostic);
@@ -711,7 +819,7 @@ const stylexValidStyles = {
               });
             }
 
-            const { message, suggest } = check;
+            const { message, fix, suggest } = check;
             const isBackgroundBlendModeFormatError =
               key === 'backgroundBlendMode' &&
               typeof message === 'string' &&
@@ -731,6 +839,7 @@ const stylexValidStyles = {
               node: style.value,
               loc: style.value.loc,
               message: finalMessage,
+              fix: fix != null ? fix : undefined,
               suggest: suggest != null ? [suggest] : undefined,
             } as Rule.ReportDescriptor);
           }

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -147,7 +147,10 @@ const showErrorWithFix =
     const fixFn = (fixer: Rule.RuleFixer) => {
       return fixer.replaceText(prop, newPropertiesText);
     };
-    response.fix = fixFn;
+    // animation is suggest-only since animationName needs a keyframes() reference
+    if (propertyKey !== 'animation') {
+      response.fix = fixFn;
+    }
     response.suggest = {
       desc: `Split '${propertyKey}' shorthand into individual longhand properties?`,
       fix: fixFn,

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -91,6 +91,22 @@ const shorthandExpansionMap: { [string]: string } = {
   gridGap: 'gap',
 };
 
+const LEGACY_CONDITIONAL_SHORTHAND_FIXERS = new Set(['animation', 'font']);
+
+const LEGACY_CONDITIONAL_REPLACEMENT_FIXERS = new Set([
+  'border',
+  'borderTop',
+  'borderBlockStart',
+  'borderEnd',
+  'borderInlineEnd',
+  'borderRight',
+  'borderBottom',
+  'borderBlockEnd',
+  'borderStart',
+  'borderInlineStart',
+  'borderLeft',
+]);
+
 const NUMERIC_LITERAL_VALUE_REGEX = /^[-+]?(?:\d+|\d*\.\d+)$/;
 
 const NUMERIC_LITERAL_PROPERTIES = new Set([
@@ -200,6 +216,14 @@ const stylexValidStyles = {
             type: 'boolean',
             default: false,
           },
+          styleResolution: {
+            type: 'string',
+            enum: [
+              'application-order',
+              'property-specificity',
+              'legacy-expand-shorthands',
+            ],
+          },
           propLimits: {
             type: 'object',
             additionalProperties: {
@@ -257,6 +281,10 @@ const stylexValidStyles = {
       allowRawCSSVars: boolean,
       allowOuterPseudoAndMedia: boolean,
       banPropsForLegacy: boolean,
+      styleResolution?:
+        | 'application-order'
+        | 'property-specificity'
+        | 'legacy-expand-shorthands',
       propLimits?: PropLimits,
     };
 
@@ -283,8 +311,18 @@ const stylexValidStyles = {
       allowRawCSSVars = true,
       allowOuterPseudoAndMedia,
       banPropsForLegacy = false,
+      styleResolution,
       propLimits = {},
     }: Schema = context.options[0] || {};
+
+    const isLegacyExpandShorthands =
+      styleResolution === 'legacy-expand-shorthands' || banPropsForLegacy;
+
+    const shouldEnableLegacyConditionalShorthandFixer = (
+      propertyKey: string,
+    ): boolean =>
+      isLegacyExpandShorthands ||
+      !LEGACY_CONDITIONAL_SHORTHAND_FIXERS.has(propertyKey);
 
     /**
      * Check if a file has a valid extension for StyleX variable imports.
@@ -323,7 +361,7 @@ const stylexValidStyles = {
     const styleXWhenImports = new Set<string>();
 
     const overrides: PropLimits = {
-      ...(banPropsForLegacy ? legacyProps : {}),
+      ...(isLegacyExpandShorthands ? legacyProps : {}),
       ...propLimits,
     };
 
@@ -342,6 +380,12 @@ const stylexValidStyles = {
         all,
       ),
     };
+    const getOverrideErrorRule = (reason: string, propertyKey: string) =>
+      shorthandExpansionMap[propertyKey] != null &&
+      shouldEnableLegacyConditionalShorthandFixer(propertyKey)
+        ? showErrorWithFix(reason, propertyKey)
+        : showError(reason);
+
     for (const overrideKey in overrides) {
       const { limit, reason } = overrides[overrideKey];
       if (limit === null) {
@@ -349,17 +393,17 @@ const stylexValidStyles = {
         if (overrideKey.includes('*') || overrideKey.includes('+')) {
           for (const key in CSSPropertiesWithOverrides) {
             if (micromatch.isMatch(key, overrideKey)) {
-              CSSPropertiesWithOverrides[key] =
-                shorthandExpansionMap[key] != null
-                  ? showErrorWithFix(reason, key)
-                  : showError(reason);
+              CSSPropertiesWithOverrides[key] = getOverrideErrorRule(
+                reason,
+                key,
+              );
             }
           }
         } else {
-          CSSPropertiesWithOverrides[overrideKey] =
-            shorthandExpansionMap[overrideKey] != null
-              ? showErrorWithFix(reason, overrideKey)
-              : showError(reason);
+          CSSPropertiesWithOverrides[overrideKey] = getOverrideErrorRule(
+            reason,
+            overrideKey,
+          );
         }
         continue;
       }
@@ -725,7 +769,15 @@ const stylexValidStyles = {
           const val: Property = style;
           const check = propCheck(style.value, variables, style);
           if (check != null) {
-            const { message, fix, suggest } = check;
+            const { message } = check;
+            const { suggest } = check;
+            let { fix } = check;
+            if (
+              !isLegacyExpandShorthands &&
+              LEGACY_CONDITIONAL_REPLACEMENT_FIXERS.has(key)
+            ) {
+              fix = undefined;
+            }
             const diagnostic: Rule.ReportDescriptor = {
               node: style,
               loc: style.loc,
@@ -833,6 +885,7 @@ const stylexValidStyles = {
               fix == null &&
               suggest == null &&
               shorthandExpansionMap[key] != null &&
+              shouldEnableLegacyConditionalShorthandFixer(key) &&
               style.value.type === 'Literal'
             ) {
               const val = style.value.value;

--- a/packages/@stylexjs/eslint-plugin/src/utils/formatPropertiesWithNodeIndentation.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/formatPropertiesWithNodeIndentation.js
@@ -28,8 +28,6 @@ export default function formatPropertiesWithNodeIndentation(
   const newLineAndIndent = `\n${indentation}`;
 
   return properties
-    .map(
-      (property, index) => `${index > 0 ? newLineAndIndent : ''}${property}`,
-    )
+    .map((property, index) => `${index > 0 ? newLineAndIndent : ''}${property}`)
     .join(',');
 }

--- a/packages/@stylexjs/eslint-plugin/src/utils/formatPropertiesWithNodeIndentation.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/formatPropertiesWithNodeIndentation.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+import type { SourceCode } from 'eslint/eslint-rule';
+import type { Node } from 'estree';
+import getNodeIndentation from './getNodeIndentation';
+
+export default function formatPropertiesWithNodeIndentation(
+  node: $ReadOnly<Node>,
+  properties: $ReadOnlyArray<string>,
+  sourceCode?: SourceCode,
+): string {
+  const indentation =
+    sourceCode != null
+      ? getNodeIndentation(sourceCode, node)
+      : node.loc != null
+        ? ' '.repeat(node.loc.start.column)
+        : '';
+
+  const newLineAndIndent = `\n${indentation}`;
+
+  return properties
+    .map(
+      (property, index) => `${index > 0 ? newLineAndIndent : ''}${property}`,
+    )
+    .join(',');
+}

--- a/packages/@stylexjs/eslint-plugin/src/utils/getNodeIndentation.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/getNodeIndentation.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+import type { Token } from 'eslint/eslint-ast';
+import type { SourceCode } from 'eslint/eslint-rule';
+import type { Comment, Node } from 'estree';
+
+function isSameLine(
+  aNode: Node | Comment | Token,
+  bNode: Node | Comment | Token,
+): boolean {
+  return Boolean(
+    aNode.loc && bNode.loc && aNode.loc?.start.line === bNode.loc?.start.line,
+  );
+}
+
+export default function getNodeIndentation(
+  sourceCode: SourceCode,
+  node: $ReadOnly<Node | Comment>,
+): string {
+  const tokenBefore = sourceCode.getTokenBefore(node, {
+    includeComments: false,
+  });
+
+  const isTokenBeforeSameLineAsNode =
+    !!tokenBefore && isSameLine(tokenBefore, node);
+
+  const sliceStart =
+    isTokenBeforeSameLineAsNode && tokenBefore?.loc
+      ? tokenBefore.loc.end.column
+      : 0;
+
+  return node?.loc
+    ? sourceCode.lines[node.loc.start.line - 1].slice(
+        sliceStart,
+        node.loc.start.column,
+      )
+    : '';
+}

--- a/packages/docs/content/docs/api/configuration/eslint-plugin.mdx
+++ b/packages/docs/content/docs/api/configuration/eslint-plugin.mdx
@@ -29,6 +29,13 @@ type Options = {
   //
   // Default: false
   banPropsForLegacy: boolean;
+
+  // Mirrors the compiler option and enables legacy-mode
+  // shorthand autofixers when set to 'legacy-expand-shorthands'.
+  styleResolution?:
+    | 'application-order'
+    | 'property-specificity'
+    | 'legacy-expand-shorthands';
 };
 
 type PropLimits = {

--- a/packages/old-docs/docs/api/configuration/eslint-plugin.mdx
+++ b/packages/old-docs/docs/api/configuration/eslint-plugin.mdx
@@ -16,30 +16,35 @@ sidebar_position: 2
 type Options = {
   // Possible strings where you can import stylex from
   // Default: ['stylex', '@stylexjs/stylex']
-  validImports: Array<string | { from: string, as: string }>,
+  validImports: Array<string | { from: string; as: string }>;
 
   // Custom limits for values of various properties
-  propLimits?: PropLimits,
+  propLimits?: PropLimits;
 
   // @deprecated
   // Allow At Rules and Pseudo Selectors outside of style values.
   // Default: false
-  allowOuterPseudoAndMedia: boolean,
+  allowOuterPseudoAndMedia: boolean;
 
   // @deprecated
   // Disallow properties that are known to break
   // in 'legacy-expand-shorthands' style resolution mode.
   // Default: false
-  banPropsForLegacy: boolean,
+  banPropsForLegacy: boolean;
 
+  // Mirrors the compiler option and enables legacy-mode
+  // shorthand autofixers when set to 'legacy-expand-shorthands'.
+  styleResolution?:
+    | 'application-order'
+    | 'property-specificity'
+    | 'legacy-expand-shorthands';
 };
 
 type PropLimits = {
   // The property name as a string or a glob pattern
   [propertyName: string]: {
-    limit:
-      // Disallow the property
-      | null
+    limit: // Disallow the property
+    | null
       // Allow any string value
       | 'string'
       // Allow any number value
@@ -53,13 +58,14 @@ type PropLimits = {
       | number
       // You can also provide an array of valid
       // number or string constant values.
-      | Array<string | number>,
+      | Array<string | number>;
     // The error message to show when a value doesn't
     // conform to the provided restriction.
-    reason: string,
-  },
+    reason: string;
+  };
 };
 ```
+
 #### Example
 
 ```json
@@ -94,15 +100,15 @@ type PropLimits = {
 type Options = {
   // Possible string where you can import stylex from
   // Default: ['stylex', '@stylexjs/stylex']
-  validImports: Array<string | { from: string, as: string }>,
+  validImports: Array<string | { from: string; as: string }>;
 
   // Minimum number of keys required after which the rule is enforced
   // Default: 2
-  minKeys: number,
+  minKeys: number;
 
   // Sort groups of keys that have a blank line between them separately
   // Default: false
-  allowLineSeparatedGroups: boolean,
+  allowLineSeparatedGroups: boolean;
 };
 ```
 
@@ -129,39 +135,41 @@ type Options = {
 type Options = {
   // Possible string where you can import stylex from
   // Default: ['stylex', '@stylexjs/stylex']
-  validImports: Array<string | { from: string, as: string }>,
+  validImports: Array<string | { from: string; as: string }>;
 
   // Whether `!important` is allowed
   // Default: false
-  allowImportant: boolean,
+  allowImportant: boolean;
 
   // Whether the expansion uses logical direction properties over physical
   // Default: false
-  preferInline: boolean,
+  preferInline: boolean;
 };
 ```
 
 ### `@stylexjs/enforce-extension` rule
 
-Ensures that files exporting `defineVars` or `defineConsts` variables end with a configurable extension (defaults to `.stylex`). This rule helps maintain consistent file naming conventions for StyleX theme and constant files.
+Ensures that files exporting `defineVars` or `defineConsts` variables end with a
+configurable extension (defaults to `.stylex`). This rule helps maintain
+consistent file naming conventions for StyleX theme and constant files.
 
 ```ts
 type Options = {
   // Possible string where you can import stylex from
   // Default: ['stylex', '@stylexjs/stylex']
-  validImports: Array<string | { from: string, as: string }>,
+  validImports: Array<string | { from: string; as: string }>;
 
   // The file extension to enforce for theme files
   // Default: '.stylex'
-  themeFileExtension: string,
+  themeFileExtension: string;
 
   // Allow mixed exports in the same file (legacy support)
   // Default: false
-  legacyAllowMixedExports: boolean,
+  legacyAllowMixedExports: boolean;
 
   // Enforce a separate `.const` suffix for defineConsts files
   // Default: false
-  enforceDefineConstsExtension: boolean,
+  enforceDefineConstsExtension: boolean;
 };
 ```
 
@@ -183,7 +191,9 @@ type Options = {
 ```
 
 When `enforceDefineConstsExtension` is enabled:
-- Files with `stylex.defineConsts()` exports must use `.stylex.const.js` extension
+
+- Files with `stylex.defineConsts()` exports must use `.stylex.const.js`
+  extension
 - Files with `stylex.defineVars()` exports must use `.stylex.js` extension
 - Files cannot mix `defineConsts`, `defineVars`, and other exports
 
@@ -193,7 +203,7 @@ When `enforceDefineConstsExtension` is enabled:
 type Options = {
   // Possible string where you can import stylex from
   // Default: ['stylex', '@stylexjs/stylex']
-  validImports: Array<string | { from: string, as: string }>,
+  validImports: Array<string | { from: string; as: string }>;
 };
 ```
 
@@ -203,19 +213,21 @@ type Options = {
 type Options = {
   // Possible string where you can import stylex from
   // Default: ['stylex', '@stylexjs/stylex']
-  validImports: Array<string | { from: string, as: string }>,
+  validImports: Array<string | { from: string; as: string }>;
 };
 ```
 
 ### `@stylexjs/no-lookahead-selectors` rule
 
-Warns against usage of `stylex.when.anySibling`, `stylex.when.descendant`, and `stylex.when.siblingAfter` due to their reliance on the CSS `:has()` selector, which does not yet have widespread browser support.
+Warns against usage of `stylex.when.anySibling`, `stylex.when.descendant`, and
+`stylex.when.siblingAfter` due to their reliance on the CSS `:has()` selector,
+which does not yet have widespread browser support.
 
 ```ts
 type Options = {
   // Possible string where you can import stylex from
   // Default: ['stylex', '@stylexjs/stylex']
-  validImports: Array<string | { from: string, as: string }>,
+  validImports: Array<string | { from: string; as: string }>;
 };
 ```
 
@@ -250,17 +262,20 @@ const styles = stylex.create({
 }
 ```
 
-See [caniuse.com/css-has](https://caniuse.com/css-has) for current browser compatibility.
+See [caniuse.com/css-has](https://caniuse.com/css-has) for current browser
+compatibility.
 
 ### `@stylexjs/no-nonstandard-styles` rule
 
-Enforces that you create standard CSS values and properties for StyleX. This rule validates that all CSS properties and values conform to standard CSS specifications.
+Enforces that you create standard CSS values and properties for StyleX. This
+rule validates that all CSS properties and values conform to standard CSS
+specifications.
 
 ```ts
 type Options = {
   // Possible string where you can import stylex from
   // Default: ['stylex', '@stylexjs/stylex']
-  validImports: Array<string | { from: string, as: string }>,
+  validImports: Array<string | { from: string; as: string }>;
 };
 ```
 
@@ -275,7 +290,9 @@ type Options = {
 ```
 
 This rule will:
+
 - Detect invalid CSS property names
 - Suggest standard property names for common mistakes
 - Validate CSS values against property specifications
-- Provide auto-fixes for common issues like non-standard `float: start` (suggesting `float: inline-start`)
+- Provide auto-fixes for common issues like non-standard `float: start`
+  (suggesting `float: inline-start`)


### PR DESCRIPTION
## Summary

- **Narrow `grid*` glob** in `legacyProps` to only block grid shorthands (`grid`, `gridArea`, `gridColumn`, `gridRow`, `gridTemplate`, `gridGap`, `gridColumnGap`, `gridRowGap`). Grid longhands like `gridTemplateColumns`, `gridRowStart`, etc. are now allowed under `banPropsForLegacy`.
- **Add auto-fixers for grid shorthands** when blocked via `banPropsForLegacy` or `propLimits`. Reuses the existing expansion logic in `splitShorthands.js`. Fixers only fire when the property is already an error — they are conditional on `banPropsForLegacy`/`propLimits`, not unconditional.
- **Upgrade border from suggest-only to auto-fix** — the `border()` function now returns both `fix` and `suggest`.
- **Add font shorthand auto-fixer** — expands to `fontSize`, `fontFamily`, `fontWeight`, etc.
- **Add animation shorthand suggest-fixer** (suggest-only, not auto-fix, because `animationName` requires a `keyframes()` reference that can't be produced deterministically).
- **Add suggest-fix for empty string** (`''` → suggest `null`).
- **Add suggest-fix for bare numeric strings** (e.g. `zIndex: '10'` → suggest `zIndex: 10`).
- **Wire `fix` propagation** through `makeUnionRule` and both reporting paths (`CSSPropertyReplacements` and `validateStyleValue`).
- **Property-aware `serializeValue`** — emits number literals for properties that accept them (`lineHeight`, `fontWeight`, `rowGap`, etc.), quoted strings everywhere else. Handles single-quote escaping.

### Design decisions

- Grid shorthand fixers are gated on `banPropsForLegacy`/`propLimits` (the property must already be blocked). This matches the internal config where `banPropsForLegacy: true` is set on every surface.
- Animation is suggest-only because the expanded `animationName` would be a raw string literal, which fails the same rule (it expects a `stylex.keyframes()` reference).
- The `grid` shorthand itself (as opposed to `gridArea`, `gridColumn`, etc.) has no auto-fixer because it's too complex for deterministic expansion.

## Test plan

- [x] All 532 existing + new tests pass (`jest --watchman=false --no-coverage __tests__/`)
- [x] ESLint: zero errors on changed files
- [x] Flow: zero errors on changed files
- [x] Verified grid auto-fix output is lint-clean on re-run (no secondary lint errors)
- [x] Verified animation suggest-only does not auto-apply