### PR TITLE
[docs] Add publication date to blog posts

### DIFF
--- a/packages/docs/src/lib/blog-date.ts
+++ b/packages/docs/src/lib/blog-date.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Blog posts encode their publication date as a `YYYY-MM-DD` prefix on the
+// filename (e.g. `2026-06-23-my-post.mdx`); there is no `date` frontmatter field.
+// These helpers are the single source of truth for reading and formatting that
+// date, shared by the blog post page and the RSS feed.
+
+/**
+ * Parse the `YYYY-MM-DD` prefix from a blog page path into a Date.
+ * Returns `null` when the path has no date prefix.
+ */
+export function parseBlogDate(path: string): Date | null {
+  const dateStr = path.match(/^(\d{4}-\d{2}-\d{2})/)?.[1];
+  return dateStr ? new Date(dateStr) : null;
+}
+
+/**
+ * Format a blog date as e.g. "June 23, 2026".
+ *
+ * The date is interpreted and formatted in UTC: `new Date('2026-06-23')` is UTC
+ * midnight, so formatting in a behind-UTC zone would roll the displayed day back
+ * by one. UTC keeps the date exactly as written in the filename.
+ */
+export function formatBlogDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}

--- a/packages/docs/src/lib/rss.ts
+++ b/packages/docs/src/lib/rss.ts
@@ -6,6 +6,7 @@
  */
 import { Feed } from 'feed';
 import { blogSource } from '@/lib/source';
+import { parseBlogDate } from '@/lib/blog-date';
 import { marked } from 'marked';
 import type { InferPageType } from 'fumadocs-core/source';
 
@@ -65,9 +66,7 @@ async function createFeed(): Promise<Feed> {
     const url = `${baseUrl}/blog/${page.data.slug}`;
 
     // Parse date from the path (format: YYYY-MM-DD-title)
-    const pathMatch = page.path.match(/^(\d{4}-\d{2}-\d{2})/);
-    const dateStr = pathMatch?.[1];
-    const date = dateStr ? new Date(dateStr) : new Date();
+    const date = parseBlogDate(page.path) ?? new Date();
 
     const authors = (page.data.authors ?? [])
       .map((authorId: string) => AUTHORS[authorId])
@@ -107,4 +106,3 @@ export async function getAtom(): Promise<string> {
   const feed = await getFeed();
   return feed.atom1();
 }
-

--- a/packages/docs/src/pages/blog/[...slugs].tsx
+++ b/packages/docs/src/pages/blog/[...slugs].tsx
@@ -14,6 +14,7 @@ import {
   DocsTitle,
 } from '@/components/layout/page';
 import { baseOptions } from '@/lib/layout.shared';
+import { parseBlogDate, formatBlogDate } from '@/lib/blog-date';
 import { mdxComponents } from '@/components/mdx';
 import nmnImage from '@/static/img/nmn.jpg';
 import necolasImage from '@/static/img/necolas.jpg';
@@ -43,6 +44,7 @@ export default function BlogPage({ slugs }: PageProps<'/blog/[...slugs]'>) {
   const authors = page.data.authors.map(
     (author) => AUTHORS[author as keyof typeof AUTHORS],
   );
+  const publishedDate = parseBlogDate(page.path);
 
   return (
     <DocsPage
@@ -59,6 +61,14 @@ export default function BlogPage({ slugs }: PageProps<'/blog/[...slugs]'>) {
           {slugs.length === 1 && slugs[0] === page.data.slug ? 'true' : 'false'}
         </code> */}
       </DocsTitle>
+      {publishedDate && (
+        <time
+          dateTime={publishedDate.toISOString().slice(0, 10)}
+          {...stylex.props(styles.date)}
+        >
+          {formatBlogDate(publishedDate)}
+        </time>
+      )}
       <div {...stylex.props(styles.authors)}>
         {authors.map((author) => (
           <a href={author.url} target="_blank" {...stylex.props(styles.author)}>
@@ -106,6 +116,15 @@ const styles = stylex.create({
     color: `${vars['--color-fd-foreground']}`,
   },
   fallbackDescription: {
+    color: `${vars['--color-fd-muted-foreground']}`,
+  },
+  date: {
+    // The parent <article> is a flex column with `gap: 24`. The big title's
+    // line-height makes that 24px gap read as too much above the date, so pull the
+    // date in with an equal negative block margin — leaving a tighter, uniform
+    // ~12px of space between title, date, and authors.
+    marginBlock: -12,
+    fontSize: 14,
     color: `${vars['--color-fd-muted-foreground']}`,
   },
   authors: {


### PR DESCRIPTION
## What changed / motivation ?

Blog posts didn't display a publication date. Each post now shows its date (e.g. **June 14, 2026**) under the title, parsed from the filename's `YYYY-MM-DD` prefix.

- New `src/lib/blog-date.ts` (`parseBlogDate` / `formatBlogDate`) — a single source of truth for reading and formatting blog dates. Formatted in UTC to avoid an off-by-one day.
- `src/lib/rss.ts` now uses the same helper instead of its own inline regex, so the page and the RSS feed can't drift apart (no behavior change — verified the feed's `<pubDate>` values are unchanged).
- Rendered as a semantic `<time dateTime="…">` element, spaced uniformly between the title and authors.

## Linked PR/Issues

Part of #1550

## Additional Context

`tsc`, Prettier, ESLint, and `waku build` all pass. Verified locally by serving the build: the date renders on posts and the RSS `<pubDate>` values are unchanged.


|       | Before | After |
|-------|--------|-------|
| Light | <img width="480" src="https://github.com/user-attachments/assets/3cf1f473-af24-4dba-ad5c-a959fbd7c7f1" /> | <img width="480" src="https://github.com/user-attachments/assets/17787f01-2383-48be-84f1-a2274bb26007" /> |
| Dark  | <img width="480" src="https://github.com/user-attachments/assets/6b3b8450-3739-4c1c-940a-ea3704dd3ae9" /> | <img width="480" src="https://github.com/user-attachments/assets/65cdbc48-07f6-4971-ac9a-6201e1101bc8" /> |

Click on images to enlarge.


## Pre-flight checklist

- [x] I have read the contributing guidelines [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code