### PR TITLE
Expand changelog entries for 0.18.2 and 0.18.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Changelog
 
 ## 0.18.3 (Apr 29, 2026)
+- Experimental nested APIs for `defineVars`, `defineConsts`, and `createTheme`.
 - Add recursive derivation support for `defineVars`.
+- ESLint auto-fixers for shorthand expansion, gated by `styleResolution` config.
+- Respect project `browserslist` config instead of hardcoding `>= 1%`.
+- Add `:empty` pseudo-class and unclosed string detection to the compiler.
 - StyleX DevTools extension now available in the Chrome Web Store.
 
 ## 0.18.2 (Mar 23, 2026)
 - Bring back `stylex.attrs` for SSR and non-React frameworks.
 - Add `layersBefore`, `layersAfter`, and `layersPrefix` for `@layer` control.
-- Add `flex` and `grid` shorthand expansion to ESLint plugin.
+- Add `flex`, `grid`, and `animation` shorthand expansion to ESLint plugin.
 - ESLint fixes: bare number support, false positive fixes in `stylex.create`.
 
 ## 0.18.1 (Mar 5, 2026)


### PR DESCRIPTION
## Summary
- Expand 0.18.3 changelog with nested APIs, ESLint auto-fixers, browserslist support, compiler improvements
- Add animation shorthand to 0.18.2 entry

Replaces #1641