### PR TITLE
Catch evaluate() failures when resolving stylex props

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-props.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-props.js
@@ -363,17 +363,21 @@ function parseNullableStyle(
     }
   }
 
-  const parsedObj = evaluate(path, state, evaluatePathFnConfig);
+  try {
+    const parsedObj = evaluate(path, state, evaluatePathFnConfig);
 
-  if (
-    parsedObj.confident &&
-    parsedObj.value != null &&
-    typeof parsedObj.value === 'object'
-  ) {
-    if (parsedObj.value.__IS_PROXY === true) {
-      return 'other';
+    if (
+      parsedObj.confident &&
+      parsedObj.value != null &&
+      typeof parsedObj.value === 'object'
+    ) {
+      if (parsedObj.value.__IS_PROXY === true) {
+        return 'other';
+      }
+      return parsedObj.value;
     }
-    return parsedObj.value;
+  } catch {
+    return 'other';
   }
 
   return 'other';


### PR DESCRIPTION
## What changed / motivation ?

Handle exceptions thrown while evaluating `stylex.props()` arguments in the Babel transform.

This change wraps the evaluation path in `parseNullableStyle()` with a `try/catch` and treats evaluation failures as a bailout case (`'other'`) instead of letting the transform crash.

Some expressions passed into `stylex.props()` can cause `evaluate()` to throw during compile-time analysis. Before this change, those exceptions could fail the transform entirely.

This changeset:
- add a `try/catch` around `evaluate(...)` in `stylex/packages/@stylexjs/babel-plugin/src/visitors/stylex-props.js`
- if evaluation throws, return `'other'`
- this preserves the existing bailout behavior for non-optimizable expressions

When the transform cannot confidently resolve a style expression, bailing out is already the intended fallback behavior. This change just extends that behavior to thrown evaluation errors.

## Linked PR/Issues
Caught this issue when running Meta script to generate CSS stylesheets for comparison during the upgrade process. The script throws on valid stylex patterns during evaluation.

## Additional Context

`npm run test`

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code