### PR TITLE
fix(babel-plugin): correct typos in comment and test name

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
@@ -3385,7 +3385,7 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
-    test('hoisting correctly with duplicte names', () => {
+    test('hoisting correctly with duplicate names', () => {
       expect(
         transform(
           `

--- a/packages/@stylexjs/babel-plugin/src/visitors/parse-stylex-create-arg.js
+++ b/packages/@stylexjs/babel-plugin/src/visitors/parse-stylex-create-arg.js
@@ -275,7 +275,7 @@ function evaluateObjKey(
   } else if (keyPath.isIdentifier()) {
     key = keyPath.node.name;
   } else {
-    // TODO: This is'nt handling all possible types that `keyPath` could be
+    // TODO: This isn't handling all possible types that `keyPath` could be
     key = (keyPath.node as $FlowFixMe).value;
   }
   return {


### PR DESCRIPTION
## Summary

Fixes two self-evident spelling typos in the `@stylexjs/babel-plugin` package. These are comment / test-name only changes with no behavior impact.

| File | Before | After |
| --- | --- | --- |
| `packages/@stylexjs/babel-plugin/src/visitors/parse-stylex-create-arg.js` | `// TODO: This is'nt handling all possible types...` | `// TODO: This isn't handling all possible types...` |
| `packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js` | `test('hoisting correctly with duplicte names', ...)` | `test('hoisting correctly with duplicate names', ...)` |

## Notes

- No production behavior change; the test-name change only affects the human-readable describe/test label.
- I swept the rest of the repo (comments, README, docs/MDX) for typo patterns and stale `facebookexperimental/` references and found no other confident fixes, so this PR is kept intentionally small.