### PR TITLE
[docs] Add @stylexjs/no-conflicting-props to eslint-plugin docs

### DIFF
--- a/packages/docs/content/docs/api/configuration/eslint-plugin.mdx
+++ b/packages/docs/content/docs/api/configuration/eslint-plugin.mdx
@@ -178,6 +178,19 @@ type Options = {
 };
 ```
 
+### `@stylexjs/no-conflicting-props` rule
+
+Disallows using `className` or `style` props on elements that spread `stylex.props()`, which would cause conflicts.
+
+```ts
+type Options = {
+  // Possible strings where you can import stylex from
+  //
+  // Default: ['stylex', '@stylexjs/stylex']
+  validImports: Array<string | { from: string; as: string }>;
+};
+```
+
 ### `@stylexjs/no-legacy-contextual-styles` rule
 
 ```ts


### PR DESCRIPTION
## What changed / motivation?

The `@stylexjs/no-conflicting-props` ESLint rule was added in #1381 but was never documented on the eslint-plugin configuration page. This adds the missing entry.

## Linked PR/Issues

Related: #1381

## Additional Context

N/A

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
