### PR TITLE
Fix StyleX CSS injection for Rspack unplugin

### DIFF
--- a/packages/@stylexjs/unplugin/src/rspack.js
+++ b/packages/@stylexjs/unplugin/src/rspack.js
@@ -11,5 +11,5 @@ import { unpluginFactory } from './core';
 import { attachWebpackHooks } from './webpack';
 
 export default createRspackPlugin((options, metaOptions) =>
-  attachWebpackHooks(unpluginFactory(options, metaOptions)),
+  attachWebpackHooks(unpluginFactory(options, metaOptions), 'rspack'),
 );

--- a/packages/@stylexjs/unplugin/src/webpack.js
+++ b/packages/@stylexjs/unplugin/src/webpack.js
@@ -9,12 +9,12 @@ import { createWebpackPlugin } from 'unplugin';
 
 import { unpluginFactory } from './core';
 
-export function attachWebpackHooks(plugin) {
+export function attachWebpackHooks(plugin, hookName = 'webpack') {
   const cssInjectionTarget = plugin.__stylexCssInjectionTarget;
 
   return {
     ...plugin,
-    webpack(compiler) {
+    [hookName](compiler) {
       const PLUGIN_NAME = '@stylexjs/unplugin';
       compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
         plugin.__stylexResetState?.();

--- a/packages/@stylexjs/unplugin/src/webpack.js
+++ b/packages/@stylexjs/unplugin/src/webpack.js
@@ -9,12 +9,12 @@ import { createWebpackPlugin } from 'unplugin';
 
 import { INDEX_CSS_RE, STYLE_CSS_RE, unpluginFactory } from './core';
 
-export function attachWebpackHooks(plugin) {
+export function attachWebpackHooks(plugin, hookName = 'webpack') {
   const cssInjectionTarget = plugin.__stylexCssInjectionTarget;
 
   return {
     ...plugin,
-    webpack(compiler) {
+    [hookName](compiler) {
       const PLUGIN_NAME = '@stylexjs/unplugin';
       compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
         plugin.__stylexResetState?.();


### PR DESCRIPTION
## What changed / motivation ?

Fixes the Rspack entry for `@stylexjs/unplugin` so StyleX CSS injection hooks are registered through the Rspack-specific hook.

`unplugin` invokes framework-specific hooks for Rspack via `plugin.rspack(compiler)`. The StyleX Rspack entry reused the Webpack hook registration as `plugin.webpack(compiler)`, which meant the JS transform could run while the CSS asset injection hook was skipped.

This updates the shared Webpack hook helper to accept the framework hook name, keeps `webpack` as the default, and makes the Rspack entry register the hook as `rspack`.


## Pre-flight checklist

- [x] I have read the contributing guidelines
      `https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md`
- [x] Performed a self-review of my code