### PR TITLE
[eslint-plugin] Skip single-value flex in valid-shorthands

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -553,6 +553,55 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         });
       `,
     },
+    // flex: single values are valid (not multi-value shorthands)
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: { flex: 1 },
+      })
+    `,
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: { flex: '2' },
+      })
+    `,
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: { flex: 'auto' },
+      })
+    `,
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: { flex: 'none' },
+      })
+    `,
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: { flex: 'initial' },
+      })
+    `,
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: { flex: '100px' },
+      })
+    `,
+    },
   ],
   invalid: [
     {
@@ -2177,168 +2226,6 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         },
       ],
     },
-    // flex: single number expands to grow/shrink/basis
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            flex: 1,
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            flexGrow: '1',
-            flexShrink: '1',
-            flexBasis: '0%',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "flex: 1" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // flex: string single number
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            flex: '2',
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            flexGrow: '2',
-            flexShrink: '1',
-            flexBasis: '0%',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "flex: 2" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // flex: auto keyword
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            flex: 'auto',
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            flexGrow: '1',
-            flexShrink: '1',
-            flexBasis: 'auto',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "flex: auto" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // flex: none keyword
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            flex: 'none',
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            flexGrow: '0',
-            flexShrink: '0',
-            flexBasis: 'auto',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "flex: none" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // flex: initial keyword
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            flex: 'initial',
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            flexGrow: '0',
-            flexShrink: '1',
-            flexBasis: 'auto',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "flex: initial" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // flex: single basis value (with unit)
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            flex: '100px',
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            flexGrow: '1',
-            flexShrink: '1',
-            flexBasis: '100px',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "flex: 100px" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
     // flex: two numbers (grow shrink)
     {
       code: `
@@ -2527,6 +2414,32 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         },
       ],
     },
+    // gridGap: single numeric value expands to rowGap + columnGap
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            gridGap: 10,
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            rowGap: 10,
+            columnGap: 10,
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "gridGap: 10" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
     // gridGap: two values splits to rowGap + columnGap
     {
       code: `
@@ -2679,32 +2592,6 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         {
           message:
             'Property shorthands using multiple values like "gap: 10px 20px !important" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // gridGap: single numeric value expands to rowGap + columnGap
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            gridGap: 10,
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            rowGap: 10,
-            columnGap: 10,
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "gridGap: 10" are not supported in StyleX. Separate into individual properties.',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
@@ -15,7 +15,7 @@ import {
   createSpecificTransformer,
   createDirectionalTransformer,
 } from './utils/splitShorthands.js';
-import { CANNOT_FIX } from './utils/splitShorthands.js';
+import { CANNOT_FIX, isSingleToken } from './utils/splitShorthands.js';
 import getSourceCode from './utils/getSourceCode';
 import getNodeIndentation from './utils/getNodeIndentation';
 import createImportTracker from './utils/createImportTracker';
@@ -184,6 +184,10 @@ const stylexValidShorthands = {
 
       const v = property.value.value;
       if (typeof v !== 'string' && typeof v !== 'number') {
+        return;
+      }
+
+      if (key === 'flex' && isSingleToken(String(v))) {
         return;
       }
 

--- a/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
@@ -1391,3 +1391,9 @@ export function splitDirectionalShorthands(
 
   return nodes;
 }
+
+export function isSingleToken(value: string): boolean {
+  const { value: baseValue } = extractImportant(value);
+  const { parts } = splitTopLevelValueTokens(baseValue);
+  return parts.length <= 1;
+}


### PR DESCRIPTION
## What changed / motivation ?

Single-value `flex` usages (`flex: 1`, `flex: 'auto'`, `flex: 'none'`) are incorrectly flagged as errors by `valid-shorthands`, with an autofix that expands them to `flexGrow`/`flexShrink`/`flexBasis`. This is inconsistent with the rule's stated purpose — enforcing single-value shorthands and longhands over multi-value shorthands — and inconsistent with how every other property in the rule behaves (`border: 'none'`, `margin: '8px'` are both allowed).

The root cause is the same as the gap issue fixed in #1668: the `flex` shorthand alias expands even single values (e.g. `flex: 1` → `flexGrow`/`flexShrink`/`flexBasis`). Unlike other shorthands where a single value passes through unchanged, `flex: 1` expands to different values, so the existing same-key same-value check doesn't catch it. The post-transformer approach used in #1668 for gap doesn't work here either — gap's two output values happen to equal the original input, but flex's three output values don't.

This PR adds an `isSingleToken` utility to `splitShorthands.js` that checks whether a CSS value is a single top-level token before calling the transformer. It correctly handles `var()`, `calc()`, and `!important`. Multi-value `flex` (`flex: '1 0 auto'`, `flex: '1 0'`) still correctly flags and expands.

## Linked PR/Issues

Follow-up to #1537, #1668.

## Additional Context

6 single-value `flex` test cases moved from `invalid` to `valid`. All 546 tests pass.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code