### PR TITLE
Fix outlineWidth calc validation

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -922,6 +922,22 @@ eslintTester.run('stylex-valid-styles', rule.default, {
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           foo: {
+            outlineWidth: 'calc(0.25rem + 1px)',
+          },
+          hover: {
+            outlineWidth: {
+              default: 'calc(0.25rem + 1px)',
+              ':hover': 'calc(0.5rem + 1px)',
+            },
+          },
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          foo: {
             outlineOffset: 2,
           },
         });

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -2077,7 +2077,7 @@ const CSSProperties = {
     'inset',
     'outset',
   ) as RuleCheck,
-  outlineWidth: makeUnionRule(isNumber, isLength) as RuleCheck,
+  outlineWidth: borderWidth,
   blockOverflow: overflow, // TODO - Add support to Babel Plugin
   inlineOverflow: overflow, // TODO - Add support to Babel Plugin
   overflow: overflow,


### PR DESCRIPTION
## What changed / motivation ?

Allow `outlineWidth` to use the same width validator as border widths, which accepts CSS length expressions like `calc(...)` while continuing to reject numeric strings such as `"10"`.

Added a focused regression test covering direct `outlineWidth: 'calc(...)'` and nested pseudoselector value syntax.

## Linked PR/Issues

Fixes #1690

## Additional Context

Tests run:

- `npm test --workspace @stylexjs/eslint-plugin -- --runTestsByPath __tests__/stylex-valid-styles-test.js --runInBand --coverage=false`
- `npx prettier --check packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js`
- `npx eslint packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js`
- `git diff --check`
- `npm run build --workspace @stylexjs/eslint-plugin`

Note: `yarn install --frozen-lockfile` installed dependencies and began the repo postinstall build, but the full monorepo build timed out while building docs after `@stylexjs/eslint-plugin` had built successfully.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
