### PR TITLE
[ci] group Dependabot updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# Dependabot configuration
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# `groups` bundles all updates for an ecosystem into a SINGLE pull request
+# instead of one PR per dependency. This applies to both version updates and
+# (when "Grouped security updates" is enabled in repo settings) security
+# updates.
+#
+# NOTE: severity filtering (e.g. "only critical") is NOT configurable here —
+# it is set via repo Settings > Code security > Dependabot auto-triage rules.
+version: 2
+updates:
+  # JavaScript/TypeScript dependencies across the monorepo (root + workspaces).
+  - package-ecosystem: 'npm'
+    directories:
+      - '/'
+      - '/packages/**'
+      - '/examples/**'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    groups:
+      npm-dependencies:
+        patterns:
+          - '*'
+
+  # GitHub Actions used in .github/workflows.
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` so Dependabot bundles updates into **one grouped PR per ecosystem** instead of one PR per dependency.

- **npm** (root + `packages/**` + `examples/**`): all updates → a single `npm-dependencies` PR
- **github-actions**: all updates → a single `github-actions` PR

The repo currently has no Dependabot config, so security updates open one PR each (16 open right now). `groups` collapses those into a single PR. Grouping also applies to security updates when **Grouped security updates** is enabled in repo settings.

## What this does NOT do — severity filtering ("critical only")

There is **no `dependabot.yml` option to filter by severity**, and no public API for it. To only get fixes for the most critical issues, a repo **admin** must add a Dependabot **auto-triage rule**:

1. Repo **Settings → Code security → Dependabot** → **Auto-triage rules** → **New rule**
2. Condition: severity **is one of** `Low`, `Medium`, `High` → action **Dismiss** (or "Snooze until patch")
3. Result: only `Critical` alerts stay open, so Dependabot only opens (grouped) security PRs for them.

And to group the existing **security** PRs (not just version updates):
- **Settings → Code security → Dependabot** → enable **Grouped security updates**.

(Current alert counts: 6 critical, 48 high, 43 medium, 3 low.)
