### PR TITLE
Add no-raw-media-queries rule to eslint-plugin

### DIFF
--- a/packages/@stylexjs/eslint-plugin/README.md
+++ b/packages/@stylexjs/eslint-plugin/README.md
@@ -273,3 +273,65 @@ This rule disallows using `className` or `style` props on elements that spread
   "validImports": ["stylex", "@stylexjs/stylex"]
 }
 ```
+
+### `@stylexjs/no-raw-media-queries`
+
+This rule disallows raw media query strings within `stylex.create` calls. It
+helps keep breakpoints consistent across a codebase by requiring media queries
+to be defined once with
+[`stylex.defineConsts`](https://stylexjs.com/docs/api/javascript/defineConsts/)
+and referenced as shared constants.
+
+#### Invalid example
+
+```js
+const styles = stylex.create({
+  root: {
+    width: {
+      default: '100%',
+      '@media (max-width: 600px)': '50%',
+    },
+  },
+});
+```
+
+#### Instead...
+
+```js
+// breakpoints.stylex.js
+export const breakpoints = stylex.defineConsts({
+  small: '@media (max-width: 600px)',
+});
+```
+
+```js
+import { breakpoints } from './breakpoints.stylex';
+
+const styles = stylex.create({
+  root: {
+    width: {
+      default: '100%',
+      [breakpoints.small]: '50%',
+    },
+  },
+});
+```
+
+#### Config options
+
+```json
+{
+  "validImports": ["stylex", "@stylexjs/stylex"],
+  "allowedMediaQueries": []
+}
+```
+
+Use `allowedMediaQueries` to permit specific raw media query strings, which can
+be useful while migrating a codebase incrementally. Entries are compared as
+exact strings, so they must match the source character for character:
+
+```json
+{
+  "allowedMediaQueries": ["@media print"]
+}
+```

--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-no-raw-media-queries-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-no-raw-media-queries-test.js
@@ -1,0 +1,268 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const { RuleTester: ESLintTester } = require('eslint');
+const rule = require('../src/stylex-no-raw-media-queries');
+
+const eslintTester = new ESLintTester({
+  parser: require.resolve('hermes-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+const errorMessage =
+  'Raw media query strings are not allowed. Define this query with `stylex.defineConsts` and use the shared constant instead. See https://stylexjs.com/docs/api/javascript/defineConsts/';
+
+eslintTester.run('stylex-no-raw-media-queries', rule.default, {
+  valid: [
+    {
+      // media query conditions referencing shared constants
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        import { breakpoints } from './breakpoints.stylex';
+        const styles = stylex.create({
+          root: {
+            width: {
+              default: '100%',
+              [breakpoints.small]: '50%',
+            },
+          },
+        });
+      `,
+    },
+    {
+      // template literal keys containing expressions reference constants
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        import { breakpoints } from './breakpoints.stylex';
+        const styles = stylex.create({
+          root: {
+            width: {
+              default: '100%',
+              [\`\${breakpoints.small}\`]: '50%',
+            },
+          },
+        });
+      `,
+    },
+    {
+      // dynamic styles referencing shared constants
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        import { breakpoints } from './breakpoints.stylex';
+        const styles = stylex.create({
+          root: (width) => ({
+            width: {
+              default: width,
+              [breakpoints.small]: '50%',
+            },
+          }),
+        });
+      `,
+    },
+    {
+      // pseudo classes and default conditions are unaffected
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          root: {
+            color: {
+              default: 'black',
+              ':hover': 'blue',
+            },
+          },
+        });
+      `,
+    },
+    {
+      // raw media queries as *values* (not keys) are fine — this is how
+      // constants are defined in the first place
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        export const breakpoints = stylex.defineConsts({
+          small: '@media (max-width: 600px)',
+        });
+      `,
+    },
+    {
+      // create calls from untracked imports are ignored
+      code: `
+        import * as stylex from 'other-library';
+        const styles = stylex.create({
+          root: {
+            width: {
+              default: '100%',
+              '@media (min-width: 600px)': '50%',
+            },
+          },
+        });
+      `,
+    },
+    {
+      // queries listed in allowedMediaQueries are permitted
+      options: [{ allowedMediaQueries: ['@media print'] }],
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          root: {
+            display: {
+              default: 'flex',
+              '@media print': 'none',
+            },
+          },
+        });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      // raw media query condition in the modern syntax
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          root: {
+            width: {
+              default: '100%',
+              '@media (min-width: 600px)': '50%',
+            },
+          },
+        });
+      `,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      // raw media query in the legacy contextual syntax
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          root: {
+            '@media (min-width: 600px)': {
+              width: '50%',
+            },
+          },
+        });
+      `,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      // nested raw media queries are each reported
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          root: {
+            width: {
+              default: '100%',
+              '@media (min-width: 600px)': {
+                default: '50%',
+                '@media screen': '40%',
+              },
+            },
+          },
+        });
+      `,
+      errors: [{ message: errorMessage }, { message: errorMessage }],
+    },
+    {
+      // raw media queries inside dynamic styles are reported
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          root: (width) => ({
+            width: {
+              default: width,
+              '@media (min-width: 600px)': '50%',
+            },
+          }),
+        });
+      `,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      // template literal keys without expressions are still raw strings
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          root: {
+            width: {
+              default: '100%',
+              [\`@media (min-width: 600px)\`]: '50%',
+            },
+          },
+        });
+      `,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      // named create imports are tracked too
+      code: `
+        import { create } from '@stylexjs/stylex';
+        const styles = create({
+          root: {
+            width: {
+              default: '100%',
+              '@media (min-width: 600px)': '50%',
+            },
+          },
+        });
+      `,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      // at-rule matching is case-insensitive
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          root: {
+            width: {
+              default: '100%',
+              '@MEDIA (min-width: 600px)': '50%',
+            },
+          },
+        });
+      `,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      // custom import sources are respected
+      options: [{ validImports: ['custom-stylex'] }],
+      code: `
+        import * as stylex from 'custom-stylex';
+        const styles = stylex.create({
+          root: {
+            width: {
+              default: '100%',
+              '@media (min-width: 600px)': '50%',
+            },
+          },
+        });
+      `,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      // allowedMediaQueries only permits exact matches
+      options: [{ allowedMediaQueries: ['@media print'] }],
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          root: {
+            display: {
+              default: 'flex',
+              '@media (min-width: 600px)': 'none',
+            },
+          },
+        });
+      `,
+      errors: [{ message: errorMessage }],
+    },
+  ],
+});

--- a/packages/@stylexjs/eslint-plugin/src/index.js
+++ b/packages/@stylexjs/eslint-plugin/src/index.js
@@ -12,6 +12,7 @@ import noLegacyContextualStyles from './stylex-no-legacy-contextual-styles';
 import noLookaheadSelectors from './stylex-no-lookahead-selectors';
 import noNonStandardStyles from './stylex-no-nonstandard-styles';
 import noConflictingProps from './stylex-no-conflicting-props';
+import noRawMediaQueries from './stylex-no-raw-media-queries';
 import noUnused from './stylex-no-unused';
 import sortKeys from './stylex-sort-keys';
 import validShorthands from './stylex-valid-shorthands';
@@ -23,6 +24,7 @@ const rules: {
   'no-lookahead-selectors': typeof noLookaheadSelectors,
   'no-nonstandard-styles': typeof noNonStandardStyles,
   'no-conflicting-props': typeof noConflictingProps,
+  'no-raw-media-queries': typeof noRawMediaQueries,
   'no-unused': typeof noUnused,
   'sort-keys': typeof sortKeys,
   'valid-shorthands': typeof validShorthands,
@@ -33,6 +35,7 @@ const rules: {
   'no-lookahead-selectors': noLookaheadSelectors,
   'no-nonstandard-styles': noNonStandardStyles,
   'no-conflicting-props': noConflictingProps,
+  'no-raw-media-queries': noRawMediaQueries,
   'no-unused': noUnused,
   'sort-keys': sortKeys,
   'valid-shorthands': validShorthands,

--- a/packages/@stylexjs/eslint-plugin/src/stylex-no-raw-media-queries.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-no-raw-media-queries.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+import type { Node, CallExpression, ObjectExpression, Property } from 'estree';
+import type { ValidImportSource } from './utils/createImportTracker';
+import createImportTracker from './utils/createImportTracker';
+/*:: import { Rule } from 'eslint'; */
+
+type Schema = {
+  validImports: Array<ValidImportSource>,
+  allowedMediaQueries: Array<string>,
+};
+
+const MEDIA_QUERY_PATTERN: RegExp = /^@media\b/i;
+
+const stylexNoRawMediaQueries = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow raw media query strings within `stylex.create` calls in favor of shared constants defined with `stylex.defineConsts`',
+      recommended: false,
+      url: 'https://github.com/facebook/stylex/tree/main/packages/@stylexjs/eslint-plugin',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validImports: {
+            type: 'array',
+            items: {
+              oneOf: [
+                { type: 'string' },
+                {
+                  type: 'object',
+                  properties: {
+                    from: { type: 'string' },
+                    as: { type: 'string' },
+                  },
+                },
+              ],
+            },
+            default: ['stylex', '@stylexjs/stylex'],
+          },
+          allowedMediaQueries: {
+            type: 'array',
+            items: { type: 'string' },
+            default: [] as Array<string>,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context: Rule.RuleContext): { ... } {
+    const {
+      validImports: importsToLookFor = ['stylex', '@stylexjs/stylex'],
+      allowedMediaQueries = [],
+    }: Schema = context.options[0] || {};
+
+    const importTracker = createImportTracker(importsToLookFor);
+    const allowedQueries = new Set<string>(allowedMediaQueries);
+
+    function isStylexCreateCallee(node: Node) {
+      return (
+        (node.type === 'MemberExpression' &&
+          node.object.type === 'Identifier' &&
+          importTracker.isStylexDefaultImport(node.object.name) &&
+          node.property.type === 'Identifier' &&
+          node.property.name === 'create') ||
+        (node.type === 'Identifier' &&
+          importTracker.isStylexNamedImport('create', node.name))
+      );
+    }
+
+    function isStylexCreateDeclaration(node: Node) {
+      return (
+        node &&
+        node.type === 'CallExpression' &&
+        isStylexCreateCallee(node.callee) &&
+        node.arguments.length === 1
+      );
+    }
+
+    // Returns the raw media query string when the key is written inline
+    // (a string literal or a template literal without any expressions).
+    // Keys computed from identifiers or member expressions are assumed to
+    // reference shared constants and return undefined.
+    function getRawMediaQueryFromKey(property: Property): string | void {
+      const key = property.key;
+
+      if (key.type === 'Literal') {
+        const value = key.value;
+        if (typeof value === 'string' && MEDIA_QUERY_PATTERN.test(value)) {
+          return value;
+        }
+      }
+
+      if (
+        key.type === 'TemplateLiteral' &&
+        key.expressions.length === 0 &&
+        key.quasis.length === 1
+      ) {
+        const cooked = key.quasis[0].value.cooked;
+        if (typeof cooked === 'string' && MEDIA_QUERY_PATTERN.test(cooked)) {
+          return cooked;
+        }
+      }
+
+      return undefined;
+    }
+
+    // Dynamic styles are declared as arrow functions that return the style
+    // object (`root: (width) => ({ ... })`). Returns the returned object so
+    // the rule can descend into it, mirroring `stylex-valid-styles`.
+    function unwrapDynamicStyle(value: Node): Node {
+      if (value.type === 'ArrowFunctionExpression') {
+        let body = value.body;
+        // $FlowFixMe[invalid-compare]
+        if (body.type === 'TSAsExpression') {
+          body = body.expression;
+        }
+        if (body.type === 'ObjectExpression') {
+          return body;
+        }
+      }
+      return value;
+    }
+
+    function checkObjectExpression(node: ObjectExpression): void {
+      node.properties.forEach((property) => {
+        if (property.type !== 'Property') {
+          return;
+        }
+
+        const rawMediaQuery = getRawMediaQueryFromKey(property);
+        if (rawMediaQuery != null && !allowedQueries.has(rawMediaQuery)) {
+          context.report({
+            node: property.key,
+            message:
+              'Raw media query strings are not allowed. Define this query with `stylex.defineConsts` and use the shared constant instead. See https://stylexjs.com/docs/api/javascript/defineConsts/',
+          });
+        }
+
+        const value = unwrapDynamicStyle(property.value);
+        if (value.type === 'ObjectExpression') {
+          checkObjectExpression(value);
+        }
+      });
+    }
+
+    return {
+      ImportDeclaration: importTracker.ImportDeclaration,
+
+      CallExpression(node: CallExpression): void {
+        const firstArg = node.arguments[0];
+        if (
+          isStylexCreateDeclaration(node) &&
+          firstArg.type === 'ObjectExpression'
+        ) {
+          checkObjectExpression(firstArg);
+        }
+      },
+      'Program:exit'() {
+        importTracker.clear();
+      },
+    };
+  },
+};
+
+export default stylexNoRawMediaQueries as typeof stylexNoRawMediaQueries;

--- a/packages/docs/content/docs/api/configuration/eslint-plugin.mdx
+++ b/packages/docs/content/docs/api/configuration/eslint-plugin.mdx
@@ -188,3 +188,25 @@ type Options = {
   validImports: Array<string | { from: string; as: string }>;
 };
 ```
+
+### `@stylexjs/no-raw-media-queries` rule
+
+Disallows raw media query strings within `stylex.create` calls in favor of
+shared constants defined with
+[`stylex.defineConsts`](/docs/api/javascript/defineConsts).
+
+```ts
+type Options = {
+  // Possible strings where you can import stylex from
+  //
+  // Default: ['stylex', '@stylexjs/stylex']
+  validImports: Array<string | { from: string; as: string }>;
+
+  // Raw media query strings that are still allowed,
+  // e.g. while migrating a codebase incrementally.
+  // Entries are compared as exact strings.
+  //
+  // Default: []
+  allowedMediaQueries: Array<string>;
+};
+```


### PR DESCRIPTION
## What changed / motivation ?

Adds a new opt-in lint rule, `@stylexjs/no-raw-media-queries`, that flags raw media query strings inside `stylex.create` calls and suggests defining them once with `stylex.defineConsts` and referencing the shared constant instead.

Without this rule nothing stops hardcoded breakpoints from drifting across a codebase (five slightly different "mobile" queries, etc.). Now that `defineConsts` is shipped, this rule makes the shared-constants pattern enforceable.

What it catches:

- raw string keys like `'@media (min-width: 600px)'` at any nesting depth (modern conditional-value syntax and the legacy contextual syntax)
- expressionless template literal keys, e.g. ``[`@media (min-width: 600px)`]``
- `@MEDIA`-style casing (matching is case-insensitive)
- dynamic styles declared as arrow functions, e.g. `root: (width) => ({ ... })`

What it deliberately leaves alone:

- computed keys referencing constants, e.g. `[breakpoints.small]` — that's the pattern being encouraged
- media queries as *values* inside `stylex.defineConsts` — that's where they belong
- `create` calls from imports not listed in `validImports`

Options follow the plugin's conventions: `validImports` (same shape as the other rules) plus an `allowedMediaQueries` exact-match allowlist so large codebases can migrate incrementally.

Scope notes for v1, happy to adjust:

- Only `stylex.create` is checked. `defineVars` / `createTheme` condition keys could be covered in a follow-up if you'd like.
- Only `@media` is flagged (per the rule name). `@supports` / `@container` could be added behind an option.
- The "Advanced: file tree knowledge" idea from the issue (discovering near-equal constants across the codebase) is intentionally out of scope here.

Also happy to rename the rule if you prefer something broader like `enforce-consts`.

## Linked PR/Issues

Fixes #725

## Additional Context

- 16 new RuleTester cases in `__tests__/stylex-no-raw-media-queries-test.js`; full eslint-plugin suite passes (565 tests, 10 suites)
- Documented in the package README and the docs site (`eslint-plugin.mdx`), matching the format of the existing rules
- Side note: #724 is still open but `defineConsts` appears to have shipped (v0.13) — it may be safe to close

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
