### PR TITLE
[chore] Update babel-plugin common-types.d.ts

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts
@@ -40,17 +40,23 @@ export type StyleXOptions = Readonly<{
   classNamePrefix: string;
   debug: null | undefined | boolean;
   definedStylexCSSVariables?: { [key: string]: unknown };
+  env?: Readonly<{ [$$Key$$: string]: any }>;
   dev: boolean;
   propertyValidationMode?: 'throw' | 'warn' | 'silent';
   enableDebugClassNames?: null | undefined | boolean;
   enableDebugDataProp?: null | undefined | boolean;
   enableDevClassNames?: null | undefined | boolean;
   enableFontSizePxToRem?: null | undefined | boolean;
+  enableInlinedConditionalMerge?: null | undefined | boolean;
   enableMediaQueryOrder?: null | undefined | boolean;
   enableLegacyValueFlipping?: null | undefined | boolean;
   enableLogicalStylesPolyfill?: null | undefined | boolean;
   enableLTRRTLComments?: null | undefined | boolean;
   enableMinifiedKeys?: null | undefined | boolean;
+  importSources?: ReadonlyArray<
+    string | Readonly<{ from: string; as: string }>
+  >;
+  treeshakeCompensation?: boolean;
   styleResolution:
     | 'application-order'
     | 'property-specificity'


### PR DESCRIPTION
## What changed / motivation ?

The DTS file at `packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts` has become outdated. Update it against the latest in `packages/@stylexjs/babel-plugin/src/shared/common-types.js`.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code