### PR TITLE
fix(eslint-plugin): respect enableMediaQueryOrder in sort-keys

### DIFF
--- a/packages/@stylexjs/eslint-plugin/README.md
+++ b/packages/@stylexjs/eslint-plugin/README.md
@@ -57,11 +57,21 @@ This rule helps to sort the StyleX property keys according to
 
 #### Config options
 
-```json
+```js
 {
-  "validImports": ["stylex", "@stylexjs/stylex"]
+  order: 'default',                            // Sort order: 'default', 'clean', or 'recess'
+  minKeys: 2,                                  // Minimum number of keys before sorting is enforced
+  allowLineSeparatedGroups: false,             // Treat blank-line-separated blocks as independent groups
+  enableMediaQueryOrder: false,                // Preserve authored `@media` order to match StyleX's `enableMediaQueryOrder`
+  validImports: ['stylex', '@stylexjs/stylex']
 }
 ```
+
+When you compile with StyleX's `enableMediaQueryOrder`, overlapping media
+queries are resolved by source order (the last matching query wins). Sorting
+`@media` keys alphabetically inverts that cascade, so set
+`enableMediaQueryOrder: true` here to keep the rule from reordering media
+queries and let you control the cascade through their authored order.
 
 ### @stylexjs/valid-shorthands
 

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-sort-keys-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-sort-keys-test.js
@@ -365,6 +365,39 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         },
       });`,
     },
+    {
+      // With `enableMediaQueryOrder`, authored media query order is preserved,
+      // so a max-width cascade written largest-first is reported as valid.
+      options: [{ enableMediaQueryOrder: true }],
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          container: {
+            padding: {
+              default: '2rem',
+              '@media (max-width: 768px)': '1.5rem',
+              '@media (max-width: 640px)': '1rem',
+            },
+          },
+        });
+      `,
+    },
+    {
+      // min-width breakpoints authored smallest-first are also left untouched.
+      options: [{ enableMediaQueryOrder: true }],
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          container: {
+            fontSize: {
+              default: '1rem',
+              '@media (min-width: 640px)': '1.25rem',
+              '@media (min-width: 1024px)': '1.5rem',
+            },
+          },
+        });
+      `,
+    },
   ],
   invalid: [
     {
@@ -1413,6 +1446,71 @@ eslintTester.run('stylex-sort-keys', rule.default, {
         {
           message:
             'StyleX property key ":when:api:active" should be above ":when:api:focus"',
+        },
+      ],
+    },
+    {
+      // Default behavior is unchanged: without the option, max-width media
+      // queries are still reordered alphabetically (the cascade-breaking bug).
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          container: {
+            padding: {
+              default: '2rem',
+              '@media (max-width: 768px)': '1.5rem',
+              '@media (max-width: 640px)': '1rem',
+            },
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          container: {
+            padding: {
+              default: '2rem',
+              '@media (max-width: 640px)': '1rem',
+              '@media (max-width: 768px)': '1.5rem',
+            },
+          },
+        });
+      `,
+      errors: [
+        {
+          message:
+            'StyleX property key "@media (max-width: 640px)" should be above "@media (max-width: 768px)"',
+        },
+      ],
+    },
+    {
+      // With `enableMediaQueryOrder`, regular property keys are still sorted;
+      // only media query ordering is left to the author.
+      options: [{ enableMediaQueryOrder: true }],
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            animationDuration: '100ms',
+            padding: 10,
+            fontSize: 12,
+          }
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          main: {
+            padding: 10,
+            animationDuration: '100ms',
+            fontSize: 12,
+          }
+        });
+      `,
+      errors: [
+        {
+          message:
+            'StyleX property key "padding" should be above "animationDuration"',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/src/stylex-sort-keys.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-sort-keys.js
@@ -36,6 +36,7 @@ type Schema = {
   order: 'default' | 'clean' | 'recess',
   minKeys: number,
   allowLineSeparatedGroups: boolean,
+  enableMediaQueryOrder: boolean,
 };
 
 type Stack = null | {
@@ -54,11 +55,28 @@ type SortableProperty = {
   rangeEnd: number,
 };
 
+function isMediaQuery(name: string): boolean {
+  return typeof name === 'string' && name.startsWith('@media');
+}
+
 function isValidOrder(
   prevName: string,
   currName: string,
   order: Schema['order'],
+  enableMediaQueryOrder: boolean,
 ): boolean {
+  // When `enableMediaQueryOrder` is set, StyleX resolves overlapping media
+  // queries by source order ("last media query wins"). Sorting `@media`
+  // condition keys alphabetically inverts that cascade, so we treat any
+  // authored order between two media queries as valid and leave it untouched.
+  if (
+    enableMediaQueryOrder &&
+    isMediaQuery(prevName) &&
+    isMediaQuery(currName)
+  ) {
+    return true;
+  }
+
   const prev = getPropertyPriorityAndType(prevName, order);
   const curr = getPropertyPriorityAndType(currName, order);
 
@@ -74,12 +92,20 @@ function comparePropertyNames(
   aName: string,
   bName: string,
   order: Schema['order'],
+  enableMediaQueryOrder: boolean,
 ): number {
   if (aName === bName) {
     return 0;
   }
 
-  return isValidOrder(aName, bName, order) ? -1 : 1;
+  // Preserve the authored relative order of media queries so the autofix does
+  // not reshuffle them (the sort below is stable and falls back to the
+  // original index when this returns 0).
+  if (enableMediaQueryOrder && isMediaQuery(aName) && isMediaQuery(bName)) {
+    return 0;
+  }
+
+  return isValidOrder(aName, bName, order, enableMediaQueryOrder) ? -1 : 1;
 }
 
 const stylexSortKeys = {
@@ -124,6 +150,10 @@ const stylexSortKeys = {
             type: 'boolean',
             default: false,
           },
+          enableMediaQueryOrder: {
+            type: 'boolean',
+            default: false,
+          },
         },
         additionalProperties: false,
       },
@@ -135,6 +165,7 @@ const stylexSortKeys = {
       order = 'default',
       minKeys = 2,
       allowLineSeparatedGroups = false,
+      enableMediaQueryOrder = false,
     }: Schema = context.options[0] || {};
 
     const importTracker = createImportTracker(importsToLookFor);
@@ -293,7 +324,7 @@ const stylexSortKeys = {
           return;
         }
 
-        if (!isValidOrder(prevName, currName, order)) {
+        if (!isValidOrder(prevName, currName, order, enableMediaQueryOrder)) {
           context.report({
             // $FlowFixMe[incompatible-type]
             node,
@@ -305,6 +336,7 @@ const stylexSortKeys = {
               sourceCode,
               order,
               allowLineSeparatedGroups,
+              enableMediaQueryOrder,
             }),
           });
         }
@@ -328,11 +360,13 @@ function createFix({
   sourceCode,
   order,
   allowLineSeparatedGroups,
+  enableMediaQueryOrder,
 }: {
   currNode: Property,
   sourceCode: SourceCode,
   order: Schema['order'],
   allowLineSeparatedGroups: boolean,
+  enableMediaQueryOrder: boolean,
 }) {
   return function (fixer: RuleFixer) {
     const group = getSortableGroup(currNode);
@@ -342,7 +376,12 @@ function createFix({
     }
 
     const sortedGroup = [...group].sort((a, b) => {
-      const result = comparePropertyNames(a.name, b.name, order);
+      const result = comparePropertyNames(
+        a.name,
+        b.name,
+        order,
+        enableMediaQueryOrder,
+      );
 
       return result === 0 ? group.indexOf(a) - group.indexOf(b) : result;
     });


### PR DESCRIPTION
## What

Adds an `enableMediaQueryOrder` option to the `@stylexjs/sort-keys` rule. When it is on, the rule keeps the authored order of `@media` condition keys instead of sorting them alphabetically. It defaults to `false`, so existing behavior is unchanged.

## Why

Fixes #1416. When a project compiles with StyleX's `enableMediaQueryOrder`, overlapping media queries are resolved by source order, so the last matching query wins. Sorting `@media` keys alphabetically inverts that cascade. A correctly authored `max-width: 768px` followed by `max-width: 640px` gets flipped by `--fix`, so mobile viewports pick up the tablet value. Right now the only workaround is wrapping every responsive property in an `eslint-disable` block.

## How

All `@media` keys share a single at-rule priority, so the comparator was falling through to an alphabetical tiebreak. With the option on, two media-query keys are treated as already ordered when reporting and compared as equal when autofixing (the sort is stable and falls back to the original index), so their source order is kept. Non-media keys still sort normally. This matches how the compiler orders queries by source order, and it can fall back to the #1407 breakpoint sort once that merges.

## Tests

Added regression tests to `stylex-sort-keys-test.js`: valid cases for max-width and min-width cascades under the option, an invalid case confirming the default still reorders, and one confirming regular keys still sort with the option on. `jest stylex-sort-keys` passes 59/59.
