### PR TITLE
Update copyright year to 2026 in Footer component

### DIFF
--- a/packages/docs/src/components/Footer.tsx
+++ b/packages/docs/src/components/Footer.tsx
@@ -68,6 +68,7 @@ export default function Footer({
 }: {
   noBorderTop?: boolean;
 }) {
+
   return (
     <footer
       {...stylex.props(styles.footer, noBorderTop && styles.footerNoBorder)}
@@ -166,7 +167,7 @@ export default function Footer({
 
         <div {...stylex.props(styles.bottom)}>
           <span {...stylex.props(styles.copyright)}>
-            Copyright © 2026 Meta Platforms, Inc.
+            Copyright © {new Date().getFullYear()} Meta Platforms, Inc.
           </span>
 
           <div {...stylex.props(styles.bottomSpacer)} />

--- a/packages/docs/src/components/Footer.tsx
+++ b/packages/docs/src/components/Footer.tsx
@@ -166,7 +166,7 @@ export default function Footer({
 
         <div {...stylex.props(styles.bottom)}>
           <span {...stylex.props(styles.copyright)}>
-            Copyright © 2025 Meta Platforms, Inc.
+            Copyright © 2026 Meta Platforms, Inc.
           </span>
 
           <div {...stylex.props(styles.bottomSpacer)} />

--- a/packages/docs/src/components/Footer.tsx
+++ b/packages/docs/src/components/Footer.tsx
@@ -68,7 +68,6 @@ export default function Footer({
 }: {
   noBorderTop?: boolean;
 }) {
-
   return (
     <footer
       {...stylex.props(styles.footer, noBorderTop && styles.footerNoBorder)}


### PR DESCRIPTION
## What changed / motivation ?

2025 in footer updated to 2026 to reflect actual current year. 

## Linked PR/Issues

Fixes #1693 

## Additional Context

<img width="522" height="78" alt="image" src="https://github.com/user-attachments/assets/07793331-e7ed-43cd-b691-fdbbc6dd73c2" />


Screenshot attached 

## Pre-flight checklist

- [X] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [X] Performed a self-review of my code