### PR TITLE
[babel-plugin] Fix sx runtime stylex import injection

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
@@ -10,11 +10,25 @@
 jest.autoMockOff();
 
 import { transformSync } from '@babel/core';
+import flow from '@babel/plugin-syntax-flow';
 import jsx from '@babel/plugin-syntax-jsx';
+import typescript from '@babel/plugin-syntax-typescript';
 import stylexPlugin from '../src/index';
 import path from 'path';
 
 function transform(source, opts = {}) {
+  return transformWithSyntaxPlugins(source, [flow, jsx], opts);
+}
+
+function transformTypeScript(source, opts = {}) {
+  return transformWithSyntaxPlugins(
+    source,
+    [jsx, [typescript, { allExtensions: true, isTSX: true }]],
+    { filename: 'test.tsx', ...opts },
+  );
+}
+
+function transformWithSyntaxPlugins(source, syntaxPlugins, opts = {}) {
   return transformSync(source, {
     filename: opts.filename,
     parserOpts: {
@@ -23,7 +37,7 @@ function transform(source, opts = {}) {
     },
     babelrc: false,
     plugins: [
-      jsx,
+      ...syntaxPlugins,
       [
         stylexPlugin,
         {
@@ -306,6 +320,183 @@ describe('@stylexjs/babel-plugin', () => {
             return <div className="color-x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4">Hello World</div>;
           }"
         `);
+      });
+
+      describe('sx attribute runtime binding', () => {
+        test('injects a value namespace import alongside a type namespace import', () => {
+          expect(
+            transformTypeScript(`
+              import type * as stylex from '@stylexjs/stylex';
+              function Foo(props) {
+                const x = props.x;
+                return <svg sx={x} />;
+              }
+            `),
+          ).toMatchInlineSnapshot(`
+            "import * as _stylex from "@stylexjs/stylex";
+            import type * as stylex from '@stylexjs/stylex';
+            function Foo(props) {
+              const x = props.x;
+              return <svg {..._stylex.props(x)} />;
+            }"
+          `);
+        });
+
+        test('injects a value namespace import alongside a named type import', () => {
+          expect(
+            transform(`
+              import type { StyleXStyles } from '@stylexjs/stylex';
+              function Foo(props) {
+                const x = props.x;
+                return <svg sx={x} />;
+              }
+            `),
+          ).toMatchInlineSnapshot(`
+            "import * as _stylex from "@stylexjs/stylex";
+            import type { StyleXStyles } from '@stylexjs/stylex';
+            function Foo(props) {
+              const x = props.x;
+              return <svg {..._stylex.props(x)} />;
+            }"
+          `);
+        });
+
+        test('injects a value namespace import when there is no stylex import', () => {
+          expect(
+            transform(`
+              function Foo(props) {
+                const x = props.x;
+                return <svg sx={x} />;
+              }
+            `),
+          ).toMatchInlineSnapshot(`
+            "import * as stylex from "@stylexjs/stylex";
+            function Foo(props) {
+              const x = props.x;
+              return <svg {...stylex.props(x)} />;
+            }"
+          `);
+        });
+
+        test('injects from configured import source when there is no stylex import', () => {
+          expect(
+            transform(
+              `
+                function Foo(props) {
+                  const x = props.x;
+                  return <svg sx={x} />;
+                }
+              `,
+              { importSources: ['custom-stylex-path'] },
+            ),
+          ).toMatchInlineSnapshot(`
+            "import * as stylex from "custom-stylex-path";
+            function Foo(props) {
+              const x = props.x;
+              return <svg {...stylex.props(x)} />;
+            }"
+          `);
+        });
+
+        test('injects from existing type-only custom import source', () => {
+          expect(
+            transform(
+              `
+                import type { StyleXStyles } from 'custom-stylex-path';
+                function Foo(props) {
+                  const x = props.x;
+                  return <svg sx={x} />;
+                }
+              `,
+              { importSources: ['custom-stylex-path'] },
+            ),
+          ).toMatchInlineSnapshot(`
+            "import * as _stylex from "custom-stylex-path";
+            import type { StyleXStyles } from 'custom-stylex-path';
+            function Foo(props) {
+              const x = props.x;
+              return <svg {..._stylex.props(x)} />;
+            }"
+          `);
+        });
+
+        test('reuses an existing value namespace import', () => {
+          expect(
+            transform(`
+              import * as stylex from '@stylexjs/stylex';
+              function Foo(props) {
+                const x = props.x;
+                return <svg sx={x} />;
+              }
+            `),
+          ).toMatchInlineSnapshot(`
+            "import * as stylex from '@stylexjs/stylex';
+            function Foo(props) {
+              const x = props.x;
+              return <svg {...stylex.props(x)} />;
+            }"
+          `);
+        });
+
+        test('avoids a local stylex binding that would shadow the injected import', () => {
+          expect(
+            transform(`
+              function Foo(props) {
+                const stylex = props.stylex;
+                const x = props.x;
+                return <svg sx={x} />;
+              }
+            `),
+          ).toMatchInlineSnapshot(`
+            "import * as _stylex from "@stylexjs/stylex";
+            function Foo(props) {
+              const stylex = props.stylex;
+              const x = props.x;
+              return <svg {..._stylex.props(x)} />;
+            }"
+          `);
+        });
+
+        test('injects one value namespace import for multiple sx attributes', () => {
+          expect(
+            transform(`
+              function Foo(props) {
+                const x = props.x;
+                return (
+                  <>
+                    <svg sx={x} />
+                    <svg sx={props.y} />
+                  </>
+                );
+              }
+            `),
+          ).toMatchInlineSnapshot(`
+            "import * as stylex from "@stylexjs/stylex";
+            function Foo(props) {
+              const x = props.x;
+              return <>
+                                <svg {...stylex.props(x)} />
+                                <svg {...stylex.props(props.y)} />
+                              </>;
+            }"
+          `);
+        });
+
+        test('does not transform sx on capitalized components', () => {
+          expect(
+            transform(`
+              function Foo(props) {
+                const x = props.x;
+                return <CustomComponent sx={x} />;
+              }
+            `),
+          ).toMatchInlineSnapshot(`
+            "function Foo(props) {
+              const x = props.x;
+              return <CustomComponent sx={x} />;
+            }"
+          `);
+        });
       });
 
       test('local dynamic styles', () => {

--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -44,7 +44,7 @@ import transformStyleXCreateThemeNested from './visitors/stylex-create-theme-nes
 import { createUtilityStylesVisitor } from '@stylexjs/atoms/babel-transform';
 import { convertObjectToAST } from './utils/js-to-ast';
 import styleXCreateSet from './shared/stylex-create';
-import { hoistExpression } from './utils/ast-helpers';
+import { getProgramPath, hoistExpression } from './utils/ast-helpers';
 import { injectDevClassNames } from './utils/dev-classname';
 
 const NAME = 'stylex';
@@ -409,7 +409,10 @@ function getStylexRuntimeBinding(
   path: NodePath<t.JSXOpeningElement>,
   state: StateManager,
 ): string {
-  const program = path.scope.getProgramParent().path;
+  const program = getProgramPath(path);
+  if (program == null) {
+    throw new Error('Unable to find program path for JSX element.');
+  }
 
   for (const localName of state.stylexImport) {
     const programBinding = program.scope.getBinding(localName);

--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -332,11 +332,12 @@ function styleXTransform(): PluginObj<> {
           if (value.isJSXEmptyExpression()) {
             continue;
           }
+          const stylexLocalName = getStylexRuntimeBinding(path, state);
           attr.replaceWith(
             t.jsxSpreadAttribute(
               t.callExpression(
                 t.memberExpression(
-                  t.identifier('stylex'),
+                  t.identifier(stylexLocalName),
                   t.identifier('props'),
                 ),
                 [value.node],
@@ -402,6 +403,50 @@ function isExported(path: null | NodePath<t.Node>): boolean {
     return true;
   }
   return isExported(path.parentPath);
+}
+
+function getStylexRuntimeBinding(
+  path: NodePath<t.JSXOpeningElement>,
+  state: StateManager,
+): string {
+  const program = path.scope.getProgramParent().path;
+
+  for (const localName of state.stylexImport) {
+    const programBinding = program.scope.getBinding(localName);
+    if (
+      programBinding != null &&
+      path.scope.getBinding(localName) === programBinding
+    ) {
+      return localName;
+    }
+  }
+
+  const existingImport = program.node.body.find(
+    (statement) =>
+      statement.type === 'ImportDeclaration' &&
+      state.importSources.includes(statement.source.value),
+  );
+  const existingImportSource =
+    existingImport?.type === 'ImportDeclaration'
+      ? existingImport.source.value
+      : null;
+  const importSource =
+    existingImportSource ?? state.importSources[2] ?? state.importSources[0];
+  const stylexLocalName =
+    existingImportSource != null || path.scope.hasBinding('stylex')
+      ? program.scope.generateUid('stylex')
+      : 'stylex';
+
+  const [importPath] = program.unshiftContainer(
+    'body',
+    t.importDeclaration(
+      [t.importNamespaceSpecifier(t.identifier(stylexLocalName))],
+      t.stringLiteral(importSource),
+    ),
+  );
+  program.scope.registerDeclaration(importPath);
+  state.stylexImport.add(stylexLocalName);
+  return stylexLocalName;
 }
 
 /**

--- a/packages/@stylexjs/babel-plugin/src/utils/ast-helpers.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/ast-helpers.js
@@ -64,7 +64,7 @@ export function pathReplaceHoisted(
   path.replaceWith(nameIdent);
 }
 
-function getProgramPath(path: NodePath<>): ?NodePath<t.Program> {
+export function getProgramPath(path: NodePath<>): ?NodePath<t.Program> {
   let programPath = path;
   while (programPath != null && !programPath.isProgram()) {
     if (programPath.parentPath) {


### PR DESCRIPTION
## What changed / motivation ?

Fixes `sx` JSX transforms for intrinsic elements when a file has only type-only StyleX imports or no StyleX import at all. The Babel plugin now ensures a value-level StyleX namespace import exists before emitting `stylex.props(...)`, reuses existing runtime imports, and respects configured import sources.

## Linked PR/Issues

Fixes https://github.com/facebook/stylex/issues/1676

## Additional Context

n/a

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code