### PR TITLE
fix: stylex.attrs doesn't work with dynamic styles when using multi-word properties

### DIFF
--- a/packages/@stylexjs/stylex/__tests__/stylex-test.js
+++ b/packages/@stylexjs/stylex/__tests__/stylex-test.js
@@ -317,6 +317,7 @@ describe('stylex', () => {
             marginTop: '10px',
             opacity: 0.5,
             '--foo': 2,
+            '--fooBar': 3,
             MsTransition: 'none',
             WebkitTapHighlightColor: 'transparent',
           },
@@ -325,7 +326,7 @@ describe('stylex', () => {
         {
           "class": "backgroundColor-red",
           "data-style-src": "components/Foo.react.js:1",
-          "style": "color:red;margin-top:10px;opacity:0.5;--foo:2;-ms-transition:none;-webkit-tap-highlight-color:transparent",
+          "style": "color:red;margin-top:10px;opacity:0.5;--foo:2;--fooBar:3;-ms-transition:none;-webkit-tap-highlight-color:transparent",
         }
       `);
     });

--- a/packages/@stylexjs/stylex/src/stylex.js
+++ b/packages/@stylexjs/stylex/src/stylex.js
@@ -193,7 +193,13 @@ export function attrs(
   }
   if (style != null) {
     result.style = Object.entries(style)
-      .map(([key, value]) => `${toKebabCase(key)}:${value}`)
+      .map(([key, value]) => {
+        if (key.startsWith('--')) {
+          return `${key}:${value}`;
+        }
+
+        return `${toKebabCase(key)}:${value}`;
+      })
       .join(';');
   }
   if (dataStyleSrc != null) {


### PR DESCRIPTION
fix: [stylex.attrs doesn't work with dynamic styles when using multi-word properties](https://github.com/facebook/stylex/issues/1709)

## What changed / motivation ?

exclude generated custom properties set in style prop/attr from being converted to kebab case, to sync with the ones used in generated CSS.

## Linked PR/Issues

Fixes [#1709](https://github.com/facebook/stylex/issues/1709)

## Additional Context

[Issue reproduction](https://github.com/chbybnwr/stylex-issues-1709)

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code