### PR TITLE
[Stylex] Add detector for unclosed strings

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/validation-stylex-create-test.js
@@ -671,6 +671,84 @@ describe('@stylexjs/babel-plugin', () => {
         }).toThrow(messages.LINT_UNCLOSED_FUNCTION);
       });
 
+      test('invalid value: unclosed double-quoted string', () => {
+        expect(() => {
+          transform(`
+            import * as stylex from '@stylexjs/stylex';
+            const styles = stylex.create({
+              root: {
+                fontFamily: '"Helvetica Neue'
+              }
+            });
+          `);
+        }).toThrow(messages.LINT_UNCLOSED_STRING);
+      });
+
+      test('invalid value: unclosed single-quoted string', () => {
+        expect(() => {
+          transform(`
+            import * as stylex from '@stylexjs/stylex';
+            const styles = stylex.create({
+              root: {
+                fontFamily: "'Helvetica Neue"
+              }
+            });
+          `);
+        }).toThrow(messages.LINT_UNCLOSED_STRING);
+      });
+
+      test('invalid value: unclosed string in multi-value property', () => {
+        expect(() => {
+          transform(`
+            import * as stylex from '@stylexjs/stylex';
+            const styles = stylex.create({
+              root: {
+                fontFamily: '"Helvetica Neue, sans-serif'
+              }
+            });
+          `);
+        }).toThrow(messages.LINT_UNCLOSED_STRING);
+      });
+
+      test('invalid value: stray apostrophe in font-family list', () => {
+        expect(() => {
+          transform(`
+            import * as stylex from '@stylexjs/stylex';
+            const styles = stylex.create({
+              root: {
+                fontFamily: "'SF Pro Text', 'SF Pro Icons', Helvetica Neue', 'Helvetica', sans-serif",
+              }
+            });
+          `);
+        }).toThrow(messages.LINT_UNCLOSED_STRING);
+      });
+
+      test('valid value: properly closed strings do not throw', () => {
+        expect(() => {
+          transform(`
+            import * as stylex from '@stylexjs/stylex';
+            const styles = stylex.create({
+              root: {
+                fontFamily: '"Helvetica Neue", sans-serif',
+              }
+            });
+          `);
+        }).not.toThrow();
+      });
+
+      test('valid value: properly closed single-quoted string', () => {
+        expect(() => {
+          transform(`
+            import * as stylex from '@stylexjs/stylex';
+            const styles = stylex.create({
+              root: {
+                fontFamily: "'Helvetica Neue', sans-serif",
+              }
+            });
+          `);
+        }).not.toThrow();
+      });
+
       test('invalid CSS variable: unprefixed custom property', () => {
         const options = { definedStylexCSSVariables: { foo: 1 } };
         expect(() => {

--- a/packages/@stylexjs/babel-plugin/src/shared/messages.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/messages.js
@@ -48,6 +48,7 @@ export const INVALID_PSEUDO = 'Invalid pseudo selector, not on the whitelist.';
 export const INVALID_PSEUDO_OR_AT_RULE = 'Invalid pseudo or at-rule.';
 export const INVALID_MEDIA_QUERY_SYNTAX = 'Invalid media query syntax.';
 export const LINT_UNCLOSED_FUNCTION = 'Rule contains an unclosed function';
+export const LINT_UNCLOSED_STRING = 'Rule contains an unclosed string';
 export const LOCAL_ONLY =
   'The return value of create() should not be exported.';
 export const NON_OBJECT_KEYFRAME =

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/normalize-value.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/normalize-value.js
@@ -19,6 +19,7 @@ import normalizeWhitespace from './normalizers/whitespace';
 import normalizeZeroDimensions from './normalizers/zero-dimensions';
 
 import detectUnclosedFns from './normalizers/detect-unclosed-fns';
+import detectUnclosedStrings from './normalizers/detect-unclosed-strings';
 import parser from 'postcss-value-parser';
 import convertCamelCaseValues from './normalizers/convert-camel-case-values';
 
@@ -26,6 +27,7 @@ import convertCamelCaseValues from './normalizers/convert-camel-case-values';
 // changes 500ms to 0.5s, then `LeadingZero` makes it .5s
 const normalizers = [
   detectUnclosedFns,
+  detectUnclosedStrings,
   normalizeWhitespace,
   normalizeTimings,
   normalizeZeroDimensions,

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/normalizers/detect-unclosed-strings.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/normalizers/detect-unclosed-strings.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+import * as messages from '../../messages';
+
+/**
+ * Detect unclosed strings in stylex property definitions
+ */
+export default function detectUnclosedStrings(
+  ast: PostCSSValueAST,
+  _: mixed,
+): PostCSSValueAST {
+  ast.walk((node) => {
+    if (node.type === 'string' && node.unclosed) {
+      throw new Error(messages.LINT_UNCLOSED_STRING);
+    }
+  });
+  return ast;
+}


### PR DESCRIPTION
# What changed / motivation ?
Added a detectUnclosedStrings normalizer to the StyleX Babel plugin that detects unclosed string literals in CSS property values at compile time.

Unclosed strings in CSS values (e.g., a stray apostrophe in a font-family list) are subtle typos that produce broken styles at runtime with no warning. This change mirrors the existing detectUnclosedFns normalizer but for string nodes, catching errors like:

```
fontFamily: "'SF Pro Text', 'SF Pro Icons', Helvetica Neue', 'Helvetica', sans-serif"
                                                          ^ stray apostrophe
```
# Changes:

New detect-unclosed-strings.js normalizer that walks the postcss-value-parser AST and throws on any string node with unclosed: true
Added LINT_UNCLOSED_STRING error message to messages.js
Registered the normalizer in normalize-value.js (runs right after detectUnclosedFns)
Added 6 new test cases covering unclosed double/single quotes, stray apostrophes in font-family lists, and valid closed strings

# Additional Context
Tests added:

invalid value: unclosed double-quoted string — catches "Helvetica Neue (missing closing ")
invalid value: unclosed single-quoted string — catches 'Helvetica Neue (missing closing ')
invalid value: unclosed string in multi-value property — catches "Helvetica Neue, sans-serif (unclosed quote spanning comma-separated values)
invalid value: stray apostrophe in font-family list — catches the exact real-world bug from D101828355
valid value: properly closed strings do not throw — ensures "Helvetica Neue", sans-serif passes
valid value: properly closed single-quoted string — ensures 'Helvetica Neue', sans-serif passes
All existing tests continue to pass.

Pre-flight checklist
 I have read the contributing guidelines [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
tests :) 