### PR TITLE
Add Copilot code review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+## StyleX Code Review Guidelines
+
+Focus on critical issues only. Do not nitpick naming, style preferences, or suggest refactors on bug-fix PRs.
+
+### Must-haves
+
+- **CLA**: External contributors must have a signed CLA. Flag if the `CLA Signed` label is missing.
+- **CI signals**: Flag if any CI check is failing and the PR does not acknowledge it.
+- **Tests**: New babel-plugin features or bug fixes must include tests. Prefer `toMatchInlineSnapshot()` for all assertion snapshots.
+- **Types**: Changes to babel-plugin source must update both Flow (`.js.flow`) and TypeScript (`.d.ts`) declarations if the public API changes.
+- **Flow syntax**: Use modern Flow — `Readonly<>` not `$ReadOnly<>`, `unknown` not `mixed`, `ReadonlyArray` not `$ReadOnlyArray`.
+- **Lint and formatting**: Code must pass eslint and prettier. Flag obvious violations.
+
+### Babel plugin
+
+- New compile-time APIs must throw at runtime with a clear error message.
+- New APIs should include documentation, eslint plugin support, and tests.
+
+### Release PRs
+
+- Must include a changelog entry or blog post update.
+- Version bumps must be consistent across all workspace packages.
+- Credit community contributors with `(Thanks [username](url)!)` format.
+
+### Documentation
+
+- Code examples in docs and blog posts must use valid CSS and JS syntax.
+- Blog posts should credit community contributors.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,6 @@ Focus on critical issues only. Do not nitpick naming, style preferences, or sugg
 - **CLA**: External contributors must sign the CLA at https://code.facebook.com/cla. Flag if the `CLA Signed` label is missing on external PRs.
 - **CI signals**: Flag if any CI check is failing and the PR does not acknowledge it.
 - **Tests**: New babel-plugin features or bug fixes must include tests. Prefer `toMatchInlineSnapshot()` for all assertion snapshots.
-- **Types**: Changes to babel-plugin source must update both Flow (`.js.flow`) and TypeScript (`.d.ts`) declarations if the public API changes.
 - **Flow syntax**: Use modern Flow — `Readonly<>` not `$ReadOnly<>`, `unknown` not `mixed`, `ReadonlyArray` not `$ReadOnlyArray`.
 - **Lint and formatting**: Code must pass eslint and prettier. Flag obvious violations.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ Focus on critical issues only. Do not nitpick naming, style preferences, or sugg
 
 ### Must-haves
 
-- **CLA**: External contributors must have a signed CLA. Flag if the `CLA Signed` label is missing.
+- **CLA**: External contributors must sign the CLA at https://code.facebook.com/cla. Flag if the `CLA Signed` label is missing on external PRs.
 - **CI signals**: Flag if any CI check is failing and the PR does not acknowledge it.
 - **Tests**: New babel-plugin features or bug fixes must include tests. Prefer `toMatchInlineSnapshot()` for all assertion snapshots.
 - **Types**: Changes to babel-plugin source must update both Flow (`.js.flow`) and TypeScript (`.d.ts`) declarations if the public API changes.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ Focus on critical issues only. Do not nitpick naming, style preferences, or sugg
 
 ### Release PRs
 
-- Must include a changelog entry or blog post update.
+- Must include a changelog entry.
 - Version bumps must be consistent across all workspace packages.
 - Release blog posts should credit community contributors with `(Thanks [username](url)!)` format.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,7 @@ Focus on critical issues only. Do not nitpick naming, style preferences, or sugg
 
 - New compile-time APIs must throw at runtime with a clear error message.
 - New APIs should include documentation, eslint plugin support, and tests.
+- Review test snapshot output and compiled JS/CSS to verify no regressions in generated code.
 
 ### Release PRs
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,9 +21,12 @@ Focus on critical issues only. Do not nitpick naming, style preferences, or sugg
 
 - Must include a changelog entry or blog post update.
 - Version bumps must be consistent across all workspace packages.
-- Credit community contributors with `(Thanks [username](url)!)` format.
+- Release blog posts should credit community contributors with `(Thanks [username](url)!)` format.
 
 ### Documentation
 
 - Code examples in docs and blog posts must use valid CSS and JS syntax.
-- Blog posts should credit community contributors.
+
+### Style
+
+- Flag minor issues like typos, grammar, and formatting as low-priority nits.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,3 @@ Focus on critical issues only. Do not nitpick naming, style preferences, or sugg
 ### Documentation
 
 - Code examples in docs and blog posts must use valid CSS and JS syntax.
-
-### Style
-
-- Flag minor issues like typos, grammar, and formatting as low-priority nits.


### PR DESCRIPTION
We'll probably need to tweak this, but adding this as scaffolding for now.

## Summary
- Add `.github/copilot-instructions.md` to customize GitHub Copilot code review for StyleX
- Focuses on critical issues: CLA, CI signals, tests with inline snapshots, type declarations, modern Flow syntax, babel plugin patterns, release changelogs, and doc accuracy

## Test plan
- Copilot will read this file when reviewing future PRs