### PR TITLE
[babel-plugin] resolve destructured stylex.env bindings

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -222,6 +222,88 @@ describe('@stylexjs/babel-plugin', () => {
         `);
       });
 
+      test('stylex.env destructured at top level resolves compile-time constants', () => {
+        const { code, metadata } = transform(
+          `
+          import * as stylex from '@stylexjs/stylex';
+          const { colors } = stylex.env;
+          export const styles = stylex.create({
+            root: {
+              color: colors.brand,
+            }
+          });
+        `,
+          { env: { colors: { brand: '#0066ff' } } },
+        );
+        expect(code).toMatchInlineSnapshot(`
+          "import * as stylex from '@stylexjs/stylex';
+          const {
+            colors
+          } = stylex.env;
+          export const styles = {
+            root: {
+              kMwMTN: "xcudlns",
+              $$css: true
+            }
+          };"
+        `);
+        expect(metadata).toMatchInlineSnapshot(`
+          {
+            "stylex": [
+              [
+                "xcudlns",
+                {
+                  "ltr": ".xcudlns{color:#0066ff}",
+                  "rtl": null,
+                },
+                3000,
+              ],
+            ],
+          }
+        `);
+      });
+
+      test('stylex.env destructured with alias resolves compile-time constants', () => {
+        const { code, metadata } = transform(
+          `
+          import * as stylex from '@stylexjs/stylex';
+          const { colors: palette } = stylex.env;
+          export const styles = stylex.create({
+            root: {
+              color: palette.brand,
+            }
+          });
+        `,
+          { env: { colors: { brand: '#abcdef' } } },
+        );
+        expect(code).toMatchInlineSnapshot(`
+          "import * as stylex from '@stylexjs/stylex';
+          const {
+            colors: palette
+          } = stylex.env;
+          export const styles = {
+            root: {
+              kMwMTN: "x1r1tdag",
+              $$css: true
+            }
+          };"
+        `);
+        expect(metadata).toMatchInlineSnapshot(`
+          {
+            "stylex": [
+              [
+                "x1r1tdag",
+                {
+                  "ltr": ".x1r1tdag{color:#abcdef}",
+                  "rtl": null,
+                },
+                3000,
+              ],
+            ],
+          }
+        `);
+      });
+
       test('stylex.env function call resolves at compile time', () => {
         const { code, metadata } = transform(
           `

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
@@ -665,6 +665,57 @@ function _evaluate(path: NodePath<>, state: State): any {
       return deopt(binding.path, state, errMsgs.USED_BEFORE_DECLARATION);
     }
 
+    // Destructured bindings: `const { colors } = stylex.env` / `const { a: b } = expr`.
+    // Babel's default `path.resolve()` surfaces the VariableDeclarator here,
+    // which falls into the "Unsupported expression" deopt. Evaluate the init
+    // expression and pull out the matching key so downstream member access
+    // (e.g. `colors.brand`) can continue statically.
+    if (
+      binding &&
+      bindingPath &&
+      bindingPath.isVariableDeclarator() &&
+      (bindingPath as NodePath<t.VariableDeclarator>)
+        .get('id')
+        .isObjectPattern()
+    ) {
+      const declarator: NodePath<t.VariableDeclarator> =
+        bindingPath as NodePath<t.VariableDeclarator>;
+      const idPath = declarator.get('id');
+      const initPath = declarator.get('init');
+      if (initPath.node != null && initPath.isExpression()) {
+        const propPaths: $ReadOnlyArray<NodePath<>> = (
+          idPath as NodePath<t.ObjectPattern>
+        ).get('properties');
+        for (const propPath of propPaths) {
+          if (!propPath.isObjectProperty()) {
+            continue;
+          }
+          const valueNode = propPath.node.value;
+          if (
+            valueNode.type !== 'Identifier' ||
+            valueNode.name !== path.node.name
+          ) {
+            continue;
+          }
+          const keyNode = propPath.node.key;
+          let key: string | number | null = null;
+          if (!propPath.node.computed && keyNode.type === 'Identifier') {
+            key = keyNode.name;
+          } else if (keyNode.type === 'StringLiteral') {
+            key = keyNode.value;
+          } else if (keyNode.type === 'NumericLiteral') {
+            key = keyNode.value;
+          }
+          if (key == null) {
+            break;
+          }
+          const initValue = evaluateCached(initPath, state);
+          if (!state.confident) return;
+          return initValue != null ? initValue[key] : undefined;
+        }
+      }
+    }
+
     if (binding && binding.hasValue) {
       return binding.value;
     } else {


### PR DESCRIPTION
## Summary

`const { foo } = stylex.env` (or `{ foo: bar }`) used inside a later
`stylex.create()` call throws `Unsupported expression: VariableDeclarator`
today. The static evaluator doesn't know how to follow Babel's default
identifier resolution through a destructuring pattern, so it falls all
the way through to the final deopt in `_evaluate`.

Fixes #1541.

## What changed

In `packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js`, inside
the `path.isReferencedIdentifier()` branch, handle `ObjectPattern`
destructuring on a `const` binding before the fallback `path.resolve()`
step:

1. Match the pattern property whose local name equals the reference.
2. Evaluate the declarator's `init` expression (already works for
   `stylex.env`, `.stylex.js` tokens, etc).
3. Return the value at the property's source key.

Plain `const { x } = expr` and aliased `const { x: y } = expr` are now
supported. Rest, array, nested patterns, and default values still deopt
the same way they do today; I kept the patch tightly scoped to the
reported shape.

## Reproduction

```js
import * as stylex from '@stylexjs/stylex';
const { colors } = stylex.env;

export const styles = stylex.create({
  root: { color: colors.brand },
});
```

With babel config `{ env: { colors: { brand: '#0066ff' } } }`:

Before: `SyntaxError: Unsupported expression: VariableDeclarator`
After: compiles to `.xcudlns { color: #0066ff }`

## Tests

Two new cases in
`packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js`:

- `stylex.env destructured at top level resolves compile-time constants`
- `stylex.env destructured with alias resolves compile-time constants`

Full `@stylexjs/babel-plugin` suite (`npx jest`) green: 928 passed, 64
skipped, same counts as the pre-patch baseline plus the two new cases.
