### PR TITLE
Tighten types for nested APIs

### DIFF
--- a/packages/@stylexjs/stylex/src/stylex.js
+++ b/packages/@stylexjs/stylex/src/stylex.js
@@ -14,6 +14,9 @@ import type {
   InlineStyles,
   Keyframes,
   MapNamespaces,
+  NestedConstsValue,
+  NestedStringValue,
+  NestedVarsValue,
   StaticStyles,
   StaticStylesWithout,
   StyleX$Create,
@@ -86,26 +89,26 @@ export const defineVars: StyleX$DefineVars = function stylexDefineVars(
 };
 
 export const unstable_conditional = function stylexConditional<
-  const T: { +default: mixed, +[string]: mixed },
+  const T extends { +default: unknown, +[string]: unknown },
 >(_value: T): T {
   throw errorForFn('unstable_conditional');
 };
 
 export const unstable_defineVarsNested = function stylexDefineVarsNested<
-  const T: { +[string]: mixed },
+  const T extends { +[string]: NestedVarsValue },
 >(_styles: T): T {
   throw errorForFn('unstable_defineVarsNested');
 };
 
 export const unstable_defineConstsNested = function stylexDefineConstsNested<
-  const T: { +[string]: unknown },
+  const T extends { +[string]: NestedConstsValue },
 >(_styles: T): T {
   throw errorForFn('unstable_defineConstsNested');
 };
 
 export const unstable_createThemeNested = (
-  _baseTokens: { +[string]: mixed },
-  _overrides: { +[string]: mixed },
+  _baseTokens: { +[string]: NestedStringValue },
+  _overrides: { +[string]: NestedVarsValue },
 ): CompiledStyles => {
   throw errorForFn('unstable_createThemeNested');
 };
@@ -346,24 +349,30 @@ type IStyleX = {
   viewTransitionClass: (viewTransitionClass: ViewTransitionClass) => string,
   types: typeof types,
   when: typeof when,
-  unstable_conditional: <const T: { +default: mixed, +[string]: mixed }>(
+  unstable_conditional: <
+    const T extends { +default: unknown, +[string]: unknown },
+  >(
     value: T,
   ) => T,
-  unstable_defineVarsNested: (tokens: { +[string]: mixed }) => mixed,
-  unstable_defineConstsNested: <const T: { +[string]: unknown }>(
+  unstable_defineVarsNested: <const T extends { +[string]: NestedVarsValue }>(
+    tokens: T,
+  ) => T,
+  unstable_defineConstsNested: <
+    const T extends { +[string]: NestedConstsValue },
+  >(
     tokens: T,
   ) => T,
   unstable_createThemeNested: (
-    baseTokens: { +[string]: mixed },
-    overrides: { +[string]: mixed },
-  ) => mixed,
+    baseTokens: { +[string]: NestedStringValue },
+    overrides: { +[string]: NestedVarsValue },
+  ) => CompiledStyles,
   __customProperties?: { [string]: unknown },
   ...
 };
 
 export const legacyMerge: IStyleX = /*@__PURE__*/ (function () {
   function _legacyMerge(
-    ...styles: $ReadOnlyArray<StyleXArray<?CompiledStyles | boolean>>
+    ...styles: ReadonlyArray<StyleXArray<?CompiledStyles | boolean>>
   ): string {
     const [className] = styleq(styles);
     return className;

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
@@ -369,26 +369,40 @@ export type StyleX$Env = Register extends { env: infer TEnv }
 
 // === Nested API Types ===
 
+export type NestedVarsValue =
+  | string
+  | CSSType<string | number>
+  | { readonly [key: string]: NestedVarsValue };
+
+export type NestedConstsValue =
+  | string
+  | number
+  | { readonly [key: string]: NestedConstsValue };
+
+export type NestedStringValue =
+  | string
+  | { readonly [key: string]: NestedStringValue };
+
 // unstable_defineVarsNested: preserves nested key structure in output.
 // Uses generic <T> to give consumers key-level autocomplete.
 // Leaf values are replaced with var(--hash) strings at compile time.
 export type StyleX$DefineVarsNested = <
-  const T extends { [key: string]: unknown },
+  const T extends { [key: string]: NestedVarsValue },
 >(
   tokens: T,
 ) => T;
 
 // unstable_defineConstsNested: same as input — values inlined at compile time.
 export type StyleX$DefineConstsNested = <
-  const T extends { [key: string]: unknown },
+  const T extends { [key: string]: NestedConstsValue },
 >(
   tokens: T,
 ) => T;
 
 // unstable_createThemeNested: returns a flat theme object like createTheme.
 export type StyleX$CreateThemeNested = (
-  baseTokens: { readonly [key: string]: unknown },
-  overrides: { readonly [key: string]: unknown },
+  baseTokens: { readonly [key: string]: NestedStringValue },
+  overrides: { readonly [key: string]: NestedVarsValue },
 ) => CompiledStyles;
 
 // unstable_conditional: identity function for type disambiguation.

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.js
@@ -219,6 +219,18 @@ type TTokens = Readonly<{
     | CSSType<null | string | number>,
 }>;
 
+export type NestedVarsValue =
+  | string
+  | CSSType<string | number>
+  | { +[string]: NestedVarsValue };
+
+export type NestedConstsValue =
+  | string
+  | number
+  | { +[string]: NestedConstsValue };
+
+export type NestedStringValue = string | { +[string]: NestedStringValue };
+
 type UnwrapVar<+T> = T extends () => infer U
   ? UnwrapVar<U>
   : T extends StyleXVar<infer U>


### PR DESCRIPTION

## What changed / motivation ?

The four `unstable_*` nested APIs in `stylex.js` used `unknown` as the value type in their generic bounds. While `unknown` was correct (replacing deprecated `mixed`), the babel plugin already defines exact recursive structures for what each API accepts. This PR exports proper recursive types and uses them as tighter bounds, improving type safety and documentation.

**Changes:**

- Added three exported recursive types to `StyleXTypes.js`:
  - `NestedVarsValue` — `string | CSSType<string | number> | { +[string]: NestedVarsValue }`
  - `NestedConstsValue` — `string | number | { +[string]: NestedConstsValue }`
  - `NestedStringValue` — `string | { +[string]: NestedStringValue }`
- Updated function signatures in `stylex.js`:
  - `unstable_defineVarsNested`: bound → `{ +[string]: NestedVarsValue }`
  - `unstable_defineConstsNested`: bound → `{ +[string]: NestedConstsValue }`
  - `unstable_createThemeNested`: `_baseTokens` → `{ +[string]: NestedStringValue }`, `_overrides` → `{ +[string]: NestedVarsValue }`
- Updated the `IStyleX` legacy interface type to match.

`unstable_conditional` intentionally keeps `unknown` bounds (generic identity function where type safety comes from calling context).

## Linked PR/Issues

N/A

## Additional Context

- Full project Flow check passes with zero errors
- `yarn workspace typescript-tests test` PASS
- Types mirror the babel plugin internal types from `stylex-nested-utils.js`
- `StyleXVar<T>` is an opaque subtype of `string`, so it is already covered by the `string` branch

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
