### PR TITLE
[babel-plugin] add constKey/constVal to Rule type

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/index.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/index.d.ts
@@ -38,7 +38,16 @@ declare function stylexPluginWithOptions(
  *
  * End-users can choose to not use this function and use their own logic instead.
  */
-export type Rule = [string, { ltr: string; rtl?: null | string }, number];
+export type Rule = [
+  string,
+  {
+    ltr: string;
+    rtl?: null | string;
+    constKey?: string;
+    constVal?: string | number;
+  },
+  number,
+];
 declare function processStylexRules(
   rules: Array<Rule>,
   config?:


### PR DESCRIPTION
## What changed / motivation ?

The hand-written `packages/@stylexjs/babel-plugin/src/index.d.ts` types a `Rule`'s object as `{ ltr: string; rtl?: null | string }`, but the Flow source (`src/index.js`) also declares optional `constKey` / `constVal` (used by `defineConsts` rules). Consumers reading the rule objects passed to `processStylexRules` can't access those fields without casting.

This adds `constKey?` / `constVal?` to the `.d.ts` so it matches the Flow source of truth.

## Linked PR/Issues

Extracted from #1322, which bundles this same fix into a broader CJS-compat restructure — pulling the type change out so it can land on its own.

## Additional Context

Type-only change. `prettier --check` passes, and the added fields match the existing Flow `Rule` type in `src/index.js`.

## Pre-flight checklist

- [x] I have read the contributing guidelines [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
