### PR TITLE
Fix Inset.toString() shortest-form serialization

### DIFF
--- a/packages/style-value-parser/src/css-types/__tests__/basic-shape.js
+++ b/packages/style-value-parser/src/css-types/__tests__/basic-shape.js
@@ -62,6 +62,23 @@ describe('Basic Shapes', () => {
       expect(() => Inset.parser.parseToEnd('inset(invalid)')).toThrow();
       expect(() => Inset.parser.parseToEnd('inset(10px, invalid)')).toThrow();
     });
+
+    it('should stringify the shortest valid form', () => {
+      const roundtrip = (css: string): string =>
+        Inset.parser.parseToEnd(css).toString();
+      // 1 value: all four sides equal.
+      expect(roundtrip('inset(10px)')).toBe('inset(10px)');
+      // 2 values: vertical / horizontal.
+      expect(roundtrip('inset(10px 20px)')).toBe('inset(10px 20px)');
+      // 3 values: top / horizontal / bottom (left === right).
+      expect(roundtrip('inset(10px 20px 30px)')).toBe('inset(10px 20px 30px)');
+      // 4 values: all distinct (no trailing space before the paren).
+      expect(roundtrip('inset(10px 20px 30px 40px)')).toBe(
+        'inset(10px 20px 30px 40px)',
+      );
+      // round radius is preserved.
+      expect(roundtrip('inset(10px round 5px)')).toBe('inset(10px round 5px)');
+    });
   });
 
   describe('Circle', () => {

--- a/packages/style-value-parser/src/css-types/basic-shape.js
+++ b/packages/style-value-parser/src/css-types/basic-shape.js
@@ -41,24 +41,19 @@ export class Inset extends BasicShape {
   }
   // Stringify the shortest possible version of the inset
   toString(): string {
-    const { top, right, bottom, left, round } = this;
+    const { top, right, bottom, left } = this;
     const roundStr =
       this.round != null ? ` round ${this.round.toString()}` : '';
-    if (
-      top === right &&
-      right === bottom &&
-      bottom === left &&
-      left === round
-    ) {
+    if (top === right && right === bottom && bottom === left && left === top) {
       return `inset(${top.toString()}${roundStr})`;
     }
     if (top === bottom && left === right) {
       return `inset(${top.toString()} ${right.toString()}${roundStr})`;
     }
-    if (top === bottom) {
+    if (left === right) {
       return `inset(${top.toString()} ${right.toString()} ${bottom.toString()}${roundStr})`;
     }
-    return `inset(${top.toString()} ${right.toString()} ${bottom.toString()} ${left.toString()} ${roundStr})`;
+    return `inset(${top.toString()} ${right.toString()} ${bottom.toString()} ${left.toString()}${roundStr})`;
   }
 
   static get parser(): TokenParser<Inset> {


### PR DESCRIPTION
## Summary

`Inset.toString()` (in `@stylexjs/style-value-parser`) aims to emit the shortest valid `inset()` form, but had three defects (the method had no prior `toString()` test coverage):

1. **1-value collapse never fired.** The all-sides-equal check compared `left === round` — `round` is the border-radius value, handled separately via `roundStr` and usually `null` — instead of `left === top`. So `inset(10px)` serialized as `inset(10px 10px)`.
2. **3-value branch keyed on the wrong sides.** It used `top === bottom` instead of `left === right` (the condition the 3-value form actually requires), so a 3-value input round-tripped to 4 values, and an asymmetric case like `inset(10px 20px 10px 40px)` could drop the `left` value.
3. **Stray trailing space.** The 4-value branch emitted `inset(10px 20px 30px 40px )` (space before `)`).

## Test plan

Added a round-trip test in `basic-shape.js` covering the 1/2/3/4-value and `round` forms (fails before, passes after). Full package suite green:

```
yarn --cwd packages/style-value-parser jest
# Tests: 325 passed
```