### PR TITLE
Add :empty to pseudoClassesAndAtRules

### DIFF
--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -2340,6 +2340,7 @@ export const pseudoClassesAndAtRules: RuleCheck = makeUnionRule(
   makeLiteralRule(':only-child'),
   makeLiteralRule(':nth-child'),
   makeLiteralRule(':nth-of-type'),
+  makeLiteralRule(':empty'),
   makeLiteralRule(':hover'),
   makeLiteralRule(':focus'),
   makeLiteralRule(':focus-visible'),


### PR DESCRIPTION
## What changed / motivation ?

:empty is a useful pseudo class that stylex already supports. This change prevents the eslint plugin from flagging it. 

## Additional Context

<img width="1034" height="130" alt="image" src="https://github.com/user-attachments/assets/c04bfcfa-362c-41c3-8c2d-e5fde4875c51" />

Screenshots, Tests, Anything Else

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code