### PR TITLE
[eslint-plugin] Allow type exports in enforce-extension rule

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-enforce-extension-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-enforce-extension-test.js
@@ -1024,3 +1024,78 @@ ruleTester.run('stylex-enforce-extension', rule.default, {
     },
   ],
 });
+
+const typeExportRuleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: { sourceType: 'module' },
+});
+
+typeExportRuleTester.run(
+  'stylex-enforce-extension (type exports)',
+  rule.default,
+  {
+    valid: [
+      {
+        code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const colors = stylex.defineVars({
+          primary: 'blue',
+          secondary: 'green',
+          accent: 'coral',
+        });
+        export type Colors = keyof typeof colors;
+      `,
+        filename: 'colors.stylex.ts',
+      },
+      {
+        code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const colors = stylex.defineConsts({
+          primary: 'blue',
+          secondary: 'green',
+        });
+        export type Colors = keyof typeof colors;
+      `,
+        filename: 'colors.stylex.const.ts',
+        options: [{ enforceDefineConstsExtension: true }],
+      },
+      {
+        code: `
+        import * as stylex from '@stylexjs/stylex';
+        type Colors = keyof typeof colors;
+        export const colors = stylex.defineVars({
+          primary: 'blue',
+          secondary: 'green',
+        });
+        export type { Colors };
+      `,
+        filename: 'colors.stylex.ts',
+      },
+      {
+        code: `
+        import * as stylex from '@stylexjs/stylex';
+        type Colors = keyof typeof colors;
+        export const colors = stylex.defineVars({
+          primary: 'blue',
+          secondary: 'green',
+        });
+        export { type Colors };
+      `,
+        filename: 'colors.stylex.ts',
+      },
+    ],
+
+    invalid: [
+      {
+        code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const colors = stylex.defineVars({ primary: 'blue' });
+        export type Colors = keyof typeof colors;
+        export const helper = someFunction();
+      `,
+        filename: 'colors.stylex.ts',
+        errors: [{ message: invalidExportFromThemeFiles }],
+      },
+    ],
+  },
+);

--- a/packages/@stylexjs/eslint-plugin/src/stylex-enforce-extension.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-enforce-extension.js
@@ -431,6 +431,9 @@ const stylexEnforceExtension = {
         });
       },
       'ExportNamedDeclaration, ExportDefaultDeclaration'(node: Node): void {
+        if ((node as any).exportKind === 'type') {
+          return;
+        }
         reportedDefaultExportError = false;
         checkExports(node);
         if (!reportedDefaultExportError) {


### PR DESCRIPTION
## What changed / motivation ?

We ran into this adopting the `@stylexjs/enforce-extension` rule in our own codebase. The rule currently treats TypeScript type exports (`export type`, `export interface`, `export type { ... }`, `export { type ... }`) as "other exports," causing false positives for the mixed-export check. A `.stylex` file that exports a type alongside `defineVars`/`defineConsts`/`defineMarker` is flagged as invalid.

Type exports are erased at compile time and have no runtime impact, so they don't violate the intent of the rule — which is to keep `.stylex` files focused on style definitions without side-effect-producing value exports. You could work around this by putting the type in a separate file, but there's no reason to force that when the type is derived from the definitions in the same file.

The fix skips export nodes with `exportKind === 'type'`, making them invisible to the rule.

## Linked PR/Issues

## Additional Context

Tests cover `export type Colors = ...`, `export type { Colors }`, and `export { type Colors }` using `@typescript-eslint/parser`. An invalid test confirms that type exports don't suppress errors from actual value-level mixed exports.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code