### PR TITLE
Fix two correctness bugs in style-value-parser (shorthand hex + border-radius)

### DIFF
--- a/packages/style-value-parser/src/css-types/__tests__/color-test.js
+++ b/packages/style-value-parser/src/css-types/__tests__/color-test.js
@@ -27,6 +27,21 @@ describe('Test CSS Type: <color>', () => {
     expect(Color.parser.parse('#ffffff')).toEqual(new HashColor('ffffff'));
   });
 
+  test('hash color channel getters expand 3-digit shorthand', () => {
+    // The parser accepts 3-digit shorthand hex, so the channel getters must
+    // expand each digit (#f0a === #ff00aa) rather than slicing fixed windows.
+    expect(Color.parser.parse('#f0a')).toEqual(new HashColor('f0a'));
+    const short = new HashColor('f0a');
+    expect(short.r).toBe(255);
+    expect(short.g).toBe(0);
+    expect(short.b).toBe(170);
+    expect(short.a).toBe(1);
+    // Full-length hex (with and without alpha) is unaffected.
+    const full = new HashColor('ff00aa');
+    expect([full.r, full.g, full.b]).toEqual([255, 0, 170]);
+    expect(new HashColor('ff00aa80').a).toBeCloseTo(128 / 255);
+  });
+
   test('parses RGB values', () => {
     expect(Color.parser.parse('rgb(255, 0, 0)')).toEqual(new Rgb(255, 0, 0));
     expect(Color.parser.parse('rgb(0, 255, 0)')).toEqual(new Rgb(0, 255, 0));

--- a/packages/style-value-parser/src/css-types/color.js
+++ b/packages/style-value-parser/src/css-types/color.js
@@ -208,22 +208,32 @@ export class HashColor extends Color {
     return `#${this.value}`;
   }
 
+  // Expand 3-digit shorthand (e.g. 'f0a' -> 'ff00aa') so the channel getters
+  // can slice fixed 2-char windows. 6- and 8-digit values are returned as-is.
+  #expanded(): string {
+    return this.value.length === 3
+      ? this.value
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : this.value;
+  }
+
   get r(): number {
-    return parseInt(this.value.slice(0, 2), 16);
+    return parseInt(this.#expanded().slice(0, 2), 16);
   }
 
   get g(): number {
-    return parseInt(this.value.slice(2, 4), 16);
+    return parseInt(this.#expanded().slice(2, 4), 16);
   }
 
   get b(): number {
-    return parseInt(this.value.slice(4, 6), 16);
+    return parseInt(this.#expanded().slice(4, 6), 16);
   }
 
   get a(): number {
-    return this.value.length === 8
-      ? parseInt(this.value.slice(6, 8), 16) / 255
-      : 1;
+    const value = this.#expanded();
+    return value.length === 8 ? parseInt(value.slice(6, 8), 16) / 255 : 1;
   }
 
   static get parser(): TokenParser<HashColor> {

--- a/packages/style-value-parser/src/properties/__tests__/border-radius.test.js
+++ b/packages/style-value-parser/src/properties/__tests__/border-radius.test.js
@@ -240,6 +240,23 @@ describe('Test CSS property shorthand: `border-radius`', () => {
     );
   });
 
+  test('toString: distinct vertical radii are not overwritten by horizontal', () => {
+    // Horizontal group collapses to a single value (all 5px); the vertical
+    // group is fully asymmetric (1/2/3/4), so it must be serialized as-is and
+    // not fall back to the horizontal values.
+    const radius = new BorderRadiusShorthand(
+      new Length(5, 'px'),
+      new Length(5, 'px'),
+      new Length(5, 'px'),
+      new Length(5, 'px'),
+      new Length(1, 'px'),
+      new Length(2, 'px'),
+      new Length(3, 'px'),
+      new Length(4, 'px'),
+    );
+    expect(radius.toString()).toBe('5px / 1px 2px 3px 4px');
+  });
+
   test('Valid: border-radius: <length-percentage> <length-percentage> / <length-percentage> <length-percentage>', () => {
     expect(
       BorderRadiusShorthand.parse.parseToEnd('10px 20px / 30px 40px'),

--- a/packages/style-value-parser/src/properties/border-radius.js
+++ b/packages/style-value-parser/src/properties/border-radius.js
@@ -106,7 +106,7 @@ export class BorderRadiusShorthand {
     const verticalBottomRight = this.verticalBottomRight.toString();
     const verticalBottomLeft = this.verticalBottomLeft.toString();
 
-    let sStr = `${horizontalTopLeft} ${horizontalTopRight} ${horizontalBottomRight} ${horizontalBottomLeft}`;
+    let sStr = `${verticalTopLeft} ${verticalTopRight} ${verticalBottomRight} ${verticalBottomLeft}`;
     // All three are the same
     if (
       verticalTopLeft === verticalTopRight &&


### PR DESCRIPTION
Two small, independent correctness fixes in `@stylexjs/style-value-parser`, each with a regression test. Both were found by reading the code; the affected APIs currently have little/no test coverage on these paths.

## 1. `HashColor` channel getters mishandle 3-digit shorthand hex
`HashColor.parser` accepts 3-, 6-, and 8-digit hex, but the `r`/`g`/`b`/`a` getters slice fixed 2-char windows assuming 6/8 digits. For shorthand like `#f0a` (= `#ff00aa` → 255/0/170) they returned `r=240, g=10, b=NaN`.

Fix: a private `#expanded()` helper doubles each digit of a 3-digit value before slicing; 6/8-digit values are untouched, and the stored `value` is left intact so `toString()`/equality semantics are unchanged.

## 2. `border-radius` serializer drops asymmetric vertical radii
`BorderRadiusShorthand.toString()` initialized the vertical group string (`sStr`) from the **horizontal** corner values — a copy-paste of the horizontal initializer. The following branches only overwrite `sStr` when the vertical radii are symmetric, so a fully asymmetric vertical group fell through to the wrong default:

```
5px / 1px 2px 3px 4px   ->   emitted as   5px / 5px 5px 5px 5px
```

Fix: initialize `sStr` from the vertical values (one line).

## Test plan
Added regression tests in `color-test.js` and `border-radius.test.js` (both fail before the respective fix, pass after). Full package suite green:

```
yarn --cwd packages/style-value-parser jest
# Tests: 326 passed
```