### PR TITLE
[unplugin] type externalPackages option

### DIFF
--- a/packages/@stylexjs/unplugin/package.json
+++ b/packages/@stylexjs/unplugin/package.json
@@ -9,54 +9,104 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "import": "./lib/es/index.mjs",
-      "require": "./lib/index.js",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/es/index.d.ts",
+        "default": "./lib/es/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
     },
     "./vite": {
-      "import": "./lib/es/vite.mjs",
-      "require": "./lib/vite.js",
-      "types": "./lib/vite.d.ts"
+      "import": {
+        "types": "./lib/es/vite.d.ts",
+        "default": "./lib/es/vite.mjs"
+      },
+      "require": {
+        "types": "./lib/vite.d.ts",
+        "default": "./lib/vite.js"
+      }
     },
     "./rollup": {
-      "import": "./lib/es/rollup.mjs",
-      "require": "./lib/rollup.js",
-      "types": "./lib/rollup.d.ts"
+      "import": {
+        "types": "./lib/es/rollup.d.ts",
+        "default": "./lib/es/rollup.mjs"
+      },
+      "require": {
+        "types": "./lib/rollup.d.ts",
+        "default": "./lib/rollup.js"
+      }
     },
     "./esbuild": {
-      "import": "./lib/es/esbuild.mjs",
-      "require": "./lib/esbuild.js",
-      "types": "./lib/esbuild.d.ts"
+      "import": {
+        "types": "./lib/es/esbuild.d.ts",
+        "default": "./lib/es/esbuild.mjs"
+      },
+      "require": {
+        "types": "./lib/esbuild.d.ts",
+        "default": "./lib/esbuild.js"
+      }
     },
     "./webpack": {
-      "import": "./lib/es/webpack.mjs",
-      "require": "./lib/webpack.js",
-      "types": "./lib/webpack.d.ts"
+      "import": {
+        "types": "./lib/es/webpack.d.ts",
+        "default": "./lib/es/webpack.mjs"
+      },
+      "require": {
+        "types": "./lib/webpack.d.ts",
+        "default": "./lib/webpack.js"
+      }
     },
     "./rspack": {
-      "import": "./lib/es/rspack.mjs",
-      "require": "./lib/rspack.js",
-      "types": "./lib/rspack.d.ts"
+      "import": {
+        "types": "./lib/es/rspack.d.ts",
+        "default": "./lib/es/rspack.mjs"
+      },
+      "require": {
+        "types": "./lib/rspack.d.ts",
+        "default": "./lib/rspack.js"
+      }
     },
     "./rolldown": {
-      "import": "./lib/es/rolldown.mjs",
-      "require": "./lib/rolldown.js",
-      "types": "./lib/rolldown.d.ts"
+      "import": {
+        "types": "./lib/es/rolldown.d.ts",
+        "default": "./lib/es/rolldown.mjs"
+      },
+      "require": {
+        "types": "./lib/rolldown.d.ts",
+        "default": "./lib/rolldown.js"
+      }
     },
     "./farm": {
-      "import": "./lib/es/farm.mjs",
-      "require": "./lib/farm.js",
-      "types": "./lib/farm.d.ts"
+      "import": {
+        "types": "./lib/es/farm.d.ts",
+        "default": "./lib/es/farm.mjs"
+      },
+      "require": {
+        "types": "./lib/farm.d.ts",
+        "default": "./lib/farm.js"
+      }
     },
     "./unloader": {
-      "import": "./lib/es/unloader.mjs",
-      "require": "./lib/unloader.js",
-      "types": "./lib/unloader.d.ts"
+      "import": {
+        "types": "./lib/es/unloader.d.ts",
+        "default": "./lib/es/unloader.mjs"
+      },
+      "require": {
+        "types": "./lib/unloader.d.ts",
+        "default": "./lib/unloader.js"
+      }
     },
     "./bun": {
-      "import": "./lib/es/bun.mjs",
-      "require": "./lib/bun.js",
-      "types": "./lib/bun.d.ts"
+      "import": {
+        "types": "./lib/es/bun.d.ts",
+        "default": "./lib/es/bun.mjs"
+      },
+      "require": {
+        "types": "./lib/bun.d.ts",
+        "default": "./lib/bun.js"
+      }
     }
   },
   "keywords": [
@@ -70,7 +120,7 @@
   ],
   "scripts": {
     "build:cjs": "cross-env BABEL_ENV=cjs babel src/ --out-dir lib/ --copy-files",
-    "build:esm": "cross-env BABEL_ENV=esm babel src/ --out-dir lib/es --out-file-extension .mjs",
+    "build:esm": "cross-env BABEL_ENV=esm babel src/ --out-dir lib/es --out-file-extension .mjs --copy-files && node -e \"require('fs').writeFileSync('lib/es/package.json', JSON.stringify({ type: 'module' }))\"",
     "build": "npm run build:cjs && npm run build:esm",
     "test": "jest"
   },

--- a/packages/@stylexjs/unplugin/src/bun.d.ts
+++ b/packages/@stylexjs/unplugin/src/bun.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { UserOptions } from './core';
+import type { UserOptions } from './core.js';
 
 type BunOptions = UserOptions & {
   bunDevCssOutput?: string;

--- a/packages/@stylexjs/unplugin/src/core.d.ts
+++ b/packages/@stylexjs/unplugin/src/core.d.ts
@@ -4,11 +4,28 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { type UnpluginFactory, type UnpluginInstance } from 'unplugin';
 import type { Options as StyleXOptions } from '@stylexjs/babel-plugin';
 import type { TransformOptions } from 'lightningcss';
 
 type LightningcssOptions = Omit<TransformOptions<any>, 'filename' | 'code'>;
+
+type UnpluginMetaOptions = {
+  framework?:
+    | 'rollup'
+    | 'vite'
+    | 'webpack'
+    | 'rspack'
+    | 'esbuild'
+    | 'rolldown'
+    | 'farm'
+    | 'unloader'
+    | 'bun';
+};
+
+type StyleXUnpluginFactory<Options> = (
+  options?: Options,
+  metaOptions?: UnpluginMetaOptions,
+) => any;
 
 export type CSSLayersConfig =
   | boolean
@@ -29,8 +46,8 @@ export type UserOptions = StyleXOptions & {
   devMode?: 'full' | 'css-only' | 'off';
 };
 
-export const unpluginFactory: UnpluginFactory<Partial<UserOptions>, false>;
+export const unpluginFactory: StyleXUnpluginFactory<Partial<UserOptions>>;
 
-declare const unplugin: UnpluginInstance<Partial<UserOptions>, false>;
+declare const unplugin: any;
 
 export default unplugin;

--- a/packages/@stylexjs/unplugin/src/core.d.ts
+++ b/packages/@stylexjs/unplugin/src/core.d.ts
@@ -24,6 +24,7 @@ export type UserOptions = StyleXOptions & {
   legacyDisableLayers?: boolean;
   lightningcssOptions?: LightningcssOptions;
   cssInjectionTarget?: (filepath: string) => boolean;
+  externalPackages?: ReadonlyArray<string>;
   devPersistToDisk?: boolean;
   devMode?: 'full' | 'css-only' | 'off';
 };

--- a/packages/@stylexjs/unplugin/src/esbuild.d.ts
+++ b/packages/@stylexjs/unplugin/src/esbuild.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { UserOptions } from './core';
+import type { UserOptions } from './core.js';
 
 declare const plugin: (options?: Partial<UserOptions>) => any;
 

--- a/packages/@stylexjs/unplugin/src/farm.d.ts
+++ b/packages/@stylexjs/unplugin/src/farm.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { UserOptions } from './core';
+import type { UserOptions } from './core.js';
 
 declare const plugin: (options?: Partial<UserOptions>) => any;
 

--- a/packages/@stylexjs/unplugin/src/index.d.ts
+++ b/packages/@stylexjs/unplugin/src/index.d.ts
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { UserOptions } from './core';
+import type { UserOptions } from './core.js';
 
-export { unpluginFactory } from './core';
-export type { UserOptions } from './core';
-export { createStylexBunPlugin } from './bun';
+export { unpluginFactory } from './core.js';
+export type { UserOptions } from './core.js';
+export { createStylexBunPlugin } from './bun.js';
 
 declare const stylex: {
   bun: (options?: Partial<UserOptions>) => any;
@@ -21,7 +21,7 @@ declare const stylex: {
   unloader: (options?: Partial<UserOptions>) => any;
   vite: (options?: Partial<UserOptions>) => any;
   webpack: (options?: Partial<UserOptions>) => any;
-  raw: typeof import('./core').unpluginFactory;
+  raw: typeof import('./core.js').unpluginFactory;
 };
 
 export const unplugin: typeof stylex;

--- a/packages/@stylexjs/unplugin/src/rolldown.d.ts
+++ b/packages/@stylexjs/unplugin/src/rolldown.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { UserOptions } from './core';
+import type { UserOptions } from './core.js';
 
 declare const plugin: (options?: Partial<UserOptions>) => any;
 

--- a/packages/@stylexjs/unplugin/src/rollup.d.ts
+++ b/packages/@stylexjs/unplugin/src/rollup.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { UserOptions } from './core';
+import type { UserOptions } from './core.js';
 
 declare const plugin: (options?: Partial<UserOptions>) => any;
 

--- a/packages/@stylexjs/unplugin/src/rspack.d.ts
+++ b/packages/@stylexjs/unplugin/src/rspack.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { UserOptions } from './core';
+import type { UserOptions } from './core.js';
 
 declare const plugin: (options?: Partial<UserOptions>) => any;
 

--- a/packages/@stylexjs/unplugin/src/unloader.d.ts
+++ b/packages/@stylexjs/unplugin/src/unloader.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { UserOptions } from './core';
+import type { UserOptions } from './core.js';
 
 declare const plugin: (options?: Partial<UserOptions>) => any;
 

--- a/packages/@stylexjs/unplugin/src/vite.d.ts
+++ b/packages/@stylexjs/unplugin/src/vite.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { UserOptions } from './core';
+import type { UserOptions } from './core.js';
 
 declare const plugin: (options?: Partial<UserOptions>) => any;
 

--- a/packages/@stylexjs/unplugin/src/webpack.d.ts
+++ b/packages/@stylexjs/unplugin/src/webpack.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { UserOptions } from './core';
+import type { UserOptions } from './core.js';
 
 declare const plugin: (options?: Partial<UserOptions>) => any;
 

--- a/packages/typescript-tests/package.json
+++ b/packages/typescript-tests/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "dependencies": {
     "@stylexjs/stylex": "0.18.3",
-    "@stylexjs/babel-plugin": "0.18.3"
+    "@stylexjs/babel-plugin": "0.18.3",
+    "@stylexjs/unplugin": "0.18.3"
   },
   "devDependencies": {
     "typescript": "^5.8.3",

--- a/packages/typescript-tests/src/unplugin.ts
+++ b/packages/typescript-tests/src/unplugin.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import stylex, { unpluginFactory, type UserOptions } from '@stylexjs/unplugin';
+import viteStylex from '@stylexjs/unplugin/vite';
+
+const options = {
+  externalPackages: ['@acme/components'],
+  useCSSLayers: true,
+} satisfies Partial<UserOptions>;
+
+stylex.vite(options);
+stylex.rollup({ externalPackages: ['@acme/components'] });
+viteStylex({ externalPackages: ['@acme/components'] });
+unpluginFactory(
+  { externalPackages: ['@acme/components'] },
+  { framework: 'vite' },
+);


### PR DESCRIPTION
Fixes #1563.

`externalPackages` already works at runtime; this adds it to the public unplugin options type and covers typed Vite/subpath imports.

Tested: unplugin build/test, targeted tsc, Prettier, git diff --check.
