### PR TITLE
Fix stylex import error for dev mode

### DIFF
--- a/packages/docs/content/docs/learn/installation/vite/index.mdx
+++ b/packages/docs/content/docs/learn/installation/vite/index.mdx
@@ -68,7 +68,7 @@ function DevStyleXInjectImpl() {
   useEffect(() => {
     if (import.meta.env.DEV) {
       // @ts-ignore
-      import('virtual:stylex:css-only');
+      import('virtual:stylex:runtime');
     }
   }, []);
   return <link rel="stylesheet" href="/virtual:stylex.css" />;


### PR DESCRIPTION
## What changed / motivation ?

Getting error in dev mode when following this doc:  
https://stylexjs.com/docs/learn/installation/vite#dev-server-and-hot-reloading
inside **TanStack Start** framework.

```
[plugin:vite:import-analysis] 
Failed to resolve import "virtual:stylex:css-only" from "src/components/DevStyleXInject.tsx". 
Does the file exist?
```

**NOTE:** I'm not sure if the same issue exists for other setups, but on my existing setup   
changing  `import('virtual:stylex:css-only')` to `import('virtual:stylex:runtime')` fixed the issue.

## Additional Context

<img width="679" height="79" alt="Screenshot 2026-04-19 at 8 39 36 PM" src="https://github.com/user-attachments/assets/152dfff8-dfaa-47e6-b6c4-ac317e84b748" />

<img width="679" height="116" alt="Screenshot 2026-04-19 at 8 30 27 PM" src="https://github.com/user-attachments/assets/47e7eb92-4430-4d32-af38-3f0a0e2542f6" />

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code