### PR TITLE
[babel-plugin] Fix corrupted class names from null coercion in dynamic styles

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/evaluation-import-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/evaluation-import-test.js
@@ -402,7 +402,7 @@ describe('Evaluation of imported values works based on configuration', () => {
         });
         const styles = {
           color: color => [{
-            "--__hashed_var__1jqb1tb": color != null ? "__hashed_var__1w8wjxo" : color,
+            "--__hashed_var__1jqb1tb": color != null ? "__hashed_var__1w8wjxo" : "",
             $$css: true
           }, {
             "--x---__hashed_var__1jqb1tb": color != null ? color : undefined

--- a/packages/@stylexjs/babel-plugin/__tests__/evaluation-import-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/evaluation-import-test.js
@@ -401,7 +401,7 @@ describe('Evaluation of imported values works based on configuration', () => {
           priority: 0
         });
         const styles = {
-          color: color => [{
+          color: color => [color !== undefined && {
             "--__hashed_var__1jqb1tb": color != null ? "__hashed_var__1w8wjxo" : "",
             $$css: true
           }, {

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -240,7 +240,7 @@ describe('@stylexjs/babel-plugin', () => {
             $$css: "components/main.js:71"
           },
           dynamic: color => [{
-            "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
+            "color-kMwMTN": color != null ? "color-x14rh7hd" : "",
             $$css: "components/main.js:74"
           }, {
             "--x-color": color != null ? color : undefined
@@ -333,7 +333,7 @@ describe('@stylexjs/babel-plugin', () => {
             $$css: "main.js:71"
           },
           dynamic: color => [{
-            "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
+            "color-kMwMTN": color != null ? "color-x14rh7hd" : "",
             $$css: "main.js:74"
           }, {
             "--x-color": color != null ? color : undefined
@@ -781,7 +781,7 @@ describe('@stylexjs/babel-plugin', () => {
             $$css: "main.js:71"
           },
           dynamic: color => [{
-            "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
+            "color-kMwMTN": color != null ? "color-x14rh7hd" : "",
             $$css: "main.js:74"
           }, {
             "--x-color": color != null ? color : undefined

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -239,7 +239,7 @@ describe('@stylexjs/babel-plugin', () => {
             "--orange-theme-color": "--orange-theme-color-xufgesz",
             $$css: "components/main.js:71"
           },
-          dynamic: color => [{
+          dynamic: color => [color !== undefined && {
             "color-kMwMTN": color != null ? "color-x14rh7hd" : "",
             $$css: "components/main.js:74"
           }, {
@@ -332,7 +332,7 @@ describe('@stylexjs/babel-plugin', () => {
             "--orange-theme-color": "--orange-theme-color-xufgesz",
             $$css: "main.js:71"
           },
-          dynamic: color => [{
+          dynamic: color => [color !== undefined && {
             "color-kMwMTN": color != null ? "color-x14rh7hd" : "",
             $$css: "main.js:74"
           }, {
@@ -780,7 +780,7 @@ describe('@stylexjs/babel-plugin', () => {
             "--orange-theme-color": "--orange-theme-color-xufgesz",
             $$css: "main.js:71"
           },
-          dynamic: color => [{
+          dynamic: color => [color !== undefined && {
             "color-kMwMTN": color != null ? "color-x14rh7hd" : "",
             $$css: "main.js:74"
           }, {

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -3645,7 +3645,7 @@ describe('@stylexjs/babel-plugin', () => {
           };
           export const styles = {
             root: color => [_temp, {
-              kMwMTN: color != null ? "x14rh7hd" : color,
+              kMwMTN: color != null ? "x14rh7hd" : "",
               $$css: true
             }, {
               "--x-color": color != null ? color : undefined
@@ -3700,7 +3700,7 @@ describe('@stylexjs/babel-plugin', () => {
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
             one: color => [{
-              kMwMTN: color != null ? "x14rh7hd" : color,
+              kMwMTN: color != null ? "x14rh7hd" : "",
               $$css: true
             }, {
               "--x-color": color != null ? color : undefined
@@ -3758,8 +3758,8 @@ describe('@stylexjs/babel-plugin', () => {
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
             root: (bgColor, otherColor) => [{
-              "--background-color": bgColor != null ? "xwn82o0" : bgColor,
-              "--otherColor": otherColor != null ? "xp3hsad" : otherColor,
+              "--background-color": bgColor != null ? "xwn82o0" : "",
+              "--otherColor": otherColor != null ? "xp3hsad" : "",
               $$css: true
             }, {
               "--x---background-color": bgColor != null ? bgColor : undefined,
@@ -3822,7 +3822,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: width => [{
-                kzqmXN: width != null ? "x5lhr3w" : width,
+                kzqmXN: width != null ? "x5lhr3w" : "",
                 $$css: true
               }, {
                 "--x-width": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
@@ -3874,7 +3874,7 @@ describe('@stylexjs/babel-plugin', () => {
             };
             export const styles = {
               root: width => [_temp, {
-                kzqmXN: width != null ? "x5lhr3w" : width,
+                kzqmXN: width != null ? "x5lhr3w" : "",
                 $$css: true
               }, {
                 "--x-width": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width),
@@ -3953,7 +3953,7 @@ describe('@stylexjs/babel-plugin', () => {
             import { vars } from 'vars.stylex.js';
             export const styles = {
               root: width => [{
-                "--x1anmu0j": width != null ? "x5fq457" : width,
+                "--x1anmu0j": width != null ? "x5fq457" : "",
                 $$css: true
               }, {
                 "--x---x1anmu0j": width != null ? width : undefined
@@ -4407,7 +4407,7 @@ describe('@stylexjs/babel-plugin', () => {
             };
             export const styles = {
               root: (color, isDark) => [_temp, {
-                kMwMTN: (isDark ? color : 'black') != null ? "x14rh7hd" : isDark ? color : 'black',
+                kMwMTN: (isDark ? color : 'black') != null ? "x14rh7hd" : "",
                 $$css: true
               }, {
                 "--x-backgroundColor": (isDark ? 'black' : 'white') != null ? isDark ? 'black' : 'white' : undefined,
@@ -4577,8 +4577,8 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: color => [{
-                kWkggS: color != null ? "x1j2k28p" : color,
-                kMwMTN: color != null ? "x1qvlgnj" : color,
+                kWkggS: color != null ? "x1j2k28p" : "",
+                kMwMTN: color != null ? "x1qvlgnj" : "",
                 $$css: true
               }, {
                 "--x-1e2mv7m": color != null ? color : undefined,
@@ -4644,7 +4644,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (hover, active, focus) => [{
-                kMwMTN: (hover != null ? "x1qvlgnj " : hover) + (active != null ? "xx746rz " : active) + (focus != null ? "x152n5rj " : focus) + "x126ychx",
+                kMwMTN: (hover != null ? "x1qvlgnj " : "") + (active != null ? "xx746rz " : "") + (focus != null ? "x152n5rj " : "") + "x126ychx",
                 $$css: true
               }, {
                 "--x-1113oo7": hover != null ? hover : undefined,
@@ -4737,8 +4737,8 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               foo: (a, b) => [{
-                kxBb7d: a != null ? "xaigonn" : a,
-                kB1Fuz: b != null ? "x1p1099i" : b,
+                kxBb7d: a != null ? "xaigonn" : "",
+                kB1Fuz: b != null ? "x1p1099i" : "",
                 $$css: true
               }, {
                 "--x-1g451k2": a != null ? a : undefined,
@@ -4801,7 +4801,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               foo: color => [{
-                k8Qsv1: color != null ? "x1mzl164" : color,
+                k8Qsv1: color != null ? "x1mzl164" : "",
                 $$css: true
               }, {
                 "--x-163tekb": color != null ? color : undefined
@@ -4847,7 +4847,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               foo: width => [{
-                k8pbKx: width != null ? "x18fgbt0" : width,
+                k8pbKx: width != null ? "x18fgbt0" : "",
                 $$css: true
               }, {
                 "--x-msahdu": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
@@ -4951,7 +4951,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               repro: color => [{
-                kB1Fuz: color != null ? "x1p1099i" : color,
+                kB1Fuz: color != null ? "x1p1099i" : "",
                 $$css: true
               }, {
                 "--x-19erzii": color != null ? color : undefined
@@ -5001,7 +5001,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (a, b, c) => [{
-                kzqmXN: "x11ymkkh " + "x38mdg9 " + (c != null ? "x1bai16n" : c),
+                kzqmXN: "x11ymkkh " + "x38mdg9 " + (c != null ? "x1bai16n" : ""),
                 $$css: true
               }, {
                 "--x-1xmrurk": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)('color-mix(' + color + ', blue)'),
@@ -5083,7 +5083,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (a, b, c) => [{
-                kMwMTN: (a != null ? "x3d248p " : a) + (b != null ? "x1iuwwch " : b) + (c != null ? "x5268pl" : c),
+                kMwMTN: (a != null ? "x3d248p " : "") + (b != null ? "x1iuwwch " : "") + (c != null ? "x5268pl" : ""),
                 $$css: true
               }, {
                 "--x-4xs81a": a != null ? a : undefined,
@@ -5167,7 +5167,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (a, b, c) => [{
-                kGuDYH: (a != null ? "xww4jgc " : a) + (b != null ? "xfqys7t " : b) + (c != null ? "x13w7uki" : c),
+                kGuDYH: (a != null ? "xww4jgc " : "") + (b != null ? "xfqys7t " : "") + (c != null ? "x13w7uki" : ""),
                 $$css: true
               }, {
                 "--x-19zvkyr": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(a),
@@ -5250,7 +5250,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
               root: (a, b, c) => [{
-                kGuDYH: ((a ? '16px' : undefined) != null ? "xww4jgc " : a ? '16px' : undefined) + ((b ? '18px' : undefined) != null ? "xqdov8i " : b ? '18px' : undefined) + ((c ? '20px' : undefined) != null ? "x1j86d60" : c ? '20px' : undefined),
+                kGuDYH: ((a ? '16px' : undefined) != null ? "xww4jgc " : "") + ((b ? '18px' : undefined) != null ? "xqdov8i " : "") + ((c ? '20px' : undefined) != null ? "x1j86d60" : ""),
                 $$css: true
               }, {
                 "--x-19zvkyr": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(a ? '16px' : undefined),
@@ -6042,9 +6042,9 @@ describe('@stylexjs/babel-plugin', () => {
           });
           export const styles = {
             default: margin => [_temp, {
-              k71WvV: (margin != null ? "x17e2bsb " : margin) + "xtcj1g9",
-              k1K539: (margin != null ? "xg6eqc8 " : margin) + "xgrn1a3",
-              keTefX: (margin != null ? "x19ja4a5 " : margin) + "x2tye95",
+              k71WvV: (margin != null ? "x17e2bsb " : "") + "xtcj1g9",
+              k1K539: (margin != null ? "xg6eqc8 " : "") + "xgrn1a3",
+              keTefX: (margin != null ? "x19ja4a5 " : "") + "x2tye95",
               $$css: true
             }, {
               "--x-14mfytm": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(margin),

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -3644,7 +3644,7 @@ describe('@stylexjs/babel-plugin', () => {
             "$$css": true
           };
           export const styles = {
-            root: color => [_temp, {
+            root: color => [_temp, color !== undefined && {
               kMwMTN: color != null ? "x14rh7hd" : "",
               $$css: true
             }, {
@@ -3699,7 +3699,7 @@ describe('@stylexjs/babel-plugin', () => {
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
-            one: color => [{
+            one: color => [color !== undefined && {
               kMwMTN: color != null ? "x14rh7hd" : "",
               $$css: true
             }, {
@@ -3757,8 +3757,10 @@ describe('@stylexjs/babel-plugin', () => {
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
-            root: (bgColor, otherColor) => [{
+            root: (bgColor, otherColor) => [bgColor !== undefined && {
               "--background-color": bgColor != null ? "xwn82o0" : "",
+              $$css: true
+            }, otherColor !== undefined && {
               "--otherColor": otherColor != null ? "xp3hsad" : "",
               $$css: true
             }, {
@@ -3821,7 +3823,7 @@ describe('@stylexjs/babel-plugin', () => {
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
-              root: width => [{
+              root: width => [width !== undefined && {
                 kzqmXN: width != null ? "x5lhr3w" : "",
                 $$css: true
               }, {
@@ -3873,7 +3875,7 @@ describe('@stylexjs/babel-plugin', () => {
               "$$css": true
             };
             export const styles = {
-              root: width => [_temp, {
+              root: width => [_temp, width !== undefined && {
                 kzqmXN: width != null ? "x5lhr3w" : "",
                 $$css: true
               }, {
@@ -3952,7 +3954,7 @@ describe('@stylexjs/babel-plugin', () => {
             "import * as stylex from '@stylexjs/stylex';
             import { vars } from 'vars.stylex.js';
             export const styles = {
-              root: width => [{
+              root: width => [width !== undefined && {
                 "--x1anmu0j": width != null ? "x5fq457" : "",
                 $$css: true
               }, {
@@ -4406,7 +4408,7 @@ describe('@stylexjs/babel-plugin', () => {
               "$$css": true
             };
             export const styles = {
-              root: (color, isDark) => [_temp, {
+              root: (color, isDark) => [_temp, (isDark ? color : 'black') !== undefined && {
                 kMwMTN: (isDark ? color : 'black') != null ? "x14rh7hd" : "",
                 $$css: true
               }, {
@@ -4576,8 +4578,10 @@ describe('@stylexjs/babel-plugin', () => {
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
-              root: color => [{
+              root: color => [color !== undefined && {
                 kWkggS: color != null ? "x1j2k28p" : "",
+                $$css: true
+              }, color !== undefined && {
                 kMwMTN: color != null ? "x1qvlgnj" : "",
                 $$css: true
               }, {
@@ -4736,8 +4740,10 @@ describe('@stylexjs/babel-plugin', () => {
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
-              foo: (a, b) => [{
+              foo: (a, b) => [a !== undefined && {
                 kxBb7d: a != null ? "xaigonn" : "",
+                $$css: true
+              }, b !== undefined && {
                 kB1Fuz: b != null ? "x1p1099i" : "",
                 $$css: true
               }, {
@@ -4800,7 +4806,7 @@ describe('@stylexjs/babel-plugin', () => {
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
-              foo: color => [{
+              foo: color => [color !== undefined && {
                 k8Qsv1: color != null ? "x1mzl164" : "",
                 $$css: true
               }, {
@@ -4846,7 +4852,7 @@ describe('@stylexjs/babel-plugin', () => {
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
-              foo: width => [{
+              foo: width => [width !== undefined && {
                 k8pbKx: width != null ? "x18fgbt0" : "",
                 $$css: true
               }, {
@@ -4950,7 +4956,7 @@ describe('@stylexjs/babel-plugin', () => {
           expect(code).toMatchInlineSnapshot(`
             "import * as stylex from '@stylexjs/stylex';
             export const styles = {
-              repro: color => [{
+              repro: color => [color !== undefined && {
                 kB1Fuz: color != null ? "x1p1099i" : "",
                 $$css: true
               }, {

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
@@ -543,7 +543,7 @@ describe('@stylexjs/babel-plugin', () => {
         };
         export const styles = {
           node: padding => [_temp, {
-            kmVPX3: padding != null ? "x1fozly0" : padding,
+            kmVPX3: padding != null ? "x1fozly0" : "",
             $$css: true
           }, {
             "--x-padding": (val => typeof val === "number" ? val + "px" : val != null ? val : undefined)(padding)
@@ -603,7 +603,7 @@ describe('@stylexjs/babel-plugin', () => {
         import { breakpoints } from './constants.stylex';
         export const styles = {
           node: color => [{
-            kMwMTN: "xbs0o1n " + (color != null ? "x3d248p" : color),
+            kMwMTN: "xbs0o1n " + (color != null ? "x3d248p" : ""),
             $$css: true
           }, {
             "--x-4xs81a": color != null ? color : undefined

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineConsts-test.js
@@ -542,7 +542,7 @@ describe('@stylexjs/babel-plugin', () => {
           "$$css": true
         };
         export const styles = {
-          node: padding => [_temp, {
+          node: padding => [_temp, padding !== undefined && {
             kmVPX3: padding != null ? "x1fozly0" : "",
             $$css: true
           }, {

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
@@ -544,7 +544,7 @@ describe('@stylexjs/babel-plugin', () => {
               $$css: "npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4"
             },
             opacity: opacity => [{
-              "opacity-kSiTet": opacity != null ? "opacity-xb4nw82" : opacity,
+              "opacity-kSiTet": opacity != null ? "opacity-xb4nw82" : "",
               $$css: "npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:7"
             }, {
               "--x-opacity": opacity != null ? opacity : undefined
@@ -806,7 +806,7 @@ describe('@stylexjs/babel-plugin', () => {
           });
           const styles = {
             color: c => [{
-              kMwMTN: c != null ? "x14rh7hd" : c,
+              kMwMTN: c != null ? "x14rh7hd" : "",
               $$css: true
             }, {
               "--x-color": c != null ? c : undefined
@@ -902,7 +902,7 @@ describe('@stylexjs/babel-plugin', () => {
           });
           const styles = {
             opacity: o => [{
-              kSiTet: o != null ? "xb4nw82" : o,
+              kSiTet: o != null ? "xb4nw82" : "",
               $$css: true
             }, {
               "--x-opacity": o != null ? o : undefined
@@ -944,7 +944,7 @@ describe('@stylexjs/babel-plugin', () => {
           });
           const styles = {
             opacity: o => [{
-              kSiTet: o != null ? "xb4nw82" : o,
+              kSiTet: o != null ? "xb4nw82" : "",
               $$css: true
             }, {
               "--x-opacity": o != null ? o : undefined

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
@@ -543,7 +543,7 @@ describe('@stylexjs/babel-plugin', () => {
               "color-kMwMTN": "color-x1e2nbdu",
               $$css: "npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4"
             },
-            opacity: opacity => [{
+            opacity: opacity => [opacity !== undefined && {
               "opacity-kSiTet": opacity != null ? "opacity-xb4nw82" : "",
               $$css: "npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:7"
             }, {
@@ -805,7 +805,7 @@ describe('@stylexjs/babel-plugin', () => {
             priority: 0
           });
           const styles = {
-            color: c => [{
+            color: c => [c !== undefined && {
               kMwMTN: c != null ? "x14rh7hd" : "",
               $$css: true
             }, {
@@ -901,7 +901,7 @@ describe('@stylexjs/babel-plugin', () => {
             priority: 0
           });
           const styles = {
-            opacity: o => [{
+            opacity: o => [o !== undefined && {
               kSiTet: o != null ? "xb4nw82" : "",
               $$css: true
             }, {
@@ -943,7 +943,7 @@ describe('@stylexjs/babel-plugin', () => {
             priority: 0
           });
           const styles = {
-            opacity: o => [{
+            opacity: o => [o !== undefined && {
               kSiTet: o != null ? "xb4nw82" : "",
               $$css: true
             }, {

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
@@ -421,7 +421,7 @@ export default function transformStyleXCreate(
                       t.conditionalExpression(
                         t.binaryExpression('!=', expr, t.nullLiteral()),
                         t.stringLiteral(clsWithSpace),
-                        expr,
+                        t.stringLiteral(''),
                       ),
                     );
                   } else {

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-create.js
@@ -351,6 +351,11 @@ export default function transformStyleXCreate(
 
               const conditionalProps: Array<t.ObjectProperty> = [];
 
+              const guardedProps: Array<{
+                +prop: t.ObjectProperty,
+                +expr: t.Expression,
+              }> = [];
+
               value.properties.forEach((prop) => {
                 if (!t.isObjectProperty(prop) || t.isPrivateName(prop.key)) {
                   return;
@@ -379,6 +384,7 @@ export default function transformStyleXCreate(
                   : [];
 
                 let isStatic = true;
+                let controllingExpr: t.Expression | null = null;
                 const exprList: t.Expression[] = [];
 
                 classList.forEach((cls, index) => {
@@ -417,6 +423,7 @@ export default function transformStyleXCreate(
 
                   if (expr && !isSafeToSkipNullCheck(expr)) {
                     isStatic = false;
+                    controllingExpr = expr;
                     exprList.push(
                       t.conditionalExpression(
                         t.binaryExpression('!=', expr, t.nullLiteral()),
@@ -438,6 +445,12 @@ export default function transformStyleXCreate(
 
                 if (isStatic) {
                   staticProps.push(t.objectProperty(objProp.key, joined));
+                } else if (classList.length === 1 && controllingExpr != null) {
+                  const guardExpr = controllingExpr;
+                  guardedProps.push({
+                    prop: t.objectProperty(objProp.key, joined),
+                    expr: guardExpr,
+                  });
                 } else {
                   conditionalProps.push(t.objectProperty(objProp.key, joined));
                 }
@@ -460,15 +473,38 @@ export default function transformStyleXCreate(
                 conditionalObj = t.objectExpression(conditionalProps);
               }
 
+              const guardedObjs = guardedProps.map(({ prop, expr }) =>
+                t.logicalExpression(
+                  '&&',
+                  t.binaryExpression(
+                    '!==',
+                    t.cloneNode(expr),
+                    t.identifier('undefined'),
+                  ),
+                  t.objectExpression([
+                    prop,
+                    t.objectProperty(
+                      t.identifier('$$css'),
+                      t.cloneNode(cssTagValue),
+                    ),
+                  ]),
+                ),
+              );
+
               let finalFnValue: t.Expression = t.objectExpression(
                 Object.entries(inlineStyles).map(([key, val]) =>
                   t.objectProperty(t.stringLiteral(key), val.expression),
                 ),
               );
-              if (staticObj != null || conditionalObj != null) {
+              if (
+                staticObj != null ||
+                conditionalObj != null ||
+                guardedObjs.length > 0
+              ) {
                 finalFnValue = t.arrayExpression(
                   [
                     staticObj && hoistExpression(path, staticObj),
+                    ...guardedObjs,
                     conditionalObj,
                     finalFnValue,
                   ].filter(Boolean),


### PR DESCRIPTION
## What changed / motivation ?

When a dynamic style has multiple conditional class names for a single CSS property (e.g. multiple media queries or pseudo-classes), the generated code joins them with `+` string concatenation. If any condition evaluates to `null` or `undefined` at runtime, JavaScript coerces it to the string `"null"` or `"undefined"`, producing corrupted class names like `"nullxafpxz5"`.

The fix changes the else branch of the null-check ternary from `expr` to `t.stringLiteral('')`, so a non-matching condition contributes nothing to the concatenation instead of contributing `"null"`.

This is a regression from 7a1ed95a which refactored the single-class and multi-class code paths into one. The original code before that refactor already used `""` for the multi-class case — the refactor replaced it with `expr`, likely reasoning that `expr` would be null anyway in the else branch. That's true, but `null + "string"` produces `"nullstring"` in JavaScript.

As a side benefit, this also produces smaller output since `""` replaces what was previously a duplicated copy of the original expression in the else branch (unless the expression is a single-character variable).

Note that `""` and `null` are not identical in styleq's merge logic — `null` is the intentional "unset" semantic while `""` is treated as an empty string value. In practice they behave the same (both claim the property slot, neither adds a real class name), and the all-null case was already broken before this fix (producing `"nullnull"`), so this is strictly an improvement.

## Linked PR/Issues

Fixes #1702

## Additional Context

Existing snapshot tests updated to reflect the new `""` fallback. All tests pass.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code