### PR TITLE
[eslint-plugin] Validate arguments of firstThatWorks

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -801,6 +801,31 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       },
     });
     `,
+    // test for firstThatWorks
+    `
+    import stylex from '@stylexjs/stylex';
+    stylex.create({
+      default: {
+        position: stylex.firstThatWorks('sticky', 'fixed'),
+      },
+    });
+    `,
+    `
+    import * as stylex from '@stylexjs/stylex';
+    stylex.create({
+      default: {
+        display: stylex.firstThatWorks('grid', 'flex'),
+      },
+    });
+    `,
+    `
+    import { create, firstThatWorks } from '@stylexjs/stylex';
+    create({
+      default: {
+        position: firstThatWorks('sticky', 'fixed'),
+      },
+    });
+    `,
     // test for ternary and logical expressions
     {
       code: `
@@ -2353,6 +2378,58 @@ revert`,
 none
 a CSS Variable
 a \`positionTry(...)\` function call, a reference to it, or a list of references
+null
+initial
+inherit
+unset
+revert`,
+        },
+      ],
+    },
+    // test for firstThatWorks with an invalid argument value
+    {
+      code: `
+        import stylex from '@stylexjs/stylex';
+        stylex.create({
+          default: {
+            position: stylex.firstThatWorks('invalid-value', 'fixed'),
+          },
+        });
+      `,
+      errors: [
+        {
+          message: `position value must be one of:
+static
+relative
+absolute
+sticky
+fixed
+null
+initial
+inherit
+unset
+revert`,
+        },
+      ],
+    },
+    // test for firstThatWorks with an invalid argument value in second position
+    {
+      code: `
+        import stylex from '@stylexjs/stylex';
+        stylex.create({
+          default: {
+            position: stylex.firstThatWorks('fixed', 'invalid-value'),
+          },
+        });
+      `,
+      errors: [
+        {
+          message: `position value must be one of:
+static
+relative
+absolute
+sticky
+fixed
 null
 initial
 inherit

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -241,6 +241,7 @@ const stylexValidStyles = {
     const styleXCreateImports = new Set<string>();
     const styleXKeyframesImports = new Set<string>();
     const styleXPositionTryImports = new Set<string>();
+    const styleXFirstThatWorksImports = new Set<string>();
     const styleXWhenImports = new Set<string>();
 
     const overrides: PropLimits = {
@@ -391,6 +392,37 @@ const stylexValidStyles = {
           return rightCheck;
         }
         return null;
+      }
+
+      if (valueNode.type === 'CallExpression') {
+        const callee = valueNode.callee;
+        if (
+          (callee.type === 'MemberExpression' &&
+            callee.object.type === 'Identifier' &&
+            styleXDefaultImports.has(callee.object.name) &&
+            callee.property.type === 'Identifier' &&
+            callee.property.name === 'firstThatWorks') ||
+          (callee.type === 'Identifier' &&
+            styleXFirstThatWorksImports.has(callee.name))
+        ) {
+          for (const arg of valueNode.arguments) {
+            if (arg.type === 'SpreadElement') {
+              continue;
+            }
+            const argCheck = validateStyleValue(
+              arg,
+              varsWithFnArgs,
+              style,
+              styleKey,
+              propertyKey,
+              ruleChecker,
+            );
+            if (argCheck != null) {
+              return argCheck;
+            }
+          }
+          return null;
+        }
       }
 
       if (
@@ -895,6 +927,12 @@ const stylexValidStyles = {
                 specifier.imported.name === 'positionTry'
               ) {
                 styleXPositionTryImports.add(specifier.local.name);
+              }
+              if (
+                specifier.type === 'ImportSpecifier' &&
+                specifier.imported.name === 'firstThatWorks'
+              ) {
+                styleXFirstThatWorksImports.add(specifier.local.name);
               }
               if (
                 specifier.type === 'ImportSpecifier' &&


### PR DESCRIPTION
## What changed / motivation ?

Added validation for arguments passed to `firstThatWorks()` in the ESLint plugin.

## Linked PR/Issues

Fixes #699

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

n/a

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code