### PR TITLE
Fix leading-zero normalizer skipping negative fractional values

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-value-normalization-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-value-normalization-test.js
@@ -174,6 +174,15 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
+    test('strip leading zeros from negative values', () => {
+      const code = transform(`
+        import stylex from 'stylex';
+        const styles = stylex.create({ x: { marginTop: '-0.5px' } });
+      `);
+      expect(code).toContain('margin-top:-.5px');
+      expect(code).not.toContain('-0.5px');
+    });
+
     test('use double quotes in empty strings', () => {
       expect(
         transform(`

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/normalizers/leading-zero.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/normalizers/leading-zero.js
@@ -27,7 +27,7 @@ export default function normalizeLeadingZero(
       return;
     }
     const dimension = parser.unit(node.value);
-    if (value < 1 && value >= 0) {
+    if (Math.abs(value) < 1) {
       node.value =
         value.toString().replace('0.', '.') + (dimension ? dimension.unit : '');
     }


### PR DESCRIPTION
## Summary

The leading-zero normalizer shortens fractional CSS values for smaller output (`0.5px` → `.5px`). But its guard excludes negative numbers:

```js
if (value < 1 && value >= 0) {   // value >= 0 excludes negatives
  node.value = value.toString().replace('0.', '.') + (dimension ? dimension.unit : '');
}
```

So `-0.5px` is emitted as-is while `0.5px` becomes `.5px` — inconsistent output for equivalent magnitudes. The transform already produces the correct shortened string for negatives (`(-0.5).toString().replace('0.', '.')` → `-.5`); only the value gate blocked it.

## Fix

Use `Math.abs(value) < 1` so negative fractions are normalized too (`-0.5px` → `-.5px`). `0`/`-0` and `|value| >= 1` are unchanged.

## Test plan

```
yarn --cwd packages/@stylexjs/babel-plugin jest
```
Added a regression test (`marginTop: '-0.5px'` → `margin-top:-.5px`) that fails before and passes after. Full babel-plugin suite: **960 passed**, no snapshot regressions.