### PR TITLE
[eslint-plugin] valid-styles support for scroll timeline & webkit app region

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -522,6 +522,15 @@ eslintTester.run('stylex-valid-styles', rule.default, {
      })`,
     `import * as stylex from '@stylexjs/stylex';
      stylex.create({
+       default: {
+         scrollTimeline: '--main-scroll block',
+         scrollTimelineAxis: 'inline',
+         scrollTimelineName: '--main-scroll',
+         WebkitAppRegion: 'drag',
+       },
+     })`,
+    `import * as stylex from '@stylexjs/stylex';
+     stylex.create({
        a: {
          interpolateSize: 'numeric-only',
        },

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -1183,6 +1183,12 @@ const scrollSnapType: RuleCheck = makeUnionRule(
   makeLiteralRule('x mandatory'),
   makeLiteralRule('y mandatory'),
 );
+const scrollTimelineAxis: RuleCheck = makeUnionRule(
+  makeLiteralRule('block'),
+  makeLiteralRule('inline'),
+  makeLiteralRule('x'),
+  makeLiteralRule('y'),
+);
 const shapeImageThreshold: RuleCheck = isStringOrNumber;
 const shapeOutside: RuleCheck = makeUnionRule(
   makeLiteralRule('none'),
@@ -2161,6 +2167,9 @@ const CSSProperties = {
   scrollSnapAlign: scrollSnapAlign,
   scrollSnapType: scrollSnapType,
   scrollSnapStop: makeUnionRule('normal', 'always') as RuleCheck,
+  scrollTimeline: isString,
+  scrollTimelineAxis: scrollTimelineAxis,
+  scrollTimelineName: isString,
 
   // scrollMargin: makeUnionRule(isNumber, isString),
   scrollMarginBlockEnd: makeUnionRule(isNumber, isString) as RuleCheck,

--- a/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.js
@@ -958,6 +958,7 @@ type OptionalArray<T> = Array<T> | T;
 export type SupportedVendorSpecificCSSProperties = Readonly<{
   MozOsxFontSmoothing?: null | 'grayscale',
   WebkitAppearance?: null | appearance,
+  WebkitAppRegion?: null | 'drag' | 'no-drag',
   WebkitFontSmoothing?: null | 'antialiased',
   WebkitTapHighlightColor?: null | color,
 }>;
@@ -969,6 +970,7 @@ export type CSSProperties = Readonly<{
   // ...$Exact<SupportedVendorSpecificCSSProperties>, for TypeScript compatibility
   MozOsxFontSmoothing?: all | 'grayscale',
   WebkitAppearance?: all | appearance,
+  WebkitAppRegion?: all | 'drag' | 'no-drag',
   WebkitFontSmoothing?: all | 'antialiased',
   WebkitTapHighlightColor?: all | color,
 


### PR DESCRIPTION
## What changed / motivation ?

Add valid-styles support for scroll timeline & webkit app region

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code