### PR TITLE
[workflows] update stale Node.js version requirement in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Fork, then clone the repo:
 git clone https://github.com/your-username/stylex.git
 ```
 
-Make sure you have yarn@1.22 and node@>=16 installed. Then install the package
+Make sure you have yarn@1.22 and node@>=18 installed. Then install the package
 dependencies:
 
 ```


### PR DESCRIPTION
## What changed / motivation ?

Updated the minimum Node.js version requirement in `CONTRIBUTING.md` from `>=16` to `>=18`. Current project dependencies (such as `expect@30.2.0`) are incompatible with Node 16 and cause a hard failure during `yarn install`.

<img width="2286" height="146" alt="image" src="https://github.com/user-attachments/assets/aa2236f3-8db1-4f1b-90b2-677846a72257" />


## Linked PR/Issues

Fixes #1671

## Additional Context

Documentation-only change. No code or test updates required.

## Pre-flight checklist

* [x] I have read the contributing guidelines
[[Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
* [x] Performed a self-review of my code