### PR TITLE
[babel-plugin] Don't hoist $$css objects that reference local variables

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
@@ -3457,6 +3457,44 @@ describe('@stylexjs/babel-plugin', () => {
         }"
       `);
     });
+
+    test('does not hoist $$css objects that reference local variables', () => {
+      expect(
+        transform(
+          `
+            import * as stylex from '@stylexjs/stylex';
+            const styles = stylex.create({
+              root: { display: 'flex' },
+            });
+            function Foo({className}) {
+              return <div {...stylex.props(styles.root, className && {$$css: true, __: className})}>Hello, foo!</div>;
+            }
+          `,
+        ),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import * as stylex from '@stylexjs/stylex';
+        _inject2({
+          ltr: ".x78zum5{display:flex}",
+          priority: 3000
+        });
+        const styles = {
+          root: {
+            k1xSpc: "x78zum5",
+            $$css: true
+          }
+        };
+        function Foo({
+          className
+        }) {
+          return <div {...stylex.props(styles.root, className && {
+            $$css: true,
+            __: className
+          })}>Hello, foo!</div>;
+        }"
+      `);
+    });
   });
 
   describe('dealing with imports', () => {

--- a/packages/@stylexjs/babel-plugin/src/visitors/stylex-props.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/stylex-props.js
@@ -286,7 +286,7 @@ export default function transformStylexProps(
               (t.isStringLiteral(prop.key) && prop.key.value === '$$css')) &&
             t.isBooleanLiteral(prop.value, { value: true }),
         );
-        if (hasCssMarker) {
+        if (hasCssMarker && canHoistObject(objPath)) {
           const hoisted = hoistExpression(objPath, objPath.node);
           objPath.replaceWith(hoisted);
         }
@@ -507,6 +507,31 @@ function genBitwiseOrOfConditions(
   return binaryExpressions.reduce((acc, expr) => {
     return t.binaryExpression('|', acc, expr);
   });
+}
+
+function canHoistObject(objPath: NodePath<t.ObjectExpression>): boolean {
+  const programScope = objPath.scope.getProgramParent();
+  for (const prop of objPath.node.properties) {
+    if (!t.isObjectProperty(prop)) {
+      return false;
+    }
+    if (prop.computed && t.isIdentifier(prop.key)) {
+      const binding = objPath.scope.getBinding(prop.key.name);
+      if (binding != null && binding.scope !== programScope) {
+        return false;
+      }
+    }
+    const val = prop.value;
+    if (t.isIdentifier(val)) {
+      const binding = objPath.scope.getBinding(val.name);
+      if (binding != null && binding.scope !== programScope) {
+        return false;
+      }
+    } else if (!t.isLiteral(val)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function getPropsLikeCall(


### PR DESCRIPTION
## What changed / motivation ?

We ran into this after upgrading to 0.19.0. The `$$css` object hoisting added in #1406 (for `@stylexjs/atoms`) unconditionally hoists any inline object with `$$css: true` to module scope, even when its property values reference function-scoped variables.

For example, this (admittedly unsupported) pattern:

```jsx
function Foo({className}) {
  return <div {...stylex.props(styles.root, className && {$$css: true, __: className})}>Hello</div>;
}
```

Gets compiled to:

```js
const _temp = { $$css: true, __: className }; // className is not in scope here
function Foo({className}) {
  return <div {...stylex.props(styles.root, className && _temp)}>Hello</div>;
}
```

We acknowledge that using `$$css` directly like this is unsupported — we're actively working around it and moving away from the pattern. But since it was working before 0.19.0, we thought it would be worth patching in case anyone else hits it.

This adds a `canHoistObject` check that verifies all identifiers referenced in the object are available at program scope before hoisting.

It might also be worth considering a different approach where the hoisting only targets objects known to come from atoms compilation, rather than pattern-matching on `$$css: true` in the general `stylex.props` bailout path. That way this class of issue couldn't arise at all.

Please feel free to close this if you don't think it's worth fixing — it's a pretty major edge case.

## Additional Context

Regression test added.

## Pre-flight checklist

- [x] I have read the contributing guidelines
- [x] Performed a self-review of my code