### PR TITLE
eslint: enforce-extension rule for unstable nested APIs

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-enforce-extension-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-enforce-extension-test.js
@@ -319,6 +319,42 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
       `,
       filename: 'testComponent.stylex.jsx',
     },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.unstable_defineVarsNested({});
+      `,
+      filename: 'testComponent.stylex.jsx',
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const consts = stylex.unstable_defineConstsNested({});
+      `,
+      filename: 'testComponent.stylex.jsx',
+    },
+    {
+      code: `
+        import { unstable_defineVarsNested } from '@stylexjs/stylex';
+        export const vars = unstable_defineVarsNested({});
+      `,
+      filename: 'testComponent.stylex.jsx',
+    },
+    {
+      code: `
+        import { unstable_defineConstsNested } from '@stylexjs/stylex';
+        export const consts = unstable_defineConstsNested({});
+      `,
+      filename: 'testComponent.stylex.jsx',
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const consts = stylex.unstable_defineConstsNested({});
+      `,
+      filename: 'myComponent.stylex.const.jsx',
+      options: [{ enforceDefineConstsExtension: true }],
+    },
   ],
 
   invalid: [
@@ -912,6 +948,79 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
       `,
       filename: 'myComponent.stylex.jsx',
       errors: [{ message: invalidDefaultExport('defineMarker') }],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.unstable_defineVarsNested({});
+      `,
+      filename: 'testComponent.jsx',
+      errors: [
+        { message: invalidFilenameWithRestrictedExports('.stylex.jsx') },
+      ],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const consts = stylex.unstable_defineConstsNested({});
+      `,
+      filename: 'testComponent.jsx',
+      errors: [
+        { message: invalidFilenameWithRestrictedExports('.stylex.jsx') },
+      ],
+    },
+    {
+      code: `
+        import { unstable_defineVarsNested } from '@stylexjs/stylex';
+        export const vars = unstable_defineVarsNested({});
+      `,
+      filename: 'testComponent.jsx',
+      errors: [
+        { message: invalidFilenameWithRestrictedExports('.stylex.jsx') },
+      ],
+    },
+    {
+      code: `
+        import { unstable_defineConstsNested } from '@stylexjs/stylex';
+        export const consts = unstable_defineConstsNested({});
+      `,
+      filename: 'testComponent.jsx',
+      errors: [
+        { message: invalidFilenameWithRestrictedExports('.stylex.jsx') },
+      ],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const vars = stylex.unstable_defineVarsNested({});
+        export const somethingElse = someFunction();
+      `,
+      filename: 'myComponent.stylex.jsx',
+      errors: [{ message: invalidExportFromThemeFiles }],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const consts = stylex.unstable_defineConstsNested({});
+      `,
+      filename: 'myComponent.jsx',
+      options: [{ enforceDefineConstsExtension: true }],
+      errors: [
+        {
+          message:
+            invalidConstsFilenameWithRestrictedExports('.stylex.const.jsx'),
+        },
+      ],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const consts = stylex.unstable_defineConstsNested({});
+        export const somethingElse = someFunction();
+      `,
+      filename: 'myComponent.stylex.const.jsx',
+      options: [{ enforceDefineConstsExtension: true }],
+      errors: [{ message: invalidExportFromConstsFiles }],
     },
   ],
 });

--- a/packages/@stylexjs/eslint-plugin/src/stylex-enforce-extension.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-enforce-extension.js
@@ -108,9 +108,14 @@ const stylexEnforceExtension = {
           callee.object?.type === 'Identifier' &&
           importTracker.isStylexDefaultImport(callee.object.name) &&
           callee.property?.type === 'Identifier' &&
-          callee.property.name === 'defineVars') ||
+          (callee.property.name === 'defineVars' ||
+            callee.property.name === 'unstable_defineVarsNested')) ||
         (callee?.type === 'Identifier' &&
-          importTracker.isStylexNamedImport('defineVars', callee.name))
+          (importTracker.isStylexNamedImport('defineVars', callee.name) ||
+            importTracker.isStylexNamedImport(
+              'unstable_defineVarsNested',
+              callee.name,
+            )))
       );
     }
 
@@ -127,9 +132,14 @@ const stylexEnforceExtension = {
           callee.object?.type === 'Identifier' &&
           importTracker.isStylexDefaultImport(callee.object.name) &&
           callee.property?.type === 'Identifier' &&
-          callee.property.name === 'defineConsts') ||
+          (callee.property.name === 'defineConsts' ||
+            callee.property.name === 'unstable_defineConstsNested')) ||
         (callee?.type === 'Identifier' &&
-          importTracker.isStylexNamedImport('defineConsts', callee.name))
+          (importTracker.isStylexNamedImport('defineConsts', callee.name) ||
+            importTracker.isStylexNamedImport(
+              'unstable_defineConstsNested',
+              callee.name,
+            )))
       );
     }
 


### PR DESCRIPTION
## What changed / motivation ?

After upgrading to v0.18.3, we noticed the `enforce-extension` ESLint rule
doesn't recognize `unstable_defineVarsNested` or `unstable_defineConstsNested`.
Files exporting these APIs aren't subject to the `.stylex` extension requirement
even though they serve the same purpose as `defineVars` and `defineConsts`.

This extends `isDefineVarsExport()` and `isDefineConstsExport()` to also match
the unstable nested variants, for both member expression and named import patterns.

## Linked PR/Issues

N/A

## Additional Context

Tests added for valid and invalid cases covering both nested APIs with member
expressions, named imports, wrong extensions, mixed exports, and the
`enforceDefineConstsExtension` option.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code