### PR TITLE
fix(babel-plugin): resolve aliased theme files expanded to absolute paths

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
@@ -61,6 +61,41 @@ function transformWithInlineConsts(source, opts = {}) {
   return { code, metadata };
 }
 
+function transformWithAliasedInlineConsts(source, opts = {}) {
+  const fixtureDir = path.join(__dirname, '__fixtures__');
+  const repoRoot = path.resolve(__dirname, '../../../../..');
+  const fixtureGlob = path.join(fixtureDir, '*');
+  const rootFixtureGlob = `/ROOT/${path
+    .relative(repoRoot, fixtureDir)
+    .replace(/\\/g, '/')}/*`;
+
+  const { code, metadata } = transformSync(source, {
+    filename: path.join(fixtureDir, 'main.stylex.js'),
+    parserOpts: { sourceType: 'module' },
+    babelrc: false,
+    plugins: [
+      [
+        stylexPlugin,
+        {
+          ...opts,
+          aliases: {
+            '~fixture/*': [fixtureGlob],
+            ...(opts.useRootAlias
+              ? { '~root-fixture/*': [rootFixtureGlob] }
+              : null),
+          },
+          unstable_moduleResolution: {
+            rootDir: fixtureDir,
+            type: 'commonJS',
+          },
+        },
+      ],
+    ],
+  });
+
+  return { code, metadata };
+}
+
 describe('@stylexjs/babel-plugin', () => {
   describe('[transform] stylex.defineConsts()', () => {
     test('constants are unique', () => {
@@ -399,6 +434,65 @@ describe('@stylexjs/babel-plugin', () => {
           ],
         }
       `);
+    });
+
+    test('resolves aliased absolute paths for defineConsts imports', () => {
+      const { code, metadata } = transformWithAliasedInlineConsts(`
+        import * as stylex from '@stylexjs/stylex';
+        import { breakpoints } from '~fixture/constants.stylex';
+
+        export const styles = stylex.create({
+          root: {
+            color: {
+              default: 'red',
+              [breakpoints.small]: 'blue',
+            },
+          },
+        });
+      `);
+
+      expect(code).toContain('xbs0o1n');
+      expect(metadata.stylex).toEqual(
+        expect.arrayContaining([
+          expect.arrayContaining([
+            'xbs0o1n',
+            expect.objectContaining({
+              ltr: expect.stringContaining('color:blue'),
+            }),
+          ]),
+        ]),
+      );
+    });
+
+    test('resolves /ROOT placeholder alias paths for defineConsts imports', () => {
+      const { code, metadata } = transformWithAliasedInlineConsts(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        import { breakpoints } from '~root-fixture/constants.stylex';
+
+        export const styles = stylex.create({
+          root: {
+            color: {
+              default: 'red',
+              [breakpoints.small]: 'blue',
+            },
+          },
+        });
+      `,
+        { useRootAlias: true },
+      );
+
+      expect(code).toContain('xbs0o1n');
+      expect(metadata.stylex).toEqual(
+        expect.arrayContaining([
+          expect.arrayContaining([
+            'xbs0o1n',
+            expect.objectContaining({
+              ltr: expect.stringContaining('color:blue'),
+            }),
+          ]),
+        ]),
+      );
     });
 
     test.skip('works with firstThatWorks', () => {

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -864,6 +864,56 @@ const getPossibleFilePaths = (filePath: string) => {
   return [filePath, ...EXTENSIONS.map((ext) => filePathNoCodeExtension + ext)];
 };
 
+const resolveRootPlaceholderPath = (
+  filePath: string,
+  sourceFilePath: string,
+): ?string => {
+  const suffix = filePath.slice('/ROOT/'.length);
+  let currentDir = path.dirname(sourceFilePath);
+
+  while (true) {
+    const candidate = path.join(currentDir, suffix);
+
+    for (const fileCandidate of getPossibleFilePaths(candidate)) {
+      if (fs.existsSync(fileCandidate)) {
+        return fileCandidate;
+      }
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
+
+  return null;
+};
+
+const resolveAbsoluteFilePath = (
+  filePath: string,
+  sourceFilePath: string,
+): ?string => {
+  if (filePath.startsWith('/ROOT/')) {
+    const resolvedRootPath = resolveRootPlaceholderPath(
+      filePath,
+      sourceFilePath,
+    );
+
+    if (resolvedRootPath != null) {
+      return resolvedRootPath;
+    }
+  }
+
+  for (const candidate of getPossibleFilePaths(filePath)) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+};
+
 // a function that resolves the absolute path of a file when given the
 // relative path of the file from the source file
 export const filePathResolver = (
@@ -886,6 +936,17 @@ export const filePathResolver = (
     // Otherwise, try to resolve the path with aliases
     const allAliases = possibleAliasedPaths(importPathStr, aliases);
     for (const possiblePath of allAliases) {
+      if (path.isAbsolute(possiblePath)) {
+        const resolvedAbsolutePath = resolveAbsoluteFilePath(
+          possiblePath,
+          sourceFilePath,
+        );
+
+        if (resolvedAbsolutePath != null) {
+          return resolvedAbsolutePath;
+        }
+      }
+
       try {
         return url.fileURLToPath(
           moduleResolve(possiblePath, url.pathToFileURL(sourceFilePath)),


### PR DESCRIPTION
## What changed / motivation ?

This fixes aliased theme/const imports for `stylex.create()` when the alias expands to an absolute filesystem path.

In our Next.js + Turbopack integration, a relative import like `../../shared/.../media.stylex` worked, but an aliased import failed during the StyleX Babel phase. The resolver was delegating alias-expanded absolute paths to `moduleResolve()` only, which does not handle plain filesystem paths or Turbopack-style `/ROOT/...` placeholder paths well.

This change:
- resolves alias-expanded absolute paths by checking real file candidates directly
- restores `/ROOT/...` placeholder paths back to real files relative to the importing source file
- adds regression tests for both cases using `defineConsts`

## Linked PR/Issues

N/A

## Additional Context

Validation performed:
- `corepack yarn workspace @stylexjs/babel-plugin build`

I also verified the same resolver fix against the original failing integration in our Next.js app before opening this PR.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
