### PR TITLE
[unplugin] Add `babel` option to pass through to internal transformAsync

### DIFF
--- a/packages/@stylexjs/unplugin/README.md
+++ b/packages/@stylexjs/unplugin/README.md
@@ -140,6 +140,13 @@ esbuild.build({
   `['stylex', '@stylexjs/stylex']`.
 - `useCSSLayers`: boolean, emit CSS layers.
 - `babelConfig`: `{ plugins, presets }` to merge into the internal Babel call.
+- `babel`: pass-through options for the internal `@babel/core` call. Useful
+  for opting out of root-config discovery (`babel: { configFile: false }`),
+  which otherwise applies your project's `babel.config.*` — including
+  plugins like `react-compiler`, `relay`, or `module-resolver` — to every
+  StyleX file the plugin transforms. The plugin's own mandatory options
+  (`babelrc: false`, `filename`, `presets`, `plugins`, `caller`) always
+  win and cannot be overridden.
 - `unstable_moduleResolution`: forwarded to the StyleX Babel plugin.
 - `lightningcssOptions`: pass-through options for `lightningcss`. Can override
   `targets`, `exclude`, etc. See [Browserslist & CSS lowering](#browserslist--css-lowering).

--- a/packages/@stylexjs/unplugin/__tests__/unplugin.test.js
+++ b/packages/@stylexjs/unplugin/__tests__/unplugin.test.js
@@ -186,6 +186,45 @@ describe('@stylexjs/unplugin', () => {
     }
   });
 
+  test('forwards `babel` option to the internal transformAsync call', async () => {
+    // Babel will only throw about a bad `configFile` if the option reached transformAsync.
+    const plugin = unplugin.raw({
+      dev: false,
+      devPersistToDisk: false,
+      babel: { configFile: '/definitely/does/not/exist/babel.config.js' },
+    });
+    if (typeof plugin.buildStart === 'function') {
+      plugin.buildStart();
+    }
+    const source = `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({ foo: { color: 'red' } });
+      export default styles;
+    `;
+    await expect(
+      plugin.transform(source, '/virtual/example.js'),
+    ).rejects.toThrow(/definitely\/does\/not\/exist\/babel\.config\.js/);
+  });
+
+  test('consumer-supplied `babel` options cannot override plugin internals', async () => {
+    // Pass-through must not be able to override `babelrc: false` / `filename`.
+    const plugin = unplugin.raw({
+      dev: false,
+      devPersistToDisk: false,
+      babel: { babelrc: true, filename: '/should/be/ignored.js' },
+    });
+    if (typeof plugin.buildStart === 'function') {
+      plugin.buildStart();
+    }
+    const source = `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({ foo: { color: 'red' } });
+      export default styles;
+    `;
+    const result = await plugin.transform(source, '/virtual/example.js');
+    expect(result).not.toBeNull();
+  });
+
   test('marks StyleX deps as non-optimized in Vite', async () => {
     const tempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'stylex-unplugin-vite-'),

--- a/packages/@stylexjs/unplugin/src/core.js
+++ b/packages/@stylexjs/unplugin/src/core.js
@@ -219,6 +219,7 @@ export const unpluginFactory = (userOptions = {}, metaOptions) => {
       process.env.BABEL_ENV === 'development',
     unstable_moduleResolution = { type: 'commonJS', rootDir: process.cwd() },
     babelConfig: { plugins = [], presets = [] } = {},
+    babel: babelExtraOptions = {},
     importSources = ['stylex', '@stylexjs/stylex'],
     useCSSLayers = false,
     lightningcssOptions,
@@ -282,6 +283,8 @@ export const unpluginFactory = (userOptions = {}, metaOptions) => {
 
   async function runBabelTransform(inputCode, filename, callerName) {
     const result = await transformAsync(inputCode, {
+      // Consumer pass-through; the plugin's own options below always win.
+      ...babelExtraOptions,
       babelrc: false,
       filename,
       presets,


### PR DESCRIPTION
Fixes #1792.

## Summary

Adds a `babel` option to `@stylexjs/unplugin` that is passed through to the internal `@babel/core` `transformAsync` call — so consumers can set options like `configFile: false` without having to fork the plugin.

## Problem

`@stylexjs/unplugin` runs its own internal Babel pass over every StyleX file to apply the StyleX Babel plugin. Today that pass hardcodes `babelrc: false`, which prevents `.babelrc*` discovery — but **does not** prevent Babel from discovering a root `babel.config.*`.

For any project that has a root `babel.config.js`/`.cjs`/`.ts` (which is most non-toy projects — Vite templates, Next.js apps, and monorepos with a shared Babel config), the plugin's internal Babel call ends up running **every plugin and preset in that root config** against every StyleX file. In practice that means transforms like `react-compiler`, `relay`, `module-resolver`, and Flow/TS stripping all run twice — once inside the StyleX pass, and again in the consumer's main pipeline.

Symptoms range from wasted CPU (~15-30% of a Vite dev warm build in our case) to real bugs (React Compiler running twice, `module-resolver` producing subtly different rewrites depending on whose config runs first).

The correct escape hatch in Babel is `configFile: false`, but there's currently no way to set it because the plugin doesn't expose `transformAsync`'s options.

## Change

Adds a `babel` option to the plugin's user options. Its contents are spread into `transformAsync` **before** the plugin's own mandatory options:

```js
// packages/@stylexjs/unplugin/src/core.js
const result = await transformAsync(inputCode, {
  ...babelExtraOptions,        // ← new: consumer options first
  babelrc: false,              // ← mandatory, always wins
  filename,
  presets,
  plugins: [...],
  caller: {...},
});
```

Because consumer options come first and the plugin's mandatory options are set after, consumers can extend Babel behaviour but **cannot** override the options the plugin depends on (`babelrc`, `filename`, `presets`, `plugins`, `caller`). The added test asserts this invariant.

## Primary use case

```js
stylex.vite({
  // ...
  babel: { configFile: false },
})
```

This lets the plugin's internal Babel pass ignore your project's root config while your main Vite/Rollup/webpack Babel pass continues using it. Any other Babel option (custom `sourceMaps`, `assumptions`, custom `parserOpts`, etc.) also works through the same passthrough.

## Backwards compatibility

Fully non-breaking:
- The option defaults to `{}`, so existing users see no change.
- The mandatory options set after the spread guarantee that even if a consumer passes `babel: { babelrc: true, filename: 'wrong.js' }`, the plugin still runs correctly (there's a test for this).

## Tests

Two new tests in `__tests__/unplugin.test.js`:

- `forwards \`babel\` option to the internal transformAsync call` — passes `babel: { configFile: '/nonexistent' }` and asserts Babel throws with the expected path, proving the option actually reaches `transformAsync`.
- `consumer-supplied \`babel\` options cannot override plugin internals` — passes `babel: { babelrc: true, filename: '/should/be/ignored.js' }` and asserts the transform still works, proving the plugin's mandatory options still win.

All 11 tests pass: `npx jest` in `packages/@stylexjs/unplugin`.

## Docs

README updated with a new bullet under **Options (shared)** documenting `babel`, the primary `configFile: false` use case, and the "consumer options cannot override internals" contract.

---

We've been running this patched against `@stylexjs/unplugin@0.19.0` at Mixcloud for a few weeks (via `pnpm patch`) and it cleanly resolves both the perf issue and the double-compile problem. Happy to iterate on option naming, docs wording, or split the tests differently if the maintainers prefer.
