### PR TITLE
[eslint-plugin] fix valid-styles rejecting nested stylex.when.* conditions

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -341,6 +341,43 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       `,
       options: [{ allowOuterPseudoAndMedia: true }],
     },
+    // test for nested media query inside stylex.when.ancestor()
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          icon: {
+            transitionDuration: {
+              default: '0.5s',
+              [stylex.when.ancestor(":active")]: '0.1s',
+              [stylex.when.ancestor(":hover")]: {
+                default: null,
+                "@media (hover: hover)": '0.1s',
+              },
+            },
+          },
+        })
+      `,
+      options: [{ allowOuterPseudoAndMedia: true }],
+    },
+    // test for nested media query inside when.descendant() with destructured import
+    {
+      code: `
+        import { when, create } from '@stylexjs/stylex';
+        const styles = create({
+          icon: {
+            transitionDuration: {
+              default: '0.5s',
+              [when.ancestor(":hover")]: {
+                default: null,
+                "@media (hover: hover)": '0.1s',
+              },
+            },
+          },
+        })
+      `,
+      options: [{ allowOuterPseudoAndMedia: true }],
+    },
     // test for positive numbers
     "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {marginInlineStart: 5}});",
     // test for literals as namespaces

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -358,7 +358,6 @@ eslintTester.run('stylex-valid-styles', rule.default, {
           },
         })
       `,
-      options: [{ allowOuterPseudoAndMedia: true }],
     },
     // test for nested media query inside when.descendant() with destructured import
     {
@@ -376,7 +375,6 @@ eslintTester.run('stylex-valid-styles', rule.default, {
           },
         })
       `,
-      options: [{ allowOuterPseudoAndMedia: true }],
     },
     // test for positive numbers
     "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {marginInlineStart: 5}});",

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -409,6 +409,26 @@ eslintTester.run('stylex-valid-styles', rule.default, {
         })
       `,
     },
+    // test for functional pseudo selectors in conditional style values
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          input: {
+            color: {
+              default: 'black',
+              ':where([data-state="open"])': {
+                default: 'red',
+                '@media (hover: hover)': 'orange',
+              },
+              ':is([data-state="closed"])': 'blue',
+              ':dir(rtl)': 'green',
+              '::placeholder': 'gray',
+            },
+          },
+        })
+      `,
+    },
     // test for positive numbers
     "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {marginInlineStart: 5}});",
     // test for literals as namespaces

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -392,6 +392,23 @@ eslintTester.run('stylex-valid-styles', rule.default, {
         })
       `,
     },
+    // test for nested attribute selector inside stylex.when.ancestor()
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          icon: {
+            color: {
+              default: 'black',
+              [stylex.when.ancestor(':hover')]: {
+                default: 'blue',
+                '[data-state="open"]': 'red',
+              },
+            },
+          },
+        })
+      `,
+    },
     // test for positive numbers
     "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {marginInlineStart: 5}});",
     // test for literals as namespaces
@@ -2968,6 +2985,56 @@ revert`,
       errors: [
         {
           message: 'Keys must be strings',
+        },
+      ],
+    },
+    // test for invalid keys nested inside a stylex.when object
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: {
+            transitionDuration: {
+              default: '0.5s',
+              [stylex.when.ancestor(':hover')]: {
+                foo: '0.1s',
+              },
+            },
+          },
+        })
+      `,
+      errors: [
+        {
+          message:
+            'Invalid Pseudo class or At Rule used for conditional style value',
+        },
+      ],
+    },
+    // test for invalid numeric keys nested inside a stylex.when object
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const INVALID_CONDITION = 456;
+        const styles = stylex.create({
+          base: {
+            transitionDuration: {
+              default: '0.5s',
+              [stylex.when.ancestor(':hover')]: {
+                123: '0.1s',
+                [INVALID_CONDITION]: '0.2s',
+              },
+            },
+          },
+        })
+      `,
+      errors: [
+        {
+          message:
+            'Invalid Pseudo class or At Rule used for conditional style value',
+        },
+        {
+          message:
+            'Invalid Pseudo class or At Rule used for conditional style value',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -263,7 +263,9 @@ eslintTester.run('stylex-valid-styles', rule.default, {
             width: {
               default: 10,
               [when.descendant(":focus")]: 20,
-              [when.siblingAfter(":active")]: 30,
+              [when.anySibling(":focus")]: 30,
+              [when.siblingBefore(":active")]: 40,
+              [when.siblingAfter(":active")]: 50,
             },
           },
         })
@@ -381,7 +383,7 @@ eslintTester.run('stylex-valid-styles', rule.default, {
           icon: {
             transitionDuration: {
               default: '0.5s',
-              [when.ancestor(":hover")]: {
+              [when.descendant(":hover")]: {
                 default: null,
                 "@media (hover: hover)": '0.1s',
               },
@@ -2944,6 +2946,70 @@ revert`,
         {
           message:
             'float value must be one of:\nleft\nright\nnone\ninline-start\ninline-end\nnull\ninitial\ninherit\nunset\nrevert',
+        },
+      ],
+    },
+    // test for unsupported stylex.when method with an object value
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: {
+            width: {
+              default: 10,
+              [stylex.when.notAMethod(":hover")]: {
+                default: 20,
+                "@media (hover: hover)": 30,
+              },
+            },
+          },
+        })
+      `,
+      errors: [
+        {
+          message: 'Keys must be strings',
+        },
+      ],
+    },
+    // test for unsupported destructured when method with an object value
+    {
+      code: `
+        import { create, when } from '@stylexjs/stylex';
+        const styles = create({
+          base: {
+            width: {
+              default: 10,
+              [when.notAMethod(":hover")]: {
+                default: 20,
+                "@media (hover: hover)": 30,
+              },
+            },
+          },
+        })
+      `,
+      errors: [
+        {
+          message: 'Keys must be strings',
+        },
+      ],
+    },
+    // test for stylex.when group nested inside a pseudo-element
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: {
+            '::after': {
+              [stylex.when.ancestor(":hover")]: {
+                width: 20,
+              },
+            },
+          },
+        })
+      `,
+      errors: [
+        {
+          message: 'Keys must be strings',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -372,7 +372,6 @@ eslintTester.run('stylex-valid-styles', rule.default, {
           },
         })
       `,
-      options: [{ allowOuterPseudoAndMedia: true }],
     },
     // test for nested media query inside when.descendant() with destructured import
     {
@@ -390,7 +389,6 @@ eslintTester.run('stylex-valid-styles', rule.default, {
           },
         })
       `,
-      options: [{ allowOuterPseudoAndMedia: true }],
     },
     // test for positive numbers
     "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {marginInlineStart: 5}});",

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -355,6 +355,43 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       `,
       options: [{ allowOuterPseudoAndMedia: true }],
     },
+    // test for nested media query inside stylex.when.ancestor()
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          icon: {
+            transitionDuration: {
+              default: '0.5s',
+              [stylex.when.ancestor(":active")]: '0.1s',
+              [stylex.when.ancestor(":hover")]: {
+                default: null,
+                "@media (hover: hover)": '0.1s',
+              },
+            },
+          },
+        })
+      `,
+      options: [{ allowOuterPseudoAndMedia: true }],
+    },
+    // test for nested media query inside when.descendant() with destructured import
+    {
+      code: `
+        import { when, create } from '@stylexjs/stylex';
+        const styles = create({
+          icon: {
+            transitionDuration: {
+              default: '0.5s',
+              [when.ancestor(":hover")]: {
+                default: null,
+                "@media (hover: hover)": '0.1s',
+              },
+            },
+          },
+        })
+      `,
+      options: [{ allowOuterPseudoAndMedia: true }],
+    },
     // test for positive numbers
     "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {marginInlineStart: 5}});",
     // test for literals as namespaces

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -603,6 +603,31 @@ const stylexValidStyles = {
         };
       }
     }
+    function isStylexWhenCallExpression(
+      node: Expression | PrivateIdentifier,
+      computed: boolean,
+    ): boolean {
+      if (
+        !computed ||
+        node.type !== 'CallExpression' ||
+        node.callee.type !== 'MemberExpression'
+      ) {
+        return false;
+      }
+      const calleeObject = node.callee.object;
+      const calleeProperty = node.callee.property;
+      return (
+        (calleeObject.type === 'MemberExpression' &&
+          calleeObject.object.type === 'Identifier' &&
+          styleXDefaultImports.has(calleeObject.object.name) &&
+          calleeObject.property.type === 'Identifier' &&
+          calleeObject.property.name === 'when' &&
+          calleeProperty.type === 'Identifier') ||
+        (calleeObject.type === 'Identifier' &&
+          styleXWhenImports.has(calleeObject.name) &&
+          calleeProperty.type === 'Identifier')
+      );
+    }
     function checkStyleProperty(
       style: Node,
       level: number,
@@ -647,63 +672,74 @@ const stylexValidStyles = {
           if (isStylexResolvedVarsToken(key, stylexResolvedVarsTokenImports)) {
             return undefined;
           }
-          if (
-            typeof keyName !== 'string' ||
-            (key.type !== 'Literal' && key.type !== 'Identifier')
-          ) {
-            return context.report({
-              node: key,
-              loc: key.loc,
-              message: 'Keys must be strings',
-            } as Rule.ReportDescriptor);
-          }
-          if (keyName.startsWith('@') || keyName.startsWith(':')) {
-            if (level === 0) {
-              const ruleCheck = (
-                allowOuterPseudoAndMedia ? allModifiers : pseudoElements
-              )(key, variables);
+          const isWhenCall =
+            level > 0 && isStylexWhenCallExpression(key, style.computed);
 
-              if (ruleCheck !== undefined) {
-                if (keyName.startsWith('::')) {
+          if (!isWhenCall) {
+            if (
+              typeof keyName !== 'string' ||
+              (key.type !== 'Literal' && key.type !== 'Identifier')
+            ) {
+              return context.report({
+                node: key,
+                loc: key.loc,
+                message: 'Keys must be strings',
+              } as Rule.ReportDescriptor);
+            }
+            if (keyName.startsWith('@') || keyName.startsWith(':')) {
+              if (level === 0) {
+                const ruleCheck = (
+                  allowOuterPseudoAndMedia ? allModifiers : pseudoElements
+                )(key, variables);
+
+                if (ruleCheck !== undefined) {
+                  if (keyName.startsWith('::')) {
+                    return context.report({
+                      node: style.value,
+                      loc: style.value.loc,
+                      message: `Unknown pseudo element "${keyName}"`,
+                    } as $ReadOnly<Rule.ReportDescriptor>);
+                  }
                   return context.report({
                     node: style.value,
                     loc: style.value.loc,
-                    message: `Unknown pseudo element "${keyName}"`,
+                    message: allowOuterPseudoAndMedia
+                      ? 'Nested styles can only be used for the pseudo selectors in the stylex allowlist and for @media queries'
+                      : 'Pseudo Classes, Media Queries and other At Rules should be nested as conditions within style properties. Only Pseudo Elements (::after) are allowed at the top-level',
                   } as $ReadOnly<Rule.ReportDescriptor>);
                 }
-                return context.report({
-                  node: style.value,
-                  loc: style.value.loc,
-                  message: allowOuterPseudoAndMedia
-                    ? 'Nested styles can only be used for the pseudo selectors in the stylex allowlist and for @media queries'
-                    : 'Pseudo Classes, Media Queries and other At Rules should be nested as conditions within style properties. Only Pseudo Elements (::after) are allowed at the top-level',
-                } as $ReadOnly<Rule.ReportDescriptor>);
-              }
-            } else {
-              const ruleCheck = pseudoClassesAndAtRules(key, variables);
+              } else {
+                const ruleCheck = pseudoClassesAndAtRules(key, variables);
 
-              if (ruleCheck !== undefined) {
-                return context.report({
-                  node: style.value,
-                  loc: style.value.loc,
-                  message:
-                    'Invalid Pseudo class or At Rule used for conditional style value',
-                } as $ReadOnly<Rule.ReportDescriptor>);
+                if (ruleCheck !== undefined) {
+                  return context.report({
+                    node: style.value,
+                    loc: style.value.loc,
+                    message:
+                      'Invalid Pseudo class or At Rule used for conditional style value',
+                  } as $ReadOnly<Rule.ReportDescriptor>);
+                }
               }
             }
           }
+
+          // stylex.when.*() calls and condition keys (@media, :pseudo, default)
+          // are not property names — pass null so nested levels know they're
+          // inside a condition rather than a CSS property.
+          const isConditionKey =
+            isWhenCall ||
+            (typeof keyName === 'string' &&
+              (keyName.startsWith('@') ||
+                keyName.startsWith(':') ||
+                keyName === 'default'));
 
           return styleValue.properties.forEach((prop) =>
             checkStyleProperty(
               prop,
               level + 1,
-              propName ??
-                (keyName.startsWith('@') ||
-                keyName.startsWith(':') ||
-                keyName === 'default'
-                  ? null
-                  : keyName),
-              outerIsPseudoElement || keyName.startsWith('::'),
+              propName ?? (isConditionKey ? null : keyName),
+              outerIsPseudoElement ||
+                (typeof keyName === 'string' && keyName.startsWith('::')),
             ),
           );
         }
@@ -721,44 +757,26 @@ const stylexValidStyles = {
           return undefined;
         }
 
-        let isStylexWhenCall = false;
-        if (style.computed && styleKey.type !== 'Literal') {
-          if (
-            styleKey.type === 'CallExpression' &&
-            styleKey.callee.type === 'MemberExpression'
-          ) {
-            const calleeObject = styleKey.callee.object;
-            const calleeProperty = styleKey.callee.property;
-
-            isStylexWhenCall =
-              (calleeObject.type === 'MemberExpression' &&
-                calleeObject.object.type === 'Identifier' &&
-                styleXDefaultImports.has(calleeObject.object.name) &&
-                calleeObject.property.type === 'Identifier' &&
-                calleeObject.property.name === 'when' &&
-                calleeProperty.type === 'Identifier') ||
-              (calleeObject.type === 'Identifier' &&
-                styleXWhenImports.has(calleeObject.name) &&
-                calleeProperty.type === 'Identifier');
-
-            if (!isStylexWhenCall) {
-              const val = evaluate(styleKey, variables);
-              if (val == null) {
-                return context.report({
-                  node: style.key,
-                  loc: style.key.loc,
-                  message: 'Computed key cannot be resolved.',
-                } as Rule.ReportDescriptor);
-              } else if (val === 'ARG') {
-                return context.report({
-                  node: style.key,
-                  loc: style.key.loc,
-                  message: 'Computed key cannot depend on function argument',
-                } as Rule.ReportDescriptor);
-              } else {
-                styleKey = val;
-              }
-            }
+        const isStylexWhenCall = isStylexWhenCallExpression(
+          styleKey,
+          style.computed,
+        );
+        if (style.computed && styleKey.type !== 'Literal' && !isStylexWhenCall) {
+          const val = evaluate(styleKey, variables);
+          if (val == null) {
+            return context.report({
+              node: style.key,
+              loc: style.key.loc,
+              message: 'Computed key cannot be resolved.',
+            } as Rule.ReportDescriptor);
+          } else if (val === 'ARG') {
+            return context.report({
+              node: style.key,
+              loc: style.key.loc,
+              message: 'Computed key cannot depend on function argument',
+            } as Rule.ReportDescriptor);
+          } else {
+            styleKey = val;
           }
         }
         if (

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -434,6 +434,31 @@ const stylexValidStyles = {
         };
       }
     }
+    function isStylexWhenCallExpression(
+      node: Expression | PrivateIdentifier,
+      computed: boolean,
+    ): boolean {
+      if (
+        !computed ||
+        node.type !== 'CallExpression' ||
+        node.callee.type !== 'MemberExpression'
+      ) {
+        return false;
+      }
+      const calleeObject = node.callee.object;
+      const calleeProperty = node.callee.property;
+      return (
+        (calleeObject.type === 'MemberExpression' &&
+          calleeObject.object.type === 'Identifier' &&
+          styleXDefaultImports.has(calleeObject.object.name) &&
+          calleeObject.property.type === 'Identifier' &&
+          calleeObject.property.name === 'when' &&
+          calleeProperty.type === 'Identifier') ||
+        (calleeObject.type === 'Identifier' &&
+          styleXWhenImports.has(calleeObject.name) &&
+          calleeProperty.type === 'Identifier')
+      );
+    }
     function checkStyleProperty(
       style: Node,
       level: number,
@@ -478,63 +503,74 @@ const stylexValidStyles = {
           if (isStylexResolvedVarsToken(key, stylexResolvedVarsTokenImports)) {
             return undefined;
           }
-          if (
-            typeof keyName !== 'string' ||
-            (key.type !== 'Literal' && key.type !== 'Identifier')
-          ) {
-            return context.report({
-              node: key,
-              loc: key.loc,
-              message: 'Keys must be strings',
-            } as Rule.ReportDescriptor);
-          }
-          if (keyName.startsWith('@') || keyName.startsWith(':')) {
-            if (level === 0) {
-              const ruleCheck = (
-                allowOuterPseudoAndMedia ? allModifiers : pseudoElements
-              )(key, variables);
+          const isWhenCall =
+            level > 0 && isStylexWhenCallExpression(key, style.computed);
 
-              if (ruleCheck !== undefined) {
-                if (keyName.startsWith('::')) {
+          if (!isWhenCall) {
+            if (
+              typeof keyName !== 'string' ||
+              (key.type !== 'Literal' && key.type !== 'Identifier')
+            ) {
+              return context.report({
+                node: key,
+                loc: key.loc,
+                message: 'Keys must be strings',
+              } as Rule.ReportDescriptor);
+            }
+            if (keyName.startsWith('@') || keyName.startsWith(':')) {
+              if (level === 0) {
+                const ruleCheck = (
+                  allowOuterPseudoAndMedia ? allModifiers : pseudoElements
+                )(key, variables);
+
+                if (ruleCheck !== undefined) {
+                  if (keyName.startsWith('::')) {
+                    return context.report({
+                      node: style.value,
+                      loc: style.value.loc,
+                      message: `Unknown pseudo element "${keyName}"`,
+                    } as $ReadOnly<Rule.ReportDescriptor>);
+                  }
                   return context.report({
                     node: style.value,
                     loc: style.value.loc,
-                    message: `Unknown pseudo element "${keyName}"`,
+                    message: allowOuterPseudoAndMedia
+                      ? 'Nested styles can only be used for the pseudo selectors in the stylex allowlist and for @media queries'
+                      : 'Pseudo Classes, Media Queries and other At Rules should be nested as conditions within style properties. Only Pseudo Elements (::after) are allowed at the top-level',
                   } as $ReadOnly<Rule.ReportDescriptor>);
                 }
-                return context.report({
-                  node: style.value,
-                  loc: style.value.loc,
-                  message: allowOuterPseudoAndMedia
-                    ? 'Nested styles can only be used for the pseudo selectors in the stylex allowlist and for @media queries'
-                    : 'Pseudo Classes, Media Queries and other At Rules should be nested as conditions within style properties. Only Pseudo Elements (::after) are allowed at the top-level',
-                } as $ReadOnly<Rule.ReportDescriptor>);
-              }
-            } else {
-              const ruleCheck = pseudoClassesAndAtRules(key, variables);
+              } else {
+                const ruleCheck = pseudoClassesAndAtRules(key, variables);
 
-              if (ruleCheck !== undefined) {
-                return context.report({
-                  node: style.value,
-                  loc: style.value.loc,
-                  message:
-                    'Invalid Pseudo class or At Rule used for conditional style value',
-                } as $ReadOnly<Rule.ReportDescriptor>);
+                if (ruleCheck !== undefined) {
+                  return context.report({
+                    node: style.value,
+                    loc: style.value.loc,
+                    message:
+                      'Invalid Pseudo class or At Rule used for conditional style value',
+                  } as $ReadOnly<Rule.ReportDescriptor>);
+                }
               }
             }
           }
+
+          // stylex.when.*() calls and condition keys (@media, :pseudo, default)
+          // are not property names — pass null so nested levels know they're
+          // inside a condition rather than a CSS property.
+          const isConditionKey =
+            isWhenCall ||
+            (typeof keyName === 'string' &&
+              (keyName.startsWith('@') ||
+                keyName.startsWith(':') ||
+                keyName === 'default'));
 
           return styleValue.properties.forEach((prop) =>
             checkStyleProperty(
               prop,
               level + 1,
-              propName ??
-                (keyName.startsWith('@') ||
-                keyName.startsWith(':') ||
-                keyName === 'default'
-                  ? null
-                  : keyName),
-              outerIsPseudoElement || keyName.startsWith('::'),
+              propName ?? (isConditionKey ? null : keyName),
+              outerIsPseudoElement ||
+                (typeof keyName === 'string' && keyName.startsWith('::')),
             ),
           );
         }
@@ -552,44 +588,26 @@ const stylexValidStyles = {
           return undefined;
         }
 
-        let isStylexWhenCall = false;
-        if (style.computed && styleKey.type !== 'Literal') {
-          if (
-            styleKey.type === 'CallExpression' &&
-            styleKey.callee.type === 'MemberExpression'
-          ) {
-            const calleeObject = styleKey.callee.object;
-            const calleeProperty = styleKey.callee.property;
-
-            isStylexWhenCall =
-              (calleeObject.type === 'MemberExpression' &&
-                calleeObject.object.type === 'Identifier' &&
-                styleXDefaultImports.has(calleeObject.object.name) &&
-                calleeObject.property.type === 'Identifier' &&
-                calleeObject.property.name === 'when' &&
-                calleeProperty.type === 'Identifier') ||
-              (calleeObject.type === 'Identifier' &&
-                styleXWhenImports.has(calleeObject.name) &&
-                calleeProperty.type === 'Identifier');
-
-            if (!isStylexWhenCall) {
-              const val = evaluate(styleKey, variables);
-              if (val == null) {
-                return context.report({
-                  node: style.key,
-                  loc: style.key.loc,
-                  message: 'Computed key cannot be resolved.',
-                } as Rule.ReportDescriptor);
-              } else if (val === 'ARG') {
-                return context.report({
-                  node: style.key,
-                  loc: style.key.loc,
-                  message: 'Computed key cannot depend on function argument',
-                } as Rule.ReportDescriptor);
-              } else {
-                styleKey = val;
-              }
-            }
+        const isStylexWhenCall = isStylexWhenCallExpression(
+          styleKey,
+          style.computed,
+        );
+        if (style.computed && styleKey.type !== 'Literal' && !isStylexWhenCall) {
+          const val = evaluate(styleKey, variables);
+          if (val == null) {
+            return context.report({
+              node: style.key,
+              loc: style.key.loc,
+              message: 'Computed key cannot be resolved.',
+            } as Rule.ReportDescriptor);
+          } else if (val === 'ARG') {
+            return context.report({
+              node: style.key,
+              loc: style.key.loc,
+              message: 'Computed key cannot depend on function argument',
+            } as Rule.ReportDescriptor);
+          } else {
+            styleKey = val;
           }
         }
         if (

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -48,7 +48,6 @@ import {
   CSSProperties,
   CSSPropertyReplacements,
   pseudoElements,
-  pseudoClassesAndAtRules,
   allModifiers,
   all,
 } from './reference/cssProperties';
@@ -688,15 +687,13 @@ const stylexValidStyles = {
       if (
         keyName === 'default' ||
         keyName.startsWith('[') ||
-        keyName.startsWith('var(--')
+        keyName.startsWith('var(--') ||
+        keyName.startsWith('@') ||
+        keyName.startsWith(':')
       ) {
         return null;
       }
-      if (!keyName.startsWith('@') && !keyName.startsWith(':')) {
-        return key;
-      }
-
-      return pseudoClassesAndAtRules(key, variables) === undefined ? null : key;
+      return key;
     }
     function checkStyleProperty(
       style: Node,
@@ -769,17 +766,6 @@ const stylexValidStyles = {
                     message: allowOuterPseudoAndMedia
                       ? 'Nested styles can only be used for the pseudo selectors in the stylex allowlist and for @media queries'
                       : 'Pseudo Classes, Media Queries and other At Rules should be nested as conditions within style properties. Only Pseudo Elements (::after) are allowed at the top-level',
-                  } as $ReadOnly<Rule.ReportDescriptor>);
-                }
-              } else {
-                const ruleCheck = pseudoClassesAndAtRules(key, variables);
-
-                if (ruleCheck !== undefined) {
-                  return context.report({
-                    node: style.value,
-                    loc: style.value.loc,
-                    message:
-                      'Invalid Pseudo class or At Rule used for conditional style value',
                   } as $ReadOnly<Rule.ReportDescriptor>);
                 }
               }

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -644,6 +644,60 @@ const stylexValidStyles = {
           styleXWhenImports.has(calleeObject.name))
       );
     }
+    function getStylePropertyKeyName(style: Property): null | string {
+      const key = style.key;
+      return key.type === 'Literal'
+        ? typeof key.value === 'string'
+          ? key.value
+          : null
+        : key.type === 'Identifier'
+          ? !style.computed
+            ? key.name
+            : (resolveKey(key, variables) ?? null)
+          : null;
+    }
+    function getInvalidConditionalStyleKey(
+      style: Node,
+    ): null | Expression | PrivateIdentifier {
+      if (style.type !== 'Property') {
+        return null;
+      }
+
+      const key = style.key;
+      if (
+        key.type === 'PrivateIdentifier' ||
+        isStylexResolvedVarsToken(key, stylexResolvedVarsTokenImports) ||
+        isStylexWhenCallExpression(key, style.computed)
+      ) {
+        return null;
+      }
+
+      let keyName = getStylePropertyKeyName(style);
+      if (keyName == null) {
+        const evaluatedKey = evaluate(key, variables);
+        if (evaluatedKey == null || evaluatedKey === 'ARG') {
+          // Let checkStyleProperty report the more specific error for dynamic
+          // keys and keys that depend on function arguments.
+          return null;
+        }
+        if (typeof evaluatedKey.value !== 'string') {
+          return key;
+        }
+        keyName = evaluatedKey.value;
+      }
+      if (
+        keyName === 'default' ||
+        keyName.startsWith('[') ||
+        keyName.startsWith('var(--')
+      ) {
+        return null;
+      }
+      if (!keyName.startsWith('@') && !keyName.startsWith(':')) {
+        return key;
+      }
+
+      return pseudoClassesAndAtRules(key, variables) === undefined ? null : key;
+    }
     function checkStyleProperty(
       style: Node,
       level: number,
@@ -677,16 +731,7 @@ const stylexValidStyles = {
               message: 'Private properties are not allowed in stylex',
             } as Rule.ReportDescriptor);
           }
-          const keyName: null | string =
-            key.type === 'Literal'
-              ? typeof key.value === 'string'
-                ? key.value
-                : null
-              : key.type === 'Identifier'
-                ? !style.computed
-                  ? key.name
-                  : (resolveKey(key, variables) ?? null)
-                : null;
+          const keyName = getStylePropertyKeyName(style);
           if (isStylexResolvedVarsToken(key, stylexResolvedVarsTokenImports)) {
             return undefined;
           }
@@ -751,15 +796,27 @@ const stylexValidStyles = {
                 keyName.startsWith(':') ||
                 keyName === 'default'));
 
-          return styleValue.properties.forEach((prop) =>
-            checkStyleProperty(
+          const nextPropName = propName ?? (isConditionKey ? null : keyName);
+          return styleValue.properties.forEach((prop) => {
+            const invalidConditionKey =
+              nextPropName != null ? getInvalidConditionalStyleKey(prop) : null;
+            if (invalidConditionKey != null) {
+              return context.report({
+                node: invalidConditionKey,
+                loc: invalidConditionKey.loc,
+                message:
+                  'Invalid Pseudo class or At Rule used for conditional style value',
+              } as $ReadOnly<Rule.ReportDescriptor>);
+            }
+
+            return checkStyleProperty(
               prop,
               level + 1,
-              propName ?? (isConditionKey ? null : keyName),
+              nextPropName,
               outerIsPseudoElement ||
                 (typeof keyName === 'string' && keyName.startsWith('::')),
-            ),
-          );
+            );
+          });
         }
         let styleKey: Expression | PrivateIdentifier = style.key;
         if (styleKey.type === 'PrivateIdentifier') {

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -110,6 +110,14 @@ const LEGACY_CONDITIONAL_REPLACEMENT_FIXERS = new Set([
   'borderLeft',
 ]);
 
+const STYLEX_WHEN_METHODS = new Set([
+  'ancestor',
+  'descendant',
+  'anySibling',
+  'siblingBefore',
+  'siblingAfter',
+]);
+
 const NUMERIC_LITERAL_VALUE_REGEX = /^[-+]?(?:\d+|\d*\.\d+)$/;
 
 const NUMERIC_LITERAL_PROPERTIES = new Set([
@@ -610,22 +618,30 @@ const stylexValidStyles = {
       if (
         !computed ||
         node.type !== 'CallExpression' ||
-        node.callee.type !== 'MemberExpression'
+        node.callee.type !== 'MemberExpression' ||
+        node.callee.computed
       ) {
         return false;
       }
       const calleeObject = node.callee.object;
       const calleeProperty = node.callee.property;
+
+      if (
+        calleeProperty.type !== 'Identifier' ||
+        !STYLEX_WHEN_METHODS.has(calleeProperty.name)
+      ) {
+        return false;
+      }
+
       return (
         (calleeObject.type === 'MemberExpression' &&
+          !calleeObject.computed &&
           calleeObject.object.type === 'Identifier' &&
           styleXDefaultImports.has(calleeObject.object.name) &&
           calleeObject.property.type === 'Identifier' &&
-          calleeObject.property.name === 'when' &&
-          calleeProperty.type === 'Identifier') ||
+          calleeObject.property.name === 'when') ||
         (calleeObject.type === 'Identifier' &&
-          styleXWhenImports.has(calleeObject.name) &&
-          calleeProperty.type === 'Identifier')
+          styleXWhenImports.has(calleeObject.name))
       );
     }
     function checkStyleProperty(
@@ -661,19 +677,21 @@ const stylexValidStyles = {
               message: 'Private properties are not allowed in stylex',
             } as Rule.ReportDescriptor);
           }
-          const keyName =
+          const keyName: null | string =
             key.type === 'Literal'
-              ? key.value
+              ? typeof key.value === 'string'
+                ? key.value
+                : null
               : key.type === 'Identifier'
                 ? !style.computed
                   ? key.name
-                  : resolveKey(key, variables)
+                  : (resolveKey(key, variables) ?? null)
                 : null;
           if (isStylexResolvedVarsToken(key, stylexResolvedVarsTokenImports)) {
             return undefined;
           }
           const isWhenCall =
-            level > 0 && isStylexWhenCallExpression(key, style.computed);
+            propName != null && isStylexWhenCallExpression(key, style.computed);
 
           if (!isWhenCall) {
             if (
@@ -761,7 +779,11 @@ const stylexValidStyles = {
           styleKey,
           style.computed,
         );
-        if (style.computed && styleKey.type !== 'Literal' && !isStylexWhenCall) {
+        if (
+          style.computed &&
+          styleKey.type !== 'Literal' &&
+          !isStylexWhenCall
+        ) {
           const val = evaluate(styleKey, variables);
           if (val == null) {
             return context.report({


### PR DESCRIPTION
## What changed / motivation ?

The `ObjectExpression` branch in `checkStyleProperty` did not recognize `stylex.when.*()` computed keys, causing "Keys must be strings" errors when nesting a media query or other condition inside a when call. 

## Linked PR/Issues

Fixes https://github.com/facebook/stylex/issues/1614

## Additional Context

n/a

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code