### PR TITLE
[codemods] Convert static css props to StyleX (Emotion→StyleX, 2/6)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,9 @@ module.exports = {
     '**/*.d.ts',
     '**/pages.gen.ts',
     '**/devtools-extension/extension/**',
+    // codemod fixtures are deliberately non-conforming (broken-on-purpose
+    // inputs that the correctness gates must fail on)
+    '**/codemods/__fixtures__/**',
   ],
   overrides: [
     {

--- a/.flowconfig
+++ b/.flowconfig
@@ -24,6 +24,7 @@ module.name_mapper='^@stylexjs/babel-plugin$' -> '<PROJECT_ROOT>/packages/@style
 module.name_mapper='^@stylexjs/stylex$' -> '<PROJECT_ROOT>/packages/@stylexjs/stylex/src/stylex.js'
 module.name_mapper='^@stylexjs/shared$' -> '<PROJECT_ROOT>/packages/@stylexjs/shared/src/index.js'
 module.name_mapper='^style-value-parser$' -> '<PROJECT_ROOT>/packages/style-value-parser/src/index.js'
+module.name_mapper='^@stylexjs/eslint-plugin$' -> '<PROJECT_ROOT>/packages/@stylexjs/eslint-plugin/src/index.js'
 ; type-stubs
 module.system.node.resolve_dirname=flow_modules
 module.system.node.resolve_dirname=node_modules

--- a/packages/@stylexjs/codemods/.babelrc.js
+++ b/packages/@stylexjs/codemods/.babelrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  assumptions: {
+    iterableIsArray: true,
+  },
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        exclude: ['@babel/plugin-transform-typeof-symbol'],
+        targets: 'defaults',
+      },
+    ],
+    '@babel/preset-flow',
+    '@babel/preset-react',
+  ],
+  plugins: [['babel-plugin-syntax-hermes-parser', { flow: 'detect' }]],
+};

--- a/packages/@stylexjs/codemods/ARCHITECTURE.md
+++ b/packages/@stylexjs/codemods/ARCHITECTURE.md
@@ -1,0 +1,100 @@
+# Architecture
+
+The codemod is a source-to-source compiler: styling code in, equivalent
+StyleX out. It is built so that supporting a new source library never means
+rebuilding the compiler — only writing a new front-end for it.
+
+> **One engine, swappable readers.** A small library-specific **adapter**
+> turns one styling library into a neutral style model (the IR). A single
+> library-agnostic **core** turns that model into correct, lint-clean
+> StyleX. To add Emotion, MUI, or CSS Modules you write an adapter — the
+> engine never changes.
+
+## The seam
+
+| | Adapter (per source) | Core engine (shared) |
+| --- | --- | --- |
+| Owns | detect, read, rewrite call sites, import cleanup | IR build, conflict referee, value normalization, emit, registry, postprocess, gates |
+| Knows about | one styling library's syntax | only the IR and StyleX |
+| Changes when | a new source is added | StyleX itself gains a feature |
+
+**Load-bearing invariant:** `src/core/` imports *nothing* from
+`src/adapters/` and never touches a parser node — it only sees
+declarations, the IR, and emitted StyleX fragments. Enforced by
+`__tests__/seam-test.js` from commit one. The seam is crossed exactly
+twice:
+
+1. **Adapter → core:** a flat list of `declarations`
+   (`{ context, property, value }`) — "here is what styles exist".
+2. **Core → adapter:** the **binding map** — "style site #1 becomes
+   `styles.button`" — which the adapter places back into that library's
+   idiom.
+
+A second invariant keeps the AST toolkit swappable: only
+`src/core/rewriter.js` may import jscodeshift/recast (also enforced by the
+seam test).
+
+## The IR (`src/core/ir.js`)
+
+The IR is shaped like **StyleX's output** (property-grouped, conditions
+nested inside a property), not like any source's input. A style either maps
+into the IR (convertible) or it does not (flagged — never guessed); the
+edge of the IR is the edge of what is automatable.
+
+Its only two open axes are the ones StyleX itself grows along, both modeled
+as variant types so growth stays additive:
+
+- `Condition` — `pseudo-class` / `pseudo-element` / `at-rule` (later:
+  ancestor selectors, `@supports`, `@container`).
+- `Value` — `static` and `first-that-works` today; a `dynamic`
+  (function-form) variant lands in v1.1.
+
+Completeness is **measured, not asserted**: the IR-completeness harness
+(`__tests__/ir-completeness-test.js`) round-trips valid StyleX style
+objects through a test-only reader and reports a coverage percentage. An
+IR gap is safe — in the pipeline the construct is flagged, never
+emitted incorrectly.
+
+## The gates (`src/core/gates/`)
+
+Independent correctness checks, used as test assertions and as a runtime
+safety net. Each is proven to FAIL on a deliberately-broken input
+(`__fixtures__/broken/`) — a gate that never fails is worthless.
+
+- **Compile** (`compile.js`) — output must compile through the real
+  `@stylexjs/babel-plugin`; also yields the plugin's rule metadata.
+- **Lint** (`lint.js`) — output must pass every `@stylexjs/eslint-plugin`
+  rule at *error* with zero messages (zero autofixes needed).
+- **Semantic diff** (`semanticDiff.js`) — net CSS before (from
+  `@emotion/serialize`, the source library's own ground truth) and after
+  (from babel-plugin metadata) must match across every condition
+  combination, minus an explicit allowlist of sanctioned diffs
+  (hover-guard, physical→logical). Its parsers throw on anything they
+  cannot provably represent, so an unparsable input can never diff clean
+  by accident.
+- **Render gate** *(future, v2.0)* — Playwright computed-style diff in a
+  real browser, keeping the semantic-diff gate honest.
+
+## Testing layers
+
+1. **Gate self-tests** — each gate green on the trivial pair AND red on a
+   broken pair (`__tests__/gates-test.js`).
+2. **Fixture tests** — the executable spec. Every
+   `__fixtures__/emotion/<name>/{input,expected}.js` pair must: match the
+   transform byte-exactly (after Prettier), compile, lint clean, and pass
+   the semantic diff (`__tests__/emotion-fixtures-test.js`).
+3. **Engine unit tests** — hand-written IR fed to the engine (from M1),
+   proving the engine is source-neutral.
+4. **Seam tests** — the architectural invariants, as assertions.
+5. **IR-completeness** — the measured coverage number.
+
+## Layer map
+
+| Layer | Module |
+| --- | --- |
+| Parse/print wrapper | `src/core/rewriter.js` (jscodeshift, isolated) |
+| IR types | `src/core/ir.js` |
+| Gates | `src/core/gates/{compile,lint,semanticDiff}.js` |
+| Emotion adapter | `src/adapters/emotion/` (M1+) |
+| Engine (build IR, referee, normalize, emit) | `src/core/` (M1–M4) |
+| CLI & dry-run report | `src/cli/` (M6) |

--- a/packages/@stylexjs/codemods/README.md
+++ b/packages/@stylexjs/codemods/README.md
@@ -1,0 +1,51 @@
+# @stylexjs/codemods
+
+Codemods for migrating styling libraries to [StyleX](https://stylexjs.com) —
+Emotion first, built as **one library-agnostic engine with swappable
+per-library adapters**.
+
+> **Status: pre-release scaffold (M0).** The correctness harness — fixture
+> tests plus three gates (compile, lint, semantic-diff) — is in place and
+> proven; transforms land milestone by milestone. Nothing here is published
+> yet, and the package name/location is pending maintainer confirmation.
+
+## Principles
+
+- **Bail loudly.** Only provably-safe styles are converted. Anything else is
+  flagged with a `// TODO(stylex-migration): …` comment, and a file is
+  refused outright when a partial conversion could change rendering.
+  Wrong-but-plausible output is the one unacceptable result.
+- **Gated output.** Every conversion must compile through
+  `@stylexjs/babel-plugin`, pass `@stylexjs/eslint-plugin` at *error* with
+  zero autofixes needed, and have semantically identical net CSS (checked
+  against Emotion's own serializer, minus an explicit allowlist:
+  hover-guard, physical→logical properties).
+
+## Converts / flags / refuses (planned v1.0 scope)
+
+| Bucket | Patterns |
+| --- | --- |
+| Converts | static `css={{…}}` / `css({})` / object-form `styled.div({})`; self-targeting pseudo-classes/elements; media queries; object-form `keyframes`; fallback arrays; shorthands; mapped theme tokens |
+| Flags | template literals; dynamic styles; `styled(Component)`; out-of-element selectors; `<Global>`; `shouldForwardProp`; unmapped tokens; `!important` |
+| Refuses | any file where partial conversion could change rendering |
+
+## Compatibility
+
+| | Version |
+| --- | --- |
+| Emits StyleX | 0.19.x |
+| Reads Emotion | 10–11 (object syntax) |
+
+See [`ARCHITECTURE.md`](./ARCHITECTURE.md) for the design.
+
+## Development
+
+```sh
+cd packages/@stylexjs/codemods
+yarn jest          # run from the package cwd, not the repo root
+yarn build
+```
+
+Fixture pairs live in `__fixtures__/emotion/<name>/{input,expected}.js`; set
+`UPDATE_STYLEX_CODEMOD_FIXTURES=1` to regenerate expected files when a
+change is intentional.

--- a/packages/@stylexjs/codemods/__fixtures__/broken/compile-invalid.js
+++ b/packages/@stylexjs/codemods/__fixtures__/broken/compile-invalid.js
@@ -1,0 +1,12 @@
+// DELIBERATELY BROKEN: `stylex.create` must be called with a statically
+// analyzable object literal — a function call argument makes the real
+// @stylexjs/babel-plugin throw. The compile gate must FAIL on this file.
+import * as stylex from '@stylexjs/stylex';
+
+function getStyles() {
+  return { badge: { color: 'red' } };
+}
+
+const styles = stylex.create(getStyles());
+
+export default styles;

--- a/packages/@stylexjs/codemods/__fixtures__/broken/lint-invalid.js
+++ b/packages/@stylexjs/codemods/__fixtures__/broken/lint-invalid.js
@@ -1,0 +1,12 @@
+// DELIBERATELY BROKEN: compiles, but violates @stylexjs/eslint-plugin rules
+// ('colr' is not a valid property; styles are never used). The lint gate
+// must FAIL on this file.
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  badge: { colr: 'red' },
+});
+
+export default function Badge() {
+  return styles != null;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/css-call-form/expected.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/css-call-form/expected.js
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  alert: {
+    color: 'maroon',
+    fontWeight: 700,
+  },
+});
+
+export default function Alert() {
+  return <p {...stylex.props(styles.alert)}>Alert</p>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/css-call-form/input.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/css-call-form/input.js
@@ -1,0 +1,7 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+import { css } from '@emotion/react';
+
+export default function Alert() {
+  return <p css={css({ color: 'maroon', fontWeight: 700 })}>Alert</p>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/skip-component-css/expected.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/skip-component-css/expected.js
@@ -1,0 +1,7 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+import { Button } from './Button';
+
+export default function Toolbar() {
+  return <Button css={{ color: 'white' }}>Save</Button>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/skip-component-css/input.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/skip-component-css/input.js
@@ -1,0 +1,7 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+import { Button } from './Button';
+
+export default function Toolbar() {
+  return <Button css={{ color: 'white' }}>Save</Button>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/skip-existing-stylex/expected.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/skip-existing-stylex/expected.js
@@ -1,0 +1,17 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  card: {
+    padding: '8px',
+  },
+});
+
+export default function Mixed() {
+  return (
+    <div {...stylex.props(styles.card)}>
+      <span css={{ color: 'gray' }}>Mixed</span>
+    </div>
+  );
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/skip-existing-stylex/input.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/skip-existing-stylex/input.js
@@ -1,0 +1,17 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  card: {
+    padding: '8px',
+  },
+});
+
+export default function Mixed() {
+  return (
+    <div {...stylex.props(styles.card)}>
+      <span css={{ color: 'gray' }}>Mixed</span>
+    </div>
+  );
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/skip-pseudo/expected.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/skip-pseudo/expected.js
@@ -1,0 +1,10 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+
+export default function Link() {
+  return (
+    <a css={{ color: 'blue', ':hover': { color: 'navy' } }} href="#top">
+      Link
+    </a>
+  );
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/skip-pseudo/input.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/skip-pseudo/input.js
@@ -1,0 +1,10 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+
+export default function Link() {
+  return (
+    <a css={{ color: 'blue', ':hover': { color: 'navy' } }} href="#top">
+      Link
+    </a>
+  );
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/skip-shorthand-conflict/expected.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/skip-shorthand-conflict/expected.js
@@ -1,0 +1,6 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+
+export default function Box() {
+  return <div css={{ marginTop: 20, margin: 4 }}>Box</div>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/skip-shorthand-conflict/input.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/skip-shorthand-conflict/input.js
@@ -1,0 +1,6 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+
+export default function Box() {
+  return <div css={{ marginTop: 20, margin: 4 }}>Box</div>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/skip-template-literal/expected.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/skip-template-literal/expected.js
@@ -1,0 +1,11 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+import { css } from '@emotion/react';
+
+const fancy = css`
+  color: red;
+`;
+
+export default function Fancy() {
+  return <div css={fancy}>Fancy</div>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/skip-template-literal/input.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/skip-template-literal/input.js
@@ -1,0 +1,11 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+import { css } from '@emotion/react';
+
+const fancy = css`
+  color: red;
+`;
+
+export default function Fancy() {
+  return <div css={fancy}>Fancy</div>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/static-flat-color/expected.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/static-flat-color/expected.js
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  badge: { color: 'red' },
+});
+
+export default function Badge() {
+  return <div {...stylex.props(styles.badge)}>Badge</div>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/static-flat-color/expected.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/static-flat-color/expected.js
@@ -1,8 +1,11 @@
 import * as React from 'react';
+
 import * as stylex from '@stylexjs/stylex';
 
 const styles = stylex.create({
-  badge: { color: 'red' },
+  badge: {
+    color: 'red',
+  },
 });
 
 export default function Badge() {

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/static-flat-color/input.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/static-flat-color/input.js
@@ -1,0 +1,6 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+
+export default function Badge() {
+  return <div css={{ color: 'red' }}>Badge</div>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/static-values/expected.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/static-values/expected.js
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  fancyCard: {
+    color: 'rgb(10, 20, 30)',
+    fontSize: 16,
+    lineHeight: 1.5,
+    marginTop: -4,
+  },
+});
+
+export default function Card() {
+  return <section {...stylex.props(styles.fancyCard)}>Card</section>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/static-values/input.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/static-values/input.js
@@ -1,0 +1,18 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+
+export default function Card() {
+  return (
+    <section
+      css={{
+        label: 'fancyCard',
+        fontSize: 16,
+        lineHeight: 1.5,
+        marginTop: -4,
+        color: 'rgb(10, 20, 30)',
+      }}
+    >
+      Card
+    </section>
+  );
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/two-sites/expected.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/two-sites/expected.js
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  badge: {
+    color: 'darkgreen',
+  },
+
+  card: {
+    padding: '16px',
+  },
+});
+
+export function Badge() {
+  return <span {...stylex.props(styles.badge)}>Badge</span>;
+}
+
+export function Card() {
+  return <article {...stylex.props(styles.card)}>Card</article>;
+}

--- a/packages/@stylexjs/codemods/__fixtures__/emotion/two-sites/input.js
+++ b/packages/@stylexjs/codemods/__fixtures__/emotion/two-sites/input.js
@@ -1,0 +1,10 @@
+/** @jsxImportSource @emotion/react */
+import * as React from 'react';
+
+export function Badge() {
+  return <span css={{ color: 'darkgreen' }}>Badge</span>;
+}
+
+export function Card() {
+  return <article css={{ padding: '16px' }}>Card</article>;
+}

--- a/packages/@stylexjs/codemods/__tests__/emit-test.js
+++ b/packages/@stylexjs/codemods/__tests__/emit-test.js
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Engine unit tests: hand-written IR in, emitted create data out.
+ * Deliberately NO Emotion anywhere in this file — this is what proves the
+ * engine is source-neutral (any adapter producing this IR gets the same
+ * output).
+ */
+
+import type { FileIR } from '../src/core/ir';
+import { buildFileIR } from '../src/core/buildIR';
+import { emitFileIR, sanitizeKey, EmitError } from '../src/core/emit';
+
+function irOf(
+  entries: Array<[string, Array<[string, string | number]>]>,
+): FileIR {
+  return {
+    rules: entries.map(([name, decls]) => ({
+      name,
+      atoms: decls.map(([property, value]) => ({
+        property,
+        conditions: [],
+        value: { kind: 'static', value },
+      })),
+    })),
+    keyframes: [],
+  };
+}
+
+describe('emitFileIR', () => {
+  test('one rule becomes one create entry plus its binding', () => {
+    const result = emitFileIR(irOf([['badge', [['color', 'red']]]]));
+    expect(result.rules).toEqual([{ key: 'badge', style: { color: 'red' } }]);
+    expect(result.bindings).toEqual(['badge']);
+  });
+
+  test('sorts properties alphabetically (stylex/sort-keys, zero autofixes) and keeps value types', () => {
+    // Safe for flat longhands: order-dependent cases (duplicates,
+    // shorthand/longhand overlap) are refused before emit.
+    const result = emitFileIR(
+      irOf([
+        [
+          'card',
+          [
+            ['fontSize', 16],
+            ['lineHeight', 1.5],
+            ['color', 'rgb(0, 0, 0)'],
+          ],
+        ],
+      ]),
+    );
+    expect(Object.entries(result.rules[0].style)).toEqual([
+      ['color', 'rgb(0, 0, 0)'],
+      ['fontSize', 16],
+      ['lineHeight', 1.5],
+    ]);
+  });
+
+  test('key collisions get numeric suffixes in rule order', () => {
+    const result = emitFileIR(
+      irOf([
+        ['badge', [['color', 'red']]],
+        ['badge', [['color', 'blue']]],
+        ['badge', [['color', 'green']]],
+      ]),
+    );
+    expect(result.bindings).toEqual(['badge', 'badge2', 'badge3']);
+  });
+
+  test('sanitizes hostile name hints instead of emitting bad keys', () => {
+    expect(sanitizeKey('MyButton')).toBe('myButton');
+    expect(sanitizeKey('nav-bar item')).toBe('navBarItem');
+    expect(sanitizeKey('123')).toBe('styles');
+    expect(sanitizeKey('')).toBe('styles');
+    expect(sanitizeKey('default')).toBe('styles');
+  });
+
+  test('REFUSES conditions (M2) rather than emitting incorrectly', () => {
+    const ir: FileIR = {
+      rules: [
+        {
+          name: 'badge',
+          atoms: [
+            {
+              property: 'color',
+              conditions: [{ kind: 'pseudo-class', name: ':hover' }],
+              value: { kind: 'static', value: 'blue' },
+            },
+          ],
+        },
+      ],
+      keyframes: [],
+    };
+    expect(() => emitFileIR(ir)).toThrow(EmitError);
+  });
+
+  test('REFUSES duplicate properties within a rule', () => {
+    const ir = irOf([
+      [
+        'badge',
+        [
+          ['color', 'red'],
+          ['color', 'blue'],
+        ],
+      ],
+    ]);
+    expect(() => emitFileIR(ir)).toThrow(EmitError);
+  });
+});
+
+describe('buildFileIR', () => {
+  test('flat declarations become zero-condition static atoms', () => {
+    const ir = buildFileIR([
+      {
+        nameHint: 'badge',
+        declarations: [
+          { property: 'color', value: 'red' },
+          { property: 'fontSize', value: 16 },
+        ],
+      },
+    ]);
+    expect(ir).toEqual({
+      rules: [
+        {
+          name: 'badge',
+          atoms: [
+            {
+              property: 'color',
+              conditions: [],
+              value: { kind: 'static', value: 'red' },
+            },
+            {
+              property: 'fontSize',
+              conditions: [],
+              value: { kind: 'static', value: 16 },
+            },
+          ],
+        },
+      ],
+      keyframes: [],
+    });
+  });
+
+  test('buildFileIR -> emitFileIR round-trips a group into create data', () => {
+    const { rules, bindings } = emitFileIR(
+      buildFileIR([
+        {
+          nameHint: 'Badge',
+          declarations: [{ property: 'color', value: 'red' }],
+        },
+      ]),
+    );
+    expect(rules).toEqual([{ key: 'badge', style: { color: 'red' } }]);
+    expect(bindings).toEqual(['badge']);
+  });
+});

--- a/packages/@stylexjs/codemods/__tests__/emotion-fixtures-test.js
+++ b/packages/@stylexjs/codemods/__tests__/emotion-fixtures-test.js
@@ -15,23 +15,25 @@
  *   2. expected compiles through @stylexjs/babel-plugin;
  *   3. expected passes @stylexjs/eslint-plugin at error, zero messages;
  *   4. the net CSS of input and expected is semantically identical
- *      (minus the sanctioned allowlist).
+ *      (Emotion's own serializer vs the babel-plugin metadata, minus the
+ *      sanctioned allowlist). Skip-fixtures (expected === input) assert
+ *      that the transform really did refuse.
  *
  * Set UPDATE_STYLEX_CODEMOD_FIXTURES=1 to regenerate expected files when a
  * change is intentional.
- *
- * M0 status: no transform exists yet, so checks 1 and 4 (which need the
- * transform / the adapter's reader) are pending and explicitly skipped;
- * checks 2 and 3 run for real. M1 wires `transform` below and un-skips.
  */
 
 import * as fs from 'fs';
+import { serializeStyles } from '@emotion/serialize';
 import { compileGate } from '../src/core/gates/compile';
 import { lintGate } from '../src/core/gates/lint';
+import {
+  semanticDiffGate,
+  netCssFromSerializedCss,
+  netCssFromStylexMetadata,
+} from '../src/core/gates/semanticDiff';
+import { transformEmotionFile } from '../src/adapters/emotion/transform';
 import { loadFixtures, formatWithPrettier } from './utils/harness';
-
-// M1: replace with the real emotion transform (input source -> output source).
-const transform: ((source: string, filename: string) => string) | null = null;
 
 const UPDATE = process.env.UPDATE_STYLEX_CODEMOD_FIXTURES === '1';
 
@@ -50,17 +52,12 @@ test('prettier normalization is available and idempotent', () => {
 describe.each(fixtures.map((f) => [f.name, f]))(
   'fixture: %s',
   (_name, fixture) => {
-    const testIfTransform = transform == null ? test.skip : test;
+    const result = transformEmotionFile(fixture.input, fixture.inputPath);
+    const output = result.status === 'converted' ? result.code : fixture.input;
 
-    // Check 1 — pending M1 (needs the transform).
-    testIfTransform('transform(input) matches expected byte-exactly', () => {
-      if (transform == null) {
-        throw new Error('unreachable');
-      }
-      const actual = formatWithPrettier(
-        transform(fixture.input, fixture.inputPath),
-        fixture.expectedPath,
-      );
+    // Check 1 — byte-exact against expected, formatting-insensitive.
+    test('transform(input) matches expected byte-exactly', () => {
+      const actual = formatWithPrettier(output, fixture.expectedPath);
       if (UPDATE) {
         fs.writeFileSync(fixture.expectedPath, actual);
       }
@@ -69,35 +66,72 @@ describe.each(fixtures.map((f) => [f.name, f]))(
       );
     });
 
-    // Check 2 — live from M0.
+    // Check 2.
     test('expected compiles through @stylexjs/babel-plugin', () => {
-      const result = compileGate(fixture.expected, {
+      const compiled = compileGate(fixture.expected, {
         filename: fixture.expectedPath,
       });
-      if (!result.ok) {
-        throw new Error(result.errors.join('\n'));
+      if (!compiled.ok) {
+        throw new Error(compiled.errors.join('\n'));
       }
-      expect(result.ok).toBe(true);
+      expect(compiled.ok).toBe(true);
     });
 
-    // Check 3 — live from M0.
+    // Check 3.
     test('expected passes @stylexjs/eslint-plugin at error with zero messages', () => {
-      const result = lintGate(fixture.expected, {
+      const linted = lintGate(fixture.expected, {
         filename: fixture.expectedPath,
       });
-      if (!result.ok) {
-        throw new Error(JSON.stringify(result.messages, null, 2));
+      if (!linted.ok) {
+        throw new Error(JSON.stringify(linted.messages, null, 2));
       }
-      expect(result.ok).toBe(true);
+      expect(linted.ok).toBe(true);
     });
 
-    // Check 4 — pending M1 (extracting the input's style objects is the
-    // adapter reader's job; the gate itself is proven in gates-test.js).
-    testIfTransform(
-      'net CSS of input and expected is semantically identical',
-      () => {
-        throw new Error('wired in M1 with the emotion adapter reader');
-      },
-    );
+    // Check 4.
+    test('net CSS of input and expected is semantically identical', () => {
+      if (result.status !== 'converted') {
+        // A skip-fixture: the transform must have refused (loudly, with
+        // reasons) and left the file byte-identical.
+        expect(fixture.expected).toEqual(fixture.input);
+        if (result.status === 'skipped') {
+          expect(result.reasons.length).toBeGreaterThan(0);
+        }
+        return;
+      }
+      // Before: Emotion's own serializer over each converted object.
+      // (Fixture-design constraint: sites must not restate the same
+      // property+conditions with different values, or the union is lossy.)
+      const before: { [string]: $FlowFixMe } = {};
+      for (const site of result.sites) {
+        const net = netCssFromSerializedCss(
+          serializeStyles([site.cssObject]).styles,
+        );
+        for (const coordinate of Object.keys(net)) {
+          if (
+            before[coordinate] != null &&
+            before[coordinate].value !== net[coordinate].value
+          ) {
+            throw new Error(
+              `fixture restates '${coordinate}' with different values across sites`,
+            );
+          }
+          before[coordinate] = net[coordinate];
+        }
+      }
+      // After: the real babel-plugin metadata for the converted output.
+      const compiled = compileGate(output, { filename: fixture.expectedPath });
+      if (!compiled.ok) {
+        throw new Error(compiled.errors.join('\n'));
+      }
+      const diff = semanticDiffGate(
+        before,
+        netCssFromStylexMetadata(compiled.metadata),
+      );
+      if (!diff.ok) {
+        throw new Error(JSON.stringify(diff.diffs, null, 2));
+      }
+      expect(diff.ok).toBe(true);
+    });
   },
 );

--- a/packages/@stylexjs/codemods/__tests__/emotion-fixtures-test.js
+++ b/packages/@stylexjs/codemods/__tests__/emotion-fixtures-test.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * The fixture harness — the executable spec. Every input/expected pair
+ * under `__fixtures__/emotion/` must satisfy four checks:
+ *
+ *   1. transform(input) matches expected byte-exactly (after Prettier);
+ *   2. expected compiles through @stylexjs/babel-plugin;
+ *   3. expected passes @stylexjs/eslint-plugin at error, zero messages;
+ *   4. the net CSS of input and expected is semantically identical
+ *      (minus the sanctioned allowlist).
+ *
+ * Set UPDATE_STYLEX_CODEMOD_FIXTURES=1 to regenerate expected files when a
+ * change is intentional.
+ *
+ * M0 status: no transform exists yet, so checks 1 and 4 (which need the
+ * transform / the adapter's reader) are pending and explicitly skipped;
+ * checks 2 and 3 run for real. M1 wires `transform` below and un-skips.
+ */
+
+import * as fs from 'fs';
+import { compileGate } from '../src/core/gates/compile';
+import { lintGate } from '../src/core/gates/lint';
+import { loadFixtures, formatWithPrettier } from './utils/harness';
+
+// M1: replace with the real emotion transform (input source -> output source).
+const transform: ((source: string, filename: string) => string) | null = null;
+
+const UPDATE = process.env.UPDATE_STYLEX_CODEMOD_FIXTURES === '1';
+
+const fixtures = loadFixtures('emotion');
+
+test('there is at least one fixture pair', () => {
+  expect(fixtures.length).toBeGreaterThan(0);
+});
+
+test('prettier normalization is available and idempotent', () => {
+  const [fixture] = fixtures;
+  const once = formatWithPrettier(fixture.expected, fixture.expectedPath);
+  expect(formatWithPrettier(once, fixture.expectedPath)).toEqual(once);
+});
+
+describe.each(fixtures.map((f) => [f.name, f]))(
+  'fixture: %s',
+  (_name, fixture) => {
+    const testIfTransform = transform == null ? test.skip : test;
+
+    // Check 1 — pending M1 (needs the transform).
+    testIfTransform('transform(input) matches expected byte-exactly', () => {
+      if (transform == null) {
+        throw new Error('unreachable');
+      }
+      const actual = formatWithPrettier(
+        transform(fixture.input, fixture.inputPath),
+        fixture.expectedPath,
+      );
+      if (UPDATE) {
+        fs.writeFileSync(fixture.expectedPath, actual);
+      }
+      expect(actual).toEqual(
+        formatWithPrettier(fixture.expected, fixture.expectedPath),
+      );
+    });
+
+    // Check 2 — live from M0.
+    test('expected compiles through @stylexjs/babel-plugin', () => {
+      const result = compileGate(fixture.expected, {
+        filename: fixture.expectedPath,
+      });
+      if (!result.ok) {
+        throw new Error(result.errors.join('\n'));
+      }
+      expect(result.ok).toBe(true);
+    });
+
+    // Check 3 — live from M0.
+    test('expected passes @stylexjs/eslint-plugin at error with zero messages', () => {
+      const result = lintGate(fixture.expected, {
+        filename: fixture.expectedPath,
+      });
+      if (!result.ok) {
+        throw new Error(JSON.stringify(result.messages, null, 2));
+      }
+      expect(result.ok).toBe(true);
+    });
+
+    // Check 4 — pending M1 (extracting the input's style objects is the
+    // adapter reader's job; the gate itself is proven in gates-test.js).
+    testIfTransform(
+      'net CSS of input and expected is semantically identical',
+      () => {
+        throw new Error('wired in M1 with the emotion adapter reader');
+      },
+    );
+  },
+);

--- a/packages/@stylexjs/codemods/__tests__/gates-test.js
+++ b/packages/@stylexjs/codemods/__tests__/gates-test.js
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Gate self-tests. A gate that never fails is worthless, so every gate is
+ * proven BOTH ways: green on the trivial hand-written pair, and red on a
+ * deliberately-broken input.
+ */
+
+import { serializeStyles } from '@emotion/serialize';
+import { compileGate } from '../src/core/gates/compile';
+import { lintGate } from '../src/core/gates/lint';
+import {
+  semanticDiffGate,
+  netCssFromSerializedCss,
+  netCssFromStylexMetadata,
+  UnsupportedCssError,
+} from '../src/core/gates/semanticDiff';
+import { loadFixtures, readBrokenFixture } from './utils/harness';
+
+const [trivialPair] = loadFixtures('emotion').filter(
+  (f) => f.name === 'static-flat-color',
+);
+
+// The style object literally present in the trivial pair's input.js.
+const trivialEmotionObject = { color: 'red' };
+
+function emotionNetCss(styleObject: mixed) {
+  return netCssFromSerializedCss(serializeStyles([styleObject]).styles);
+}
+
+describe('compile gate', () => {
+  test('passes on the trivial expected output', () => {
+    const result = compileGate(trivialPair.expected, {
+      filename: trivialPair.expectedPath,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test('FAILS on the deliberately-broken pair (non-static create arg)', () => {
+    const result = compileGate(readBrokenFixture('compile-invalid.js'));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.join('\n')).toMatch(/create\(\)/);
+    }
+  });
+});
+
+describe('lint gate', () => {
+  test('passes on the trivial expected output', () => {
+    const result = lintGate(trivialPair.expected, {
+      filename: trivialPair.expectedPath,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test('FAILS on the deliberately-broken pair (invalid property, unused styles)', () => {
+    const result = lintGate(readBrokenFixture('lint-invalid.js'));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const ruleIds = result.messages.map((m) => m.ruleId);
+      expect(ruleIds).toContain('@stylexjs/valid-styles');
+      expect(ruleIds).toContain('@stylexjs/no-unused');
+    }
+  });
+});
+
+describe('semantic-diff gate', () => {
+  test('trivial pair end-to-end: Emotion input and compiled StyleX output have equal net CSS', () => {
+    const compiled = compileGate(trivialPair.expected, {
+      filename: trivialPair.expectedPath,
+    });
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) {
+      return;
+    }
+    const before = emotionNetCss(trivialEmotionObject);
+    const after = netCssFromStylexMetadata(compiled.metadata);
+    const result = semanticDiffGate(before, after);
+    expect(result.ok).toBe(true);
+  });
+
+  test('FAILS end-to-end when the output renders a different value', () => {
+    const wrongExpected = trivialPair.expected.replace("'red'", "'blue'");
+    const compiled = compileGate(wrongExpected);
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) {
+      return;
+    }
+    const result = semanticDiffGate(
+      emotionNetCss(trivialEmotionObject),
+      netCssFromStylexMetadata(compiled.metadata),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.diffs).toEqual([
+        expect.objectContaining({
+          property: 'color',
+          beforeValue: 'red',
+          afterValue: 'blue',
+        }),
+      ]);
+    }
+  });
+
+  test('FAILS when a declaration is dropped entirely', () => {
+    const result = semanticDiffGate(
+      emotionNetCss({ color: 'red', fontSize: 16 }),
+      emotionNetCss({ color: 'red' }),
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  test('parses nested pseudo-class and media conditions', () => {
+    const net = emotionNetCss({
+      color: 'red',
+      ':hover': { color: 'blue' },
+      '@media (min-width: 600px)': { color: 'green' },
+    });
+    expect(Object.keys(net).sort()).toEqual([
+      'color',
+      'color @ :hover',
+      'color @ @media(min-width:600px)',
+    ]);
+  });
+
+  test('allowlist: the hover-guard is a sanctioned diff', () => {
+    const before = emotionNetCss({ ':hover': { color: 'blue' } });
+    const after = emotionNetCss({
+      '@media (hover: hover)': { ':hover': { color: 'blue' } },
+    });
+    const result = semanticDiffGate(before, after);
+    expect(result.ok).toBe(true);
+    expect(result.allowed.length).toBeGreaterThan(0);
+  });
+
+  test('allowlist: physical -> logical is a sanctioned diff', () => {
+    const result = semanticDiffGate(
+      emotionNetCss({ marginLeft: '8px' }),
+      emotionNetCss({ marginInlineStart: '8px' }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.allowed.length).toBeGreaterThan(0);
+  });
+
+  test('allowlist does NOT excuse a value change under the same disguise', () => {
+    const result = semanticDiffGate(
+      emotionNetCss({ marginLeft: '8px' }),
+      emotionNetCss({ marginInlineStart: '9px' }),
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  test('BAILS LOUDLY on selectors that reach outside the element', () => {
+    expect(() => emotionNetCss({ '& > span': { color: 'red' } })).toThrow(
+      UnsupportedCssError,
+    );
+    expect(() => emotionNetCss({ 'div span': { color: 'red' } })).toThrow(
+      UnsupportedCssError,
+    );
+  });
+
+  test('BAILS LOUDLY on unrecognized StyleX metadata', () => {
+    expect(() => netCssFromStylexMetadata({ nope: true })).toThrow(
+      UnsupportedCssError,
+    );
+  });
+});

--- a/packages/@stylexjs/codemods/__tests__/ir-completeness-test.js
+++ b/packages/@stylexjs/codemods/__tests__/ir-completeness-test.js
@@ -8,23 +8,30 @@
  */
 
 /**
- * IR-completeness harness (M0 stub).
+ * IR-completeness harness.
  *
  * Completeness is MEASURED, not asserted: every valid StyleX style object
- * in the corpus is read into the IR; whatever cannot be represented is a
- * concrete, safe coverage gap (in the real pipeline it would be flagged,
- * never emitted incorrectly). The reader lands with the M1 emitter — until then
- * every entry counts as uncovered and the reported coverage is 0%.
+ * in the corpus is read into the IR, re-emitted, compiled through the real
+ * babel-plugin, and required to be semantically identical to the original
+ * (empty allowlist — same object, so zero sanctioned drift). Whatever the
+ * reader cannot represent is a concrete, SAFE coverage gap (in the real
+ * pipeline it would be flagged, never emitted incorrectly).
  *
- * M1+: replace the seed corpus with extraction from StyleX's own valid
- * fixtures (`@stylexjs/babel-plugin` / `@stylexjs/eslint-plugin` tests),
- * and round-trip each covered entry (IR -> emit -> compile + semantic-diff).
+ * M1+: grow the corpus toward extraction from StyleX's own valid fixtures
+ * (`@stylexjs/babel-plugin` / `@stylexjs/eslint-plugin` tests).
  */
 
 import {
   stylexObjectToIR,
   IRCoverageGapError,
 } from '../src/testing/stylexToIR';
+import { emitFileIR } from '../src/core/emit';
+import type { EmittedStyle, EmittedValue } from '../src/core/emit';
+import { compileGate } from '../src/core/gates/compile';
+import {
+  semanticDiffGate,
+  netCssFromStylexMetadata,
+} from '../src/core/gates/semanticDiff';
 
 const SEED_CORPUS: $ReadOnlyArray<[string, mixed]> = [
   ['flat static styles', { color: 'red', fontSize: 16 }],
@@ -44,24 +51,81 @@ const SEED_CORPUS: $ReadOnlyArray<[string, mixed]> = [
   ['fallback array (firstThatWorks)', { position: ['sticky', 'fixed'] }],
 ];
 
-test('every corpus entry is either covered by the IR or a typed coverage gap', () => {
-  let covered = 0;
+function valueToSource(value: EmittedValue | mixed): string {
+  if (typeof value === 'string') {
+    return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(valueToSource).join(', ')}]`;
+  }
+  throw new Error(`unstringifiable value: ${String(value)}`);
+}
+
+function styleToSource(style: EmittedStyle | mixed): string {
+  if (style == null || typeof style !== 'object') {
+    throw new Error('unstringifiable style object');
+  }
+  const entries = Object.keys(style).map(
+    (property) => `${property}: ${valueToSource(style[property])}`,
+  );
+  return `{ ${entries.join(', ')} }`;
+}
+
+function netCssOfStyleObject(style: EmittedStyle | mixed) {
+  const source = [
+    "import * as stylex from '@stylexjs/stylex';",
+    `export const styles = stylex.create({ k: ${styleToSource(style)} });`,
+    '',
+  ].join('\n');
+  const compiled = compileGate(source);
+  if (!compiled.ok) {
+    throw new Error(
+      `corpus entry does not compile:\n${compiled.errors.join('\n')}`,
+    );
+  }
+  return netCssFromStylexMetadata(compiled.metadata);
+}
+
+test('every corpus entry round-trips through the IR or is a typed coverage gap', () => {
+  const covered: Array<string> = [];
   const gaps: Array<string> = [];
   for (const [name, styleObject] of SEED_CORPUS) {
+    let rule;
     try {
-      stylexObjectToIR(name, styleObject);
-      covered += 1;
+      rule = stylexObjectToIR(name, styleObject);
     } catch (error) {
       if (!(error instanceof IRCoverageGapError)) {
         throw error; // a real bug, not a coverage gap
       }
       gaps.push(name);
+      continue;
     }
+    // Round-trip: IR -> emit -> compile, and compare against the original
+    // object compiled directly. Empty allowlist: any drift is a failure.
+    const { rules } = emitFileIR({ rules: [rule], keyframes: [] });
+    const diff = semanticDiffGate(
+      netCssOfStyleObject(styleObject),
+      netCssOfStyleObject(rules[0].style),
+      { allowlist: [] },
+    );
+    if (!diff.ok) {
+      throw new Error(
+        `round-trip drift for '${name}': ${JSON.stringify(diff.diffs)}`,
+      );
+    }
+    covered.push(name);
   }
-  expect(covered + gaps.length).toBe(SEED_CORPUS.length);
+  expect(covered.length + gaps.length).toBe(SEED_CORPUS.length);
+  expect(covered).toEqual([
+    'flat static styles',
+    'fallback array (firstThatWorks)',
+  ]);
   // eslint-disable-next-line no-console
   console.info(
-    `[ir-completeness] ${covered}/${SEED_CORPUS.length} corpus entries covered` +
+    `[ir-completeness] ${covered.length}/${SEED_CORPUS.length} corpus entries covered` +
       (gaps.length > 0 ? ` — gaps: ${gaps.join(', ')}` : ''),
   );
 });

--- a/packages/@stylexjs/codemods/__tests__/ir-completeness-test.js
+++ b/packages/@stylexjs/codemods/__tests__/ir-completeness-test.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * IR-completeness harness (M0 stub).
+ *
+ * Completeness is MEASURED, not asserted: every valid StyleX style object
+ * in the corpus is read into the IR; whatever cannot be represented is a
+ * concrete, safe coverage gap (in the real pipeline it would be flagged,
+ * never emitted incorrectly). The reader lands with the M1 emitter — until then
+ * every entry counts as uncovered and the reported coverage is 0%.
+ *
+ * M1+: replace the seed corpus with extraction from StyleX's own valid
+ * fixtures (`@stylexjs/babel-plugin` / `@stylexjs/eslint-plugin` tests),
+ * and round-trip each covered entry (IR -> emit -> compile + semantic-diff).
+ */
+
+import {
+  stylexObjectToIR,
+  IRCoverageGapError,
+} from '../src/testing/stylexToIR';
+
+const SEED_CORPUS: $ReadOnlyArray<[string, mixed]> = [
+  ['flat static styles', { color: 'red', fontSize: 16 }],
+  [
+    'pseudo-class conditions in the value object',
+    { color: { default: 'black', ':hover': 'blue' } },
+  ],
+  // Valid modern StyleX — pseudo-elements may appear inside value objects.
+  [
+    'pseudo-element condition in the value object',
+    { color: { default: 'black', '::placeholder': 'gray' } },
+  ],
+  [
+    'at-rule conditions',
+    { width: { default: '100%', '@media (min-width: 600px)': '50%' } },
+  ],
+  ['fallback array (firstThatWorks)', { position: ['sticky', 'fixed'] }],
+];
+
+test('every corpus entry is either covered by the IR or a typed coverage gap', () => {
+  let covered = 0;
+  const gaps: Array<string> = [];
+  for (const [name, styleObject] of SEED_CORPUS) {
+    try {
+      stylexObjectToIR(name, styleObject);
+      covered += 1;
+    } catch (error) {
+      if (!(error instanceof IRCoverageGapError)) {
+        throw error; // a real bug, not a coverage gap
+      }
+      gaps.push(name);
+    }
+  }
+  expect(covered + gaps.length).toBe(SEED_CORPUS.length);
+  // eslint-disable-next-line no-console
+  console.info(
+    `[ir-completeness] ${covered}/${SEED_CORPUS.length} corpus entries covered` +
+      (gaps.length > 0 ? ` — gaps: ${gaps.join(', ')}` : ''),
+  );
+});

--- a/packages/@stylexjs/codemods/__tests__/ir-test.js
+++ b/packages/@stylexjs/codemods/__tests__/ir-test.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type { Condition } from '../src/core/ir';
+import { conditionKey, atomCoordinate } from '../src/core/ir';
+
+test('conditionKey covers every condition kind', () => {
+  expect(conditionKey({ kind: 'pseudo-class', name: ':hover' })).toEqual(
+    ':hover',
+  );
+  expect(conditionKey({ kind: 'pseudo-element', name: '::before' })).toEqual(
+    '::before',
+  );
+  expect(
+    conditionKey({ kind: 'at-rule', rule: '@media (min-width: 600px)' }),
+  ).toEqual('@media (min-width: 600px)');
+});
+
+test('atomCoordinate is stable under condition ordering', () => {
+  const hover: Condition = { kind: 'pseudo-class', name: ':hover' };
+  const media: Condition = {
+    kind: 'at-rule',
+    rule: '@media (min-width: 600px)',
+  };
+  expect(atomCoordinate('color', [hover, media])).toEqual(
+    atomCoordinate('color', [media, hover]),
+  );
+  expect(atomCoordinate('color', [])).toEqual('color');
+});

--- a/packages/@stylexjs/codemods/__tests__/rewriter-test.js
+++ b/packages/@stylexjs/codemods/__tests__/rewriter-test.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import { parseSource, printSource, parserForFile } from '../src/core/rewriter';
+
+test('parse -> print with no mutation preserves the source byte-exactly', () => {
+  const source = [
+    '/** @jsxImportSource @emotion/react */',
+    "import * as React   from 'react';",
+    '',
+    'export default function Badge() {',
+    "  return <div css={{ color:   'red' }}>Badge</div>;",
+    '}',
+    '',
+  ].join('\n');
+  expect(printSource(parseSource(source))).toEqual(source);
+});
+
+test('parses Flow-typed user code', () => {
+  const source = 'const x: number = 1;\n';
+  expect(printSource(parseSource(source))).toEqual(source);
+});
+
+test('picks the TS parser for TypeScript files', () => {
+  expect(parserForFile('Component.tsx')).toEqual('tsx');
+  expect(parserForFile('Component.ts')).toEqual('tsx');
+  expect(parserForFile('Component.js')).toEqual('flow');
+  expect(parserForFile('Component.jsx')).toEqual('flow');
+});

--- a/packages/@stylexjs/codemods/__tests__/seam-test.js
+++ b/packages/@stylexjs/codemods/__tests__/seam-test.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Enforces the load-bearing architectural invariants from commit one:
+ *
+ *  1. `src/core/` never imports from `src/adapters/` — the neutral-IR seam.
+ *     The day core needs an adapter, the seam has leaked; that is a
+ *     regression, not a refactor.
+ *  2. Only `src/core/rewriter.js` may import the AST toolkit (jscodeshift),
+ *     so the toolkit stays swappable behind one wrapper.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC = path.join(__dirname, '..', 'src');
+
+function jsFilesUnder(dir: string): Array<string> {
+  const out: Array<string> = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    // String(): Flow's Dirent libdef types `name` as string | Buffer.
+    const name = String(entry.name);
+    const full = path.join(dir, name);
+    if (entry.isDirectory()) {
+      out.push(...jsFilesUnder(full));
+    } else if (name.endsWith('.js')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function importSpecifiers(source: string): Array<string> {
+  const specifiers = [];
+  const pattern = /(?:from\s+|require\(\s*|import\(\s*)['"]([^'"]+)['"]/g;
+  for (;;) {
+    const match = pattern.exec(source);
+    if (match == null) {
+      break;
+    }
+    specifiers.push(match[1]);
+  }
+  return specifiers;
+}
+
+test('src/core/ never imports from src/adapters/', () => {
+  for (const file of jsFilesUnder(path.join(SRC, 'core'))) {
+    for (const spec of importSpecifiers(fs.readFileSync(file, 'utf8'))) {
+      expect({ file: path.relative(SRC, file), imports: spec }).not.toEqual(
+        expect.objectContaining({
+          imports: expect.stringMatching(/adapters/),
+        }),
+      );
+    }
+  }
+});
+
+test('only core/rewriter.js imports the AST toolkit', () => {
+  for (const file of jsFilesUnder(SRC)) {
+    if (path.relative(SRC, file) === path.join('core', 'rewriter.js')) {
+      continue;
+    }
+    for (const spec of importSpecifiers(fs.readFileSync(file, 'utf8'))) {
+      expect({ file: path.relative(SRC, file), imports: spec }).not.toEqual(
+        expect.objectContaining({
+          imports: expect.stringMatching(/^(jscodeshift|recast)/),
+        }),
+      );
+    }
+  }
+});

--- a/packages/@stylexjs/codemods/__tests__/utils/harness.js
+++ b/packages/@stylexjs/codemods/__tests__/utils/harness.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+
+export const FIXTURES_DIR: string = path.join(
+  __dirname,
+  '..',
+  '..',
+  '__fixtures__',
+);
+
+/**
+ * Normalizes code through the Prettier CLI so fixture comparison is
+ * byte-exact but formatting-insensitive.
+ *
+ * Deliberately the CLI via spawnSync, NOT the Node API: Prettier 3's Node
+ * API is async-only and breaks under Jest's module sandbox.
+ */
+export function formatWithPrettier(code: string, filepath: string): string {
+  // $FlowFixMe[cannot-resolve-module] - untyped bin file
+  const bin = require.resolve('prettier/bin/prettier.cjs');
+  const result = spawnSync(
+    process.execPath,
+    [bin, '--stdin-filepath', filepath],
+    { input: code, encoding: 'utf8' },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `prettier failed for ${filepath}:\n${String(result.stderr)}`,
+    );
+  }
+  // String(): Flow types spawnSync stdout as string | Buffer.
+  return String(result.stdout);
+}
+
+export type Fixture = {
+  name: string,
+  inputPath: string,
+  expectedPath: string,
+  input: string,
+  expected: string,
+};
+
+/** Discovers all input/expected fixture pairs for an adapter. */
+export function loadFixtures(adapter: string): Array<Fixture> {
+  const dir = path.join(FIXTURES_DIR, adapter);
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      // String(): Flow's Dirent libdef types `name` as string | Buffer.
+      const name = String(entry.name);
+      const inputPath = path.join(dir, name, 'input.js');
+      const expectedPath = path.join(dir, name, 'expected.js');
+      return {
+        name,
+        inputPath,
+        expectedPath,
+        input: fs.readFileSync(inputPath, 'utf8'),
+        expected: fs.readFileSync(expectedPath, 'utf8'),
+      };
+    });
+}
+
+export function readBrokenFixture(name: string): string {
+  return fs.readFileSync(path.join(FIXTURES_DIR, 'broken', name), 'utf8');
+}

--- a/packages/@stylexjs/codemods/flow_modules/@emotion/serialize/index.js.flow
+++ b/packages/@stylexjs/codemods/flow_modules/@emotion/serialize/index.js.flow
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+// Minimal type stub for `@emotion/serialize` (test-only devDependency;
+// the semantic-diff gate's "before" ground truth).
+
+declare export function serializeStyles(
+  args: $ReadOnlyArray<mixed>,
+  registered?: mixed,
+  props?: mixed,
+): { +name: string, +styles: string, ... };

--- a/packages/@stylexjs/codemods/flow_modules/eslint/index.js.flow
+++ b/packages/@stylexjs/codemods/flow_modules/eslint/index.js.flow
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+// Minimal type stub for the parts of `eslint` the codemod uses. The real
+// package's entry point lives under `lib/`, which this repo's .flowconfig
+// ignores, so the module is unresolvable without a stub.
+
+export type LinterMessage = {
+  +ruleId: string | null,
+  +message: string,
+  +severity: number,
+  +line?: number,
+  +column?: number,
+  +fix?: mixed,
+  ...
+};
+
+declare export class Linter {
+  defineParser(name: string, parser: mixed): void;
+  defineRule(name: string, rule: mixed): void;
+  verify(
+    code: string,
+    config: mixed,
+    options?: mixed,
+  ): Array<LinterMessage>;
+  verifyAndFix(
+    code: string,
+    config: mixed,
+    options?: mixed,
+  ): { +fixed: boolean, +output: string, +messages: Array<LinterMessage> };
+}

--- a/packages/@stylexjs/codemods/flow_modules/hermes-eslint/index.js.flow
+++ b/packages/@stylexjs/codemods/flow_modules/hermes-eslint/index.js.flow
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+// Minimal type stub for `hermes-eslint` (its compiled entry lives under
+// `dist/`, which this repo's .flowconfig ignores). The module is
+// ESM-compiled with NO default export — always use a namespace import;
+// the namespace itself is the ESLint parser object.
+
+declare export function parseForESLint(
+  code: string,
+  options?: mixed,
+): { +ast: mixed, +scopeManager: mixed, ... };
+
+declare export function parse(code: string, options?: mixed): mixed;

--- a/packages/@stylexjs/codemods/package.json
+++ b/packages/@stylexjs/codemods/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@stylexjs/codemods",
+  "version": "0.19.0",
+  "description": "Codemods for migrating styling libraries (Emotion first) to StyleX",
+  "main": "./lib/index.js",
+  "repository": "https://www.github.com/facebook/stylex",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "prebuild": "gen-types -i src/ -o lib/",
+    "build": "cross-env BABEL_ENV=cjs babel src/ --out-dir lib/ --copy-files",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@babel/core": "^7.28.5",
+    "@stylexjs/babel-plugin": "0.19.0",
+    "@stylexjs/eslint-plugin": "0.19.0",
+    "@stylexjs/shared": "0.19.0",
+    "babel-plugin-syntax-hermes-parser": "0.36.1",
+    "eslint": "8.57.1",
+    "hermes-eslint": "0.36.1",
+    "jscodeshift": "^17.3.0",
+    "style-value-parser": "0.19.0"
+  },
+  "devDependencies": {
+    "@emotion/serialize": "^1.3.3",
+    "scripts": "0.19.0"
+  },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "/__fixtures__/",
+      "/__tests__/utils/"
+    ]
+  },
+  "files": [
+    "lib/*"
+  ]
+}

--- a/packages/@stylexjs/codemods/src/adapters/emotion/README.md
+++ b/packages/@stylexjs/codemods/src/adapters/emotion/README.md
@@ -1,0 +1,9 @@
+# Emotion adapter (reader)
+
+Lands from **M1**. This directory will hold the library-specific side of the
+seam: `detect.js` (find Emotion style sites), `read.js` (style sites ->
+neutral `declarations`), `rewriteSites.js` (binding map -> `stylex.props`
+call sites), and `imports.js` (Emotion import/pragma cleanup).
+
+Invariant: `src/core/` never imports from this directory. The seam is
+enforced by `__tests__/seam-test.js`.

--- a/packages/@stylexjs/codemods/src/adapters/emotion/detect.js
+++ b/packages/@stylexjs/codemods/src/adapters/emotion/detect.js
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * L2 — Detect. Finds every Emotion style site in the file and everything
+ * that makes the file unconvertible. M1 policy (user-ratified): a file is
+ * converted only if EVERY style site is convertible; a single blocker
+ * skips the whole file untouched.
+ *
+ * Convertible site forms:
+ *   <div css={{ ... }} />          — object literal
+ *   <div css={css({ ... })} />     — inline `css()` call around an object
+ * on host (lowercase) elements with no `className`/`style`/spread props.
+ */
+
+export type StyleSite = {
+  +attrPath: $FlowFixMe, // JSXAttribute path
+  +objectNode: $FlowFixMe, // the style ObjectExpression
+  +tagName: string,
+};
+
+export type Detection = {
+  +sites: Array<StyleSite>,
+  +blockers: Array<string>,
+};
+
+export function detectSites(
+  j: $FlowFixMe,
+  root: $FlowFixMe,
+  cssLocalName: string | null,
+): Detection {
+  const sites: Array<StyleSite> = [];
+  const blockers: Array<string> = [];
+  const siteCallees = new Set<$FlowFixMe>();
+
+  root
+    .find(j.JSXAttribute, { name: { name: 'css' } })
+    .forEach((path: $FlowFixMe) => {
+      const opening = path.parent.node;
+      const nameNode = opening.name;
+      if (nameNode.type !== 'JSXIdentifier' || !/^[a-z]/.test(nameNode.name)) {
+        blockers.push(
+          'css prop on a component element (className forwarding is not provable)',
+        );
+        return;
+      }
+      const conflicting = (opening.attributes ?? []).find(
+        (attr: $FlowFixMe) =>
+          attr.type === 'JSXSpreadAttribute' ||
+          attr.name?.name === 'className' ||
+          attr.name?.name === 'style',
+      );
+      if (conflicting != null) {
+        blockers.push(
+          `<${nameNode.name}> mixes css with className/style/spread props`,
+        );
+        return;
+      }
+      const container = path.node.value;
+      if (container?.type !== 'JSXExpressionContainer') {
+        blockers.push(`css prop on <${nameNode.name}> is not an expression`);
+        return;
+      }
+      const expression = container.expression;
+      if (expression.type === 'ObjectExpression') {
+        sites.push({
+          attrPath: path,
+          objectNode: expression,
+          tagName: nameNode.name,
+        });
+        return;
+      }
+      if (
+        expression.type === 'CallExpression' &&
+        expression.callee.type === 'Identifier' &&
+        cssLocalName != null &&
+        expression.callee.name === cssLocalName &&
+        expression.arguments.length === 1 &&
+        expression.arguments[0].type === 'ObjectExpression'
+      ) {
+        siteCallees.add(expression.callee);
+        sites.push({
+          attrPath: path,
+          objectNode: expression.arguments[0],
+          tagName: nameNode.name,
+        });
+        return;
+      }
+      blockers.push(
+        `css prop value form on <${nameNode.name}> is not convertible yet ` +
+          '(template literals, arrays, references and dynamic styles land in later milestones)',
+      );
+    });
+
+  if (cssLocalName != null) {
+    root
+      .find(j.Identifier, { name: cssLocalName })
+      .forEach((path: $FlowFixMe) => {
+        const parentNode = path.parent.node;
+        if (
+          parentNode.type === 'ImportSpecifier' ||
+          siteCallees.has(path.node) ||
+          (parentNode.type === 'Property' && parentNode.key === path.node) ||
+          parentNode.type === 'JSXAttribute'
+        ) {
+          return;
+        }
+        blockers.push(
+          `'${cssLocalName}' is used outside a convertible css prop ` +
+            '(tagged templates / shared style variables land in later milestones)',
+        );
+      });
+  }
+
+  if (
+    root
+      .find(j.ImportDeclaration)
+      .some(
+        (path: $FlowFixMe) =>
+          String(path.node.source.value) === '@stylexjs/stylex',
+      )
+  ) {
+    blockers.push(
+      'file already imports @stylexjs/stylex (registry merge lands in M4)',
+    );
+  }
+
+  return { sites, blockers };
+}

--- a/packages/@stylexjs/codemods/src/adapters/emotion/imports.js
+++ b/packages/@stylexjs/codemods/src/adapters/emotion/imports.js
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Emotion wiring: how a file opts into the css prop. M1 recognizes the
+ * modern `@emotion/react` forms only — the `@jsxImportSource` pragma and a
+ * named `css` import. Any other `@emotion/*` surface (styled, class-based
+ * `@emotion/css`, Global, keyframes, classic `jsx` pragma) is a blocker:
+ * we skip the whole file rather than half-migrate it.
+ */
+
+const PRAGMA_PATTERN = /@jsxImportSource\s+@emotion\/react/;
+
+export type EmotionWiring = {
+  +hasPragma: boolean,
+  +cssLocalName: string | null,
+  +blockers: Array<string>,
+};
+
+export function analyzeEmotionWiring(
+  j: $FlowFixMe,
+  root: $FlowFixMe,
+): EmotionWiring {
+  let cssLocalName: string | null = null;
+  const blockers: Array<string> = [];
+
+  root.find(j.ImportDeclaration).forEach((path: $FlowFixMe) => {
+    const source = String(path.node.source.value);
+    if (!source.startsWith('@emotion/')) {
+      return;
+    }
+    if (source !== '@emotion/react') {
+      blockers.push(`import from '${source}' is not convertible yet`);
+      return;
+    }
+    for (const specifier of path.node.specifiers ?? []) {
+      if (
+        specifier.type === 'ImportSpecifier' &&
+        specifier.imported.name === 'css'
+      ) {
+        cssLocalName = specifier.local.name;
+      } else {
+        blockers.push(
+          `'@emotion/react' import of '${
+            specifier.imported?.name ?? specifier.local?.name ?? '?'
+          }' is not convertible yet`,
+        );
+      }
+    }
+  });
+
+  return {
+    hasPragma: PRAGMA_PATTERN.test(findPragmaText(j, root) ?? ''),
+    cssLocalName,
+    blockers,
+  };
+}
+
+function allCommentSlots(j: $FlowFixMe, root: $FlowFixMe): Array<$FlowFixMe> {
+  const program = root.get().node.program;
+  const slots = [program];
+  if (program.body.length > 0) {
+    slots.push(program.body[0]);
+  }
+  return slots;
+}
+
+function findPragmaText(j: $FlowFixMe, root: $FlowFixMe): string | null {
+  for (const slot of allCommentSlots(j, root)) {
+    for (const comment of slot.comments ?? []) {
+      if (PRAGMA_PATTERN.test(comment.value)) {
+        return comment.value;
+      }
+    }
+  }
+  return null;
+}
+
+/** Removes the `@jsxImportSource @emotion/react` pragma comment. */
+export function removePragma(j: $FlowFixMe, root: $FlowFixMe): void {
+  for (const slot of allCommentSlots(j, root)) {
+    if (slot.comments != null) {
+      slot.comments = slot.comments.filter(
+        (comment: $FlowFixMe) => !PRAGMA_PATTERN.test(comment.value),
+      );
+    }
+  }
+}
+
+/**
+ * Removes the `css` specifier from the `@emotion/react` import (the whole
+ * declaration when nothing else remains), transplanting any non-pragma
+ * comments onto the next statement so file headers survive.
+ */
+export function removeCssImport(j: $FlowFixMe, root: $FlowFixMe): void {
+  root.find(j.ImportDeclaration).forEach((path: $FlowFixMe) => {
+    if (String(path.node.source.value) !== '@emotion/react') {
+      return;
+    }
+    const remaining = (path.node.specifiers ?? []).filter(
+      (specifier: $FlowFixMe) =>
+        !(
+          specifier.type === 'ImportSpecifier' &&
+          specifier.imported.name === 'css'
+        ),
+    );
+    if (remaining.length > 0) {
+      path.node.specifiers = remaining;
+      return;
+    }
+    const comments = (path.node.comments ?? []).filter(
+      (comment: $FlowFixMe) =>
+        comment.leading === true && !PRAGMA_PATTERN.test(comment.value),
+    );
+    const next = path.parent.node.body[path.name + 1];
+    if (comments.length > 0 && next != null) {
+      next.comments = [...comments, ...(next.comments ?? [])];
+    }
+    j(path).remove();
+  });
+}
+
+/**
+ * Inserts `import * as stylex from '@stylexjs/stylex';` after the last
+ * import. Detection of a pre-existing StyleX import is a blocker upstream
+ * (registry merge lands in M4), so this never duplicates.
+ */
+export function insertStylexImport(j: $FlowFixMe, root: $FlowFixMe): void {
+  const declaration = j.importDeclaration(
+    [j.importNamespaceSpecifier(j.identifier('stylex'))],
+    j.literal('@stylexjs/stylex'),
+  );
+  const imports = root.find(j.ImportDeclaration);
+  if (imports.size() > 0) {
+    j(imports.paths()[imports.size() - 1]).insertAfter(declaration);
+  } else {
+    root.get().node.program.body.unshift(declaration);
+  }
+}

--- a/packages/@stylexjs/codemods/src/adapters/emotion/read.js
+++ b/packages/@stylexjs/codemods/src/adapters/emotion/read.js
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * L3 — Read. Walks a detected style site's ObjectExpression into neutral
+ * declarations (the first seam hand-off). No StyleX knowledge.
+ *
+ * M1 scope: flat static string/number values only. Condition keys
+ * (':hover', '@media …', '&…'), nested objects, spreads, computed keys and
+ * non-literal values are blockers. A shorthand/longhand overlap inside one
+ * object (e.g. `margin` + `marginTop`) is refused until the M2 referee can
+ * arbitrate it — the exact bug class the old attempt shipped.
+ */
+
+import type { Declaration } from '../../core/buildIR';
+import type { StyleSite } from './detect';
+
+export type PlainStyleObject = { +[string]: string | number };
+
+export type ReadSite =
+  | {
+      +ok: true,
+      +declarations: Array<Declaration>,
+      +cssObject: PlainStyleObject,
+      +nameHint: string,
+    }
+  | { +ok: false, +blocker: string };
+
+const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+function literalValue(node: $FlowFixMe): string | number | null {
+  if (
+    (node.type === 'Literal' ||
+      node.type === 'StringLiteral' ||
+      node.type === 'NumericLiteral') &&
+    (typeof node.value === 'string' || typeof node.value === 'number')
+  ) {
+    return node.value;
+  }
+  if (node.type === 'UnaryExpression' && node.operator === '-') {
+    const inner = literalValue(node.argument);
+    if (typeof inner === 'number') {
+      return -inner;
+    }
+  }
+  return null;
+}
+
+function propertyKey(node: $FlowFixMe): string | null {
+  if (node.type === 'Identifier') {
+    return node.name;
+  }
+  if (
+    (node.type === 'Literal' || node.type === 'StringLiteral') &&
+    typeof node.value === 'string' &&
+    IDENTIFIER.test(node.value)
+  ) {
+    return node.value;
+  }
+  return null;
+}
+
+/**
+ * Conservative shorthand/longhand overlap check: `marginTop` overlaps
+ * `margin` because it extends it with a capitalized segment. Errs toward
+ * false positives (`border` vs `borderRadius`) — a false positive skips a
+ * file (safe); the M2 referee replaces this with real priority data from
+ * `@stylexjs/shared`.
+ */
+function findShorthandOverlap(properties: Array<string>): string | null {
+  for (const a of properties) {
+    for (const b of properties) {
+      if (b.length > a.length && b.startsWith(a) && /[A-Z]/.test(b[a.length])) {
+        return `'${a}' + '${b}'`;
+      }
+    }
+  }
+  return null;
+}
+
+export function readSite(site: StyleSite): ReadSite {
+  const declarations: Array<Declaration> = [];
+  const cssObject: { [string]: string | number } = {};
+  let label: string | null = null;
+
+  for (const property of site.objectNode.properties) {
+    if (property.type !== 'Property' && property.type !== 'ObjectProperty') {
+      return { ok: false, blocker: 'spread in style object' };
+    }
+    if (property.computed) {
+      return { ok: false, blocker: 'computed key in style object' };
+    }
+    const key = propertyKey(property.key);
+    if (key == null) {
+      return {
+        ok: false,
+        blocker:
+          `style key ${describeKey(property.key)} is not convertible yet ` +
+          '(conditions land in M2, kebab-case keys in M3)',
+      };
+    }
+    const value = literalValue(property.value);
+    if (value == null) {
+      return {
+        ok: false,
+        blocker:
+          `value of '${key}' is not a static string/number ` +
+          '(nested conditions land in M2; dynamic values in v1.1)',
+      };
+    }
+    if (key === 'label' && typeof value === 'string') {
+      label = value;
+      continue; // debugging metadata, not a CSS declaration
+    }
+    if (cssObject[key] !== undefined) {
+      return { ok: false, blocker: `duplicate style key '${key}'` };
+    }
+    declarations.push({ property: key, value });
+    cssObject[key] = value;
+  }
+
+  if (declarations.length === 0) {
+    return { ok: false, blocker: 'empty style object' };
+  }
+  const overlap = findShorthandOverlap(declarations.map((d) => d.property));
+  if (overlap != null) {
+    return {
+      ok: false,
+      blocker: `shorthand/longhand overlap (${overlap}) needs the M2 referee`,
+    };
+  }
+
+  return {
+    ok: true,
+    declarations,
+    cssObject,
+    nameHint: label ?? enclosingComponentName(site) ?? site.tagName,
+  };
+}
+
+function describeKey(node: $FlowFixMe): string {
+  return typeof node.value === 'string' ? `'${node.value}'` : `<${node.type}>`;
+}
+
+function enclosingComponentName(site: StyleSite): string | null {
+  for (let path = site.attrPath; path != null; path = path.parent) {
+    const node = path.node;
+    if (node.type === 'FunctionDeclaration' && node.id?.name != null) {
+      return node.id.name;
+    }
+    if (
+      node.type === 'VariableDeclarator' &&
+      node.id?.type === 'Identifier' &&
+      (node.init?.type === 'ArrowFunctionExpression' ||
+        node.init?.type === 'FunctionExpression')
+    ) {
+      return node.id.name;
+    }
+  }
+  return null;
+}

--- a/packages/@stylexjs/codemods/src/adapters/emotion/rewriteSites.js
+++ b/packages/@stylexjs/codemods/src/adapters/emotion/rewriteSites.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * L8 — Rewrite. Consumes the binding map (the second seam hand-off) and
+ * swaps each Emotion css prop for `{...stylex.props(styles.key)}` in that
+ * site's place.
+ */
+
+import type { StyleSite } from './detect';
+
+export function rewriteSite(
+  j: $FlowFixMe,
+  site: StyleSite,
+  stylesLocalName: string,
+  key: string,
+): void {
+  const spread = j.jsxSpreadAttribute(
+    j.callExpression(
+      j.memberExpression(j.identifier('stylex'), j.identifier('props')),
+      [j.memberExpression(j.identifier(stylesLocalName), j.identifier(key))],
+    ),
+  );
+  j(site.attrPath).replaceWith(spread);
+}

--- a/packages/@stylexjs/codemods/src/adapters/emotion/transform.js
+++ b/packages/@stylexjs/codemods/src/adapters/emotion/transform.js
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * The Emotion -> StyleX pipeline for one file: detect -> read (adapter),
+ * buildIR -> emit (core), rewrite -> registry -> imports (adapter).
+ *
+ * M1 policy (user-ratified): whole-file-or-nothing. A file is rewritten
+ * only when every style site is convertible; any blocker returns
+ * `skipped` with the reasons and the source untouched. TODO-comment
+ * flagging machinery lands in M5.
+ */
+
+import { buildFileIR } from '../../core/buildIR';
+import { emitFileIR } from '../../core/emit';
+import {
+  parseSource,
+  printSource,
+  parserForFile,
+  styleToObjectAst,
+} from '../../core/rewriter';
+import {
+  analyzeEmotionWiring,
+  removePragma,
+  removeCssImport,
+  insertStylexImport,
+} from './imports';
+import { detectSites } from './detect';
+import { readSite } from './read';
+import type { PlainStyleObject } from './read';
+import { rewriteSite } from './rewriteSites';
+
+export type TransformResult =
+  | {
+      +status: 'converted',
+      +code: string,
+      +sites: $ReadOnlyArray<{ +key: string, +cssObject: PlainStyleObject }>,
+    }
+  | { +status: 'skipped', +reasons: $ReadOnlyArray<string> }
+  | { +status: 'unchanged' };
+
+export function transformEmotionFile(
+  source: string,
+  filename: string = 'file.js',
+): TransformResult {
+  // Cheap bail before parsing anything.
+  if (!source.includes('@emotion/react')) {
+    return { status: 'unchanged' };
+  }
+
+  const { j, root } = parseSource(source, {
+    parser: parserForFile(filename),
+  });
+
+  const wiring = analyzeEmotionWiring(j, root);
+  if (!wiring.hasPragma && wiring.cssLocalName == null) {
+    return { status: 'unchanged' };
+  }
+
+  const detection = detectSites(j, root, wiring.cssLocalName);
+  const blockers = [...wiring.blockers, ...detection.blockers];
+  const reads = detection.sites.map(readSite);
+  for (const read of reads) {
+    if (!read.ok) {
+      blockers.push(read.blocker);
+    }
+  }
+  if (blockers.length > 0) {
+    return { status: 'skipped', reasons: blockers };
+  }
+  if (detection.sites.length === 0) {
+    return { status: 'unchanged' };
+  }
+
+  // Adapter -> core: declarations in, create data + binding map out.
+  const groups = reads.map((read) => {
+    if (!read.ok) {
+      throw new Error('unreachable: blockers were checked above');
+    }
+    return { nameHint: read.nameHint, declarations: read.declarations };
+  });
+  const { rules, bindings } = emitFileIR(buildFileIR(groups));
+
+  // Core -> adapter: place the StyleX back into the file's idiom.
+  const stylesLocalName = pickStylesName(j, root);
+  detection.sites.forEach((site, i) => {
+    rewriteSite(j, site, stylesLocalName, bindings[i]);
+  });
+  insertRegistry(j, root, detection.sites[0], stylesLocalName, rules);
+  insertStylexImport(j, root);
+  removeCssImport(j, root);
+  removePragma(j, root);
+
+  return {
+    status: 'converted',
+    code: printSource({ j, root }),
+    sites: detection.sites.map((site, i) => {
+      const read = reads[i];
+      if (!read.ok) {
+        throw new Error('unreachable: blockers were checked above');
+      }
+      return { key: bindings[i], cssObject: read.cssObject };
+    }),
+  };
+}
+
+/** `styles`, or a numbered variant if the file already uses that name. */
+function pickStylesName(j: $FlowFixMe, root: $FlowFixMe): string {
+  const taken = (name: string) => root.find(j.Identifier, { name }).size() > 0;
+  let name = 'styles';
+  for (let n = 2; taken(name); n++) {
+    name = `styles${n}`;
+  }
+  return name;
+}
+
+/**
+ * Inserts `const <styles> = stylex.create({...})` directly above the
+ * top-level statement containing the first converted site (per the
+ * best-practices doc's registry placement).
+ */
+function insertRegistry(
+  j: $FlowFixMe,
+  root: $FlowFixMe,
+  firstSite: $FlowFixMe,
+  stylesLocalName: string,
+  rules: $ReadOnlyArray<{
+    +key: string,
+    +style: { +[string]: string | number | $ReadOnlyArray<string | number> },
+  }>,
+): void {
+  const createObject = j.objectExpression(
+    rules.map((rule) =>
+      j.property(
+        'init',
+        j.identifier(rule.key),
+        styleToObjectAst(j, rule.style),
+      ),
+    ),
+  );
+  const declaration = j.variableDeclaration('const', [
+    j.variableDeclarator(
+      j.identifier(stylesLocalName),
+      j.callExpression(
+        j.memberExpression(j.identifier('stylex'), j.identifier('create')),
+        [createObject],
+      ),
+    ),
+  ]);
+
+  let statementPath = firstSite.attrPath;
+  while (
+    statementPath.parent != null &&
+    statementPath.parent.node.type !== 'Program'
+  ) {
+    statementPath = statementPath.parent;
+  }
+  j(statementPath).insertBefore(declaration);
+}

--- a/packages/@stylexjs/codemods/src/cli/README.md
+++ b/packages/@stylexjs/codemods/src/cli/README.md
@@ -1,0 +1,5 @@
+# CLI
+
+Lands in **M6**: `stylex-codemod emotion "<glob>" [--dry-run]` (dry-run is
+the default), config loading (`resolveValue` glossary, `hoverGuard`,
+logical-properties opt-out), and the convert/flag/refuse report.

--- a/packages/@stylexjs/codemods/src/core/buildIR.js
+++ b/packages/@stylexjs/codemods/src/core/buildIR.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+/**
+ * L4 — Build IR. Turns adapter-produced `declarations` (the first seam
+ * hand-off) into the neutral FileIR.
+ *
+ * M1 scope: flat static declarations only — every atom has zero
+ * conditions. "The flip" (selector-grouped -> property-grouped condition
+ * nesting) lands here in M2; this module's shape is already the flip's
+ * home so the seam does not move.
+ */
+
+import type { Atom, FileIR, StyleRule } from './ir';
+
+/**
+ * One style declaration as handed over by an adapter: no conditions yet
+ * (M1), no StyleX knowledge, no AST nodes.
+ */
+export type Declaration = {
+  +property: string,
+  +value: string | number,
+};
+
+/**
+ * One style site as handed over by an adapter: its declarations plus a
+ * suggested name (adapter knows labels/component names; core decides the
+ * final key).
+ */
+export type DeclarationGroup = {
+  +nameHint: string,
+  +declarations: $ReadOnlyArray<Declaration>,
+};
+
+export function buildFileIR(groups: $ReadOnlyArray<DeclarationGroup>): FileIR {
+  const rules: Array<StyleRule> = groups.map((group) => {
+    const atoms: Array<Atom> = group.declarations.map((declaration) => ({
+      property: declaration.property,
+      conditions: [],
+      value: { kind: 'static', value: declaration.value },
+    }));
+    return { name: group.nameHint, atoms };
+  });
+  return { rules, keyframes: [] };
+}

--- a/packages/@stylexjs/codemods/src/core/emit.js
+++ b/packages/@stylexjs/codemods/src/core/emit.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+/**
+ * L7 — Emit. Turns the FileIR into the data for a single per-file
+ * `stylex.create` registry plus the binding map (the second seam
+ * hand-off: rule #N becomes `styles.<key>`).
+ *
+ * Deliberately AST-free: emit produces plain data; the adapter (which owns
+ * the file's AST) renders it. This keeps `core/` blind to parser nodes.
+ *
+ * Naming (M1 minimal policy, superseded wholesale in M4): the adapter's
+ * nameHint (label > enclosing component) is sanitized to a camelCase
+ * identifier; collisions get a numeric suffix starting at 2.
+ */
+
+import type { FileIR, StyleRule, Value } from './ir';
+
+/**
+ * A value in a `stylex.create` entry: a static value, or a fallback array
+ * (StyleX's shorthand for `firstThatWorks`).
+ */
+export type EmittedValue = string | number | $ReadOnlyArray<string | number>;
+
+/** A `stylex.create` entry as plain data: property -> value. */
+export type EmittedStyle = { +[property: string]: EmittedValue };
+
+export type EmittedRule = {
+  +key: string,
+  +style: EmittedStyle,
+};
+
+export type EmitResult = {
+  +rules: $ReadOnlyArray<EmittedRule>,
+  /** bindings[i] is the create key for FileIR.rules[i]. */
+  +bindings: $ReadOnlyArray<string>,
+};
+
+export class EmitError extends Error {
+  constructor(message: string) {
+    super(`[stylex-codemod emit] ${message}`);
+    this.name = 'EmitError';
+  }
+}
+
+const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+const RESERVED = new Set(['default', 'delete', 'do', 'in', 'new', 'var']);
+
+/** Sanitizes an adapter name hint into a usable create key. */
+export function sanitizeKey(hint: string): string {
+  const cleaned = hint
+    .replace(/[^A-Za-z0-9_$]+(.)?/g, (_, next: string | void) =>
+      next == null ? '' : next.toUpperCase(),
+    )
+    .replace(/^[0-9]+/, '');
+  const key =
+    cleaned === '' ? 'styles' : cleaned[0].toLowerCase() + cleaned.slice(1);
+  return IDENTIFIER.test(key) && !RESERVED.has(key) ? key : 'styles';
+}
+
+function emitValue(value: Value, rule: StyleRule): EmittedValue {
+  if (value.kind === 'first-that-works') {
+    return value.values;
+  }
+  if (value.kind !== 'static' || value.value == null) {
+    throw new EmitError(
+      `rule '${rule.name}': only static non-null values are emittable in M1`,
+    );
+  }
+  return value.value;
+}
+
+export function emitFileIR(ir: FileIR): EmitResult {
+  const usedKeys = new Set<string>();
+  const rules: Array<EmittedRule> = [];
+  const bindings: Array<string> = [];
+
+  for (const rule of ir.rules) {
+    const unsorted: { [string]: EmittedValue } = {};
+    for (const atom of rule.atoms) {
+      if (atom.conditions.length > 0) {
+        throw new EmitError(
+          `rule '${rule.name}': conditions are not emittable until M2`,
+        );
+      }
+      if (unsorted[atom.property] !== undefined) {
+        throw new EmitError(
+          `rule '${rule.name}': duplicate property '${atom.property}'`,
+        );
+      }
+      unsorted[atom.property] = emitValue(atom.value, rule);
+    }
+    // Alphabetical property order satisfies stylex/sort-keys with zero
+    // autofixes. Safe in M1: flat longhands are order-independent, and the
+    // order-DEPENDENT cases (duplicates, shorthand/longhand overlap) are
+    // refused upstream. M4's scoped verifyAndFix supersedes this.
+    const style: { [string]: EmittedValue } = {};
+    for (const property of Object.keys(unsorted).sort()) {
+      style[property] = unsorted[property];
+    }
+
+    const base = sanitizeKey(rule.name);
+    let key = base;
+    for (let n = 2; usedKeys.has(key); n++) {
+      key = `${base}${n}`;
+    }
+    usedKeys.add(key);
+    rules.push({ key, style });
+    bindings.push(key);
+  }
+
+  if (ir.keyframes.length > 0) {
+    throw new EmitError('keyframes are not emittable until M3');
+  }
+  return { rules, bindings };
+}

--- a/packages/@stylexjs/codemods/src/core/gates/compile.js
+++ b/packages/@stylexjs/codemods/src/core/gates/compile.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Compile gate: the output of a conversion must compile through the real
+ * `@stylexjs/babel-plugin`. On success it also returns the plugin's
+ * metadata (the injectable CSS rules), which the semantic-diff gate uses
+ * as the StyleX side's ground truth.
+ */
+
+import * as babel from '@babel/core';
+import styleXPlugin from '@stylexjs/babel-plugin';
+
+export type CompileGateResult =
+  | { +ok: true, +code: string, +metadata: mixed }
+  | { +ok: false, +errors: $ReadOnlyArray<string> };
+
+export function compileGate(
+  source: string,
+  options?: { +filename?: string },
+): CompileGateResult {
+  const filename = options?.filename ?? 'stylex-codemod-gate-input.js';
+  try {
+    const result = babel.transformSync(source, {
+      filename,
+      babelrc: false,
+      configFile: false,
+      plugins: [
+        ['babel-plugin-syntax-hermes-parser', { flow: 'detect' }],
+        [styleXPlugin, {}],
+      ],
+    });
+    if (result == null || result.code == null) {
+      return { ok: false, errors: ['Babel produced no output'] };
+    }
+    return { ok: true, code: result.code, metadata: result.metadata };
+  } catch (error) {
+    return {
+      ok: false,
+      errors: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+}

--- a/packages/@stylexjs/codemods/src/core/gates/lint.js
+++ b/packages/@stylexjs/codemods/src/core/gates/lint.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Lint gate: the output of a conversion must pass every rule of the real
+ * `@stylexjs/eslint-plugin` at severity `error`, with zero messages —
+ * which implies zero autofixes still needed (Meta's golden rule for
+ * StyleX codemods).
+ */
+
+import { Linter } from 'eslint';
+// hermes-eslint is ESM-compiled with no default export — the namespace
+// object itself is the parser (`parseForESLint` lives on it).
+import * as hermesEslint from 'hermes-eslint';
+// The plugin has named exports only (no default) — import `rules` directly.
+import { rules as stylexRules } from '@stylexjs/eslint-plugin';
+
+export type LintMessage = {
+  +ruleId: string | null,
+  +message: string,
+  +line: number,
+  +column: number,
+  +fixable: boolean,
+};
+
+export type LintGateResult =
+  | { +ok: true }
+  | { +ok: false, +messages: $ReadOnlyArray<LintMessage> };
+
+const PARSER_NAME = 'hermes-eslint';
+
+function buildLinter(): { linter: Linter, rules: { [string]: 'error' } } {
+  const linter = new Linter();
+  linter.defineParser(PARSER_NAME, hermesEslint);
+  const ruleMap: { +[string]: mixed } = stylexRules;
+  const rules: { [string]: 'error' } = {};
+  for (const ruleName of Object.keys(ruleMap)) {
+    const qualified = `@stylexjs/${ruleName}`;
+    linter.defineRule(qualified, ruleMap[ruleName]);
+    rules[qualified] = 'error';
+  }
+  return { linter, rules };
+}
+
+export function lintGate(
+  source: string,
+  options?: { +filename?: string },
+): LintGateResult {
+  const { linter, rules } = buildLinter();
+  const messages = linter.verify(
+    source,
+    {
+      parser: PARSER_NAME,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+      rules,
+    },
+    { filename: options?.filename ?? 'stylex-codemod-gate-input.js' },
+  );
+  if (messages.length === 0) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    messages: messages.map((m) => ({
+      ruleId: m.ruleId ?? null,
+      message: m.message,
+      line: m.line ?? 0,
+      column: m.column ?? 0,
+      fixable: m.fix != null,
+    })),
+  };
+}

--- a/packages/@stylexjs/codemods/src/core/gates/semanticDiff.js
+++ b/packages/@stylexjs/codemods/src/core/gates/semanticDiff.js
@@ -1,0 +1,376 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Semantic-diff gate: the net CSS before and after a conversion must be
+ * identical across every condition combination, minus an explicit allowlist
+ * of sanctioned changes (hover-guard, physical->logical). This is the check
+ * that catches "compiles fine but renders differently".
+ *
+ * Ground truths:
+ *  - before: Emotion's own serializer (`@emotion/serialize`) output,
+ *    parsed by `netCssFromSerializedCss`.
+ *  - after: the real `@stylexjs/babel-plugin` metadata (injectable rules),
+ *    parsed by `netCssFromStylexMetadata`.
+ *
+ * Both parsers BAIL LOUDLY (throw `UnsupportedCssError`) on any construct
+ * they cannot provably represent — an unparsable input must never diff
+ * clean by accident.
+ */
+
+/** One declaration of net CSS: a property+conditions coordinate => value. */
+export type NetDeclaration = {
+  +property: string, // kebab-case
+  +conditions: $ReadOnlyArray<string>, // normalized, sorted
+  +value: string,
+};
+
+export type NetCss = { +[coordinate: string]: NetDeclaration };
+
+export type DiffEntry = {
+  +coordinate: string,
+  +property: string,
+  +conditions: $ReadOnlyArray<string>,
+  +beforeValue: string | null,
+  +afterValue: string | null,
+};
+
+export type AllowlistRule = (
+  entry: DiffEntry,
+  before: NetCss,
+  after: NetCss,
+) => boolean;
+
+export type SemanticDiffResult =
+  | { +ok: true, +allowed: $ReadOnlyArray<DiffEntry> }
+  | {
+      +ok: false,
+      +diffs: $ReadOnlyArray<DiffEntry>,
+      +allowed: $ReadOnlyArray<DiffEntry>,
+    };
+
+export class UnsupportedCssError extends Error {
+  constructor(message: string) {
+    super(`[stylex-codemod semantic-diff] unsupported CSS: ${message}`);
+    this.name = 'UnsupportedCssError';
+  }
+}
+
+// --- normalization helpers ---------------------------------------------
+
+function normalizeAtRule(rule: string): string {
+  return rule
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([():,])\s*/g, '$1')
+    .trim();
+}
+
+function normalizeValue(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+function normalizeCondition(raw: string): string {
+  let s = raw.trim();
+  if (s.startsWith('&')) {
+    s = s.slice(1).trim();
+  }
+  if (s.startsWith('@')) {
+    return normalizeAtRule(s);
+  }
+  if (/^::?[\w-]+(\([^()]*\))?$/.test(s)) {
+    return s.toLowerCase();
+  }
+  throw new UnsupportedCssError(
+    `selector context '${raw}' is not a self-targeting pseudo or at-rule`,
+  );
+}
+
+function coordinate(
+  property: string,
+  conditions: $ReadOnlyArray<string>,
+): string {
+  return conditions.length === 0
+    ? property
+    : `${property} @ ${conditions.join(' && ')}`;
+}
+
+function addDeclaration(
+  target: { [string]: NetDeclaration },
+  property: string,
+  rawConditions: $ReadOnlyArray<string>,
+  value: string,
+): void {
+  const conditions = rawConditions.map(normalizeCondition).slice().sort();
+  const prop = property.trim().toLowerCase();
+  if (!/^--|^[a-z-]+$/.test(prop)) {
+    throw new UnsupportedCssError(`property '${property}'`);
+  }
+  target[coordinate(prop, conditions)] = {
+    property: prop,
+    conditions,
+    value: normalizeValue(value),
+  };
+}
+
+// --- before: Emotion serialized CSS ------------------------------------
+
+/**
+ * Parses the `styles` string produced by `@emotion/serialize` (flat
+ * declarations plus one-or-more levels of `pseudo { ... }` / `@media { ... }`
+ * nesting) into net CSS. Throws on any selector that is not self-targeting.
+ */
+export function netCssFromSerializedCss(css: string): NetCss {
+  const out: { [string]: NetDeclaration } = {};
+  const contexts: Array<string> = [];
+  let buffer = '';
+
+  const flushDeclaration = (chunk: string) => {
+    const decl = chunk.trim();
+    if (decl === '') {
+      return;
+    }
+    const colon = decl.indexOf(':');
+    if (colon <= 0) {
+      throw new UnsupportedCssError(`declaration '${decl}'`);
+    }
+    addDeclaration(out, decl.slice(0, colon), contexts, decl.slice(colon + 1));
+  };
+
+  for (let i = 0; i < css.length; i++) {
+    const char = css[i];
+    if (char === '{') {
+      const selector = buffer.trim();
+      if (selector === '') {
+        throw new UnsupportedCssError('block with empty selector');
+      }
+      if (selector.includes(',')) {
+        throw new UnsupportedCssError(`selector list '${selector}'`);
+      }
+      contexts.push(selector);
+      buffer = '';
+    } else if (char === '}') {
+      flushDeclaration(buffer);
+      buffer = '';
+      if (contexts.length === 0) {
+        throw new UnsupportedCssError('unbalanced closing brace');
+      }
+      contexts.pop();
+    } else if (char === ';') {
+      flushDeclaration(buffer);
+      buffer = '';
+    } else {
+      buffer += char;
+    }
+  }
+  if (contexts.length !== 0) {
+    throw new UnsupportedCssError('unbalanced opening brace');
+  }
+  flushDeclaration(buffer);
+  return out;
+}
+
+// --- after: StyleX babel-plugin metadata --------------------------------
+
+/**
+ * Parses `metadata.stylex` from a `compileGate` run — entries of
+ * `[className, { ltr, rtl }, priority]` — into net CSS. Rules are applied
+ * in ascending priority order, mirroring how StyleX resolves collisions.
+ */
+export function netCssFromStylexMetadata(metadata: mixed): NetCss {
+  const rules =
+    metadata != null &&
+    typeof metadata === 'object' &&
+    Array.isArray(metadata.stylex)
+      ? metadata.stylex
+      : Array.isArray(metadata)
+        ? metadata
+        : null;
+  if (rules == null) {
+    throw new UnsupportedCssError(
+      'expected StyleX babel-plugin metadata ({ stylex: [...] })',
+    );
+  }
+  const entries = rules
+    .map((rule: mixed): { ltr: string, priority: number } => {
+      if (Array.isArray(rule)) {
+        const styles = rule[1];
+        const priority = rule[2];
+        if (
+          styles != null &&
+          typeof styles === 'object' &&
+          typeof styles.ltr === 'string' &&
+          typeof priority === 'number'
+        ) {
+          return { ltr: styles.ltr, priority };
+        }
+      }
+      throw new UnsupportedCssError(
+        `metadata rule ${JSON.stringify(rule) ?? 'undefined'}`,
+      );
+    })
+    .sort((a, b) => a.priority - b.priority);
+
+  const out: { [string]: NetDeclaration } = {};
+  for (const { ltr } of entries) {
+    parseStylexRule(ltr, out);
+  }
+  return out;
+}
+
+function parseStylexRule(ltr: string, out: { [string]: NetDeclaration }): void {
+  let rest = ltr.trim();
+  const atRules: Array<string> = [];
+  while (rest.startsWith('@')) {
+    const brace = rest.indexOf('{');
+    if (brace < 0 || !rest.endsWith('}')) {
+      throw new UnsupportedCssError(`at-rule '${ltr}'`);
+    }
+    atRules.push(rest.slice(0, brace));
+    rest = rest.slice(brace + 1, -1).trim();
+  }
+  const match =
+    /^((?:\.[\w-]+)+)((?:::?[\w-]+(?:\([^()]*\))?)*)\{([^{}]*)\}$/.exec(rest);
+  if (match == null) {
+    throw new UnsupportedCssError(`rule '${ltr}'`);
+  }
+  const pseudoChain = match[2];
+  const pseudos =
+    pseudoChain === ''
+      ? []
+      : (pseudoChain.match(/::?[\w-]+(\([^()]*\))?/g) ?? []);
+  const conditions = [...atRules, ...pseudos];
+  for (const chunk of match[3].split(';')) {
+    const decl = chunk.trim();
+    if (decl === '') {
+      continue;
+    }
+    const colon = decl.indexOf(':');
+    if (colon <= 0) {
+      throw new UnsupportedCssError(`declaration '${decl}' in '${ltr}'`);
+    }
+    addDeclaration(
+      out,
+      decl.slice(0, colon),
+      conditions,
+      decl.slice(colon + 1),
+    );
+  }
+}
+
+// --- the allowlist (sanctioned, intentional diffs) ----------------------
+
+const HOVER_GUARD = normalizeAtRule('@media (hover: hover)');
+
+const PHYSICAL_TO_LOGICAL: { +[string]: string } = {
+  'margin-left': 'margin-inline-start',
+  'margin-right': 'margin-inline-end',
+  'padding-left': 'padding-inline-start',
+  'padding-right': 'padding-inline-end',
+  'border-left': 'border-inline-start',
+  'border-right': 'border-inline-end',
+  left: 'inset-inline-start',
+  right: 'inset-inline-end',
+};
+
+const LOGICAL_TO_PHYSICAL: { [string]: string } = {};
+for (const physical of Object.keys(PHYSICAL_TO_LOGICAL)) {
+  LOGICAL_TO_PHYSICAL[PHYSICAL_TO_LOGICAL[physical]] = physical;
+}
+
+/**
+ * Sanctioned: a physical property on the before side replaced by its
+ * logical twin (same conditions, same value) on the after side.
+ */
+export const allowPhysicalToLogical: AllowlistRule = (entry, before, after) => {
+  if (entry.beforeValue != null && entry.afterValue == null) {
+    const logical = PHYSICAL_TO_LOGICAL[entry.property];
+    return (
+      logical != null &&
+      after[coordinate(logical, entry.conditions)]?.value === entry.beforeValue
+    );
+  }
+  if (entry.afterValue != null && entry.beforeValue == null) {
+    const physical = LOGICAL_TO_PHYSICAL[entry.property];
+    return (
+      physical != null &&
+      before[coordinate(physical, entry.conditions)]?.value === entry.afterValue
+    );
+  }
+  return false;
+};
+
+/**
+ * Sanctioned: a `:hover` declaration additionally wrapped in
+ * `@media (hover: hover)` on the after side (the hover-guard, on by
+ * default in the codemod).
+ */
+export const allowHoverGuard: AllowlistRule = (entry, before, after) => {
+  const hasHover = entry.conditions.some((c) => c.startsWith(':hover'));
+  if (!hasHover) {
+    return false;
+  }
+  if (entry.beforeValue != null && entry.afterValue == null) {
+    const guarded = [...entry.conditions, HOVER_GUARD].sort();
+    return (
+      after[coordinate(entry.property, guarded)]?.value === entry.beforeValue
+    );
+  }
+  if (
+    entry.afterValue != null &&
+    entry.beforeValue == null &&
+    entry.conditions.includes(HOVER_GUARD)
+  ) {
+    const unguarded = entry.conditions.filter((c) => c !== HOVER_GUARD);
+    return (
+      before[coordinate(entry.property, unguarded)]?.value === entry.afterValue
+    );
+  }
+  return false;
+};
+
+export const DEFAULT_ALLOWLIST: $ReadOnlyArray<AllowlistRule> = [
+  allowPhysicalToLogical,
+  allowHoverGuard,
+];
+
+// --- the gate -----------------------------------------------------------
+
+export function semanticDiffGate(
+  before: NetCss,
+  after: NetCss,
+  options?: { +allowlist?: $ReadOnlyArray<AllowlistRule> },
+): SemanticDiffResult {
+  const allowlist = options?.allowlist ?? DEFAULT_ALLOWLIST;
+  const coordinates = new Set([...Object.keys(before), ...Object.keys(after)]);
+  const diffs: Array<DiffEntry> = [];
+  const allowed: Array<DiffEntry> = [];
+  for (const coord of coordinates) {
+    const b = before[coord];
+    const a = after[coord];
+    if (b != null && a != null && b.value === a.value) {
+      continue;
+    }
+    const entry: DiffEntry = {
+      coordinate: coord,
+      property: (b ?? a)?.property ?? coord,
+      conditions: (b ?? a)?.conditions ?? [],
+      beforeValue: b?.value ?? null,
+      afterValue: a?.value ?? null,
+    };
+    if (allowlist.some((rule) => rule(entry, before, after))) {
+      allowed.push(entry);
+    } else {
+      diffs.push(entry);
+    }
+  }
+  return diffs.length === 0
+    ? { ok: true, allowed }
+    : { ok: false, diffs, allowed };
+}

--- a/packages/@stylexjs/codemods/src/core/gates/semanticDiff.js
+++ b/packages/@stylexjs/codemods/src/core/gates/semanticDiff.js
@@ -73,7 +73,13 @@ function normalizeAtRule(rule: string): string {
 }
 
 function normalizeValue(value: string): string {
-  return value.trim().replace(/\s+/g, ' ');
+  // Comma-whitespace is canonicalized because CSS treats
+  // `rgb(10, 20, 30)` and `rgb(10,20,30)` as the same value — and the
+  // StyleX compiler normalizes to the latter.
+  return value
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/\s*,\s*/g, ',');
 }
 
 function normalizeCondition(raw: string): string {

--- a/packages/@stylexjs/codemods/src/core/ir.js
+++ b/packages/@stylexjs/codemods/src/core/ir.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+/**
+ * The neutral intermediate representation (IR) shared by every adapter and
+ * the core engine. Its shape mirrors StyleX's OUTPUT (property-grouped, with
+ * conditions nested inside a property), not any source library's input.
+ *
+ * A style either maps into this IR (=> convertible) or it does not
+ * (=> flagged, never guessed). The edge of the IR is the edge of what is
+ * automatable.
+ *
+ * The two open axes — `Condition` and `Value` — are variant types because
+ * they are the only axes StyleX itself grows along. New condition kinds
+ * (`@supports`, `@container`, ancestor selectors) and new value kinds
+ * (dynamic/function-form) are ADDITIVE extensions; the structure never
+ * changes for a new source library.
+ */
+
+/**
+ * A single typed condition under which a value applies.
+ * Only self-targeting conditions are representable — selectors that reach
+ * outside the element have no encoding here, by design.
+ */
+export type Condition =
+  | { +kind: 'pseudo-class', +name: string } // e.g. ':hover'
+  | { +kind: 'pseudo-element', +name: string } // e.g. '::before'
+  | { +kind: 'at-rule', +rule: string }; // e.g. '@media (min-width: 600px)'
+
+/**
+ * The value of an atom. `static` is the only variant in v1.0; a
+ * `dynamic` variant (props-driven, -> StyleX function-form create) is the
+ * planned v1.1 addition.
+ */
+export type Value =
+  | { +kind: 'static', +value: string | number | null }
+  | {
+      +kind: 'first-that-works',
+      +values: $ReadOnlyArray<string | number>,
+    };
+
+/**
+ * The unit of the IR: one property, under zero or more conditions,
+ * with one value. e.g. { property: 'color', conditions: [:hover], 'blue' }.
+ */
+export type Atom = {
+  +property: string, // camelCase, StyleX-style (e.g. 'backgroundColor')
+  +conditions: $ReadOnlyArray<Condition>,
+  +value: Value,
+};
+
+/**
+ * One named entry in a `stylex.create` registry — a group of atoms with the
+ * key the emitter should try to use for it.
+ */
+export type StyleRule = {
+  +name: string,
+  +atoms: $ReadOnlyArray<Atom>,
+};
+
+/** An object-form keyframes declaration (`stylex.keyframes`). */
+export type KeyframesRule = {
+  +name: string,
+  +frames: $ReadOnlyArray<{
+    +selector: string, // 'from' | 'to' | '0%' ...
+    +atoms: $ReadOnlyArray<Atom>,
+  }>,
+};
+
+/**
+ * Everything the engine knows about one file's styles: the rules destined
+ * for the single per-file `stylex.create`, plus file-level constructs.
+ * Design tokens (`defineVars`) join in M3.
+ */
+export type FileIR = {
+  +rules: $ReadOnlyArray<StyleRule>,
+  +keyframes: $ReadOnlyArray<KeyframesRule>,
+};
+
+/** Stable string form of a condition, used for grouping and diffing. */
+export function conditionKey(condition: Condition): string {
+  switch (condition.kind) {
+    case 'pseudo-class':
+    case 'pseudo-element':
+      return condition.name;
+    case 'at-rule':
+    default:
+      return condition.rule;
+  }
+}
+
+/**
+ * Stable string form of an atom's (property, conditions) coordinate —
+ * conditions sorted so ordering differences do not create false diffs.
+ */
+export function atomCoordinate(
+  property: string,
+  conditions: $ReadOnlyArray<Condition>,
+): string {
+  const keys = conditions.map(conditionKey).slice().sort();
+  return keys.length === 0 ? property : `${property} @ ${keys.join(' && ')}`;
+}

--- a/packages/@stylexjs/codemods/src/core/rewriter.js
+++ b/packages/@stylexjs/codemods/src/core/rewriter.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * The single place in the codebase that knows which AST toolkit we use.
+ * Everything else (core and adapters alike) goes through this wrapper, so
+ * jscodeshift/recast stays swappable (hermes-parser, ts-morph, plain
+ * babel+recast) without touching any other module — a maintainer question
+ * we have deliberately kept open.
+ *
+ * jscodeshift is the default: format-preserving printing via recast, and
+ * parses the Flow/TS/JSX found in user code.
+ */
+
+import jscodeshift from 'jscodeshift';
+
+// 'flow' also covers plain JS + JSX; 'tsx' also covers plain TS.
+export type ParserChoice = 'flow' | 'tsx';
+
+export opaque type Rewriter = {
+  +j: $FlowFixMe,
+  +root: $FlowFixMe,
+};
+
+/** Picks a parser from the file extension (TS/TSX vs Flow/JS). */
+export function parserForFile(filename: string): ParserChoice {
+  return /\.(ts|tsx|mts|cts)$/.test(filename) ? 'tsx' : 'flow';
+}
+
+/** Parses source into a rewriter handle (a jscodeshift Collection). */
+export function parseSource(
+  source: string,
+  options?: { +parser?: ParserChoice },
+): Rewriter {
+  const j = jscodeshift.withParser(options?.parser ?? 'flow');
+  return { j, root: j(source) };
+}
+
+/** Prints a rewriter handle back to source, format-preserving. */
+export function printSource(rewriter: Rewriter): string {
+  return rewriter.root.toSource({ quote: 'single' });
+}

--- a/packages/@stylexjs/codemods/src/core/rewriter.js
+++ b/packages/@stylexjs/codemods/src/core/rewriter.js
@@ -15,15 +15,18 @@
  * we have deliberately kept open.
  *
  * jscodeshift is the default: format-preserving printing via recast, and
- * parses the Flow/TS/JSX found in user code.
+ * parses the Flow/TS/JSX found in user code. Adapters receive `j` and
+ * `root` from here and never import the toolkit themselves (enforced by
+ * seam-test); `core/` outside this file never sees an AST node at all.
  */
 
 import jscodeshift from 'jscodeshift';
+import type { EmittedStyle, EmittedValue } from './emit';
 
 // 'flow' also covers plain JS + JSX; 'tsx' also covers plain TS.
 export type ParserChoice = 'flow' | 'tsx';
 
-export opaque type Rewriter = {
+export type Rewriter = {
   +j: $FlowFixMe,
   +root: $FlowFixMe,
 };
@@ -45,4 +48,23 @@ export function parseSource(
 /** Prints a rewriter handle back to source, format-preserving. */
 export function printSource(rewriter: Rewriter): string {
   return rewriter.root.toSource({ quote: 'single' });
+}
+
+/**
+ * Renders emitted style data (plain values / fallback arrays) as an
+ * ObjectExpression — the bridge that lets `core/emit.js` stay AST-free.
+ */
+export function styleToObjectAst(
+  j: $FlowFixMe,
+  style: EmittedStyle,
+): $FlowFixMe {
+  const valueAst = (value: EmittedValue): $FlowFixMe =>
+    Array.isArray(value)
+      ? j.arrayExpression(value.map((v) => j.literal(v)))
+      : j.literal(value);
+  return j.objectExpression(
+    Object.keys(style).map((property) =>
+      j.property('init', j.identifier(property), valueAst(style[property])),
+    ),
+  );
 }

--- a/packages/@stylexjs/codemods/src/index.js
+++ b/packages/@stylexjs/codemods/src/index.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * @stylexjs/codemods — migrate styling libraries to StyleX.
+ *
+ * M0: gated harness only. The public surface is the IR types and the three
+ * correctness gates; transforms land from M1.
+ */
+
+export type {
+  Atom,
+  Condition,
+  Value,
+  StyleRule,
+  KeyframesRule,
+  FileIR,
+} from './core/ir';
+export { conditionKey, atomCoordinate } from './core/ir';
+
+export { compileGate } from './core/gates/compile';
+export { lintGate } from './core/gates/lint';
+export {
+  semanticDiffGate,
+  netCssFromSerializedCss,
+  netCssFromStylexMetadata,
+  DEFAULT_ALLOWLIST,
+  UnsupportedCssError,
+} from './core/gates/semanticDiff';
+
+export { parseSource, printSource, parserForFile } from './core/rewriter';

--- a/packages/@stylexjs/codemods/src/testing/stylexToIR.js
+++ b/packages/@stylexjs/codemods/src/testing/stylexToIR.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * TEST-ONLY reader: a valid `stylex.create` style object -> IR.
+ *
+ * This powers the IR-completeness harness: round-tripping StyleX's own
+ * valid-input corpus (read -> IR -> re-emit -> still compiles & semantically
+ * identical) turns "is the IR complete?" from a claim into a measured
+ * coverage percentage. An IR gap found here is SAFE — in the real pipeline
+ * the same construct would be flagged, never emitted incorrectly.
+ *
+ * Not implemented until M1 (it needs the emitter to round-trip against);
+ * the harness counts every corpus entry as uncovered until then.
+ */
+
+import type { StyleRule } from '../core/ir';
+
+export class IRCoverageGapError extends Error {
+  constructor(message: string) {
+    super(`[stylex-codemod ir-completeness] ${message}`);
+    this.name = 'IRCoverageGapError';
+  }
+}
+
+// eslint-disable-next-line no-unused-vars
+export function stylexObjectToIR(name: string, styleObject: mixed): StyleRule {
+  throw new IRCoverageGapError(
+    'stylexObjectToIR is not implemented yet (lands with the M1 emitter)',
+  );
+}

--- a/packages/@stylexjs/codemods/src/testing/stylexToIR.js
+++ b/packages/@stylexjs/codemods/src/testing/stylexToIR.js
@@ -16,11 +16,12 @@
  * coverage percentage. An IR gap found here is SAFE — in the real pipeline
  * the same construct would be flagged, never emitted incorrectly.
  *
- * Not implemented until M1 (it needs the emitter to round-trip against);
- * the harness counts every corpus entry as uncovered until then.
+ * M1 coverage: flat static values and fallback arrays. Condition objects
+ * (pseudo/at-rule keys or condition-in-value objects) are M2 gaps; null
+ * values and keyframes are M3 gaps.
  */
 
-import type { StyleRule } from '../core/ir';
+import type { Atom, StyleRule } from '../core/ir';
 
 export class IRCoverageGapError extends Error {
   constructor(message: string) {
@@ -29,9 +30,58 @@ export class IRCoverageGapError extends Error {
   }
 }
 
-// eslint-disable-next-line no-unused-vars
+// Builds a properly-typed (string | number)[] from an untyped array, or
+// null if any entry is not one of those two types. A plain `.every()`
+// predicate does not refine an `Array<mixed>` to
+// `Array<string | number>` for Flow, so this does the narrowing by hand.
+function toStaticValueArray(
+  raw: $ReadOnlyArray<mixed>,
+): Array<string | number> | null {
+  const values: Array<string | number> = [];
+  for (const entry of raw) {
+    if (typeof entry !== 'string' && typeof entry !== 'number') {
+      return null;
+    }
+    values.push(entry);
+  }
+  return values;
+}
+
 export function stylexObjectToIR(name: string, styleObject: mixed): StyleRule {
-  throw new IRCoverageGapError(
-    'stylexObjectToIR is not implemented yet (lands with the M1 emitter)',
-  );
+  if (
+    styleObject == null ||
+    typeof styleObject !== 'object' ||
+    Array.isArray(styleObject)
+  ) {
+    throw new IRCoverageGapError(`'${name}': not a style object`);
+  }
+  const atoms: Array<Atom> = [];
+  for (const property of Object.keys(styleObject)) {
+    const raw = styleObject[property];
+    if (typeof raw === 'string' || typeof raw === 'number') {
+      atoms.push({
+        property,
+        conditions: [],
+        value: { kind: 'static', value: raw },
+      });
+    } else if (Array.isArray(raw) && raw.length > 0) {
+      const values = toStaticValueArray(raw);
+      if (values == null) {
+        throw new IRCoverageGapError(
+          `'${name}.${property}': fallback array contains a non-static entry`,
+        );
+      }
+      atoms.push({
+        property,
+        conditions: [],
+        value: { kind: 'first-that-works', values },
+      });
+    } else {
+      throw new IRCoverageGapError(
+        `'${name}.${property}': value form not representable yet ` +
+          '(conditions land in M2, null/keyframes in M3)',
+      );
+    }
+  }
+  return { name, atoms };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -243,6 +243,11 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz"
   integrity sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==
 
+"@babel/compat-data@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
+  integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
+
 "@babel/core@^7.18.2", "@babel/core@^7.23.9", "@babel/core@^7.24.4", "@babel/core@^7.26.8", "@babel/core@^7.27.4", "@babel/core@^7.28.0", "@babel/core@^7.28.4", "@babel/core@^7.28.5":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz"
@@ -257,6 +262,27 @@
     "@babel/template" "^7.27.2"
     "@babel/traverse" "^7.28.5"
     "@babel/types" "^7.28.5"
+    "@jridgewell/remapping" "^2.3.5"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/core@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
+  integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helpers" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
     "@jridgewell/remapping" "^2.3.5"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
@@ -302,6 +328,13 @@
   dependencies:
     "@babel/types" "^7.27.3"
 
+"@babel/helper-annotate-as-pure@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz#c70fe3c6ecbdc3fd2dd1b0f498428b88b82ce47f"
+  integrity sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
 "@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.27.2":
   version "7.27.2"
   resolved "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz"
@@ -309,6 +342,17 @@
   dependencies:
     "@babel/compat-data" "^7.27.2"
     "@babel/helper-validator-option" "^7.27.1"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-compilation-targets@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz#7a1def704302401c47f64fa85589e974ae217042"
+  integrity sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==
+  dependencies:
+    "@babel/compat-data" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
@@ -324,6 +368,19 @@
     "@babel/helper-replace-supers" "^7.27.1"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
     "@babel/traverse" "^7.28.5"
+    semver "^6.3.1"
+
+"@babel/helper-create-class-features-plugin@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz#6eddf286f2ec418f740c91d60a83347c55838ddd"
+  integrity sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-member-expression-to-functions" "^7.29.7"
+    "@babel/helper-optimise-call-expression" "^7.29.7"
+    "@babel/helper-replace-supers" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
     semver "^6.3.1"
 
 "@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.27.1":
@@ -363,6 +420,14 @@
   dependencies:
     "@babel/traverse" "^7.28.5"
     "@babel/types" "^7.28.5"
+
+"@babel/helper-member-expression-to-functions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz#8dbdb3ce0b5c487e1aec10e13c9a43a500814df8"
+  integrity sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
 "@babel/helper-module-imports@^7.18.6", "@babel/helper-module-imports@^7.25.9", "@babel/helper-module-imports@^7.27.1":
   version "7.27.1"
@@ -405,6 +470,13 @@
   dependencies:
     "@babel/types" "^7.27.1"
 
+"@babel/helper-optimise-call-expression@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz#77b0b5b94f1997fa9d6e3125f445227b1faf9d85"
+  integrity sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.8.0":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz"
@@ -433,6 +505,15 @@
     "@babel/helper-optimise-call-expression" "^7.27.1"
     "@babel/traverse" "^7.27.1"
 
+"@babel/helper-replace-supers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz#bc3c3964329043c79112e513c1b198f16589ac21"
+  integrity sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.29.7"
+    "@babel/helper-optimise-call-expression" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz"
@@ -440,6 +521,14 @@
   dependencies:
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
+
+"@babel/helper-skip-transparent-expression-wrappers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz#50c95c7e4c4f54936cfa0116428edc559862d551"
+  integrity sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
 "@babel/helper-string-parser@^7.27.1":
   version "7.27.1"
@@ -466,6 +555,11 @@
   resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz"
   integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
 
+"@babel/helper-validator-option@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz#cf315be940213b354eb4abcc0bd01ebe3f73bc2a"
+  integrity sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==
+
 "@babel/helper-wrap-function@^7.27.1":
   version "7.28.3"
   resolved "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz"
@@ -482,6 +576,14 @@
   dependencies:
     "@babel/template" "^7.27.2"
     "@babel/types" "^7.28.4"
+
+"@babel/helpers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.7.tgz#45abfde7548997e34376c3e69feb475cffb4a607"
+  integrity sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==
+  dependencies:
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
 "@babel/highlight@^7.16.7":
   version "7.25.9"
@@ -512,7 +614,7 @@
   dependencies:
     "@babel/types" "^7.29.0"
 
-"@babel/parser@^7.29.7":
+"@babel/parser@^7.24.7", "@babel/parser@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
   integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
@@ -598,6 +700,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-syntax-flow@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.29.7.tgz#3f3278c11c896c43bf8098250819785fd1231881"
+  integrity sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
 "@babel/plugin-syntax-import-assertions@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz"
@@ -632,6 +741,13 @@
   integrity sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-syntax-jsx@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz#622c16f9ad63782fe6e83dadc7e40330744b7f1e"
+  integrity sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
   version "7.10.4"
@@ -696,6 +812,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-syntax-typescript@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz#7c29388932313ed58413a0343048d75d92fb5b24"
+  integrity sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
 "@babel/plugin-syntax-unicode-sets-regex@^7.18.6":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz"
@@ -742,6 +865,14 @@
   integrity sha512-45DmULpySVvmq9Pj3X9B+62Xe+DJGov27QravQJU1LLcapR6/10i+gYVAucGGJpHBp5mYxIMK4nDAT/QDLr47g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-class-properties@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz#034897b8a21beec163332fac2de235b14409abdf"
+  integrity sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-transform-class-properties@^7.27.1":
   version "7.27.1"
@@ -847,6 +978,14 @@
     "@babel/helper-plugin-utils" "^7.27.1"
     "@babel/plugin-syntax-flow" "^7.27.1"
 
+"@babel/plugin-transform-flow-strip-types@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.29.7.tgz#911bcb31608c3576510d7e0c95ccf64f9e1812d0"
+  integrity sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/plugin-syntax-flow" "^7.29.7"
+
 "@babel/plugin-transform-for-of@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz"
@@ -900,6 +1039,14 @@
     "@babel/helper-module-transforms" "^7.27.1"
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-transform-modules-commonjs@^7.24.7", "@babel/plugin-transform-modules-commonjs@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz#70e6835abf2663dafbe94b8ef1f51de7351ef135"
+  integrity sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
 "@babel/plugin-transform-modules-commonjs@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz"
@@ -941,6 +1088,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-transform-nullish-coalescing-operator@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz#8a54cdf88c3f50433a6173117a286195b67714cc"
+  integrity sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
 "@babel/plugin-transform-nullish-coalescing-operator@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz"
@@ -981,6 +1135,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-transform-optional-chaining@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz#b84a1b574b3c73001023092567e16c492b720e51"
+  integrity sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+
 "@babel/plugin-transform-optional-chaining@^7.27.1", "@babel/plugin-transform-optional-chaining@^7.28.5":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.5.tgz"
@@ -995,6 +1157,14 @@
   integrity sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-private-methods@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz#cea8bd3ab99533892897a02999d5b752584ad145"
+  integrity sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-transform-private-methods@^7.27.1":
   version "7.27.1"
@@ -1136,6 +1306,17 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
     "@babel/plugin-syntax-typescript" "^7.27.1"
 
+"@babel/plugin-transform-typescript@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz#f0449c3df7037bbe232043476851c38f5e4a7615"
+  integrity sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/plugin-syntax-typescript" "^7.29.7"
+
 "@babel/plugin-transform-unicode-escapes@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz"
@@ -1243,6 +1424,15 @@
     core-js-compat "^3.43.0"
     semver "^6.3.1"
 
+"@babel/preset-flow@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.29.7.tgz#ae33812dc267a296bd3709843affbb2d811c4709"
+  integrity sha512-KYIRV0BuaN68CDdsqFkAD7MU7yipUqQNuNElwATdxaIdpTjhvtY82QvkBJs7zV3Evxj2jFAAZ1iO8nyy0nhjqA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
+    "@babel/plugin-transform-flow-strip-types" "^7.29.7"
+
 "@babel/preset-flow@^7.25.9", "@babel/preset-flow@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.27.1.tgz"
@@ -1273,6 +1463,17 @@
     "@babel/plugin-transform-react-jsx-development" "^7.27.1"
     "@babel/plugin-transform-react-pure-annotations" "^7.27.1"
 
+"@babel/preset-typescript@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz#de9be1f47b785c979ec7b3a71f4cd8bae5267b62"
+  integrity sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
+    "@babel/plugin-syntax-jsx" "^7.29.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.29.7"
+    "@babel/plugin-transform-typescript" "^7.29.7"
+
 "@babel/preset-typescript@^7.25.7", "@babel/preset-typescript@^7.26.0":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz"
@@ -1283,6 +1484,17 @@
     "@babel/plugin-syntax-jsx" "^7.27.1"
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.28.5"
+
+"@babel/register@^7.24.6":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.29.7.tgz#d5bb4337065512f643b29cb565b6e8ccadcc1ec6"
+  integrity sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==
+  dependencies:
+    clone-deep "^4.0.1"
+    find-cache-dir "^2.0.0"
+    make-dir "^2.1.0"
+    pirates "^4.0.6"
+    source-map-support "^0.5.16"
 
 "@babel/register@^7.27.1":
   version "7.28.3"
@@ -1706,6 +1918,37 @@
   integrity sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==
   dependencies:
     tslib "^2.4.0"
+
+"@emotion/hash@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.2.tgz#ff9221b9f58b4dfe61e619a7788734bd63f6898b"
+  integrity sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
+
+"@emotion/memoize@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.9.0.tgz#745969d649977776b43fc7648c556aaa462b4102"
+  integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
+
+"@emotion/serialize@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.3.3.tgz#d291531005f17d704d0463a032fe679f376509e8"
+  integrity sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==
+  dependencies:
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/unitless" "^0.10.0"
+    "@emotion/utils" "^1.4.2"
+    csstype "^3.0.2"
+
+"@emotion/unitless@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.10.0.tgz#2af2f7c7e5150f497bdabd848ce7b218a27cf745"
+  integrity sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
+
+"@emotion/utils@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.4.2.tgz#6df6c45881fcb1c412d6688a311a98b7f59c1b52"
+  integrity sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==
 
 "@epic-web/invariant@^1.0.0":
   version "1.0.0"
@@ -6779,7 +7022,7 @@ babel-plugin-react-compiler@1.0.0, babel-plugin-react-compiler@^1.0.0:
   dependencies:
     "@babel/types" "^7.26.0"
 
-babel-plugin-syntax-hermes-parser@^0.36.1:
+babel-plugin-syntax-hermes-parser@0.36.1, babel-plugin-syntax-hermes-parser@^0.36.1:
   version "0.36.1"
   resolved "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.1.tgz"
   integrity sha512-ycduwJbvdvIMmVvlAZqGggS+pm5Eu4Bk9pcV9Sm2Z4PJNRVsKkv0g7vHj+LeuC1gHTeF67sJXFOq61IlqCa2hA==
@@ -9652,6 +9895,18 @@ flow-enums-runtime@^0.0.6:
   resolved "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz"
   integrity sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==
 
+flow-estree@0.322.0:
+  version "0.322.0"
+  resolved "https://registry.yarnpkg.com/flow-estree/-/flow-estree-0.322.0.tgz#8310b5bc825049fe6526969217ee29bb09fdd576"
+  integrity sha512-v7wiiFWSKbJ1HGVCRKhxl+6pQWTQV6P4c7XEfKjVlH71YkgQyJCq0AG5dhJDD/3/SkJgX/F9lvAj2rbrFzArdQ==
+
+flow-parser@0.*:
+  version "0.322.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.322.0.tgz#7a42cfae08b0cf0a35bd9fdbe84593782f6a5052"
+  integrity sha512-Qfd8N4sSuWmlf1qk5M60fi8JrvhNvj9fbwMsRkcnm3UhLYukkbm2CFkAhiTD3n4RVXb6TuCHFCp78TMXpO0zcA==
+  dependencies:
+    flow-estree "0.322.0"
+
 flow-typed@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/flow-typed/-/flow-typed-4.1.1.tgz"
@@ -11542,6 +11797,30 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+jscodeshift@^17.3.0:
+  version "17.4.0"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-17.4.0.tgz#efa0619ddb1d994e85982ec37a7afe8e618ae324"
+  integrity sha512-i3ESKiiTsGynxzTg5BhsZViD0ai72/6SsI1efDZxG6/5KCoElsmquxtyhXK5lpEgoO7MTNpYkjFEdEL97SkBNg==
+  dependencies:
+    "@babel/core" "^7.24.7"
+    "@babel/parser" "^7.24.7"
+    "@babel/plugin-transform-class-properties" "^7.24.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.24.7"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.24.7"
+    "@babel/plugin-transform-optional-chaining" "^7.24.7"
+    "@babel/plugin-transform-private-methods" "^7.24.7"
+    "@babel/preset-flow" "^7.24.7"
+    "@babel/preset-typescript" "^7.24.7"
+    "@babel/register" "^7.24.6"
+    flow-parser "0.*"
+    graceful-fs "^4.2.4"
+    neo-async "^2.5.0"
+    picocolors "^1.0.1"
+    picomatch "^4.0.2"
+    recast "^0.23.11"
+    tmp "^0.2.3"
+    write-file-atomic "^5.0.1"
+
 jsdom@^26.1.0:
   version "26.1.0"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz"
@@ -13056,7 +13335,7 @@ negotiator@~0.6.4:
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz"
   integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
 
-neo-async@^2.6.1, neo-async@^2.6.2:
+neo-async@^2.5.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -13700,7 +13979,7 @@ pend@~1.2.0:
   resolved "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
-picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1, picocolors@~1.1.1:
+picocolors@^1.0.0, picocolors@^1.0.1, picocolors@^1.1.0, picocolors@^1.1.1, picocolors@~1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -14321,6 +14600,17 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+recast@^0.23.11:
+  version "0.23.12"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.23.12.tgz#3df7589ae1877d0a634c6c7ccc995a7c053850a9"
+  integrity sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA==
+  dependencies:
+    ast-types "^0.16.1"
+    esprima "~4.0.0"
+    source-map "~0.6.1"
+    tiny-invariant "^1.3.3"
+    tslib "^2.0.1"
 
 recast@^0.23.5:
   version "0.23.11"
@@ -16182,6 +16472,11 @@ tmp@^0.2.0:
   version "0.2.5"
   resolved "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz"
   integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
+
+tmp@^0.2.3:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## What changed / motivation ?

Part of adding a tool that migrates Emotion styles to StyleX (#1766). This PR
does its first real conversion: a static Emotion `css` prop becomes a
`stylex.create` block plus a `stylex.props(...)` reference.

```jsx
// before
<div css={{ color: 'red' }}>Badge</div>

// after
const styles = stylex.create({ badge: { color: 'red' } });
<div {...stylex.props(styles.badge)}>Badge</div>
```

- Covers the object forms with static values: `css={{ … }}` and `css({ … })`.
- Converts a file only when it can safely convert **everything** in it. If a
  file has anything it can't confidently handle yet — `:hover`/media conditions,
  a value like `'8px 16px'`, a template literal, `css` on a custom component, or
  a file that already uses StyleX — it leaves the file unchanged and reports why.
  (Converting just the safe parts of a mixed file comes in a later PR.)
- Written in two layers: general code that generates StyleX (`src/core/`) and
  Emotion-specific code that reads the styles and edits the JSX
  (`src/adapters/emotion/`). The general layer knows nothing about Emotion, so it
  can be reused for other source libraries later.

**Testing**

- Input → output fixtures, each also verified to compile, lint cleanly, and
  render the same CSS as the Emotion original.
- Covers conversions (single prop, `css(...)` call form, two components in one
  file) and refusals (pseudo-selectors, shorthand conflict, template literal,
  custom component, file already using StyleX).
- The general layer is unit-tested with styles fed in directly (no Emotion),
  confirming it's self-contained.

## Linked PR/Issues

Part of #1766 · builds on #1768

## Additional Context

Stacked on #1768 (the package scaffold), but this change stands on its own to
review.

## Pre-flight checklist

- [x] I have read the contributing guidelines
- [x] Performed a self-review of my code
