### PR TITLE
[eslint-plugin] FIx: Allow valid styles in pseudo classes

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -2068,6 +2068,21 @@ eslintTester.run('stylex-valid-styles [restrictions]', rule.default, {
         });
       `,
     },
+    {
+      code: `
+        import * as stylex from "@stylexjs/stylex";
+
+        const styles = stylex.create({
+          button: {
+            backgroundColor: {
+              default: "red",
+              ":active:not(:disabled)": "blue",
+              ":hover:not(:disabled)": { default: null, "@media (any-hover: hover) and (any-pointer: fine)": "blue" },
+            },
+          },
+        });
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -2262,19 +2262,39 @@ export const pseudoElements: RuleCheck = makeUnionRule(
   makeLiteralRule('::-moz-range-progress'),
 );
 
+const generalPseudoClasses: $ReadOnlyArray<string> = [
+  ':first-child',
+  ':last-child',
+  ':only-child',
+  ':hover',
+  ':focus',
+  ':focus-visible',
+  ':focus-within',
+  ':active',
+  ':visited',
+  ':disabled',
+];
+const compoundGeneralPseudoClasses = generalPseudoClasses.join('|');
+
+const pseudoClassesWithArgs: $ReadOnlyArray<string> = [
+  ':nth-child',
+  ':nth-of-type',
+  ':not',
+];
+const compoundPseudoClassesWithArgs = `(${pseudoClassesWithArgs.join(
+  '|',
+)})\\([^\\)]+\\)`;
+
+const compoundPseudoClassesPattern = [
+  compoundGeneralPseudoClasses,
+  compoundPseudoClassesWithArgs,
+].join('|');
+
 export const pseudoClassesAndAtRules: RuleCheck = makeUnionRule(
-  makeLiteralRule(':first-child'),
-  makeLiteralRule(':last-child'),
-  makeLiteralRule(':only-child'),
-  makeLiteralRule(':nth-child'),
-  makeLiteralRule(':nth-of-type'),
-  makeLiteralRule(':hover'),
-  makeLiteralRule(':focus'),
-  makeLiteralRule(':focus-visible'),
-  makeLiteralRule(':focus-within'),
-  makeLiteralRule(':active'),
-  makeLiteralRule(':visited'),
-  makeLiteralRule(':disabled'),
+  makeRegExRule(
+    new RegExp(`^(${compoundPseudoClassesPattern})+$`),
+    'a compound pseudo class',
+  ),
   makeRegExRule(/^@media/, 'a media query'),
   makeRegExRule(/^@container/, 'a media query'),
   makeRegExRule(/^@supports/, 'a supports query'),


### PR DESCRIPTION
## What changed / motivation ?

When an at-rule is used as the value of a pseudo-class condition, nested pseudo-classes were not matched by the ESLint rule, which caused lint false positives. This PR updates the rule to handle nested pseudo-classes using pattern-based matching, fixing the issue where only single pseudo-classes were recognized.

While working on this fix, I also found that pseudo-elements can hit a similar issue. If you'd like, I can include the pseudo-element fix in this PR as well.

## Linked PR/Issues

Fixes #1618 

## Additional Context

<!--- Screenshots, Tests, Breaking Change, Anything Else ? --->

- Added test cases for the reported issue, and they are now passing.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code