### PR TITLE
fix(example-sveltekit): add missing eslint devDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,4 @@ of the project.
 ### License
 
 StyleX is [MIT licensed](./LICENSE).
+

--- a/examples/example-sveltekit/package.json
+++ b/examples/example-sveltekit/package.json
@@ -22,6 +22,7 @@
     "svelte-check": "^4.3.4",
     "typescript": "^5.9.3",
     "vite": "^7.2.6",
-    "@stylexjs/unplugin": "0.18.2"
+    "@stylexjs/unplugin": "0.18.2",
+    "eslint": "^8.57.1"
   }
 }


### PR DESCRIPTION
## Summary
- Add `eslint` to SvelteKit example's devDependencies to fix Vercel build failures
- The build was failing with `expected workspace package to exist for "eslint"` when `@sveltejs/adapter-auto` tried to install `@sveltejs/adapter-vercel`

## Test plan
- Vercel build should pass for the SvelteKit example