### PR TITLE
[docs] Fix RSS/Atom feed dates all showing the build date

### DIFF
--- a/packages/docs/src/lib/rss.ts
+++ b/packages/docs/src/lib/rss.ts
@@ -62,7 +62,7 @@ async function createFeed(): Promise<Feed> {
     const url = `${baseUrl}/blog/${page.data.slug}`;
 
     // Parse date from the path (format: YYYY-MM-DD-title)
-    const pathMatch = page.path.match(/\/(\d{4}-\d{2}-\d{2})/);
+    const pathMatch = page.path.match(/^(\d{4}-\d{2}-\d{2})/);
     const dateStr = pathMatch?.[1];
     const date = dateStr ? new Date(dateStr) : new Date();
 


### PR DESCRIPTION
## What changed / motivation ?

The regex used to extract dates from blog post paths had a leading `\/`, but
fumadocs normalizes paths without a leading slash (e.g. `2024-04-16-Release-v0.6.1`).
This caused every match to fail, so all posts fell back to `new Date()` and
showed the build timestamp instead of their actual publish date.

Fixed by anchoring the regex to `^` instead of `\/`.

## Linked PR/Issues

Fixes # (issue)

## Additional Context

N/A

## Pre-flight checklist

- [ ] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code