### PR TITLE
[eslint-plugin] Skip single-value gridArea in valid-shorthands

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-shorthands-test.js
@@ -473,6 +473,17 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
       })
     `,
     },
+    // grid-area: single-value custom-ident
+    {
+      code: `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        main: {
+          gridArea: 'header',
+        },
+      })
+    `,
+    },
     // Already-longhand grid properties
     {
       code: `
@@ -1529,34 +1540,6 @@ eslintTester.run('stylex-valid-shorthands', rule.default, {
         {
           message:
             'Property shorthands using multiple values like "borderColor: oklch(0.7 0.15 180) rgb(255 0 0)" are not supported in StyleX. Separate into individual properties.',
-        },
-      ],
-    },
-    // grid-area: custom-ident expands to 4 longhands
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            gridArea: 'header',
-          },
-        });
-      `,
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          main: {
-            gridColumnEnd: 'header',
-            gridColumnStart: 'header',
-            gridRowEnd: 'header',
-            gridRowStart: 'header',
-          },
-        });
-      `,
-      errors: [
-        {
-          message:
-            'Property shorthands using multiple values like "gridArea: header" are not supported in StyleX. Separate into individual properties.',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-shorthands.js
@@ -187,7 +187,7 @@ const stylexValidShorthands = {
         return;
       }
 
-      if (key === 'flex' && isSingleToken(String(v))) {
+      if ((key === 'flex' || key === 'gridArea') && isSingleToken(String(v))) {
         return;
       }
 


### PR DESCRIPTION
## What changed / motivation ?

Single-value `gridArea` usages like `gridArea: 'header'` are flagged by `valid-shorthands` and auto-expanded to four longhand properties (`gridRowStart`, `gridRowEnd`, `gridColumnStart`, `gridColumnEnd`). This is inconsistent with how `flex` (#1670) and `gap` (#1668) were updated to skip single-value usages, and inconsistent with the rule's stated purpose of enforcing single-value shorthands over multi-value shorthands.

`gridArea: 'header'` is a single-token value — a standard CSS Grid pattern for referencing named template areas. The existing `isSingleToken` utility (introduced in #1670) already handles this check for `flex`; this PR extends it to `gridArea`.

Multi-value `gridArea` (e.g. `gridArea: 'header / sidebar'`, `gridArea: '1 / 2 / 3 / 4'`) is still correctly flagged and auto-fixed.

## Linked PR/Issues

Follow-up to #1670, #1668, #1477.

## Additional Context

1 single-value `gridArea` test case moved from `invalid` to `valid`. All 136 tests pass.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code