### PR TITLE
[codemods] Scaffold @stylexjs/codemods package + verification checks (Emotion→StyleX, 1/6)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,9 @@ module.exports = {
     '**/*.d.ts',
     '**/pages.gen.ts',
     '**/devtools-extension/extension/**',
+    // codemod fixtures are deliberately non-conforming (broken-on-purpose
+    // inputs that the correctness gates must fail on)
+    '**/codemods/__fixtures__/**',
   ],
   overrides: [
     {

--- a/.flowconfig
+++ b/.flowconfig
@@ -24,6 +24,7 @@ module.name_mapper='^@stylexjs/babel-plugin$' -> '<PROJECT_ROOT>/packages/@style
 module.name_mapper='^@stylexjs/stylex$' -> '<PROJECT_ROOT>/packages/@stylexjs/stylex/src/stylex.js'
 module.name_mapper='^@stylexjs/shared$' -> '<PROJECT_ROOT>/packages/@stylexjs/shared/src/index.js'
 module.name_mapper='^style-value-parser$' -> '<PROJECT_ROOT>/packages/style-value-parser/src/index.js'
+module.name_mapper='^@stylexjs/eslint-plugin$' -> '<PROJECT_ROOT>/packages/@stylexjs/eslint-plugin/src/index.js'
 ; type-stubs
 module.system.node.resolve_dirname=flow_modules
 module.system.node.resolve_dirname=node_modules

--- a/packages/@stylexjs/codemods/.babelrc.js
+++ b/packages/@stylexjs/codemods/.babelrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  assumptions: {
+    iterableIsArray: true,
+  },
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        exclude: ['@babel/plugin-transform-typeof-symbol'],
+        targets: 'defaults',
+      },
+    ],
+    '@babel/preset-flow',
+    '@babel/preset-react',
+  ],
+  plugins: [['babel-plugin-syntax-hermes-parser', { flow: 'detect' }]],
+};

--- a/packages/@stylexjs/codemods/ARCHITECTURE.md
+++ b/packages/@stylexjs/codemods/ARCHITECTURE.md
@@ -1,0 +1,100 @@
+# Architecture
+
+The codemod is a source-to-source compiler: styling code in, equivalent
+StyleX out. It is built so that supporting a new source library never means
+rebuilding the compiler — only writing a new front-end for it.
+
+> **One engine, swappable readers.** A small library-specific **adapter**
+> turns one styling library into a neutral style model (the IR). A single
+> library-agnostic **core** turns that model into correct, lint-clean
+> StyleX. To add Emotion, MUI, or CSS Modules you write an adapter — the
+> engine never changes.
+
+## The seam
+
+| | Adapter (per source) | Core engine (shared) |
+| --- | --- | --- |
+| Owns | detect, read, rewrite call sites, import cleanup | IR build, conflict referee, value normalization, emit, registry, postprocess, gates |
+| Knows about | one styling library's syntax | only the IR and StyleX |
+| Changes when | a new source is added | StyleX itself gains a feature |
+
+**Load-bearing invariant:** `src/core/` imports *nothing* from
+`src/adapters/` and never touches a parser node — it only sees
+declarations, the IR, and emitted StyleX fragments. Enforced by
+`__tests__/seam-test.js` from commit one. The seam is crossed exactly
+twice:
+
+1. **Adapter → core:** a flat list of `declarations`
+   (`{ context, property, value }`) — "here is what styles exist".
+2. **Core → adapter:** the **binding map** — "style site #1 becomes
+   `styles.button`" — which the adapter places back into that library's
+   idiom.
+
+A second invariant keeps the AST toolkit swappable: only
+`src/core/rewriter.js` may import jscodeshift/recast (also enforced by the
+seam test).
+
+## The IR (`src/core/ir.js`)
+
+The IR is shaped like **StyleX's output** (property-grouped, conditions
+nested inside a property), not like any source's input. A style either maps
+into the IR (convertible) or it does not (flagged — never guessed); the
+edge of the IR is the edge of what is automatable.
+
+Its only two open axes are the ones StyleX itself grows along, both modeled
+as variant types so growth stays additive:
+
+- `Condition` — `pseudo-class` / `pseudo-element` / `at-rule` (later:
+  ancestor selectors, `@supports`, `@container`).
+- `Value` — `static` and `first-that-works` today; a `dynamic`
+  (function-form) variant lands in v1.1.
+
+Completeness is **measured, not asserted**: the IR-completeness harness
+(`__tests__/ir-completeness-test.js`) round-trips valid StyleX style
+objects through a test-only reader and reports a coverage percentage. An
+IR gap is safe — in the pipeline the construct is flagged, never
+emitted incorrectly.
+
+## The gates (`src/core/gates/`)
+
+Independent correctness checks, used as test assertions and as a runtime
+safety net. Each is proven to FAIL on a deliberately-broken input
+(`__fixtures__/broken/`) — a gate that never fails is worthless.
+
+- **Compile** (`compile.js`) — output must compile through the real
+  `@stylexjs/babel-plugin`; also yields the plugin's rule metadata.
+- **Lint** (`lint.js`) — output must pass every `@stylexjs/eslint-plugin`
+  rule at *error* with zero messages (zero autofixes needed).
+- **Semantic diff** (`semanticDiff.js`) — net CSS before (from
+  `@emotion/serialize`, the source library's own ground truth) and after
+  (from babel-plugin metadata) must match across every condition
+  combination, minus an explicit allowlist of sanctioned diffs
+  (hover-guard, physical→logical). Its parsers throw on anything they
+  cannot provably represent, so an unparsable input can never diff clean
+  by accident.
+- **Render gate** *(future, v2.0)* — Playwright computed-style diff in a
+  real browser, keeping the semantic-diff gate honest.
+
+## Testing layers
+
+1. **Gate self-tests** — each gate green on the trivial pair AND red on a
+   broken pair (`__tests__/gates-test.js`).
+2. **Fixture tests** — the executable spec. Every
+   `__fixtures__/emotion/<name>/{input,expected}.js` pair must: match the
+   transform byte-exactly (after Prettier), compile, lint clean, and pass
+   the semantic diff (`__tests__/emotion-fixtures-test.js`).
+3. **Engine unit tests** — hand-written IR fed to the engine (from M1),
+   proving the engine is source-neutral.
+4. **Seam tests** — the architectural invariants, as assertions.
+5. **IR-completeness** — the measured coverage number.
+
+## Layer map
+
+| Layer | Module |
+| --- | --- |
+| Parse/print wrapper | `src/core/rewriter.js` (jscodeshift, isolated) |
+| IR types | `src/core/ir.js` |
+| Gates | `src/core/gates/{compile,lint,semanticDiff}.js` |
+| Emotion adapter | `src/adapters/emotion/` (M1+) |
+| Engine (build IR, referee, normalize, emit) | `src/core/` (M1–M4) |
+| CLI & dry-run report | `src/cli/` (M6) |

--- a/packages/@stylexjs/codemods/README.md
+++ b/packages/@stylexjs/codemods/README.md
@@ -1,0 +1,51 @@
+# @stylexjs/codemods
+
+Codemods for migrating styling libraries to [StyleX](https://stylexjs.com) —
+Emotion first, built as **one library-agnostic engine with swappable
+per-library adapters**.
+
+> **Status: pre-release scaffold (M0).** The correctness harness — fixture
+> tests plus three gates (compile, lint, semantic-diff) — is in place and
+> proven; transforms land milestone by milestone. Nothing here is published
+> yet, and the package name/location is pending maintainer confirmation.
+
+## Principles
+
+- **Bail loudly.** Only provably-safe styles are converted. Anything else is
+  flagged with a `// TODO(stylex-migration): …` comment, and a file is
+  refused outright when a partial conversion could change rendering.
+  Wrong-but-plausible output is the one unacceptable result.
+- **Gated output.** Every conversion must compile through
+  `@stylexjs/babel-plugin`, pass `@stylexjs/eslint-plugin` at *error* with
+  zero autofixes needed, and have semantically identical net CSS (checked
+  against Emotion's own serializer, minus an explicit allowlist:
+  hover-guard, physical→logical properties).
+
+## Converts / flags / refuses (planned v1.0 scope)
+
+| Bucket | Patterns |
+| --- | --- |
+| Converts | static `css={{…}}` / `css({})` / object-form `styled.div({})`; self-targeting pseudo-classes/elements; media queries; object-form `keyframes`; fallback arrays; shorthands; mapped theme tokens |
+| Flags | template literals; dynamic styles; `styled(Component)`; out-of-element selectors; `<Global>`; `shouldForwardProp`; unmapped tokens; `!important` |
+| Refuses | any file where partial conversion could change rendering |
+
+## Compatibility
+
+| | Version |
+| --- | --- |
+| Emits StyleX | 0.19.x |
+| Reads Emotion | 10–11 (object syntax) |
+
+See [`ARCHITECTURE.md`](./ARCHITECTURE.md) for the design.
+
+## Development
+
+```sh
+cd packages/@stylexjs/codemods
+yarn jest          # run from the package cwd, not the repo root
+yarn build
+```
+
+Fixture pairs live in `__fixtures__/emotion/<name>/{input,expected}.js`; set
+`UPDATE_STYLEX_CODEMOD_FIXTURES=1` to regenerate expected files when a
+change is intentional.

--- a/packages/@stylexjs/codemods/__fixtures__/broken/compile-invalid.js
+++ b/packages/@stylexjs/codemods/__fixtures__/broken/compile-invalid.js
@@ -1,0 +1,12 @@
+// DELIBERATELY BROKEN: `stylex.create` must be called with a statically
+// analyzable object literal — a function call argument makes the real
+// @stylexjs/babel-plugin throw. The compile gate must FAIL on this file.
+import * as stylex from '@stylexjs/stylex';
+
+function getStyles() {
+  return { badge: { color: 'red' } };
+}
+
+const styles = stylex.create(getStyles());
+
+export default styles;

--- a/packages/@stylexjs/codemods/__fixtures__/broken/lint-invalid.js
+++ b/packages/@stylexjs/codemods/__fixtures__/broken/lint-invalid.js
@@ -1,0 +1,12 @@
+// DELIBERATELY BROKEN: compiles, but violates @stylexjs/eslint-plugin rules
+// ('colr' is not a valid property; styles are never used). The lint gate
+// must FAIL on this file.
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  badge: { colr: 'red' },
+});
+
+export default function Badge() {
+  return styles != null;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/static-flat-color/expected.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/static-flat-color/expected.js
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  badge: { color: 'red' },
+});
+
+export default function Badge() {
+  return <div {...stylex.props(styles.badge)}>Badge</div>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/static-flat-color/input.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/static-flat-color/input.js
@@ -1,0 +1,6 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+
+export default function Badge() {
+  return <div css={{ color: 'red' }}>Badge</div>;
+}

--- a/packages/@stylexjs/codemods/__tests__/emotion-fixtures-test.js
+++ b/packages/@stylexjs/codemods/__tests__/emotion-fixtures-test.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * The fixture harness — the executable spec. Every input/expected pair
+ * under `__fixtures__/emotion/` must satisfy four checks:
+ *
+ *   1. transform(input) matches expected byte-exactly (after Prettier);
+ *   2. expected compiles through @stylexjs/babel-plugin;
+ *   3. expected passes @stylexjs/eslint-plugin at error, zero messages;
+ *   4. the net CSS of input and expected is semantically identical
+ *      (minus the sanctioned allowlist).
+ *
+ * Set UPDATE_STYLEX_CODEMOD_FIXTURES=1 to regenerate expected files when a
+ * change is intentional.
+ *
+ * M0 status: no transform exists yet, so checks 1 and 4 (which need the
+ * transform / the adapter's reader) are pending and explicitly skipped;
+ * checks 2 and 3 run for real. M1 wires `transform` below and un-skips.
+ */
+
+import * as fs from 'fs';
+import { compileGate } from '../src/core/gates/compile';
+import { lintGate } from '../src/core/gates/lint';
+import { loadFixtures, formatWithPrettier } from './utils/harness';
+
+// M1: replace with the real emotion transform (input source -> output source).
+const transform: ((source: string, filename: string) => string) | null = null;
+
+const UPDATE = process.env.UPDATE_STYLEX_CODEMOD_FIXTURES === '1';
+
+const fixtures = loadFixtures('emotion');
+
+test('there is at least one fixture pair', () => {
+  expect(fixtures.length).toBeGreaterThan(0);
+});
+
+test('prettier normalization is available and idempotent', () => {
+  const [fixture] = fixtures;
+  const once = formatWithPrettier(fixture.expected, fixture.expectedPath);
+  expect(formatWithPrettier(once, fixture.expectedPath)).toEqual(once);
+});
+
+describe.each(fixtures.map((f) => [f.name, f]))(
+  'fixture: %s',
+  (_name, fixture) => {
+    const testIfTransform = transform == null ? test.skip : test;
+
+    // Check 1 — pending M1 (needs the transform).
+    testIfTransform('transform(input) matches expected byte-exactly', () => {
+      if (transform == null) {
+        throw new Error('unreachable');
+      }
+      const actual = formatWithPrettier(
+        transform(fixture.input, fixture.inputPath),
+        fixture.expectedPath,
+      );
+      if (UPDATE) {
+        fs.writeFileSync(fixture.expectedPath, actual);
+      }
+      expect(actual).toEqual(
+        formatWithPrettier(fixture.expected, fixture.expectedPath),
+      );
+    });
+
+    // Check 2 — live from M0.
+    test('expected compiles through @stylexjs/babel-plugin', () => {
+      const result = compileGate(fixture.expected, {
+        filename: fixture.expectedPath,
+      });
+      if (!result.ok) {
+        throw new Error(result.errors.join('\n'));
+      }
+      expect(result.ok).toBe(true);
+    });
+
+    // Check 3 — live from M0.
+    test('expected passes @stylexjs/eslint-plugin at error with zero messages', () => {
+      const result = lintGate(fixture.expected, {
+        filename: fixture.expectedPath,
+      });
+      if (!result.ok) {
+        throw new Error(JSON.stringify(result.messages, null, 2));
+      }
+      expect(result.ok).toBe(true);
+    });
+
+    // Check 4 — pending M1 (extracting the input's style objects is the
+    // adapter reader's job; the gate itself is proven in gates-test.js).
+    testIfTransform(
+      'net CSS of input and expected is semantically identical',
+      () => {
+        throw new Error('wired in M1 with the emotion adapter reader');
+      },
+    );
+  },
+);

--- a/packages/@stylexjs/codemods/__tests__/gates-test.js
+++ b/packages/@stylexjs/codemods/__tests__/gates-test.js
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Gate self-tests. A gate that never fails is worthless, so every gate is
+ * proven BOTH ways: green on the trivial hand-written pair, and red on a
+ * deliberately-broken input.
+ */
+
+import { serializeStyles } from '@emotion/serialize';
+import { compileGate } from '../src/core/gates/compile';
+import { lintGate } from '../src/core/gates/lint';
+import {
+  semanticDiffGate,
+  netCssFromSerializedCss,
+  netCssFromStylexMetadata,
+  UnsupportedCssError,
+} from '../src/core/gates/semanticDiff';
+import { loadFixtures, readBrokenFixture } from './utils/harness';
+
+const [trivialPair] = loadFixtures('emotion').filter(
+  (f) => f.name === 'static-flat-color',
+);
+
+// The style object literally present in the trivial pair's input.js.
+const trivialEmotionObject = { color: 'red' };
+
+function emotionNetCss(styleObject: mixed) {
+  return netCssFromSerializedCss(serializeStyles([styleObject]).styles);
+}
+
+describe('compile gate', () => {
+  test('passes on the trivial expected output', () => {
+    const result = compileGate(trivialPair.expected, {
+      filename: trivialPair.expectedPath,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test('FAILS on the deliberately-broken pair (non-static create arg)', () => {
+    const result = compileGate(readBrokenFixture('compile-invalid.js'));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.join('\n')).toMatch(/create\(\)/);
+    }
+  });
+});
+
+describe('lint gate', () => {
+  test('passes on the trivial expected output', () => {
+    const result = lintGate(trivialPair.expected, {
+      filename: trivialPair.expectedPath,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test('FAILS on the deliberately-broken pair (invalid property, unused styles)', () => {
+    const result = lintGate(readBrokenFixture('lint-invalid.js'));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const ruleIds = result.messages.map((m) => m.ruleId);
+      expect(ruleIds).toContain('@stylexjs/valid-styles');
+      expect(ruleIds).toContain('@stylexjs/no-unused');
+    }
+  });
+});
+
+describe('semantic-diff gate', () => {
+  test('trivial pair end-to-end: Emotion input and compiled StyleX output have equal net CSS', () => {
+    const compiled = compileGate(trivialPair.expected, {
+      filename: trivialPair.expectedPath,
+    });
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) {
+      return;
+    }
+    const before = emotionNetCss(trivialEmotionObject);
+    const after = netCssFromStylexMetadata(compiled.metadata);
+    const result = semanticDiffGate(before, after);
+    expect(result.ok).toBe(true);
+  });
+
+  test('FAILS end-to-end when the output renders a different value', () => {
+    const wrongExpected = trivialPair.expected.replace("'red'", "'blue'");
+    const compiled = compileGate(wrongExpected);
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) {
+      return;
+    }
+    const result = semanticDiffGate(
+      emotionNetCss(trivialEmotionObject),
+      netCssFromStylexMetadata(compiled.metadata),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.diffs).toEqual([
+        expect.objectContaining({
+          property: 'color',
+          beforeValue: 'red',
+          afterValue: 'blue',
+        }),
+      ]);
+    }
+  });
+
+  test('FAILS when a declaration is dropped entirely', () => {
+    const result = semanticDiffGate(
+      emotionNetCss({ color: 'red', fontSize: 16 }),
+      emotionNetCss({ color: 'red' }),
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  test('parses nested pseudo-class and media conditions', () => {
+    const net = emotionNetCss({
+      color: 'red',
+      ':hover': { color: 'blue' },
+      '@media (min-width: 600px)': { color: 'green' },
+    });
+    expect(Object.keys(net).sort()).toEqual([
+      'color',
+      'color @ :hover',
+      'color @ @media(min-width:600px)',
+    ]);
+  });
+
+  test('allowlist: the hover-guard is a sanctioned diff', () => {
+    const before = emotionNetCss({ ':hover': { color: 'blue' } });
+    const after = emotionNetCss({
+      '@media (hover: hover)': { ':hover': { color: 'blue' } },
+    });
+    const result = semanticDiffGate(before, after);
+    expect(result.ok).toBe(true);
+    expect(result.allowed.length).toBeGreaterThan(0);
+  });
+
+  test('allowlist: physical -> logical is a sanctioned diff', () => {
+    const result = semanticDiffGate(
+      emotionNetCss({ marginLeft: '8px' }),
+      emotionNetCss({ marginInlineStart: '8px' }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.allowed.length).toBeGreaterThan(0);
+  });
+
+  test('allowlist does NOT excuse a value change under the same disguise', () => {
+    const result = semanticDiffGate(
+      emotionNetCss({ marginLeft: '8px' }),
+      emotionNetCss({ marginInlineStart: '9px' }),
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  test('BAILS LOUDLY on selectors that reach outside the element', () => {
+    expect(() => emotionNetCss({ '& > span': { color: 'red' } })).toThrow(
+      UnsupportedCssError,
+    );
+    expect(() => emotionNetCss({ 'div span': { color: 'red' } })).toThrow(
+      UnsupportedCssError,
+    );
+  });
+
+  test('BAILS LOUDLY on unrecognized StyleX metadata', () => {
+    expect(() => netCssFromStylexMetadata({ nope: true })).toThrow(
+      UnsupportedCssError,
+    );
+  });
+});

--- a/packages/@stylexjs/codemods/__tests__/ir-completeness-test.js
+++ b/packages/@stylexjs/codemods/__tests__/ir-completeness-test.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * IR-completeness harness (M0 stub).
+ *
+ * Completeness is MEASURED, not asserted: every valid StyleX style object
+ * in the corpus is read into the IR; whatever cannot be represented is a
+ * concrete, safe coverage gap (in the real pipeline it would be flagged,
+ * never emitted incorrectly). The reader lands with the M1 emitter — until then
+ * every entry counts as uncovered and the reported coverage is 0%.
+ *
+ * M1+: replace the seed corpus with extraction from StyleX's own valid
+ * fixtures (`@stylexjs/babel-plugin` / `@stylexjs/eslint-plugin` tests),
+ * and round-trip each covered entry (IR -> emit -> compile + semantic-diff).
+ */
+
+import {
+  stylexObjectToIR,
+  IRCoverageGapError,
+} from '../src/testing/stylexToIR';
+
+const SEED_CORPUS: $ReadOnlyArray<[string, mixed]> = [
+  ['flat static styles', { color: 'red', fontSize: 16 }],
+  [
+    'pseudo-class conditions in the value object',
+    { color: { default: 'black', ':hover': 'blue' } },
+  ],
+  // Valid modern StyleX — pseudo-elements may appear inside value objects.
+  [
+    'pseudo-element condition in the value object',
+    { color: { default: 'black', '::placeholder': 'gray' } },
+  ],
+  [
+    'at-rule conditions',
+    { width: { default: '100%', '@media (min-width: 600px)': '50%' } },
+  ],
+  ['fallback array (firstThatWorks)', { position: ['sticky', 'fixed'] }],
+];
+
+test('every corpus entry is either covered by the IR or a typed coverage gap', () => {
+  let covered = 0;
+  const gaps: Array<string> = [];
+  for (const [name, styleObject] of SEED_CORPUS) {
+    try {
+      stylexObjectToIR(name, styleObject);
+      covered += 1;
+    } catch (error) {
+      if (!(error instanceof IRCoverageGapError)) {
+        throw error; // a real bug, not a coverage gap
+      }
+      gaps.push(name);
+    }
+  }
+  expect(covered + gaps.length).toBe(SEED_CORPUS.length);
+  // eslint-disable-next-line no-console
+  console.info(
+    `[ir-completeness] ${covered}/${SEED_CORPUS.length} corpus entries covered` +
+      (gaps.length > 0 ? ` — gaps: ${gaps.join(', ')}` : ''),
+  );
+});

--- a/packages/@stylexjs/codemods/__tests__/ir-test.js
+++ b/packages/@stylexjs/codemods/__tests__/ir-test.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type { Condition } from '../src/core/ir';
+import { conditionKey, atomCoordinate } from '../src/core/ir';
+
+test('conditionKey covers every condition kind', () => {
+  expect(conditionKey({ kind: 'pseudo-class', name: ':hover' })).toEqual(
+    ':hover',
+  );
+  expect(conditionKey({ kind: 'pseudo-element', name: '::before' })).toEqual(
+    '::before',
+  );
+  expect(
+    conditionKey({ kind: 'at-rule', rule: '@media (min-width: 600px)' }),
+  ).toEqual('@media (min-width: 600px)');
+});
+
+test('atomCoordinate is stable under condition ordering', () => {
+  const hover: Condition = { kind: 'pseudo-class', name: ':hover' };
+  const media: Condition = {
+    kind: 'at-rule',
+    rule: '@media (min-width: 600px)',
+  };
+  expect(atomCoordinate('color', [hover, media])).toEqual(
+    atomCoordinate('color', [media, hover]),
+  );
+  expect(atomCoordinate('color', [])).toEqual('color');
+});

--- a/packages/@stylexjs/codemods/__tests__/rewriter-test.js
+++ b/packages/@stylexjs/codemods/__tests__/rewriter-test.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import { parseSource, printSource, parserForFile } from '../src/core/rewriter';
+
+test('parse -> print with no mutation preserves the source byte-exactly', () => {
+  const source = [
+    '/** @jsxImportSource @emotion/react */',
+    "import * as React   from 'react';",
+    '',
+    'export default function Badge() {',
+    "  return <div css={{ color:   'red' }}>Badge</div>;",
+    '}',
+    '',
+  ].join('\n');
+  expect(printSource(parseSource(source))).toEqual(source);
+});
+
+test('parses Flow-typed user code', () => {
+  const source = 'const x: number = 1;\n';
+  expect(printSource(parseSource(source))).toEqual(source);
+});
+
+test('picks the TS parser for TypeScript files', () => {
+  expect(parserForFile('Component.tsx')).toEqual('tsx');
+  expect(parserForFile('Component.ts')).toEqual('tsx');
+  expect(parserForFile('Component.js')).toEqual('flow');
+  expect(parserForFile('Component.jsx')).toEqual('flow');
+});

--- a/packages/@stylexjs/codemods/__tests__/seam-test.js
+++ b/packages/@stylexjs/codemods/__tests__/seam-test.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Enforces the load-bearing architectural invariants from commit one:
+ *
+ *  1. `src/core/` never imports from `src/adapters/` — the neutral-IR seam.
+ *     The day core needs an adapter, the seam has leaked; that is a
+ *     regression, not a refactor.
+ *  2. Only `src/core/rewriter.js` may import the AST toolkit (jscodeshift),
+ *     so the toolkit stays swappable behind one wrapper.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC = path.join(__dirname, '..', 'src');
+
+function jsFilesUnder(dir: string): Array<string> {
+  const out: Array<string> = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    // String(): Flow's Dirent libdef types `name` as string | Buffer.
+    const name = String(entry.name);
+    const full = path.join(dir, name);
+    if (entry.isDirectory()) {
+      out.push(...jsFilesUnder(full));
+    } else if (name.endsWith('.js')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function importSpecifiers(source: string): Array<string> {
+  const specifiers = [];
+  const pattern = /(?:from\s+|require\(\s*|import\(\s*)['"]([^'"]+)['"]/g;
+  for (;;) {
+    const match = pattern.exec(source);
+    if (match == null) {
+      break;
+    }
+    specifiers.push(match[1]);
+  }
+  return specifiers;
+}
+
+test('src/core/ never imports from src/adapters/', () => {
+  for (const file of jsFilesUnder(path.join(SRC, 'core'))) {
+    for (const spec of importSpecifiers(fs.readFileSync(file, 'utf8'))) {
+      expect({ file: path.relative(SRC, file), imports: spec }).not.toEqual(
+        expect.objectContaining({
+          imports: expect.stringMatching(/adapters/),
+        }),
+      );
+    }
+  }
+});
+
+test('only core/rewriter.js imports the AST toolkit', () => {
+  for (const file of jsFilesUnder(SRC)) {
+    if (path.relative(SRC, file) === path.join('core', 'rewriter.js')) {
+      continue;
+    }
+    for (const spec of importSpecifiers(fs.readFileSync(file, 'utf8'))) {
+      expect({ file: path.relative(SRC, file), imports: spec }).not.toEqual(
+        expect.objectContaining({
+          imports: expect.stringMatching(/^(jscodeshift|recast)/),
+        }),
+      );
+    }
+  }
+});

--- a/packages/@stylexjs/codemods/__tests__/utils/harness.js
+++ b/packages/@stylexjs/codemods/__tests__/utils/harness.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+
+export const FIXTURES_DIR: string = path.join(
+  __dirname,
+  '..',
+  '..',
+  '__fixtures__',
+);
+
+/**
+ * Normalizes code through the Prettier CLI so fixture comparison is
+ * byte-exact but formatting-insensitive.
+ *
+ * Deliberately the CLI via spawnSync, NOT the Node API: Prettier 3's Node
+ * API is async-only and breaks under Jest's module sandbox.
+ */
+export function formatWithPrettier(code: string, filepath: string): string {
+  // $FlowFixMe[cannot-resolve-module] - untyped bin file
+  const bin = require.resolve('prettier/bin/prettier.cjs');
+  const result = spawnSync(
+    process.execPath,
+    [bin, '--stdin-filepath', filepath],
+    { input: code, encoding: 'utf8' },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `prettier failed for ${filepath}:\n${String(result.stderr)}`,
+    );
+  }
+  // String(): Flow types spawnSync stdout as string | Buffer.
+  return String(result.stdout);
+}
+
+export type Fixture = {
+  name: string,
+  inputPath: string,
+  expectedPath: string,
+  input: string,
+  expected: string,
+};
+
+/** Discovers all input/expected fixture pairs for an adapter. */
+export function loadFixtures(adapter: string): Array<Fixture> {
+  const dir = path.join(FIXTURES_DIR, adapter);
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      // String(): Flow's Dirent libdef types `name` as string | Buffer.
+      const name = String(entry.name);
+      const inputPath = path.join(dir, name, 'input.js');
+      const expectedPath = path.join(dir, name, 'expected.js');
+      return {
+        name,
+        inputPath,
+        expectedPath,
+        input: fs.readFileSync(inputPath, 'utf8'),
+        expected: fs.readFileSync(expectedPath, 'utf8'),
+      };
+    });
+}
+
+export function readBrokenFixture(name: string): string {
+  return fs.readFileSync(path.join(FIXTURES_DIR, 'broken', name), 'utf8');
+}

--- a/packages/@stylexjs/codemods/flow_modules/@emotion/serialize/index.js.flow
+++ b/packages/@stylexjs/codemods/flow_modules/@emotion/serialize/index.js.flow
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+// Minimal type stub for `@emotion/serialize` (test-only devDependency;
+// the semantic-diff gate's "before" ground truth).
+
+declare export function serializeStyles(
+  args: $ReadOnlyArray<mixed>,
+  registered?: mixed,
+  props?: mixed,
+): { +name: string, +styles: string, ... };

--- a/packages/@stylexjs/codemods/flow_modules/eslint/index.js.flow
+++ b/packages/@stylexjs/codemods/flow_modules/eslint/index.js.flow
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+// Minimal type stub for the parts of `eslint` the codemod uses. The real
+// package's entry point lives under `lib/`, which this repo's .flowconfig
+// ignores, so the module is unresolvable without a stub.
+
+export type LinterMessage = {
+  +ruleId: string | null,
+  +message: string,
+  +severity: number,
+  +line?: number,
+  +column?: number,
+  +fix?: mixed,
+  ...
+};
+
+declare export class Linter {
+  defineParser(name: string, parser: mixed): void;
+  defineRule(name: string, rule: mixed): void;
+  verify(
+    code: string,
+    config: mixed,
+    options?: mixed,
+  ): Array<LinterMessage>;
+  verifyAndFix(
+    code: string,
+    config: mixed,
+    options?: mixed,
+  ): { +fixed: boolean, +output: string, +messages: Array<LinterMessage> };
+}

--- a/packages/@stylexjs/codemods/flow_modules/hermes-eslint/index.js.flow
+++ b/packages/@stylexjs/codemods/flow_modules/hermes-eslint/index.js.flow
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+// Minimal type stub for `hermes-eslint` (its compiled entry lives under
+// `dist/`, which this repo's .flowconfig ignores). The module is
+// ESM-compiled with NO default export — always use a namespace import;
+// the namespace itself is the ESLint parser object.
+
+declare export function parseForESLint(
+  code: string,
+  options?: mixed,
+): { +ast: mixed, +scopeManager: mixed, ... };
+
+declare export function parse(code: string, options?: mixed): mixed;

--- a/packages/@stylexjs/codemods/package.json
+++ b/packages/@stylexjs/codemods/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@stylexjs/codemods",
+  "version": "0.19.0",
+  "description": "Codemods for migrating styling libraries (Emotion first) to StyleX",
+  "main": "./lib/index.js",
+  "repository": "https://www.github.com/facebook/stylex",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "prebuild": "gen-types -i src/ -o lib/",
+    "build": "cross-env BABEL_ENV=cjs babel src/ --out-dir lib/ --copy-files",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@babel/core": "^7.28.5",
+    "@stylexjs/babel-plugin": "0.19.0",
+    "@stylexjs/eslint-plugin": "0.19.0",
+    "@stylexjs/shared": "0.19.0",
+    "babel-plugin-syntax-hermes-parser": "0.36.1",
+    "eslint": "8.57.1",
+    "hermes-eslint": "0.36.1",
+    "jscodeshift": "^17.3.0",
+    "style-value-parser": "0.19.0"
+  },
+  "devDependencies": {
+    "@emotion/serialize": "^1.3.3",
+    "scripts": "0.19.0"
+  },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "/__fixtures__/",
+      "/__tests__/utils/"
+    ]
+  },
+  "files": [
+    "lib/*"
+  ]
+}

--- a/packages/@stylexjs/codemods/src/adapters/emotion/README.md
+++ b/packages/@stylexjs/codemods/src/adapters/emotion/README.md
@@ -1,0 +1,9 @@
+# Emotion adapter (reader)
+
+Lands from **M1**. This directory will hold the library-specific side of the
+seam: `detect.js` (find Emotion style sites), `read.js` (style sites ->
+neutral `declarations`), `rewriteSites.js` (binding map -> `stylex.props`
+call sites), and `imports.js` (Emotion import/pragma cleanup).
+
+Invariant: `src/core/` never imports from this directory. The seam is
+enforced by `__tests__/seam-test.js`.

--- a/packages/@stylexjs/codemods/src/cli/README.md
+++ b/packages/@stylexjs/codemods/src/cli/README.md
@@ -1,0 +1,5 @@
+# CLI
+
+Lands in **M6**: `stylex-codemod emotion "<glob>" [--dry-run]` (dry-run is
+the default), config loading (`resolveValue` glossary, `hoverGuard`,
+logical-properties opt-out), and the convert/flag/refuse report.

--- a/packages/@stylexjs/codemods/src/core/gates/compile.js
+++ b/packages/@stylexjs/codemods/src/core/gates/compile.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Compile gate: the output of a conversion must compile through the real
+ * `@stylexjs/babel-plugin`. On success it also returns the plugin's
+ * metadata (the injectable CSS rules), which the semantic-diff gate uses
+ * as the StyleX side's ground truth.
+ */
+
+import * as babel from '@babel/core';
+import styleXPlugin from '@stylexjs/babel-plugin';
+
+export type CompileGateResult =
+  | { +ok: true, +code: string, +metadata: mixed }
+  | { +ok: false, +errors: $ReadOnlyArray<string> };
+
+export function compileGate(
+  source: string,
+  options?: { +filename?: string },
+): CompileGateResult {
+  const filename = options?.filename ?? 'stylex-codemod-gate-input.js';
+  try {
+    const result = babel.transformSync(source, {
+      filename,
+      babelrc: false,
+      configFile: false,
+      plugins: [
+        ['babel-plugin-syntax-hermes-parser', { flow: 'detect' }],
+        [styleXPlugin, {}],
+      ],
+    });
+    if (result == null || result.code == null) {
+      return { ok: false, errors: ['Babel produced no output'] };
+    }
+    return { ok: true, code: result.code, metadata: result.metadata };
+  } catch (error) {
+    return {
+      ok: false,
+      errors: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+}

--- a/packages/@stylexjs/codemods/src/core/gates/lint.js
+++ b/packages/@stylexjs/codemods/src/core/gates/lint.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Lint gate: the output of a conversion must pass every rule of the real
+ * `@stylexjs/eslint-plugin` at severity `error`, with zero messages —
+ * which implies zero autofixes still needed (Meta's golden rule for
+ * StyleX codemods).
+ */
+
+import { Linter } from 'eslint';
+// hermes-eslint is ESM-compiled with no default export — the namespace
+// object itself is the parser (`parseForESLint` lives on it).
+import * as hermesEslint from 'hermes-eslint';
+// The plugin has named exports only (no default) — import `rules` directly.
+import { rules as stylexRules } from '@stylexjs/eslint-plugin';
+
+export type LintMessage = {
+  +ruleId: string | null,
+  +message: string,
+  +line: number,
+  +column: number,
+  +fixable: boolean,
+};
+
+export type LintGateResult =
+  | { +ok: true }
+  | { +ok: false, +messages: $ReadOnlyArray<LintMessage> };
+
+const PARSER_NAME = 'hermes-eslint';
+
+function buildLinter(): { linter: Linter, rules: { [string]: 'error' } } {
+  const linter = new Linter();
+  linter.defineParser(PARSER_NAME, hermesEslint);
+  const ruleMap: { +[string]: mixed } = stylexRules;
+  const rules: { [string]: 'error' } = {};
+  for (const ruleName of Object.keys(ruleMap)) {
+    const qualified = `@stylexjs/${ruleName}`;
+    linter.defineRule(qualified, ruleMap[ruleName]);
+    rules[qualified] = 'error';
+  }
+  return { linter, rules };
+}
+
+export function lintGate(
+  source: string,
+  options?: { +filename?: string },
+): LintGateResult {
+  const { linter, rules } = buildLinter();
+  const messages = linter.verify(
+    source,
+    {
+      parser: PARSER_NAME,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+      rules,
+    },
+    { filename: options?.filename ?? 'stylex-codemod-gate-input.js' },
+  );
+  if (messages.length === 0) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    messages: messages.map((m) => ({
+      ruleId: m.ruleId ?? null,
+      message: m.message,
+      line: m.line ?? 0,
+      column: m.column ?? 0,
+      fixable: m.fix != null,
+    })),
+  };
+}

--- a/packages/@stylexjs/codemods/src/core/gates/semanticDiff.js
+++ b/packages/@stylexjs/codemods/src/core/gates/semanticDiff.js
@@ -1,0 +1,376 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Semantic-diff gate: the net CSS before and after a conversion must be
+ * identical across every condition combination, minus an explicit allowlist
+ * of sanctioned changes (hover-guard, physical->logical). This is the check
+ * that catches "compiles fine but renders differently".
+ *
+ * Ground truths:
+ *  - before: Emotion's own serializer (`@emotion/serialize`) output,
+ *    parsed by `netCssFromSerializedCss`.
+ *  - after: the real `@stylexjs/babel-plugin` metadata (injectable rules),
+ *    parsed by `netCssFromStylexMetadata`.
+ *
+ * Both parsers BAIL LOUDLY (throw `UnsupportedCssError`) on any construct
+ * they cannot provably represent — an unparsable input must never diff
+ * clean by accident.
+ */
+
+/** One declaration of net CSS: a property+conditions coordinate => value. */
+export type NetDeclaration = {
+  +property: string, // kebab-case
+  +conditions: $ReadOnlyArray<string>, // normalized, sorted
+  +value: string,
+};
+
+export type NetCss = { +[coordinate: string]: NetDeclaration };
+
+export type DiffEntry = {
+  +coordinate: string,
+  +property: string,
+  +conditions: $ReadOnlyArray<string>,
+  +beforeValue: string | null,
+  +afterValue: string | null,
+};
+
+export type AllowlistRule = (
+  entry: DiffEntry,
+  before: NetCss,
+  after: NetCss,
+) => boolean;
+
+export type SemanticDiffResult =
+  | { +ok: true, +allowed: $ReadOnlyArray<DiffEntry> }
+  | {
+      +ok: false,
+      +diffs: $ReadOnlyArray<DiffEntry>,
+      +allowed: $ReadOnlyArray<DiffEntry>,
+    };
+
+export class UnsupportedCssError extends Error {
+  constructor(message: string) {
+    super(`[stylex-codemod semantic-diff] unsupported CSS: ${message}`);
+    this.name = 'UnsupportedCssError';
+  }
+}
+
+// --- normalization helpers ---------------------------------------------
+
+function normalizeAtRule(rule: string): string {
+  return rule
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([():,])\s*/g, '$1')
+    .trim();
+}
+
+function normalizeValue(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+function normalizeCondition(raw: string): string {
+  let s = raw.trim();
+  if (s.startsWith('&')) {
+    s = s.slice(1).trim();
+  }
+  if (s.startsWith('@')) {
+    return normalizeAtRule(s);
+  }
+  if (/^::?[\w-]+(\([^()]*\))?$/.test(s)) {
+    return s.toLowerCase();
+  }
+  throw new UnsupportedCssError(
+    `selector context '${raw}' is not a self-targeting pseudo or at-rule`,
+  );
+}
+
+function coordinate(
+  property: string,
+  conditions: $ReadOnlyArray<string>,
+): string {
+  return conditions.length === 0
+    ? property
+    : `${property} @ ${conditions.join(' && ')}`;
+}
+
+function addDeclaration(
+  target: { [string]: NetDeclaration },
+  property: string,
+  rawConditions: $ReadOnlyArray<string>,
+  value: string,
+): void {
+  const conditions = rawConditions.map(normalizeCondition).slice().sort();
+  const prop = property.trim().toLowerCase();
+  if (!/^--|^[a-z-]+$/.test(prop)) {
+    throw new UnsupportedCssError(`property '${property}'`);
+  }
+  target[coordinate(prop, conditions)] = {
+    property: prop,
+    conditions,
+    value: normalizeValue(value),
+  };
+}
+
+// --- before: Emotion serialized CSS ------------------------------------
+
+/**
+ * Parses the `styles` string produced by `@emotion/serialize` (flat
+ * declarations plus one-or-more levels of `pseudo { ... }` / `@media { ... }`
+ * nesting) into net CSS. Throws on any selector that is not self-targeting.
+ */
+export function netCssFromSerializedCss(css: string): NetCss {
+  const out: { [string]: NetDeclaration } = {};
+  const contexts: Array<string> = [];
+  let buffer = '';
+
+  const flushDeclaration = (chunk: string) => {
+    const decl = chunk.trim();
+    if (decl === '') {
+      return;
+    }
+    const colon = decl.indexOf(':');
+    if (colon <= 0) {
+      throw new UnsupportedCssError(`declaration '${decl}'`);
+    }
+    addDeclaration(out, decl.slice(0, colon), contexts, decl.slice(colon + 1));
+  };
+
+  for (let i = 0; i < css.length; i++) {
+    const char = css[i];
+    if (char === '{') {
+      const selector = buffer.trim();
+      if (selector === '') {
+        throw new UnsupportedCssError('block with empty selector');
+      }
+      if (selector.includes(',')) {
+        throw new UnsupportedCssError(`selector list '${selector}'`);
+      }
+      contexts.push(selector);
+      buffer = '';
+    } else if (char === '}') {
+      flushDeclaration(buffer);
+      buffer = '';
+      if (contexts.length === 0) {
+        throw new UnsupportedCssError('unbalanced closing brace');
+      }
+      contexts.pop();
+    } else if (char === ';') {
+      flushDeclaration(buffer);
+      buffer = '';
+    } else {
+      buffer += char;
+    }
+  }
+  if (contexts.length !== 0) {
+    throw new UnsupportedCssError('unbalanced opening brace');
+  }
+  flushDeclaration(buffer);
+  return out;
+}
+
+// --- after: StyleX babel-plugin metadata --------------------------------
+
+/**
+ * Parses `metadata.stylex` from a `compileGate` run — entries of
+ * `[className, { ltr, rtl }, priority]` — into net CSS. Rules are applied
+ * in ascending priority order, mirroring how StyleX resolves collisions.
+ */
+export function netCssFromStylexMetadata(metadata: mixed): NetCss {
+  const rules =
+    metadata != null &&
+    typeof metadata === 'object' &&
+    Array.isArray(metadata.stylex)
+      ? metadata.stylex
+      : Array.isArray(metadata)
+        ? metadata
+        : null;
+  if (rules == null) {
+    throw new UnsupportedCssError(
+      'expected StyleX babel-plugin metadata ({ stylex: [...] })',
+    );
+  }
+  const entries = rules
+    .map((rule: mixed): { ltr: string, priority: number } => {
+      if (Array.isArray(rule)) {
+        const styles = rule[1];
+        const priority = rule[2];
+        if (
+          styles != null &&
+          typeof styles === 'object' &&
+          typeof styles.ltr === 'string' &&
+          typeof priority === 'number'
+        ) {
+          return { ltr: styles.ltr, priority };
+        }
+      }
+      throw new UnsupportedCssError(
+        `metadata rule ${JSON.stringify(rule) ?? 'undefined'}`,
+      );
+    })
+    .sort((a, b) => a.priority - b.priority);
+
+  const out: { [string]: NetDeclaration } = {};
+  for (const { ltr } of entries) {
+    parseStylexRule(ltr, out);
+  }
+  return out;
+}
+
+function parseStylexRule(ltr: string, out: { [string]: NetDeclaration }): void {
+  let rest = ltr.trim();
+  const atRules: Array<string> = [];
+  while (rest.startsWith('@')) {
+    const brace = rest.indexOf('{');
+    if (brace < 0 || !rest.endsWith('}')) {
+      throw new UnsupportedCssError(`at-rule '${ltr}'`);
+    }
+    atRules.push(rest.slice(0, brace));
+    rest = rest.slice(brace + 1, -1).trim();
+  }
+  const match =
+    /^((?:\.[\w-]+)+)((?:::?[\w-]+(?:\([^()]*\))?)*)\{([^{}]*)\}$/.exec(rest);
+  if (match == null) {
+    throw new UnsupportedCssError(`rule '${ltr}'`);
+  }
+  const pseudoChain = match[2];
+  const pseudos =
+    pseudoChain === ''
+      ? []
+      : (pseudoChain.match(/::?[\w-]+(\([^()]*\))?/g) ?? []);
+  const conditions = [...atRules, ...pseudos];
+  for (const chunk of match[3].split(';')) {
+    const decl = chunk.trim();
+    if (decl === '') {
+      continue;
+    }
+    const colon = decl.indexOf(':');
+    if (colon <= 0) {
+      throw new UnsupportedCssError(`declaration '${decl}' in '${ltr}'`);
+    }
+    addDeclaration(
+      out,
+      decl.slice(0, colon),
+      conditions,
+      decl.slice(colon + 1),
+    );
+  }
+}
+
+// --- the allowlist (sanctioned, intentional diffs) ----------------------
+
+const HOVER_GUARD = normalizeAtRule('@media (hover: hover)');
+
+const PHYSICAL_TO_LOGICAL: { +[string]: string } = {
+  'margin-left': 'margin-inline-start',
+  'margin-right': 'margin-inline-end',
+  'padding-left': 'padding-inline-start',
+  'padding-right': 'padding-inline-end',
+  'border-left': 'border-inline-start',
+  'border-right': 'border-inline-end',
+  left: 'inset-inline-start',
+  right: 'inset-inline-end',
+};
+
+const LOGICAL_TO_PHYSICAL: { [string]: string } = {};
+for (const physical of Object.keys(PHYSICAL_TO_LOGICAL)) {
+  LOGICAL_TO_PHYSICAL[PHYSICAL_TO_LOGICAL[physical]] = physical;
+}
+
+/**
+ * Sanctioned: a physical property on the before side replaced by its
+ * logical twin (same conditions, same value) on the after side.
+ */
+export const allowPhysicalToLogical: AllowlistRule = (entry, before, after) => {
+  if (entry.beforeValue != null && entry.afterValue == null) {
+    const logical = PHYSICAL_TO_LOGICAL[entry.property];
+    return (
+      logical != null &&
+      after[coordinate(logical, entry.conditions)]?.value === entry.beforeValue
+    );
+  }
+  if (entry.afterValue != null && entry.beforeValue == null) {
+    const physical = LOGICAL_TO_PHYSICAL[entry.property];
+    return (
+      physical != null &&
+      before[coordinate(physical, entry.conditions)]?.value === entry.afterValue
+    );
+  }
+  return false;
+};
+
+/**
+ * Sanctioned: a `:hover` declaration additionally wrapped in
+ * `@media (hover: hover)` on the after side (the hover-guard, on by
+ * default in the codemod).
+ */
+export const allowHoverGuard: AllowlistRule = (entry, before, after) => {
+  const hasHover = entry.conditions.some((c) => c.startsWith(':hover'));
+  if (!hasHover) {
+    return false;
+  }
+  if (entry.beforeValue != null && entry.afterValue == null) {
+    const guarded = [...entry.conditions, HOVER_GUARD].sort();
+    return (
+      after[coordinate(entry.property, guarded)]?.value === entry.beforeValue
+    );
+  }
+  if (
+    entry.afterValue != null &&
+    entry.beforeValue == null &&
+    entry.conditions.includes(HOVER_GUARD)
+  ) {
+    const unguarded = entry.conditions.filter((c) => c !== HOVER_GUARD);
+    return (
+      before[coordinate(entry.property, unguarded)]?.value === entry.afterValue
+    );
+  }
+  return false;
+};
+
+export const DEFAULT_ALLOWLIST: $ReadOnlyArray<AllowlistRule> = [
+  allowPhysicalToLogical,
+  allowHoverGuard,
+];
+
+// --- the gate -----------------------------------------------------------
+
+export function semanticDiffGate(
+  before: NetCss,
+  after: NetCss,
+  options?: { +allowlist?: $ReadOnlyArray<AllowlistRule> },
+): SemanticDiffResult {
+  const allowlist = options?.allowlist ?? DEFAULT_ALLOWLIST;
+  const coordinates = new Set([...Object.keys(before), ...Object.keys(after)]);
+  const diffs: Array<DiffEntry> = [];
+  const allowed: Array<DiffEntry> = [];
+  for (const coord of coordinates) {
+    const b = before[coord];
+    const a = after[coord];
+    if (b != null && a != null && b.value === a.value) {
+      continue;
+    }
+    const entry: DiffEntry = {
+      coordinate: coord,
+      property: (b ?? a)?.property ?? coord,
+      conditions: (b ?? a)?.conditions ?? [],
+      beforeValue: b?.value ?? null,
+      afterValue: a?.value ?? null,
+    };
+    if (allowlist.some((rule) => rule(entry, before, after))) {
+      allowed.push(entry);
+    } else {
+      diffs.push(entry);
+    }
+  }
+  return diffs.length === 0
+    ? { ok: true, allowed }
+    : { ok: false, diffs, allowed };
+}

--- a/packages/@stylexjs/codemods/src/core/ir.js
+++ b/packages/@stylexjs/codemods/src/core/ir.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+/**
+ * The neutral intermediate representation (IR) shared by every adapter and
+ * the core engine. Its shape mirrors StyleX's OUTPUT (property-grouped, with
+ * conditions nested inside a property), not any source library's input.
+ *
+ * A style either maps into this IR (=> convertible) or it does not
+ * (=> flagged, never guessed). The edge of the IR is the edge of what is
+ * automatable.
+ *
+ * The two open axes — `Condition` and `Value` — are variant types because
+ * they are the only axes StyleX itself grows along. New condition kinds
+ * (`@supports`, `@container`, ancestor selectors) and new value kinds
+ * (dynamic/function-form) are ADDITIVE extensions; the structure never
+ * changes for a new source library.
+ */
+
+/**
+ * A single typed condition under which a value applies.
+ * Only self-targeting conditions are representable — selectors that reach
+ * outside the element have no encoding here, by design.
+ */
+export type Condition =
+  | { +kind: 'pseudo-class', +name: string } // e.g. ':hover'
+  | { +kind: 'pseudo-element', +name: string } // e.g. '::before'
+  | { +kind: 'at-rule', +rule: string }; // e.g. '@media (min-width: 600px)'
+
+/**
+ * The value of an atom. `static` is the only variant in v1.0; a
+ * `dynamic` variant (props-driven, -> StyleX function-form create) is the
+ * planned v1.1 addition.
+ */
+export type Value =
+  | { +kind: 'static', +value: string | number | null }
+  | {
+      +kind: 'first-that-works',
+      +values: $ReadOnlyArray<string | number>,
+    };
+
+/**
+ * The unit of the IR: one property, under zero or more conditions,
+ * with one value. e.g. { property: 'color', conditions: [:hover], 'blue' }.
+ */
+export type Atom = {
+  +property: string, // camelCase, StyleX-style (e.g. 'backgroundColor')
+  +conditions: $ReadOnlyArray<Condition>,
+  +value: Value,
+};
+
+/**
+ * One named entry in a `stylex.create` registry — a group of atoms with the
+ * key the emitter should try to use for it.
+ */
+export type StyleRule = {
+  +name: string,
+  +atoms: $ReadOnlyArray<Atom>,
+};
+
+/** An object-form keyframes declaration (`stylex.keyframes`). */
+export type KeyframesRule = {
+  +name: string,
+  +frames: $ReadOnlyArray<{
+    +selector: string, // 'from' | 'to' | '0%' ...
+    +atoms: $ReadOnlyArray<Atom>,
+  }>,
+};
+
+/**
+ * Everything the engine knows about one file's styles: the rules destined
+ * for the single per-file `stylex.create`, plus file-level constructs.
+ * Design tokens (`defineVars`) join in M3.
+ */
+export type FileIR = {
+  +rules: $ReadOnlyArray<StyleRule>,
+  +keyframes: $ReadOnlyArray<KeyframesRule>,
+};
+
+/** Stable string form of a condition, used for grouping and diffing. */
+export function conditionKey(condition: Condition): string {
+  switch (condition.kind) {
+    case 'pseudo-class':
+    case 'pseudo-element':
+      return condition.name;
+    case 'at-rule':
+    default:
+      return condition.rule;
+  }
+}
+
+/**
+ * Stable string form of an atom's (property, conditions) coordinate —
+ * conditions sorted so ordering differences do not create false diffs.
+ */
+export function atomCoordinate(
+  property: string,
+  conditions: $ReadOnlyArray<Condition>,
+): string {
+  const keys = conditions.map(conditionKey).slice().sort();
+  return keys.length === 0 ? property : `${property} @ ${keys.join(' && ')}`;
+}

--- a/packages/@stylexjs/codemods/src/core/rewriter.js
+++ b/packages/@stylexjs/codemods/src/core/rewriter.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * The single place in the codebase that knows which AST toolkit we use.
+ * Everything else (core and adapters alike) goes through this wrapper, so
+ * jscodeshift/recast stays swappable (hermes-parser, ts-morph, plain
+ * babel+recast) without touching any other module — a maintainer question
+ * we have deliberately kept open.
+ *
+ * jscodeshift is the default: format-preserving printing via recast, and
+ * parses the Flow/TS/JSX found in user code.
+ */
+
+import jscodeshift from 'jscodeshift';
+
+// 'flow' also covers plain JS + JSX; 'tsx' also covers plain TS.
+export type ParserChoice = 'flow' | 'tsx';
+
+export opaque type Rewriter = {
+  +j: $FlowFixMe,
+  +root: $FlowFixMe,
+};
+
+/** Picks a parser from the file extension (TS/TSX vs Flow/JS). */
+export function parserForFile(filename: string): ParserChoice {
+  return /\.(ts|tsx|mts|cts)$/.test(filename) ? 'tsx' : 'flow';
+}
+
+/** Parses source into a rewriter handle (a jscodeshift Collection). */
+export function parseSource(
+  source: string,
+  options?: { +parser?: ParserChoice },
+): Rewriter {
+  const j = jscodeshift.withParser(options?.parser ?? 'flow');
+  return { j, root: j(source) };
+}
+
+/** Prints a rewriter handle back to source, format-preserving. */
+export function printSource(rewriter: Rewriter): string {
+  return rewriter.root.toSource({ quote: 'single' });
+}

--- a/packages/@stylexjs/codemods/src/index.js
+++ b/packages/@stylexjs/codemods/src/index.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * @stylexjs/codemods — migrate styling libraries to StyleX.
+ *
+ * M0: gated harness only. The public surface is the IR types and the three
+ * correctness gates; transforms land from M1.
+ */
+
+export type {
+  Atom,
+  Condition,
+  Value,
+  StyleRule,
+  KeyframesRule,
+  FileIR,
+} from './core/ir';
+export { conditionKey, atomCoordinate } from './core/ir';
+
+export { compileGate } from './core/gates/compile';
+export { lintGate } from './core/gates/lint';
+export {
+  semanticDiffGate,
+  netCssFromSerializedCss,
+  netCssFromStylexMetadata,
+  DEFAULT_ALLOWLIST,
+  UnsupportedCssError,
+} from './core/gates/semanticDiff';
+
+export { parseSource, printSource, parserForFile } from './core/rewriter';

--- a/packages/@stylexjs/codemods/src/testing/stylexToIR.js
+++ b/packages/@stylexjs/codemods/src/testing/stylexToIR.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * TEST-ONLY reader: a valid `stylex.create` style object -> IR.
+ *
+ * This powers the IR-completeness harness: round-tripping StyleX's own
+ * valid-input corpus (read -> IR -> re-emit -> still compiles & semantically
+ * identical) turns "is the IR complete?" from a claim into a measured
+ * coverage percentage. An IR gap found here is SAFE — in the real pipeline
+ * the same construct would be flagged, never emitted incorrectly.
+ *
+ * Not implemented until M1 (it needs the emitter to round-trip against);
+ * the harness counts every corpus entry as uncovered until then.
+ */
+
+import type { StyleRule } from '../core/ir';
+
+export class IRCoverageGapError extends Error {
+  constructor(message: string) {
+    super(`[stylex-codemod ir-completeness] ${message}`);
+    this.name = 'IRCoverageGapError';
+  }
+}
+
+// eslint-disable-next-line no-unused-vars
+export function stylexObjectToIR(name: string, styleObject: mixed): StyleRule {
+  throw new IRCoverageGapError(
+    'stylexObjectToIR is not implemented yet (lands with the M1 emitter)',
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -243,6 +243,11 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz"
   integrity sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==
 
+"@babel/compat-data@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
+  integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
+
 "@babel/core@^7.18.2", "@babel/core@^7.23.9", "@babel/core@^7.24.4", "@babel/core@^7.26.8", "@babel/core@^7.27.4", "@babel/core@^7.28.0", "@babel/core@^7.28.4", "@babel/core@^7.28.5":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz"
@@ -257,6 +262,27 @@
     "@babel/template" "^7.27.2"
     "@babel/traverse" "^7.28.5"
     "@babel/types" "^7.28.5"
+    "@jridgewell/remapping" "^2.3.5"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/core@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
+  integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helpers" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
     "@jridgewell/remapping" "^2.3.5"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
@@ -302,6 +328,13 @@
   dependencies:
     "@babel/types" "^7.27.3"
 
+"@babel/helper-annotate-as-pure@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz#c70fe3c6ecbdc3fd2dd1b0f498428b88b82ce47f"
+  integrity sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
 "@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.27.2":
   version "7.27.2"
   resolved "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz"
@@ -309,6 +342,17 @@
   dependencies:
     "@babel/compat-data" "^7.27.2"
     "@babel/helper-validator-option" "^7.27.1"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-compilation-targets@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz#7a1def704302401c47f64fa85589e974ae217042"
+  integrity sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==
+  dependencies:
+    "@babel/compat-data" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
@@ -324,6 +368,19 @@
     "@babel/helper-replace-supers" "^7.27.1"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
     "@babel/traverse" "^7.28.5"
+    semver "^6.3.1"
+
+"@babel/helper-create-class-features-plugin@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz#6eddf286f2ec418f740c91d60a83347c55838ddd"
+  integrity sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-member-expression-to-functions" "^7.29.7"
+    "@babel/helper-optimise-call-expression" "^7.29.7"
+    "@babel/helper-replace-supers" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
     semver "^6.3.1"
 
 "@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.27.1":
@@ -363,6 +420,14 @@
   dependencies:
     "@babel/traverse" "^7.28.5"
     "@babel/types" "^7.28.5"
+
+"@babel/helper-member-expression-to-functions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz#8dbdb3ce0b5c487e1aec10e13c9a43a500814df8"
+  integrity sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
 "@babel/helper-module-imports@^7.18.6", "@babel/helper-module-imports@^7.25.9", "@babel/helper-module-imports@^7.27.1":
   version "7.27.1"
@@ -405,6 +470,13 @@
   dependencies:
     "@babel/types" "^7.27.1"
 
+"@babel/helper-optimise-call-expression@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz#77b0b5b94f1997fa9d6e3125f445227b1faf9d85"
+  integrity sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.8.0":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz"
@@ -433,6 +505,15 @@
     "@babel/helper-optimise-call-expression" "^7.27.1"
     "@babel/traverse" "^7.27.1"
 
+"@babel/helper-replace-supers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz#bc3c3964329043c79112e513c1b198f16589ac21"
+  integrity sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.29.7"
+    "@babel/helper-optimise-call-expression" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz"
@@ -440,6 +521,14 @@
   dependencies:
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
+
+"@babel/helper-skip-transparent-expression-wrappers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz#50c95c7e4c4f54936cfa0116428edc559862d551"
+  integrity sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
 "@babel/helper-string-parser@^7.27.1":
   version "7.27.1"
@@ -466,6 +555,11 @@
   resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz"
   integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
 
+"@babel/helper-validator-option@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz#cf315be940213b354eb4abcc0bd01ebe3f73bc2a"
+  integrity sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==
+
 "@babel/helper-wrap-function@^7.27.1":
   version "7.28.3"
   resolved "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz"
@@ -482,6 +576,14 @@
   dependencies:
     "@babel/template" "^7.27.2"
     "@babel/types" "^7.28.4"
+
+"@babel/helpers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.7.tgz#45abfde7548997e34376c3e69feb475cffb4a607"
+  integrity sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==
+  dependencies:
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
 "@babel/highlight@^7.16.7":
   version "7.25.9"
@@ -512,7 +614,7 @@
   dependencies:
     "@babel/types" "^7.29.0"
 
-"@babel/parser@^7.29.7":
+"@babel/parser@^7.24.7", "@babel/parser@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
   integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
@@ -598,6 +700,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-syntax-flow@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.29.7.tgz#3f3278c11c896c43bf8098250819785fd1231881"
+  integrity sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
 "@babel/plugin-syntax-import-assertions@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz"
@@ -632,6 +741,13 @@
   integrity sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-syntax-jsx@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz#622c16f9ad63782fe6e83dadc7e40330744b7f1e"
+  integrity sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
   version "7.10.4"
@@ -696,6 +812,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-syntax-typescript@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz#7c29388932313ed58413a0343048d75d92fb5b24"
+  integrity sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
 "@babel/plugin-syntax-unicode-sets-regex@^7.18.6":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz"
@@ -742,6 +865,14 @@
   integrity sha512-45DmULpySVvmq9Pj3X9B+62Xe+DJGov27QravQJU1LLcapR6/10i+gYVAucGGJpHBp5mYxIMK4nDAT/QDLr47g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-class-properties@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz#034897b8a21beec163332fac2de235b14409abdf"
+  integrity sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-transform-class-properties@^7.27.1":
   version "7.27.1"
@@ -847,6 +978,14 @@
     "@babel/helper-plugin-utils" "^7.27.1"
     "@babel/plugin-syntax-flow" "^7.27.1"
 
+"@babel/plugin-transform-flow-strip-types@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.29.7.tgz#911bcb31608c3576510d7e0c95ccf64f9e1812d0"
+  integrity sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/plugin-syntax-flow" "^7.29.7"
+
 "@babel/plugin-transform-for-of@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz"
@@ -900,6 +1039,14 @@
     "@babel/helper-module-transforms" "^7.27.1"
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-transform-modules-commonjs@^7.24.7", "@babel/plugin-transform-modules-commonjs@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz#70e6835abf2663dafbe94b8ef1f51de7351ef135"
+  integrity sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
 "@babel/plugin-transform-modules-commonjs@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz"
@@ -941,6 +1088,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-transform-nullish-coalescing-operator@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz#8a54cdf88c3f50433a6173117a286195b67714cc"
+  integrity sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
 "@babel/plugin-transform-nullish-coalescing-operator@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz"
@@ -981,6 +1135,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-transform-optional-chaining@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz#b84a1b574b3c73001023092567e16c492b720e51"
+  integrity sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+
 "@babel/plugin-transform-optional-chaining@^7.27.1", "@babel/plugin-transform-optional-chaining@^7.28.5":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.5.tgz"
@@ -995,6 +1157,14 @@
   integrity sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-private-methods@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz#cea8bd3ab99533892897a02999d5b752584ad145"
+  integrity sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-transform-private-methods@^7.27.1":
   version "7.27.1"
@@ -1136,6 +1306,17 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
     "@babel/plugin-syntax-typescript" "^7.27.1"
 
+"@babel/plugin-transform-typescript@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz#f0449c3df7037bbe232043476851c38f5e4a7615"
+  integrity sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/plugin-syntax-typescript" "^7.29.7"
+
 "@babel/plugin-transform-unicode-escapes@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz"
@@ -1243,6 +1424,15 @@
     core-js-compat "^3.43.0"
     semver "^6.3.1"
 
+"@babel/preset-flow@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.29.7.tgz#ae33812dc267a296bd3709843affbb2d811c4709"
+  integrity sha512-KYIRV0BuaN68CDdsqFkAD7MU7yipUqQNuNElwATdxaIdpTjhvtY82QvkBJs7zV3Evxj2jFAAZ1iO8nyy0nhjqA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
+    "@babel/plugin-transform-flow-strip-types" "^7.29.7"
+
 "@babel/preset-flow@^7.25.9", "@babel/preset-flow@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.27.1.tgz"
@@ -1273,6 +1463,17 @@
     "@babel/plugin-transform-react-jsx-development" "^7.27.1"
     "@babel/plugin-transform-react-pure-annotations" "^7.27.1"
 
+"@babel/preset-typescript@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz#de9be1f47b785c979ec7b3a71f4cd8bae5267b62"
+  integrity sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
+    "@babel/plugin-syntax-jsx" "^7.29.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.29.7"
+    "@babel/plugin-transform-typescript" "^7.29.7"
+
 "@babel/preset-typescript@^7.25.7", "@babel/preset-typescript@^7.26.0":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz"
@@ -1283,6 +1484,17 @@
     "@babel/plugin-syntax-jsx" "^7.27.1"
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.28.5"
+
+"@babel/register@^7.24.6":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.29.7.tgz#d5bb4337065512f643b29cb565b6e8ccadcc1ec6"
+  integrity sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==
+  dependencies:
+    clone-deep "^4.0.1"
+    find-cache-dir "^2.0.0"
+    make-dir "^2.1.0"
+    pirates "^4.0.6"
+    source-map-support "^0.5.16"
 
 "@babel/register@^7.27.1":
   version "7.28.3"
@@ -1706,6 +1918,37 @@
   integrity sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==
   dependencies:
     tslib "^2.4.0"
+
+"@emotion/hash@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.2.tgz#ff9221b9f58b4dfe61e619a7788734bd63f6898b"
+  integrity sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
+
+"@emotion/memoize@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.9.0.tgz#745969d649977776b43fc7648c556aaa462b4102"
+  integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
+
+"@emotion/serialize@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.3.3.tgz#d291531005f17d704d0463a032fe679f376509e8"
+  integrity sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==
+  dependencies:
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/unitless" "^0.10.0"
+    "@emotion/utils" "^1.4.2"
+    csstype "^3.0.2"
+
+"@emotion/unitless@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.10.0.tgz#2af2f7c7e5150f497bdabd848ce7b218a27cf745"
+  integrity sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
+
+"@emotion/utils@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.4.2.tgz#6df6c45881fcb1c412d6688a311a98b7f59c1b52"
+  integrity sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==
 
 "@epic-web/invariant@^1.0.0":
   version "1.0.0"
@@ -6779,7 +7022,7 @@ babel-plugin-react-compiler@1.0.0, babel-plugin-react-compiler@^1.0.0:
   dependencies:
     "@babel/types" "^7.26.0"
 
-babel-plugin-syntax-hermes-parser@^0.36.1:
+babel-plugin-syntax-hermes-parser@0.36.1, babel-plugin-syntax-hermes-parser@^0.36.1:
   version "0.36.1"
   resolved "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.1.tgz"
   integrity sha512-ycduwJbvdvIMmVvlAZqGggS+pm5Eu4Bk9pcV9Sm2Z4PJNRVsKkv0g7vHj+LeuC1gHTeF67sJXFOq61IlqCa2hA==
@@ -9652,6 +9895,18 @@ flow-enums-runtime@^0.0.6:
   resolved "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz"
   integrity sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==
 
+flow-estree@0.322.0:
+  version "0.322.0"
+  resolved "https://registry.yarnpkg.com/flow-estree/-/flow-estree-0.322.0.tgz#8310b5bc825049fe6526969217ee29bb09fdd576"
+  integrity sha512-v7wiiFWSKbJ1HGVCRKhxl+6pQWTQV6P4c7XEfKjVlH71YkgQyJCq0AG5dhJDD/3/SkJgX/F9lvAj2rbrFzArdQ==
+
+flow-parser@0.*:
+  version "0.322.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.322.0.tgz#7a42cfae08b0cf0a35bd9fdbe84593782f6a5052"
+  integrity sha512-Qfd8N4sSuWmlf1qk5M60fi8JrvhNvj9fbwMsRkcnm3UhLYukkbm2CFkAhiTD3n4RVXb6TuCHFCp78TMXpO0zcA==
+  dependencies:
+    flow-estree "0.322.0"
+
 flow-typed@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/flow-typed/-/flow-typed-4.1.1.tgz"
@@ -11542,6 +11797,30 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+jscodeshift@^17.3.0:
+  version "17.4.0"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-17.4.0.tgz#efa0619ddb1d994e85982ec37a7afe8e618ae324"
+  integrity sha512-i3ESKiiTsGynxzTg5BhsZViD0ai72/6SsI1efDZxG6/5KCoElsmquxtyhXK5lpEgoO7MTNpYkjFEdEL97SkBNg==
+  dependencies:
+    "@babel/core" "^7.24.7"
+    "@babel/parser" "^7.24.7"
+    "@babel/plugin-transform-class-properties" "^7.24.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.24.7"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.24.7"
+    "@babel/plugin-transform-optional-chaining" "^7.24.7"
+    "@babel/plugin-transform-private-methods" "^7.24.7"
+    "@babel/preset-flow" "^7.24.7"
+    "@babel/preset-typescript" "^7.24.7"
+    "@babel/register" "^7.24.6"
+    flow-parser "0.*"
+    graceful-fs "^4.2.4"
+    neo-async "^2.5.0"
+    picocolors "^1.0.1"
+    picomatch "^4.0.2"
+    recast "^0.23.11"
+    tmp "^0.2.3"
+    write-file-atomic "^5.0.1"
+
 jsdom@^26.1.0:
   version "26.1.0"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz"
@@ -13056,7 +13335,7 @@ negotiator@~0.6.4:
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz"
   integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
 
-neo-async@^2.6.1, neo-async@^2.6.2:
+neo-async@^2.5.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -13700,7 +13979,7 @@ pend@~1.2.0:
   resolved "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
-picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1, picocolors@~1.1.1:
+picocolors@^1.0.0, picocolors@^1.0.1, picocolors@^1.1.0, picocolors@^1.1.1, picocolors@~1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -14321,6 +14600,17 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+recast@^0.23.11:
+  version "0.23.12"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.23.12.tgz#3df7589ae1877d0a634c6c7ccc995a7c053850a9"
+  integrity sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA==
+  dependencies:
+    ast-types "^0.16.1"
+    esprima "~4.0.0"
+    source-map "~0.6.1"
+    tiny-invariant "^1.3.3"
+    tslib "^2.0.1"
 
 recast@^0.23.5:
   version "0.23.11"
@@ -16182,6 +16472,11 @@ tmp@^0.2.0:
   version "0.2.5"
   resolved "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz"
   integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
+
+tmp@^0.2.3:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION

## What changed / motivation ?

Adds the `@stylexjs/codemods` package — the foundation for an Emotion → StyleX
migration codemod (#1766). First of ~6 stacked PRs; this one is scaffolding and
test infrastructure only, with no transform logic yet, so it can be reviewed on
its own.

It sets up the package and the three checks every future conversion has to pass:

- the output compiles through `@stylexjs/babel-plugin`,
- it passes `@stylexjs/eslint-plugin` at error with no autofixes, and
- its CSS matches the original Emotion output (via `@emotion/serialize`).

Each check is proven to fail on a deliberately-broken input, not only to pass on
a valid one.

The package is split into a shared engine (`src/core/`) and per-library adapters
(`src/adapters/`, Emotion first). `core/` never imports from `adapters/`,
enforced by a test — so a new source library means a new adapter, not an engine
change. The transform itself lands in the next PR.

## Linked PR/Issues

n/a

## Additional Context

6 test suites, all green. Two end-to-end fixture assertions are skipped until the
transform lands (PR 2). Changes outside the package: a `.flowconfig` mapping and
an `.eslintrc.js` ignore for the test fixtures, small `flow_modules/` type
stubs, and `yarn.lock`.

## Pre-flight checklist

- [x] I have read the contributing guidelines
- [x] Performed a self-review of my code