### PR TITLE
Fix length validators wrongly accepting comma-prefixed values

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -2425,6 +2425,62 @@ revert`,
       ],
     },
     {
+      // A leading comma must not be accepted as a valid length. Regression
+      // test for the length validators previously using the character class
+      // `[-,+]`, which accidentally allowed a literal comma prefix.
+      // `textUnderlineOffset` is length-only (it does not accept arbitrary
+      // strings), so this exercises the length validators directly.
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            textUnderlineOffset: ',4px',
+          },
+        });
+      `,
+      errors: [
+        {
+          message: `textUnderlineOffset value must be one of:
+auto
+a number literal or math expression
+a number ending in px, mm, in, pc, pt
+a number ending in ch, em, ex, ic, rem, vh, vw, vmin, vmax, svh, dvh, lvh, svw, dvw, ldw, cqw, cqh, cqmin, cqmax
+A string literal representing a percentage (e.g. 100%)
+null
+initial
+inherit
+unset
+revert`,
+        },
+      ],
+    },
+    {
+      // Same as above, for the relative-length validator.
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          invalidStyle: {
+            textUnderlineOffset: ',4rem',
+          },
+        });
+      `,
+      errors: [
+        {
+          message: `textUnderlineOffset value must be one of:
+auto
+a number literal or math expression
+a number ending in px, mm, in, pc, pt
+a number ending in ch, em, ex, ic, rem, vh, vw, vmin, vmax, svh, dvh, lvh, svw, dvw, ldw, cqw, cqh, cqmin, cqmax
+A string literal representing a percentage (e.g. 100%)
+null
+initial
+inherit
+unset
+revert`,
+        },
+      ],
+    },
+    {
       code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({

--- a/packages/@stylexjs/eslint-plugin/src/rules/isAbsoluteLength.js
+++ b/packages/@stylexjs/eslint-plugin/src/rules/isAbsoluteLength.js
@@ -26,7 +26,7 @@ const isAbsoluteLength: RuleCheck = (
     if (
       typeof val === 'string' &&
       Array.from(absoluteLengthUnits).some((unit) =>
-        val.match(new RegExp(`^([-,+]?\\d+(\\.\\d+)?${unit})$`)),
+        val.match(new RegExp(`^([+-]?\\d+(\\.\\d+)?${unit})$`)),
       )
     ) {
       return undefined;

--- a/packages/@stylexjs/eslint-plugin/src/rules/isRelativeLength.js
+++ b/packages/@stylexjs/eslint-plugin/src/rules/isRelativeLength.js
@@ -49,7 +49,7 @@ const isRelativeLength: RuleCheck = (
     if (
       typeof val === 'string' &&
       Array.from(relativeLengthUnits).some((unit) =>
-        val.match(new RegExp(`^([-,+]?\\d+(\\.\\d+)?${unit})$`)),
+        val.match(new RegExp(`^([+-]?\\d+(\\.\\d+)?${unit})$`)),
       )
     ) {
       return undefined;


### PR DESCRIPTION
## Summary

The ESLint `valid-styles` rule accepts malformed CSS lengths like `',4px'` and `',4rem'`. Both length validators build their regex with the character class `[-,+]`, which includes a **literal comma**:

```js
// packages/@stylexjs/eslint-plugin/src/rules/isAbsoluteLength.js
new RegExp(`^([-,+]?\\d+(\\.\\d+)?${unit})$`)
//          ^^^^^ the comma here is matched literally
```

So a leading comma is accepted as if it were a sign. This changes `[-,+]` to `[+-]` in both `isAbsoluteLength.js` and `isRelativeLength.js`, allowing only an optional leading sign. Legitimate values (`4px`, `-4px`, `+4px`, `4rem`, …) are unaffected.

This is the **same defect** fixed for the percentage validator in #1574, which did not touch the two length files — so this complements that PR rather than overlapping it.

## Test plan

Added regression tests in `stylex-valid-styles-test.js` using `textUnderlineOffset` (a length-only property, so the length validators are exercised directly rather than the `non-numeric string` fallback that properties like `height` allow).

- Before the fix: the new `',4px'` / `',4rem'` cases raise **0** errors (bug) → tests fail.
- After the fix: they correctly error → tests pass.
- Full `@stylexjs/eslint-plugin` suite: **549 passed, 9 suites**, no regressions.

```
yarn --cwd packages/@stylexjs/eslint-plugin jest
```