### PR TITLE
[eslint-plugin] Fix single-value `background: foo` shorthand silently dropped — add lint error with autofix

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -2877,5 +2877,181 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         },
       ],
     },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          background: 'red'
+        },
+      })
+    `,
+      output: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          backgroundColor: 'red'
+        },
+      })
+    `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "background: red" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          background: 'transparent'
+        },
+      })
+    `,
+      output: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          backgroundColor: 'transparent'
+        },
+      })
+    `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "background: transparent" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          background: 'url("image.jpg")'
+        },
+      })
+    `,
+      output: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          backgroundImage: 'url("image.jpg")'
+        },
+      })
+    `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "background: url("image.jpg")" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          background: 'linear-gradient(to right, red, blue)'
+        },
+      })
+    `,
+      output: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          backgroundImage: 'linear-gradient(to right, red, blue)'
+        },
+      })
+    `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "background: linear-gradient(to right, red, blue)" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          background: 'no-repeat'
+        },
+      })
+    `,
+      output: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          backgroundRepeat: 'no-repeat'
+        },
+      })
+    `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "background: no-repeat" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          background: 'center'
+        },
+      })
+    `,
+      output: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          backgroundPosition: 'center'
+        },
+      })
+    `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "background: center" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          background: 'inherit'
+        },
+      })
+    `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "background: inherit" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          background: 'initial'
+        },
+      })
+    `,
+      errors: [
+        {
+          message:
+            'Property shorthands using multiple values like "background: initial" are not supported in StyleX. Separate into individual properties.',
+        },
+      ],
+    },
   ],
 });

--- a/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/utils/splitShorthands.js
@@ -138,6 +138,13 @@ const BACKGROUND_REPEAT_KEYWORDS = new Set([
   'round',
 ]);
 const BACKGROUND_ATTACHMENT_KEYWORDS = new Set(['scroll', 'fixed', 'local']);
+const CSS_GLOBAL_KEYWORDS = new Set([
+  'inherit',
+  'initial',
+  'unset',
+  'revert',
+  'revert-layer',
+]);
 const BACKGROUND_POSITION_KEYWORDS = new Set([
   'left',
   'right',
@@ -886,6 +893,16 @@ function expandBackgroundShorthand(
     return null;
   }
 
+  // CSS global keywords on background shorthand apply to ALL sub-properties.
+  // There is no safe single-longhand expansion, so bail out.
+  if (
+    beforeSlash.length === 1 &&
+    afterSlash.length === 0 &&
+    CSS_GLOBAL_KEYWORDS.has(beforeSlash[0].toLowerCase())
+  ) {
+    return null;
+  }
+
   let color = null;
   let image = null;
   let repeat = null;
@@ -1130,7 +1147,11 @@ export function splitSpecificShorthands(
   }
 
   const splitValues = splitTopLevelValueTokens(baseValue);
-  if (splitValues.parts.length <= 1 && !splitValues.hasTopLevelSlash) {
+  if (
+    splitValues.parts.length <= 1 &&
+    !splitValues.hasTopLevelSlash &&
+    property !== 'background'
+  ) {
     return [[toCamelCase(property), isNumber ? Number(rawValue) : rawValue]];
   }
 


### PR DESCRIPTION
## Problem
Single-value background shorthand like this:

<img height="150" alt="image" src="https://github.com/user-attachments/assets/76208370-8d90-48bb-8e6e-a82b2fcff66f" />

is compiled without any linter warnings but produced no `background: red` style, ommitting that style entirely, giving false-positive result. (Reproduction in [StyleX Playground](https://stylexjs.com/playground?input=N4IgggDhB0AuDOAPEAuEBLAthA9gJ1gAIAqQgQ3kPlgE8AbAU0UIDM8dNCAdEAAWvpMAVvAD0Axoh4BuLgDt5o4sXklCAdQZ0AxhwaFYOAwAt9AZVqMAGoQh0yNAObsArnIAmAQlUq5agKLu6ESwpoS67vpkHlQM%2BhIMlC4Q7mSw%2Buhy1NGwdDTQPoT%2BiBAMeFgMckQA7sHGBjgA1pWU0e4mDJiJhC7wmY4NzVnQCYhw8AV%2BpGbGZHj6ofoAqgBKADIN4Th09gBG%2BGn6%2BLExTGTYjJSGhDiLeBM%2BovLyTLgEhJEsZC50RCxu2lg6BwfkgEAAFABKQjAVSEeawFx4PzguGEQgAHiCADcYdB8aNoBB2BB4OCEhMIGRHAxIQBfAB8aMxohxTL8hEhsjkdOecl0WSIFMIAF4qJYmNBtPNDuDYRyqTSUDDmbsyNpGs4cG53MqAOTzdx6gA0hFEokIclu5CgdHQDHamRuLlgEBdzMwmQAEgx0I5jLBlTwAIwABlD7mxxh4xrhdNjPK58hAdKAA))

The compiler requires the longhand syntaxes, e.g. `background-color: red` or `background-image: url(image.jpg)` instead.

Multi-token values like background: 'red no-repeat' are already caught by the linter:

<img height="150" alt="image" src="https://github.com/user-attachments/assets/b7a8812c-0359-4a80-b2d0-a90450fcd138" />


## What changed in the fix

- The shorthand splitter already contains a full background token classifier that can identify colors, images, repeat keywords, attachment keywords, and position keywords. The fix routes single-token background values through this existing classifier instead of short-circuiting past it, so they are expanded to the correct longhand and flagged with an autofix.

- **_One special case:_**
  In CSS, global keywords (`inherit`, `initial`, `unset`, `revert`, `revert-layer`) on the background shorthand **apply to all** sub-properties simultaneously:
  
  <kbd><img width="549" height="192" alt="image" src="https://github.com/user-attachments/assets/990b68f0-2c7a-4430-a572-5c2d104c3ba8" /></kbd>
  
  There is no safe single-longhand expansion for this. Therefore, these are flagged as errors but with no autofix, leaving the developer to decide which specific longhands to set.
  
- Added test cases

## Example cases

<details>
<summary>Before (silent failure):</summary>
<img width="424" height="398" alt="image" src="https://github.com/user-attachments/assets/cac36a8a-76e0-4376-b287-e1fe0cade36c" />
</details>

<details>
<summary>After (lint error):</summary>
<img width="1022" height="401" alt="image" src="https://github.com/user-attachments/assets/7022f3d0-c9d0-4a89-a107-ef877d42a1c1" />
</details>

<details>
<summary>After (autofix applied):</summary>
<img width="547" height="401" alt="image" src="https://github.com/user-attachments/assets/51d9aa6a-a192-4b4a-b169-d1a0c685a81a" />
</details>

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code