### PR TITLE
[eslint-plugin] Allow calc() for outlineWidth in valid-styles (#1690)

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -917,6 +917,18 @@ eslintTester.run('stylex-valid-styles', rule.default, {
         }
       });
     `,
+    // outlineWidth accepts calc() / math expressions, like other <line-width>
+    // properties such as borderWidth (#1690)
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          foo: {
+            outlineWidth: 'calc(0.25rem + 1px)',
+          },
+        });
+      `,
+    },
     {
       code: `
         import * as stylex from '@stylexjs/stylex';

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -2094,7 +2094,7 @@ const CSSProperties = {
     'inset',
     'outset',
   ) as RuleCheck,
-  outlineWidth: makeUnionRule(isNumber, isLength) as RuleCheck,
+  outlineWidth: makeUnionRule(isNumber, isLength, isNonNumericString) as RuleCheck,
   blockOverflow: overflow, // TODO - Add support to Babel Plugin
   inlineOverflow: overflow, // TODO - Add support to Babel Plugin
   overflow: overflow,


### PR DESCRIPTION
## Summary

Fixes #1690. The `@stylexjs/eslint-plugin` `valid-styles` rule rejects `calc()` for `outlineWidth`:

```js
const styles = stylex.create({
  foo: { outlineWidth: 'calc(0.25rem + 1px)' }, // flagged invalid
});
```

`outlineWidth` was defined as `makeUnionRule(isNumber, isLength)`, which has no path for `calc()` / math expressions. The analogous CSS `<line-width>` property `borderWidth` already allows them via `isNonNumericString`:

```js
const borderWidth = makeUnionRule(isNumber, makeLiteralRule('thin'), makeLiteralRule('medium'), makeLiteralRule('thick'), isNonNumericString, isLength);
```

## Fix

Add `isNonNumericString` to `outlineWidth`'s union so it accepts `calc()` (and other math expressions), matching `borderWidth`. Numeric strings like `'10'` remain invalid, since `isNonNumericString` rejects them — consistent with the existing `border*Width` behavior (the suite already expects `outlineWidth: "10"` to error, and that stays an error).

## Test

Added a valid-case test asserting `outlineWidth: 'calc(0.25rem + 1px)'` passes. (Note: I couldn't run the eslint-plugin jest suite in my sandbox, but the fix mirrors `borderWidth` exactly and the existing test suite's own assertions — `border*Width: "10"` errors while `borderWidth: 'calc(...)'` is valid — confirm `isNonNumericString`'s behavior; CI will exercise the added test.)
