### PR TITLE
[docs] fix favicon data URI and broken RSS image URLs

### DIFF
--- a/packages/docs/src/lib/rss.ts
+++ b/packages/docs/src/lib/rss.ts
@@ -6,6 +6,8 @@
  */
 import { Feed } from 'feed';
 import { blogSource } from '@/lib/source';
+import logoUrl from '@/static/img/stylex-logo-small.svg?no-inline';
+import faviconUrl from '@/static/img/favicon.svg?no-inline';
 import { marked } from 'marked';
 import type { InferPageType } from 'fumadocs-core/source';
 
@@ -44,8 +46,8 @@ async function createFeed(): Promise<Feed> {
     id: `https://stylexjs.com/blog`,
     link: `https://stylexjs.com/blog`,
     language: 'en',
-    image: `${baseUrl}/img/stylex-logo-small-light.svg`,
-    favicon: `${baseUrl}/img/favicon.svg`,
+    image: `${baseUrl}${logoUrl}`,
+    favicon: `${baseUrl}${faviconUrl}`,
     copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`,
     feedLinks: {
       rss: `${baseUrl}/blog/rss.xml`,

--- a/packages/docs/src/pages/_layout.tsx
+++ b/packages/docs/src/pages/_layout.tsx
@@ -9,7 +9,7 @@ import { Provider } from '@/components/provider';
 import '@/styles/globals.css';
 import DevStyleXHMR from '@/components/DevStyleXHMR';
 import { SidebarProvider } from '@/contexts/SidebarContext';
-import faviconUrl from '@/static/img/favicon.svg';
+import faviconUrl from '@/static/img/favicon.svg?no-inline';
 import coverImageUrl from '@/static/img/stylex-cover-photo.png';
 
 const DEFAULT_TITLE = 'StyleX — The styling system for ambitious interfaces';


### PR DESCRIPTION
## What changed / motivation ?

Noticed the favicon doesn't show up in Google search results. Not sure why —
but the favicon SVG (3274 bytes) falls under Vite's 4096-byte inline threshold
and gets emitted as a `data:image/svg+xml` URI rather than a real URL. Adding
`?no-inline` fixes that. See https://vite.dev/guide/assets#explicit-inline-handling

Someone with access to Google Search Console for stylexjs.com may be able to see more.

A cleaner long-term fix would be moving the favicon to `/public` for a stable
non-hashed URL, but keeping the diff minimal for now.

Also fixed two broken URLs in the RSS/Atom feed:
- `/img/stylex-logo-small-light.svg` — file doesn't exist
- `/img/favicon.svg` — path was never served

Both now use `?no-inline` imports so the emitted asset URLs are used instead.

## Linked PR/Issues

N/A

## Additional Context

<img width="697" height="494" alt="Screenshot 2026-05-07 at 4 41 38 PM" src="https://github.com/user-attachments/assets/f31e90d7-7bdc-40a3-8eeb-46c6e0a86a75" />


## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

🤖 Generated with [Claude Code](https://claude.com/claude-code)