### PR TITLE
[style-value-parser] Fix BorderRadiusShorthand.toString dropping vertical radii

### DIFF
--- a/packages/style-value-parser/src/properties/__tests__/border-radius.test.js
+++ b/packages/style-value-parser/src/properties/__tests__/border-radius.test.js
@@ -351,4 +351,29 @@ describe('Test CSS property shorthand: `border-radius`', () => {
       ),
     );
   });
+
+  describe('serialization: `BorderRadiusShorthand.toString`', () => {
+    const roundTrip = (input: string): string =>
+      BorderRadiusShorthand.parse.parseToEnd(input).toString();
+
+    test('symmetric radii serialize without a `/`', () => {
+      expect(roundTrip('10px')).toBe('10px');
+      expect(roundTrip('10px 20px')).toBe('10px 20px');
+      expect(roundTrip('10px 20px 30px')).toBe('10px 20px 30px');
+      expect(roundTrip('10px 20px 30px 40px')).toBe('10px 20px 30px 40px');
+    });
+
+    test('asymmetric radii keep the vertical values after the `/`', () => {
+      // Regression: the vertical (post-slash) radii were previously rendered
+      // using the horizontal values, which collapsed the whole value back to
+      // the horizontal radii and dropped the vertical radii entirely.
+      expect(roundTrip('10px 20px 30px 40px / 40px 30px 20px 10px')).toBe(
+        '10px 20px 30px 40px / 40px 30px 20px 10px',
+      );
+      expect(roundTrip('10px / 20px')).toBe('10px / 20px');
+      expect(roundTrip('10px 20px / 30px 40px')).toBe(
+        '10px 20px / 30px 40px',
+      );
+    });
+  });
 });

--- a/packages/style-value-parser/src/properties/border-radius.js
+++ b/packages/style-value-parser/src/properties/border-radius.js
@@ -106,7 +106,7 @@ export class BorderRadiusShorthand {
     const verticalBottomRight = this.verticalBottomRight.toString();
     const verticalBottomLeft = this.verticalBottomLeft.toString();
 
-    let sStr = `${horizontalTopLeft} ${horizontalTopRight} ${horizontalBottomRight} ${horizontalBottomLeft}`;
+    let sStr = `${verticalTopLeft} ${verticalTopRight} ${verticalBottomRight} ${verticalBottomLeft}`;
     // All three are the same
     if (
       verticalTopLeft === verticalTopRight &&


### PR DESCRIPTION
## Summary

`BorderRadiusShorthand.toString()` builds two strings: `pStr` from the horizontal radii (rendered before the `/`) and `sStr` from the vertical radii (after the `/`). `sStr` was **initialized** from the *horizontal* radii instead of the vertical ones:

```js
let sStr = `${horizontalTopLeft} ${horizontalTopRight} ${horizontalBottomRight} ${horizontalBottomLeft}`;
```

The three reassignment branches below it all correctly use the vertical radii, but they only fire when the vertical radii have some symmetry (all equal, diagonal pairs equal, or `topRight === bottomLeft`). When all four vertical radii are distinct, none fire, so `sStr` keeps its horizontal initial value. That makes `pStr === sStr`, and `toString` returns just `pStr` — **silently dropping the vertical radii**.

Example:
```
'10px 20px 30px 40px / 40px 30px 20px 10px'  →  '10px 20px 30px 40px'   (before)
'10px 20px 30px 40px / 40px 30px 20px 10px'  →  '10px 20px 30px 40px / 40px 30px 20px 10px'  (after)
```

## Fix

Initialize `sStr` from the vertical radii, matching the reassignment branches (one-line change).

## Test

Added round-trip tests in `border-radius.test.js`: symmetric radii still serialize without a `/`, and asymmetric radii preserve the vertical values after the `/`. The asymmetric case fails before this change and passes after.

The fix is isolated to `toString`; the parser is unchanged. (I verified the exact `toString` branching against the buggy and fixed initializations with a standalone reproduction of the logic — the asymmetric case collapses before and round-trips after — since I couldn't run the full jest suite locally.)
