### PR TITLE
[eslint-plugin] Add gap auto-fix for legacy-expand-shorthands and skip single-value gap in valid-shorthands

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -498,6 +498,61 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       })
     `,
     },
+    // gap: single value is not a shorthand, no expansion needed
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            gap: '10px',
+          },
+        });
+      `,
+    },
+    // gap: single numeric value is not a shorthand
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            gap: 10,
+          },
+        });
+      `,
+    },
+    // gap: numeric zero is not a shorthand
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            gap: 0,
+          },
+        });
+      `,
+    },
+    // gap: var() single value is not a shorthand
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            gap: 'var(--spacing)',
+          },
+        });
+      `,
+    },
+    // gap: calc() single value is not a shorthand
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            gap: 'calc(10px + 1rem)',
+          },
+        });
+      `,
+    },
   ],
   invalid: [
     {
@@ -2417,136 +2472,6 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         {
           message:
             'Property shorthands using multiple values like "flex: 1 1 calc(100% - 20px)" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // gap: single value expands to rowGap + columnGap
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            gap: '10px',
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            rowGap: '10px',
-            columnGap: '10px',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "gap: 10px" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // gap: single numeric value expands to rowGap + columnGap
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            gap: 10,
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            rowGap: 10,
-            columnGap: 10,
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "gap: 10" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // gap: numeric zero expands to rowGap + columnGap
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            gap: 0,
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            rowGap: 0,
-            columnGap: 0,
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "gap: 0" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // gap: var() value expands to rowGap + columnGap
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            gap: 'var(--spacing)',
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            rowGap: 'var(--spacing)',
-            columnGap: 'var(--spacing)',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "gap: var(--spacing)" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // gap: calc() value expands to rowGap + columnGap
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            gap: 'calc(10px + 1rem)',
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            rowGap: 'calc(10px + 1rem)',
-            columnGap: 'calc(10px + 1rem)',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "gap: calc(10px + 1rem)" are not supported in StyleX. Separate into individual properties.',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
@@ -204,6 +204,18 @@ const stylexValidShorthands = {
         return;
       }
 
+      if (
+        key === 'gap' &&
+        newValues.length === 2 &&
+        newValues.every(
+          ([, val]) =>
+            val === property.value.value ||
+            val === Number(property.value.value),
+        )
+      ) {
+        return;
+      }
+
       context.report({
         node: property,
         message: `Property shorthands using multiple values like "${key}: ${String(property.value.value)}" are not supported in StyleX. Separate into individual properties.`,

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -86,6 +86,7 @@ const showError =
 const shorthandExpansionMap: { [string]: string } = {
   animation: 'animation',
   font: 'font',
+  gap: 'gap',
   gridArea: 'grid-area',
   gridColumn: 'grid-column',
   gridRow: 'grid-row',


### PR DESCRIPTION
## What changed / motivation ?

Two changes to the eslint-plugin's `gap` handling:

1. **Add `gap` to `shorthandExpansionMap` in `valid-styles`** — enables the auto-fixer to expand `gap` to `rowGap`/`columnGap` when `styleResolution: 'legacy-expand-shorthands'` or `banPropsForLegacy` is active. No impact on users who don't opt into legacy mode — the auto-fix path is already gated behind `isLegacyExpandShorthands`.

2. **Skip single-value `gap` in `valid-shorthands`** — `gap: 10px` is a valid CSS property, not a multi-value shorthand. Previously, the rule would flag it and expand to `rowGap: 10px` + `columnGap: 10px`, which is unnecessary. Multi-value `gap` (e.g., `gap: 10px 20px`) still correctly expands. `gridGap` single-value expansion is unchanged since `gridGap` is a deprecated property name.

## Linked PR/Issues

n/a

## Additional Context

All 546 eslint-plugin tests pass. 5 single-value `gap` test cases moved from `invalid` to `valid` in the `valid-shorthands` test suite.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code