### PR TITLE
[babel-plugin] Fix pseudo-element + pseudo-class selector ordering

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -2408,7 +2408,7 @@ describe('@stylexjs/babel-plugin', () => {
 
           // Pseudo-classes (:hover, :active) must come before the
           // pseudo-element (::after) in the selector for valid CSS.
-          const rules = metadata.stylex.map(([className, { ltr }]) => ltr);
+          const rules = metadata.stylex.map(([_className, { ltr }]) => ltr);
           expect(rules).toMatchInlineSnapshot(`
             [
               ".x1s928wv::after{content:""}",

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -2270,7 +2270,6 @@ describe('@stylexjs/babel-plugin', () => {
           `);
         });
 
-        // Generates invalid CSS, need to revisit this API
         test('"::before" containing pseudo-classes', () => {
           const { code, metadata } = transform(`
             import * as stylex from '@stylexjs/stylex';
@@ -2308,7 +2307,7 @@ describe('@stylexjs/babel-plugin', () => {
                 [
                   "xeb2lg0",
                   {
-                    "ltr": ".xeb2lg0::before:hover{color:blue}",
+                    "ltr": ".xeb2lg0:hover::before{color:blue}",
                     "rtl": null,
                   },
                   8130,
@@ -2387,6 +2386,36 @@ describe('@stylexjs/babel-plugin', () => {
                 ],
               ],
             }
+          `);
+        });
+
+        test('"::after" with multiple pseudo-class conditions', () => {
+          const { metadata } = transform(`
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              button: {
+                '::after': {
+                  content: '""',
+                  boxShadow: {
+                    default: '0 0 0 1px gray',
+                    ':hover': '0 0 0 1px blue',
+                    ':active': '0 0 0 1px darkblue',
+                  },
+                },
+              },
+            });
+          `);
+
+          // Pseudo-classes (:hover, :active) must come before the
+          // pseudo-element (::after) in the selector for valid CSS.
+          const rules = metadata.stylex.map(([className, { ltr }]) => ltr);
+          expect(rules).toMatchInlineSnapshot(`
+            [
+              ".x1s928wv::after{content:""}",
+              ".x5fy8b7::after{box-shadow:0 0 0 1px gray}",
+              ".xgazanr:hover::after{box-shadow:0 0 0 1px blue}",
+              ".x136huz6:active::after{box-shadow:0 0 0 1px darkblue}",
+            ]
           `);
         });
       });
@@ -4889,7 +4918,7 @@ describe('@stylexjs/babel-plugin', () => {
                 [
                   "xndy4z1",
                   {
-                    "ltr": ".xndy4z1::before:hover{color:var(--x-6bge3v)}",
+                    "ltr": ".xndy4z1:hover::before{color:var(--x-6bge3v)}",
                     "rtl": null,
                   },
                   8130,
@@ -5752,7 +5781,7 @@ describe('@stylexjs/babel-plugin', () => {
             priority: 8000
           });
           _inject2({
-            ltr: ".xeb2lg0::before:hover{color:blue}",
+            ltr: ".xeb2lg0:hover::before{color:blue}",
             priority: 8130
           });
           export const styles = {
@@ -5844,11 +5873,11 @@ describe('@stylexjs/babel-plugin', () => {
             priority: 8130
           });
           _inject2({
-            ltr: ".x1gobd9t:hover::before:hover{color:green}",
+            ltr: ".x1gobd9t:hover:hover::before{color:green}",
             priority: 8260
           });
           _inject2({
-            ltr: ".xs8jp5:hover::before:active{color:purple}",
+            ltr: ".xs8jp5:hover:active::before{color:purple}",
             priority: 8300
           });
           export const styles = {

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/generate-css-rule.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/generate-css-rule.js
@@ -31,18 +31,21 @@ function buildNestedCSSRule(
 ): string {
   // Pseudo-elements (::before, ::after, etc.) must come after pseudo-classes
   // in the selector. e.g. `.class:hover::before` not `.class::before:hover`
-const { classes, elements } = pseudos.reduce((acc, p) => {
-  if (p === '::thumb') return acc;
+  const { classes, elements } = pseudos.reduce(
+    (acc, p) => {
+      if (p === '::thumb') return acc;
 
-  if (p.startsWith('::')) {
-    acc.elements += p;
-  } else {
-    acc.classes += p;
-  }
-  return acc;
-}, { classes: '', elements: '' });
+      if (p.startsWith('::')) {
+        acc.elements += p;
+      } else {
+        acc.classes += p;
+      }
+      return acc;
+    },
+    { classes: '', elements: '' },
+  );
 
-const pseudo = classes + elements;
+  const pseudo = classes + elements;
   const combinedAtRules = atRules.concat(constRules);
 
   // Bump specificity of stylex.when selectors

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/generate-css-rule.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/generate-css-rule.js
@@ -29,12 +29,20 @@ function buildNestedCSSRule(
   atRules: $ReadOnlyArray<string>,
   constRules: $ReadOnlyArray<string>,
 ): string {
-  const filteredPseudos = pseudos.filter((p) => p !== '::thumb');
   // Pseudo-elements (::before, ::after, etc.) must come after pseudo-classes
   // in the selector. e.g. `.class:hover::before` not `.class::before:hover`
-  const pseudoClasses = filteredPseudos.filter((p) => !p.startsWith('::'));
-  const pseudoElements = filteredPseudos.filter((p) => p.startsWith('::'));
-  const pseudo = [...pseudoClasses, ...pseudoElements].join('');
+const { classes, elements } = pseudos.reduce((acc, p) => {
+  if (p === '::thumb') return acc;
+
+  if (p.startsWith('::')) {
+    acc.elements += p;
+  } else {
+    acc.classes += p;
+  }
+  return acc;
+}, { classes: '', elements: '' });
+
+const pseudo = classes + elements;
   const combinedAtRules = atRules.concat(constRules);
 
   // Bump specificity of stylex.when selectors

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/generate-css-rule.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/generate-css-rule.js
@@ -29,7 +29,12 @@ function buildNestedCSSRule(
   atRules: $ReadOnlyArray<string>,
   constRules: $ReadOnlyArray<string>,
 ): string {
-  const pseudo = pseudos.filter((p) => p !== '::thumb').join('');
+  const filteredPseudos = pseudos.filter((p) => p !== '::thumb');
+  // Pseudo-elements (::before, ::after, etc.) must come after pseudo-classes
+  // in the selector. e.g. `.class:hover::before` not `.class::before:hover`
+  const pseudoClasses = filteredPseudos.filter((p) => !p.startsWith('::'));
+  const pseudoElements = filteredPseudos.filter((p) => p.startsWith('::'));
+  const pseudo = [...pseudoClasses, ...pseudoElements].join('');
   const combinedAtRules = atRules.concat(constRules);
 
   // Bump specificity of stylex.when selectors


### PR DESCRIPTION
## What changed / motivation ?

Pseudo-elements like `::before` and `::after` must appear at the end of a CSS selector. When combining pseudo-elements with pseudo-class conditions (e.g. `:hover`, `:active`), StyleX generated invalid selectors like `.x123::after:hover` which browsers silently discard. The fix reorders them to `.x123:hover::after`.

## Linked PR/Issues

Fixes #1473

## Additional Context

n/a

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code