### PR TITLE
[style-value-parser] Fix media type incorrectly parenthesized in and-chains

### DIFF
--- a/packages/style-value-parser/src/at-queries/__tests__/media-query-transform-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/media-query-transform-test.js
@@ -256,6 +256,21 @@ describe('Media Query Transformer', () => {
     expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
   });
 
+  test('handles only screen media queries without parenthesizing the media type', () => {
+    const originalStyles = {
+      color: {
+        default: null,
+        '@media only screen and (max-width: 600px)': 'red',
+        '@media only screen and (max-width: 400px)': 'blue',
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    const resultStr = JSON.stringify(result);
+    expect(resultStr).not.toContain('only (screen)');
+    expect(resultStr).toContain('only screen');
+  });
+
   test('handles comma-separated (or) media queries', () => {
     const originalStyles = {
       width: {

--- a/packages/style-value-parser/src/at-queries/__tests__/parse-media-query-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/parse-media-query-test.js
@@ -96,7 +96,41 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media only (print) and (color)"',
+          '"@media only print and (color)"',
+        );
+      });
+
+      test('@media only screen and (max-width: 38em)', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media only screen and (max-width: 38em)',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "screen",
+                  "not": false,
+                  "only": true,
+                  "type": "media-keyword",
+                },
+                {
+                  "key": "max-width",
+                  "type": "pair",
+                  "value": {
+                    "signCharacter": undefined,
+                    "type": "integer",
+                    "unit": "em",
+                    "value": 38,
+                  },
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media only screen and (max-width: 38em)"',
         );
       });
 
@@ -139,7 +173,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media not (all) and (monochrome)"',
+          '"@media not all and (monochrome)"',
         );
       });
     });
@@ -940,7 +974,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media not (all) and (monochrome)"',
+          '"@media not all and (monochrome)"',
         );
       });
 
@@ -2050,7 +2084,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media not (all) and (monochrome) and (min-width: 600px)"',
+          '"@media not all and (monochrome) and (min-width: 600px)"',
         );
       });
 

--- a/packages/style-value-parser/src/at-queries/media-query.js
+++ b/packages/style-value-parser/src/at-queries/media-query.js
@@ -520,7 +520,13 @@ export class MediaQuery {
     switch (queries.type) {
       case 'media-keyword': {
         const prefix = queries.not ? 'not ' : queries.only ? 'only ' : '';
-        return prefix + (isTopLevel ? queries.key : `(${queries.key})`);
+        const isTypedMediaReference = queries.only || queries.not;
+        return (
+          prefix +
+          (isTopLevel || isTypedMediaReference
+            ? queries.key
+            : `(${queries.key})`)
+        );
       }
       case 'word-rule':
         return `(${queries.keyValue})`;


### PR DESCRIPTION
## What changed / motivation?

`@media only screen and (max-width: 38em)` was being serialized as `@media only (screen) and (max-width: 38em)` — with the media type incorrectly wrapped in parentheses. This is invalid CSS and rejected by strict parsers like lightningcss, which throws `Unexpected token Ident(\"only\")`.

The root cause was in `MediaQuery#toString`. The `'media-keyword'` branch used `isTopLevel` as the sole guard against parenthesization:

```js
return prefix + (isTopLevel ? queries.key : `(${queries.key})`);
```

When a `media-keyword` node with an `only` or `not` prefix appears inside an `and` chain, `isTopLevel` is `false`, so the key got wrapped. But `only`/`not` are only valid in the legacy `[not|only] <media-type> [and ...]` grammar, where the media type is always a bare identifier — parenthesizing it is a syntax error.

**Fix:** introduce `isTypedMediaReference` to capture this intent — if the node carries an `only` or `not` prefix, it's a typed media reference and must never be parenthesized regardless of nesting depth:

```js
const isTypedMediaReference = queries.only || queries.not;
return prefix + (isTopLevel || isTypedMediaReference ? queries.key : `(${queries.key})`);
```

The same bug affected `not all` in and-chains, which was being emitted as `not (all) and ...`. Three pre-existing snapshots that encoded the wrong output are corrected.

## Why it's safe

- The fix is a one-line change in `#toString` (serialization only). The parser and AST are unchanged.
- `media-keyword` nodes are only created when the parser sees `not`/`only` followed by a bare media type identifier (`screen`, `print`, `all`). The Level 4 condition form `not (min-width: 600px)` parses to a `{type: 'not', rule: ...}` node and is serialized by a completely separate branch — our change doesn't touch it.
- A bare `(screen)` (no prefix, non-top-level) still gets parenthesized correctly, as `isTypedMediaReference` is false in that case.
- All 324 tests pass, including pre-existing roundtrip tests for `only screen`, `not screen`, `not all`, and the Level 4 `not (...)` forms.
- A new transform regression test confirms `only screen` queries passed through `lastMediaQueryWinsTransform` don't re-introduce parenthesized media types.

## Linked PR/Issues

Fixes #1408

## Additional Context

The bug is invisible in browsers because the CSS spec requires malformed media queries to evaluate as `not all` (never match) rather than throw. So `@media only (screen) and (...)` silently stops applying styles. lightningcss surfaces it as a hard error at build time, which is what made it visible to users of Next.js with Turbopack.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code