### PR TITLE
fix(babel-plugin): resolve aliased theme files expanded to absolute paths

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
@@ -61,6 +61,33 @@ function transformWithInlineConsts(source, opts = {}) {
   return { code, metadata };
 }
 
+function transformWithAliasedInlineConsts(source, opts = {}) {
+  const fixtureDir = path.join(__dirname, '__fixtures__');
+
+  const { code, metadata } = transformSync(source, {
+    filename: path.join(fixtureDir, 'main.stylex.js'),
+    parserOpts: { sourceType: 'module' },
+    babelrc: false,
+    plugins: [
+      [
+        stylexPlugin,
+        {
+          ...opts,
+          aliases: {
+            '~fixture/*': [path.join(fixtureDir, '*')],
+          },
+          unstable_moduleResolution: {
+            rootDir: fixtureDir,
+            type: 'commonJS',
+          },
+        },
+      ],
+    ],
+  });
+
+  return { code, metadata };
+}
+
 describe('@stylexjs/babel-plugin', () => {
   describe('[transform] stylex.defineConsts()', () => {
     test('constants are unique', () => {
@@ -399,6 +426,34 @@ describe('@stylexjs/babel-plugin', () => {
           ],
         }
       `);
+    });
+
+    test('resolves aliased absolute paths for defineConsts imports', () => {
+      const { code, metadata } = transformWithAliasedInlineConsts(`
+        import * as stylex from '@stylexjs/stylex';
+        import { breakpoints } from '~fixture/constants.stylex';
+
+        export const styles = stylex.create({
+          root: {
+            color: {
+              default: 'red',
+              [breakpoints.small]: 'blue',
+            },
+          },
+        });
+      `);
+
+      expect(code).toContain('xbs0o1n');
+      expect(metadata.stylex).toEqual(
+        expect.arrayContaining([
+          expect.arrayContaining([
+            'xbs0o1n',
+            expect.objectContaining({
+              ltr: expect.stringContaining('color:blue'),
+            }),
+          ]),
+        ]),
+      );
     });
 
     test.skip('works with firstThatWorks', () => {

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
@@ -75,8 +75,9 @@ function transformWithAliasedInlineConsts(source, opts = {}) {
           ...opts,
           aliases: {
             '~fixture/*': [path.join(fixtureDir, '*')],
+            ...opts.aliases,
           },
-          unstable_moduleResolution: {
+          unstable_moduleResolution: opts.unstable_moduleResolution ?? {
             rootDir: fixtureDir,
             type: 'commonJS',
           },
@@ -426,6 +427,52 @@ describe('@stylexjs/babel-plugin', () => {
           ],
         }
       `);
+    });
+
+    test('resolves /ROOT/ placeholder alias paths for defineConsts imports', () => {
+      const fixtureDir = path.join(__dirname, '__fixtures__');
+      const projectRoot = path.resolve(__dirname, '../../..');
+      const relativeFixturePath = path
+        .relative(projectRoot, fixtureDir)
+        .replace(/\\/g, '/');
+      const rootFixtureGlob = `/ROOT/${relativeFixturePath}/*`;
+
+      const { code, metadata } = transformWithAliasedInlineConsts(
+        `
+        import * as stylex from '@stylexjs/stylex';
+        import { breakpoints } from '~root-fixture/constants.stylex';
+
+        export const styles = stylex.create({
+          root: {
+            color: {
+              default: 'red',
+              [breakpoints.small]: 'blue',
+            },
+          },
+        });
+      `,
+        {
+          aliases: {
+            '~root-fixture/*': [rootFixtureGlob],
+          },
+          unstable_moduleResolution: {
+            rootDir: projectRoot,
+            type: 'commonJS',
+          },
+        },
+      );
+
+      expect(code).toContain('xbs0o1n');
+      expect(metadata.stylex).toEqual(
+        expect.arrayContaining([
+          expect.arrayContaining([
+            'xbs0o1n',
+            expect.objectContaining({
+              ltr: expect.stringContaining('color:blue'),
+            }),
+          ]),
+        ]),
+      );
     });
 
     test('resolves aliased absolute paths for defineConsts imports', () => {

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -886,6 +886,17 @@ export const filePathResolver = (
     // Otherwise, try to resolve the path with aliases
     const allAliases = possibleAliasedPaths(importPathStr, aliases);
     for (const possiblePath of allAliases) {
+      // If the alias expanded to an absolute path, resolve it directly
+      // rather than going through moduleResolve which expects relative
+      // or module-style paths.
+      if (path.isAbsolute(possiblePath)) {
+        for (const candidate of getPossibleFilePaths(possiblePath)) {
+          if (fs.existsSync(candidate)) {
+            return candidate;
+          }
+        }
+        continue;
+      }
       try {
         return url.fileURLToPath(
           moduleResolve(possiblePath, url.pathToFileURL(sourceFilePath)),

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -667,6 +667,7 @@ export default class StateManager {
           importPath,
           sourceFilePath,
           aliases,
+          this.options.unstable_moduleResolution?.rootDir,
         );
         return resolvedFilePath
           ? ['themeNameRef', this.getCanonicalFilePath(resolvedFilePath)]
@@ -693,6 +694,7 @@ export default class StateManager {
           importPath,
           sourceFilePath,
           aliases,
+          this.options.unstable_moduleResolution?.rootDir,
         );
         return resolvedFilePath ? ['filePath', resolvedFilePath] : false;
       }
@@ -870,6 +872,7 @@ export const filePathResolver = (
   relativeFilePath: string,
   sourceFilePath: string,
   aliases: StyleXStateOptions['aliases'],
+  rootDir?: ?string,
 ): ?string => {
   for (const importPathStr of getPossibleFilePaths(relativeFilePath)) {
     // Try to resolve relative paths as is
@@ -886,6 +889,20 @@ export const filePathResolver = (
     // Otherwise, try to resolve the path with aliases
     const allAliases = possibleAliasedPaths(importPathStr, aliases);
     for (const possiblePath of allAliases) {
+      // Handle /ROOT/ placeholder paths (used by Turbopack).
+      // Replace /ROOT/ with the configured rootDir.
+      if (possiblePath.startsWith('/ROOT/') && rootDir != null) {
+        const realPath = path.join(
+          rootDir,
+          possiblePath.slice('/ROOT/'.length),
+        );
+        for (const candidate of getPossibleFilePaths(realPath)) {
+          if (fs.existsSync(candidate)) {
+            return candidate;
+          }
+        }
+        continue;
+      }
       // If the alias expanded to an absolute path, resolve it directly
       // rather than going through moduleResolve which expects relative
       // or module-style paths.


### PR DESCRIPTION
## Summary
- When aliases expand to absolute filesystem paths (e.g. in Next.js + Turbopack setups), `moduleResolve()` fails because it expects relative or module-style paths
- Adds direct `fs.existsSync` resolution for absolute alias expansions
- Handles Turbopack's `/ROOT/` placeholder paths by replacing `/ROOT/` with the configured `rootDir`

Supersedes #1622

## Test plan
- Added test for aliased absolute path resolution with `defineConsts`
- Added test for `/ROOT/` placeholder path resolution

Co-authored-by: Choi138 <choi138@users.noreply.github.com>