### PR TITLE
Fix zero-unit stripping inside functions after the first (invalid CSS)

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-value-normalization-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-value-normalization-test.js
@@ -95,6 +95,16 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
+    test('preserves zero units inside a non-first function', () => {
+      const code = transform(`
+        import stylex from 'stylex';
+        const styles = stylex.create({ x: { width: 'max(1px, 2px) calc(0px + 1%)' } });
+      `);
+      // calc(0 + 1%) is invalid CSS — a unitless 0 cannot be added to a %.
+      expect(code).toContain('calc(0px + 1%)');
+      expect(code).not.toContain('calc(0 + 1%)');
+    });
+
     test('0 timings are all "0s"', () => {
       expect(
         transform(`

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/normalizers/zero-dimensions.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/normalizers/zero-dimensions.js
@@ -32,8 +32,8 @@ export default function normalizeZeroDimensions(
   let endFunction = 0;
 
   ast.walk((node) => {
-    if (node.type === 'function' && !endFunction) {
-      endFunction = node.sourceEndIndex ?? 0;
+    if (node.type === 'function') {
+      endFunction = Math.max(endFunction, node.sourceEndIndex ?? 0);
     }
     if (endFunction > 0 && node.sourceIndex > endFunction) {
       endFunction = 0;


### PR DESCRIPTION
## Summary

`normalizeZeroDimensions` strips redundant units from zero values (`0px` → `0`) but must **not** do so inside a function — e.g. in `calc(0px + 1%)`, a unitless `0` is a `<number>` and cannot be added to a `<percentage>`. It tracks the active function's range via `endFunction`, but the guard only recorded the **first** function:

```js
if (node.type === 'function' && !endFunction) {   // only the first function
  endFunction = node.sourceEndIndex ?? 0;
}
if (endFunction > 0 && node.sourceIndex > endFunction) {
  endFunction = 0;                                  // reset once past it
}
```

`postcss-value-parser` walks a function node before its children, so when a *second* function is reached the `&& !endFunction` guard blocks the update, the reset line then zeroes `endFunction`, and the second function's zero values get their units stripped — producing **invalid CSS**:

| input | output |
|---|---|
| `calc(0px + 1%)` (alone) | `calc(0px + 1%)` ✅ |
| `calc(0px + 1%) max(1px,2px)` (1st) | `calc(0px + 1%) …` ✅ |
| `max(1px,2px) calc(0px + 1%)` (2nd) | `max(1px,2px) calc(0 + 1%)` ❌ |

## Fix

Record every function's end with `Math.max(endFunction, node.sourceEndIndex ?? 0)`. The existing `sourceIndex > endFunction` reset still clears the range once walking moves past the last function, so bare zeros **outside** functions (`margin: 0px` → `0`, `calc(5px) 0px` → `… 0`) still normalize correctly.

## Test plan

```
yarn --cwd packages/@stylexjs/babel-plugin jest
```
Added a regression test (`width: 'max(1px, 2px) calc(0px + 1%)'` stays `calc(0px + 1%)`) that fails before and passes after. Full babel-plugin suite: **960 passed**, no snapshot regressions.