### PR TITLE
Fix stylex-sort-keys autofix ordering

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -396,6 +396,38 @@ eslintTester.run('stylex-sort-keys', rule.default, {
       ],
     },
     {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            fontSize: 12,
+            animationDuration: '100ms',
+            padding: 10,
+          }
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            padding: 10,
+            animationDuration: '100ms',
+            fontSize: 12,
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            'StyleX property key "animationDuration" should be above "fontSize"',
+        },
+        {
+          message:
+            'StyleX property key "padding" should be above "animationDuration"',
+        },
+      ],
+    },
+    {
       options: [{ order: 'clean' }],
       code: `
         import * as stylex from '@stylexjs/stylex';
@@ -511,8 +543,8 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         import { create } from 'stylex';
         const styles = create({
           button: {
-            alignItems: 'center',
             borderColor: 'red',
+            alignItems: 'center',
             display: 'flex',
           }
         });
@@ -713,8 +745,8 @@ eslintTester.run('stylex-sort-keys', rule.default, {
             '@media (min-width: 1540px)': 1366,
             ':hover': 'red',
           },
-          display: 'flex',
           borderRadius: 10,
+          display: 'flex',
         },
       });`,
       errors: [

--- a/packages/@stylexjs/eslint-plugin/src/stylex-sort-keys.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-sort-keys.js
@@ -46,6 +46,14 @@ type Stack = null | {
   numKeys: number,
 };
 
+type SortableProperty = {
+  node: Property,
+  name: string,
+  text: string,
+  rangeStart: number,
+  rangeEnd: number,
+};
+
 function isValidOrder(
   prevName: string,
   currName: string,
@@ -60,6 +68,18 @@ function isValidOrder(
   }
 
   return prevName <= currName;
+}
+
+function comparePropertyNames(
+  aName: string,
+  bName: string,
+  order: Schema['order'],
+): number {
+  if (aName === bName) {
+    return 0;
+  }
+
+  return isValidOrder(aName, bName, order) ? -1 : 1;
 }
 
 const stylexSortKeys = {
@@ -212,7 +232,6 @@ const stylexSortKeys = {
         }
 
         const prevName = stack.prevName;
-        const prevNode = stack?.prevNode;
         const numKeys = stack.numKeys;
         const currName = getPropertyName(node);
         let isBlankLineBetweenNodes = stack?.prevBlankLine;
@@ -282,9 +301,10 @@ const stylexSortKeys = {
             message: `StyleX property key "${currName}" should be above "${prevName}"`,
             // $FlowFixMe[incompatible-type]
             fix: createFix({
-              prevNode: prevNode as $FlowFixMe,
               currNode: node as $FlowFixMe,
               sourceCode,
+              order,
+              allowLineSeparatedGroups,
             }),
           });
         }
@@ -305,87 +325,184 @@ const stylexSortKeys = {
 
 function createFix({
   currNode,
-  prevNode,
   sourceCode,
+  order,
+  allowLineSeparatedGroups,
 }: {
   currNode: Property,
-  prevNode: Property,
   sourceCode: SourceCode,
+  order: Schema['order'],
+  allowLineSeparatedGroups: boolean,
 }) {
   return function (fixer: RuleFixer) {
-    // Need to handle the case if there is white space between node and comment above
-    // This can be especially tricky if the "sort between space groups" option is turned on
-    const fixes = [];
+    const group = getSortableGroup(currNode);
 
-    // Retrieve comments before the previous node
-    const prevNodeCommentsBefore = getPropertyCommentsBefore(prevNode);
-
-    // Start node for the entire context with comments of prevNode
-    const prevNodeContextStartNode =
-      prevNodeCommentsBefore.length > 0 ? prevNodeCommentsBefore[0] : prevNode;
-
-    const { indentation: startNodeIndentation, isTokenBeforeSameLineAsNode } =
-      getNodeIndentation(prevNodeContextStartNode);
-
-    const prevNodeSameLineComment = getPropertySameLineComment(prevNode);
-
-    const tokenAfterPrevNode = sourceCode.getTokenAfter(prevNode, {
-      includeComments: false,
-    });
-
-    const prevNodeContextEndNode =
-      prevNodeSameLineComment ?? tokenAfterPrevNode;
-
-    if (!prevNodeContextEndNode?.range || !prevNodeContextStartNode.range) {
-      // Early return if range or prevNode doesn't exist
+    if (group.length < 2) {
       return [];
     }
 
-    const rangeStart =
-      prevNodeContextStartNode.range[0] - startNodeIndentation.length;
+    const sortedGroup = [...group].sort((a, b) => {
+      const result = comparePropertyNames(a.name, b.name, order);
 
-    const rangeEnd = prevNodeContextEndNode.range[1];
-
-    const textToMove = sourceCode.getText().slice(rangeStart, rangeEnd);
-
-    fixes.push(
-      fixer.removeRange([
-        // If previous token is not on the same line, we remove an extra char to account for newline
-        rangeStart - Number(!isTokenBeforeSameLineAsNode),
-        rangeEnd,
-      ]),
-    );
-
-    const currNodeSameLineComment = getPropertySameLineComment(currNode);
-
-    const tokenAfterCurrNode = sourceCode.getTokenAfter(currNode, {
-      includeComments: false,
+      return result === 0 ? group.indexOf(a) - group.indexOf(b) : result;
     });
 
-    const hasCommaAfterCurrNode =
-      tokenAfterCurrNode && isCommaToken(tokenAfterCurrNode);
-
-    if (!hasCommaAfterCurrNode) {
-      fixes.push(fixer.insertTextAfter(currNode, ','));
+    if (sortedGroup.every((item, index) => item === group[index])) {
+      return [];
     }
 
-    const newLine = isSameLine(prevNode, currNode) ? '' : '\n';
-    // If token after the current node is a comma then we insert after the comma
-    // Otherwise we insert after the current node because there is a guaranteed fix to add comma (above)
-    const fallbackNode =
-      hasCommaAfterCurrNode && tokenAfterCurrNode
-        ? tokenAfterCurrNode
-        : currNode;
+    const firstItem = group[0];
+    const lastItem = group[group.length - 1];
+    const replacementText = isInlineGroup(group)
+      ? getInlineReplacementText(sortedGroup, firstItem.text)
+      : sortedGroup.map((item) => item.text).join('\n');
 
-    fixes.push(
-      fixer.insertTextAfter(
-        currNodeSameLineComment ?? fallbackNode,
-        `${newLine}${textToMove}`,
-      ),
+    return fixer.replaceTextRange(
+      [firstItem.rangeStart, lastItem.rangeEnd],
+      replacementText,
     );
-
-    return fixes;
   };
+
+  function getSortableGroup(node: Property): SortableProperty[] {
+    const parent = (node as $FlowFixMe).parent;
+
+    if (!parent || parent.type !== 'ObjectExpression') {
+      return [];
+    }
+
+    const groups: Array<SortableProperty[]> = [];
+    let group: SortableProperty[] = [];
+
+    for (const property of parent.properties as $FlowFixMe) {
+      if (property.type !== 'Property') {
+        if (group.length > 0) {
+          groups.push(group);
+          group = [];
+        }
+        continue;
+      }
+
+      const name = getPropertyName(property);
+      if (name === null) {
+        if (group.length > 0) {
+          groups.push(group);
+          group = [];
+        }
+        continue;
+      }
+
+      const sortableProperty = getSortableProperty(property, name);
+      if (sortableProperty === null) {
+        if (group.length > 0) {
+          groups.push(group);
+          group = [];
+        }
+        continue;
+      }
+
+      if (
+        group.length > 0 &&
+        isGroupBoundary(group[group.length - 1], sortableProperty)
+      ) {
+        groups.push(group);
+        group = [];
+      }
+
+      group.push(sortableProperty);
+    }
+
+    if (group.length > 0) {
+      groups.push(group);
+    }
+
+    return (
+      groups.find((sortableGroup) =>
+        sortableGroup.some((item) => item.node === node),
+      ) ?? []
+    );
+  }
+
+  function getSortableProperty(
+    node: Property,
+    name: string,
+  ): SortableProperty | null {
+    const commentsBefore = getPropertyCommentsBefore(node);
+    const contextStartNode =
+      commentsBefore.length > 0 ? commentsBefore[0] : node;
+    const { indentation } = getNodeIndentation(contextStartNode);
+    const sameLineComment = getPropertySameLineComment(node);
+    const tokenAfterNode = sourceCode.getTokenAfter(node, {
+      includeComments: false,
+    });
+    const hasCommaAfterNode = tokenAfterNode && isCommaToken(tokenAfterNode);
+    const contextEndNode =
+      sameLineComment ?? (hasCommaAfterNode ? tokenAfterNode : node);
+    const contextStartRange = contextStartNode.range;
+    const contextEndRange = contextEndNode?.range;
+    const nodeRange = node.range;
+
+    if (!contextStartRange || !contextEndRange || !nodeRange) {
+      return null;
+    }
+
+    const rangeStart = contextStartRange[0] - indentation.length;
+    const rangeEnd = contextEndRange[1];
+    const sourceText = sourceCode.getText();
+    const commaInsertIndex = nodeRange[1] - rangeStart;
+    let text = sourceText.slice(rangeStart, rangeEnd);
+
+    if (!hasCommaAfterNode) {
+      text =
+        text.slice(0, commaInsertIndex) + ',' + text.slice(commaInsertIndex);
+    }
+
+    return {
+      node,
+      name,
+      text,
+      rangeStart,
+      rangeEnd,
+    };
+  }
+
+  function isGroupBoundary(
+    prevProperty: SortableProperty,
+    currProperty: SortableProperty,
+  ): boolean {
+    const textBetweenProperties = sourceCode
+      .getText()
+      .slice(prevProperty.rangeEnd, currProperty.rangeStart);
+
+    if (/[^ \t\r\n]/.test(textBetweenProperties)) {
+      return true;
+    }
+
+    return (
+      allowLineSeparatedGroups &&
+      /(?:\r?\n)[ \t]*(?:\r?\n)/.test(textBetweenProperties)
+    );
+  }
+
+  function isInlineGroup(group: SortableProperty[]): boolean {
+    const firstItem = group[0];
+    const lastItem = group[group.length - 1];
+
+    return !/[\r\n]/.test(
+      sourceCode.getText().slice(firstItem.rangeStart, lastItem.rangeEnd),
+    );
+  }
+
+  function getInlineReplacementText(
+    sortedGroup: SortableProperty[],
+    firstText: string,
+  ): string {
+    const leadingWhitespace = firstText.match(/^[ \t]*/)?.[0] ?? '';
+
+    return (
+      leadingWhitespace +
+      sortedGroup.map((item) => item.text.trimStart()).join(' ')
+    );
+  }
 
   function getEmptyLineCountBetweenNodes(
     aNode: Property | Comment,


### PR DESCRIPTION
## Summary
- sort each contiguous autofix-safe property segment instead of only swapping the current property with the previous one
- preserve blank-line groups, spreads, comments, and existing single-line/multiline formatting boundaries
- add regression coverage for the multi-property case from #787

Fixes #787.

## Testing
- npx -y -p node@22 -p yarn@1.22.22 yarn --ignore-engines jest __tests__/stylex-sort-keys-test.js --runInBand --no-coverage
- npx -y -p node@22 -p yarn@1.22.22 yarn --ignore-engines eslint packages/@stylexjs/eslint-plugin/src/stylex-sort-keys.js packages/@stylexjs/eslint-plugin/__tests__/stylex-sort-keys-test.js
- npx -y -p node@22 -p yarn@1.22.22 yarn --ignore-engines flow check --show-all-errors
- git diff --check