### PR TITLE
[eslint-plugin] ESLint 10 compatibility

### DIFF
--- a/packages/@stylexjs/eslint-plugin/flow_modules/eslint/eslint-rule.js.flow
+++ b/packages/@stylexjs/eslint-plugin/flow_modules/eslint/eslint-rule.js.flow
@@ -109,23 +109,20 @@ export type RuleContext = {
   id: string,
   options: Array<$FlowFixMe>,
   settings: { [name: string]: $FlowFixMe },
-  parserPath: string,
-  // parserOptions: Linter.ParserOptions;
+  // parserPath: string,
   // parserServices: SourceCode.ParserServices;
   sourceCode: SourceCode,
   getAncestors(): Array<ESTree.Node>,
 
   // getDeclaredVariables(node: ESTree.Node): Scope.Variable[];
 
-  getFilename(): string,
+  filename: string;
 
-  getPhysicalFilename(): string,
+  physicalFilename: string;
 
-  getCwd(): string,
+  cwd: string;
 
   // getScope(): Scope.Scope;
-
-  // getSourceCode(): SourceCode;
 
   markVariableAsUsed(name: string): boolean,
 

--- a/packages/@stylexjs/eslint-plugin/src/stylex-enforce-extension.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-enforce-extension.js
@@ -67,7 +67,7 @@ const stylexEnforceExtension = {
     let hasDefineVarsExports = false;
     let hasDefineMarkerExports = false;
     let reportedDefaultExportError = false;
-    const fileName = context.getFilename();
+    const fileName = context.filename;
     const options = context.options[0] || {};
     const {
       validImports: importsToLookFor = ['stylex', '@stylexjs/stylex'],

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -369,8 +369,7 @@ const stylexValidStyles = {
     const stylexResolvedVarsTokenImports = new Set<string>();
 
     // Track same-file defineVars/defineVarsNested/defineConstsNested declarations.
-    const currentFilename =
-      context.getFilename != null ? context.getFilename() : '';
+    const currentFilename = context.filename;
     const isStylexFile = isValidStylexResolvedVarsFileExtension(
       currentFilename,
       themeFileExtension,


### PR DESCRIPTION
## What changed / motivation ?
Several functions that were deprecated in ESLint 9 were deleted in ESLint 10. This diff removes usage of these legacy functions. The only one that was used in stylex is `getFilename()`, which has been replaced by the `filename` property.

https://eslint.org/docs/latest/use/migrate-to-10.0.0#-removal-of-deprecated-context-members

The `filename` property has existed since ESLint 8, so this will **not** break any projects that are still on old ESLint evrsions.

Upgrading stylex itself to ESLint v10 is outside the scope of this diff. I tried doing that, but the config file needs to be rewritten as it's in the legacy eslintrc format.

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

# Test plan
All tests for the ESLint plugin still pass:
```
10:26 danlo@danlo-fedora-MJ0FLNP7 ~/src/stylex/packages/@stylexjs/eslint-plugin  (eslint10)
% yarn test  
...
Test Suites: 9 passed, 9 total
Tests:       546 passed, 546 total
Snapshots:   0 total
Time:        7.338 s
```