### PR TITLE
[eslint-plugin] accept numeric values for grid line properties

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -22,6 +22,20 @@ const eslintTester = new ESLintTester({
 
 eslintTester.run('stylex-valid-styles', rule.default, {
   valid: [
+    // issue #1701 — numeric values are valid for grid line properties
+    `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        foo: {
+          gridColumn: 1,
+          gridColumnStart: 1,
+          gridColumnEnd: 3,
+          gridRow: 2,
+          gridRowStart: -1,
+          gridRowEnd: 4,
+        }
+      });
+    `,
     // test for local static variables
     `
       import * as stylex from '@stylexjs/stylex';

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -329,7 +329,11 @@ const absoluteSize: RuleCheck = makeUnionRule(
   makeLiteralRule('xx-large'),
 );
 const fontFamily: RuleCheck = isString;
-const gridLine: RuleCheck = makeUnionRule(makeLiteralRule('auto'), isString);
+const gridLine: RuleCheck = makeUnionRule(
+  makeLiteralRule('auto'),
+  isString,
+  isNumber,
+);
 const gridTemplate: RuleCheck = makeUnionRule(
   makeLiteralRule('none'),
   makeLiteralRule('subgrid'),


### PR DESCRIPTION
## What changed / motivation ?

The `stylex-valid-styles` rule rejected numeric literals for grid line properties, even though they are valid CSS. Writing `gridColumnStart: 1` triggered a lint error:

> gridColumnStart value must be one of: auto, a string literal, null, initial, inherit, unset, revert

This happened because the shared `gridLine` rule in `cssProperties.js` only permitted `auto` and string values, not numbers.

This change adds `isNumber` to the `gridLine` rule. Because all six grid line properties — `gridColumn`, `gridColumnStart`, `gridColumnEnd`, `gridRow`, `gridRowStart`, `gridRowEnd` (and `gridArea`) — derive from `gridLine`, the single change fixes them all. This mirrors the existing `zIndex` rule, which already uses `makeUnionRule(makeLiteralRule('auto'), isNumber)`, and follows the precedent set in #1522 / #1523 for accepting bare numbers.

## Linked PR/Issues

Fixes #1701

## Additional Context

Added valid test cases covering numeric values for all affected properties, including a negative integer (`gridRowStart: -1`), which is valid for grid lines. Full plugin suite passes (548 tests).

## Pre-flight checklist

- [x] I have read the contributing guidelines
- [x] Performed a self-review of my code
