### PR TITLE
playground: add types for `sx` prop

### DIFF
--- a/packages/docs/src/components/Playground/index.tsx
+++ b/packages/docs/src/components/Playground/index.tsx
@@ -697,6 +697,19 @@ export const vars = stylex.defineVars({
                       REACT_JSX_RUNTIME_TYPES,
                       'file:///node_modules/@types/react/jsx-runtime.d.ts',
                     );
+                    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+                      `import type { StyleXArray, CompiledStyles, InlineStyles } from '@stylexjs/stylex';
+declare module 'react' {
+  interface DOMAttributes<T> {
+    sx?: StyleXArray<
+      | (null | undefined | CompiledStyles)
+      | boolean
+      | Readonly<[CompiledStyles, InlineStyles]>
+    >;
+  }
+}`,
+                      'file:///react-augmentation.d.ts',
+                    );
                   }}
                   defaultLanguage="typescript"
                   height="100%"


### PR DESCRIPTION
## What changed / motivation ?

Using the `sx` prop in the playground currently causes a TS Error. This PR adds additional types to the Monaco editor to augment the `'react'` module and expose the `sx` prop.

## Linked PR/Issues

N/A

## Additional Context

**BEFORE**
<img width="793" height="304" alt="Screenshot 2026-04-09 at 11 49 19 PM" src="https://github.com/user-attachments/assets/ba05aba9-2b7a-4f2e-b174-1e75a0ed410c" />

**AFTER**
<img width="786" height="117" alt="Screenshot 2026-04-09 at 11 49 38 PM" src="https://github.com/user-attachments/assets/37e6bfca-b936-4d4f-b2d4-999bb153aa8c" />


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code