### PR TITLE
Fix double-negation of negative numbers in value parsers

### DIFF
--- a/packages/style-value-parser/src/css-types/__tests__/alpha-value-test.js
+++ b/packages/style-value-parser/src/css-types/__tests__/alpha-value-test.js
@@ -38,6 +38,10 @@ describe('Test CSS Type: <alpha-value>', () => {
       expect(AlphaValue.parser.parse('0.5')).toEqual(new AlphaValue(0.5));
       expect(AlphaValue.parser.parse('1')).toEqual(new AlphaValue(1));
     });
+    test('preserves the sign of negative alpha values', () => {
+      expect(AlphaValue.parser.parse('-0.5')).toEqual(new AlphaValue(-0.5));
+      expect(AlphaValue.parser.parse('-50%')).toEqual(new AlphaValue(-0.5));
+    });
   });
   describe('Percentages', () => {
     test('50%', () => {

--- a/packages/style-value-parser/src/css-types/__tests__/transform-function-test.js
+++ b/packages/style-value-parser/src/css-types/__tests__/transform-function-test.js
@@ -334,6 +334,13 @@ describe('Test CSS Type: <transform-function>', () => {
       expect(TransformFunction.parser.parseToEnd('scale(1.5, 2.5)')).toEqual(
         new Scale(1.5, 2.5),
       );
+      // Negative values must be preserved (e.g. scale(-1) flips/mirrors).
+      expect(TransformFunction.parser.parseToEnd('scale(-1)')).toEqual(
+        new Scale(-1),
+      );
+      expect(TransformFunction.parser.parseToEnd('scale(-1.5, -2)')).toEqual(
+        new Scale(-1.5, -2),
+      );
     });
     test('invalid uses', () => {
       // Not enough values

--- a/packages/style-value-parser/src/css-types/alpha-value.js
+++ b/packages/style-value-parser/src/css-types/alpha-value.js
@@ -18,14 +18,7 @@ export class AlphaValue {
     return this.value.toString();
   }
   static parser: TokenParser<AlphaValue> = TokenParser.oneOf(
-    TokenParser.tokens.Percentage.map(
-      (v) =>
-        new AlphaValue(
-          ((v[4].signCharacter === '-' ? -1 : 1) * v[4].value) / 100,
-        ),
-    ),
-    TokenParser.tokens.Number.map(
-      (v) => new AlphaValue((v[4].signCharacter === '-' ? -1 : 1) * v[4].value),
-    ),
+    TokenParser.tokens.Percentage.map((v) => new AlphaValue(v[4].value / 100)),
+    TokenParser.tokens.Number.map((v) => new AlphaValue(v[4].value)),
   );
 }

--- a/packages/style-value-parser/src/css-types/common-types.js
+++ b/packages/style-value-parser/src/css-types/common-types.js
@@ -93,7 +93,5 @@ export class Percentage {
 export const numberOrPercentage: TokenParser<number | Percentage> =
   TokenParser.oneOf(
     Percentage.parser,
-    TokenParser.token<TokenNumber>(TokenType.Number).map((v) =>
-      v[4].signCharacter === '-' ? -v[4].value : v[4].value,
-    ),
+    TokenParser.token<TokenNumber>(TokenType.Number).map((v) => v[4].value),
   );


### PR DESCRIPTION
## Summary

With `@csstools/css-tokenizer` 3.x, a Number/Percentage token's `value` field already includes the sign — e.g. `-3` tokenizes to `{ value: -3, signCharacter: '-' }`. Two parsers in `@stylexjs/style-value-parser` additionally negated the value when `signCharacter === '-'`, double-negating negative inputs:

- `numberOrPercentage` (`common-types.js`) — used by `Scale`, `Scale3d`, `ScaleAxis`. So `scale(-1)` parsed to `Scale(1)`, turning a mirror/flip into a positive scale.
- `AlphaValue.parser` (`alpha-value.js`) — negative alpha values lost their sign.

The fix reads `v[4].value` directly, matching sibling parsers (e.g. `Matrix` in `transform-function.js`) that already use the signed token value as-is. Positive and `+`-signed values are unaffected.

(Note: `flex.js` also reads `signCharacter`, but there it's a legitimate guard against negative `fr` values, so it's left unchanged.)

## Test plan

Added regression tests for negative `scale` and negative `alpha` (both fail before, pass after):

```
yarn --cwd packages/style-value-parser jest
# Tests: 325 passed
```
- Before: `scale(-1)` → `Scale { sx: 1 }`; `AlphaValue.parse('-0.5')` → `0.5`.
- After: signs preserved.