### PR TITLE
fix: correct media query breakpoint gap on strict range syntax (#1793)

### DIFF
--- a/packages/style-value-parser/src/at-queries/__tests__/media-query-transform-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/media-query-transform-test.js
@@ -696,4 +696,29 @@ describe('Media Query Transformer', () => {
     const result = lastMediaQueryWinsTransform(originalStyles);
     expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
   });
+
+  test('issue 1793: nested range media queries use strict comparison and leave no gaps', () => {
+    const originalStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (width >= 48rem)': '1 / 3',
+          '@media (width >= 64rem)': '1 / -1',
+        },
+      },
+    };
+
+    const expectedStyles = {
+      foo: {
+        gridColumn: {
+          default: '1 / 2',
+          '@media (width >= 48rem) and (width < 64rem)': '1 / 3',
+          '@media (width >= 64rem)': '1 / -1',
+        },
+      },
+    };
+
+    const result = lastMediaQueryWinsTransform(originalStyles);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedStyles));
+  });
 });

--- a/packages/style-value-parser/src/at-queries/__tests__/parse-media-query-test.js
+++ b/packages/style-value-parser/src/at-queries/__tests__/parse-media-query-test.js
@@ -2448,19 +2448,20 @@ describe('style-value-parser/at-queries', () => {
         expect(parsed).toMatchInlineSnapshot(`
           MediaQuery {
             "queries": {
-              "key": "min-width",
+              "key": "width",
+              "operator": ">",
               "type": "pair",
               "value": {
                 "signCharacter": undefined,
                 "type": "integer",
                 "unit": "px",
-                "value": 400.01,
+                "value": 400,
               },
             },
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (min-width: 400.01px)"',
+          '"@media (width > 400px)"',
         );
       });
 
@@ -2469,7 +2470,8 @@ describe('style-value-parser/at-queries', () => {
         expect(parsed).toMatchInlineSnapshot(`
           MediaQuery {
             "queries": {
-              "key": "min-width",
+              "key": "width",
+              "operator": ">=",
               "type": "pair",
               "value": {
                 "signCharacter": undefined,
@@ -2481,7 +2483,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (min-width: 400px)"',
+          '"@media (width >= 400px)"',
         );
       });
 
@@ -2490,28 +2492,8 @@ describe('style-value-parser/at-queries', () => {
         expect(parsed).toMatchInlineSnapshot(`
           MediaQuery {
             "queries": {
-              "key": "min-width",
-              "type": "pair",
-              "value": {
-                "signCharacter": undefined,
-                "type": "integer",
-                "unit": "px",
-                "value": 400.01,
-              },
-            },
-          }
-        `);
-        expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (min-width: 400.01px)"',
-        );
-      });
-
-      test('@media (400px <= width)', () => {
-        const parsed = MediaQuery.parser.parseToEnd('@media (400px <= width)');
-        expect(parsed).toMatchInlineSnapshot(`
-          MediaQuery {
-            "queries": {
-              "key": "min-width",
+              "key": "width",
+              "operator": ">",
               "type": "pair",
               "value": {
                 "signCharacter": undefined,
@@ -2523,7 +2505,29 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (min-width: 400px)"',
+          '"@media (width > 400px)"',
+        );
+      });
+
+      test('@media (400px <= width)', () => {
+        const parsed = MediaQuery.parser.parseToEnd('@media (400px <= width)');
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "key": "width",
+              "operator": ">=",
+              "type": "pair",
+              "value": {
+                "signCharacter": undefined,
+                "type": "integer",
+                "unit": "px",
+                "value": 400,
+              },
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (width >= 400px)"',
         );
       });
 
@@ -2536,7 +2540,8 @@ describe('style-value-parser/at-queries', () => {
             "queries": {
               "rules": [
                 {
-                  "key": "min-width",
+                  "key": "width",
+                  "operator": ">=",
                   "type": "pair",
                   "value": {
                     "type": "integer",
@@ -2545,7 +2550,8 @@ describe('style-value-parser/at-queries', () => {
                   },
                 },
                 {
-                  "key": "max-width",
+                  "key": "width",
+                  "operator": "<=",
                   "type": "pair",
                   "value": {
                     "type": "integer",
@@ -2559,7 +2565,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (min-width: 400px) and (max-width: 700px)"',
+          '"@media (width >= 400px) and (width <= 700px)"',
         );
       });
 
@@ -2572,16 +2578,18 @@ describe('style-value-parser/at-queries', () => {
             "queries": {
               "rules": [
                 {
-                  "key": "min-width",
+                  "key": "width",
+                  "operator": ">",
                   "type": "pair",
                   "value": {
                     "type": "integer",
                     "unit": "px",
-                    "value": 400.01,
+                    "value": 400,
                   },
                 },
                 {
-                  "key": "max-width",
+                  "key": "width",
+                  "operator": "<=",
                   "type": "pair",
                   "value": {
                     "type": "integer",
@@ -2595,7 +2603,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (min-width: 400.01px) and (max-width: 700px)"',
+          '"@media (width > 400px) and (width <= 700px)"',
         );
       });
 
@@ -2608,7 +2616,8 @@ describe('style-value-parser/at-queries', () => {
             "queries": {
               "rules": [
                 {
-                  "key": "min-width",
+                  "key": "width",
+                  "operator": ">=",
                   "type": "pair",
                   "value": {
                     "type": "integer",
@@ -2617,7 +2626,8 @@ describe('style-value-parser/at-queries', () => {
                   },
                 },
                 {
-                  "key": "max-width",
+                  "key": "width",
+                  "operator": "<=",
                   "type": "pair",
                   "value": {
                     "type": "integer",
@@ -2631,7 +2641,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (min-width: 400px) and (max-width: 700px)"',
+          '"@media (width >= 400px) and (width <= 700px)"',
         );
       });
 
@@ -2644,7 +2654,8 @@ describe('style-value-parser/at-queries', () => {
             "queries": {
               "rules": [
                 {
-                  "key": "min-width",
+                  "key": "width",
+                  "operator": ">=",
                   "type": "pair",
                   "value": {
                     "type": "integer",
@@ -2653,7 +2664,8 @@ describe('style-value-parser/at-queries', () => {
                   },
                 },
                 {
-                  "key": "max-width",
+                  "key": "width",
+                  "operator": "<=",
                   "type": "pair",
                   "value": {
                     "type": "integer",
@@ -2667,7 +2679,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (min-width: 700px) and (max-width: 1000px)"',
+          '"@media (width >= 700px) and (width <= 1000px)"',
         );
       });
 
@@ -2680,7 +2692,8 @@ describe('style-value-parser/at-queries', () => {
             "queries": {
               "rules": [
                 {
-                  "key": "min-width",
+                  "key": "width",
+                  "operator": ">=",
                   "type": "pair",
                   "value": {
                     "type": "integer",
@@ -2689,43 +2702,8 @@ describe('style-value-parser/at-queries', () => {
                   },
                 },
                 {
-                  "key": "max-width",
-                  "type": "pair",
-                  "value": {
-                    "type": "integer",
-                    "unit": "px",
-                    "value": 999.99,
-                  },
-                },
-              ],
-              "type": "and",
-            },
-          }
-        `);
-        expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (min-width: 700px) and (max-width: 999.99px)"',
-        );
-      });
-
-      test('@media (1000px >= width > 700px)', () => {
-        const parsed = MediaQuery.parser.parseToEnd(
-          '@media (1000px >= width > 700px)',
-        );
-        expect(parsed).toMatchInlineSnapshot(`
-          MediaQuery {
-            "queries": {
-              "rules": [
-                {
-                  "key": "min-width",
-                  "type": "pair",
-                  "value": {
-                    "type": "integer",
-                    "unit": "px",
-                    "value": 700.01,
-                  },
-                },
-                {
-                  "key": "max-width",
+                  "key": "width",
+                  "operator": "<",
                   "type": "pair",
                   "value": {
                     "type": "integer",
@@ -2739,7 +2717,45 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (min-width: 700.01px) and (max-width: 1000px)"',
+          '"@media (width >= 700px) and (width < 1000px)"',
+        );
+      });
+
+      test('@media (1000px >= width > 700px)', () => {
+        const parsed = MediaQuery.parser.parseToEnd(
+          '@media (1000px >= width > 700px)',
+        );
+        expect(parsed).toMatchInlineSnapshot(`
+          MediaQuery {
+            "queries": {
+              "rules": [
+                {
+                  "key": "width",
+                  "operator": ">",
+                  "type": "pair",
+                  "value": {
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 700,
+                  },
+                },
+                {
+                  "key": "width",
+                  "operator": "<=",
+                  "type": "pair",
+                  "value": {
+                    "type": "integer",
+                    "unit": "px",
+                    "value": 1000,
+                  },
+                },
+              ],
+              "type": "and",
+            },
+          }
+        `);
+        expect(parsed.toString()).toMatchInlineSnapshot(
+          '"@media (width > 700px) and (width <= 1000px)"',
         );
       });
 
@@ -2752,21 +2768,23 @@ describe('style-value-parser/at-queries', () => {
             "queries": {
               "rules": [
                 {
-                  "key": "min-width",
+                  "key": "width",
+                  "operator": ">",
                   "type": "pair",
                   "value": {
                     "type": "integer",
                     "unit": "px",
-                    "value": 700.01,
+                    "value": 700,
                   },
                 },
                 {
-                  "key": "max-width",
+                  "key": "width",
+                  "operator": "<",
                   "type": "pair",
                   "value": {
                     "type": "integer",
                     "unit": "px",
-                    "value": 999.99,
+                    "value": 1000,
                   },
                 },
               ],
@@ -2775,7 +2793,7 @@ describe('style-value-parser/at-queries', () => {
           }
         `);
         expect(parsed.toString()).toMatchInlineSnapshot(
-          '"@media (min-width: 700.01px) and (max-width: 999.99px)"',
+          '"@media (width > 700px) and (width < 1000px)"',
         );
       });
     });

--- a/packages/style-value-parser/src/at-queries/media-query.js
+++ b/packages/style-value-parser/src/at-queries/media-query.js
@@ -30,6 +30,7 @@ type MediaRulePair = {
   type: 'pair',
   key: string,
   value: MediaRuleValue,
+  operator?: string,
 };
 type MediaNotRule = { type: 'not', rule: MediaQueryRule };
 type MediaAndRules = { type: 'and', rules: $ReadOnlyArray<MediaQueryRule> };
@@ -42,25 +43,6 @@ export type MediaQueryRule =
   | MediaNotRule
   | MediaAndRules
   | MediaOrRules;
-
-// helper to adjust the numeric value when no equality sign is present.
-function adjustDimension(
-  dimension: Length,
-  op: string,
-  eq: string | void,
-  isMaxWidth: boolean = false,
-): Length {
-  let adjustedValue = dimension.value;
-  const epsilon = 0.01;
-  if (eq !== '=') {
-    if (isMaxWidth) {
-      adjustedValue -= epsilon;
-    } else {
-      adjustedValue += epsilon;
-    }
-  }
-  return { ...dimension, value: adjustedValue };
-}
 
 const basicMediaTypeParser: TokenParser<'screen' | 'print' | 'all'> =
   TokenParser.tokens.Ident.map((token) => token[4].value, '.stringValue').where(
@@ -145,14 +127,11 @@ const mediaInequalityRuleParser: TokenParser<MediaRulePair> =
   )
     .separatedBy(TokenParser.tokens.Whitespace.optional)
     .map(([_openParen, key, op, eq, dimension, _closeParen]) => {
-      // for forward inequality, e.g. (width < 1250px) becomes max-width
-      const finalKey = op === '>' ? `min-${key}` : `max-${key}`;
-      const isMaxWidth = finalKey.startsWith('max-');
-      const adjustedDimension = adjustDimension(dimension, op, eq, isMaxWidth);
       return {
         type: 'pair',
-        key: finalKey,
-        value: adjustedDimension,
+        key,
+        value: dimension,
+        operator: op + (eq || ''),
       };
     });
 
@@ -175,14 +154,12 @@ const mediaInequalityRuleParserReversed: TokenParser<MediaRulePair> =
   )
     .separatedBy(TokenParser.tokens.Whitespace.optional)
     .map(([_openParen, dimension, op, eq, key, _closeParen]) => {
-      // reversed inequality: (1250px > width) becomes max-width
-      const finalKey = op === '>' ? `max-${key}` : `min-${key}`;
-      const isMaxWidth = finalKey.startsWith('max-');
-      const adjustedDimension = adjustDimension(dimension, op, eq, isMaxWidth);
+      const forwardOp = (op === '>' ? '<' : '>') + (eq || '');
       return {
         type: 'pair',
-        key: finalKey,
-        value: adjustedDimension,
+        key,
+        value: dimension,
+        operator: forwardOp,
       };
     });
 
@@ -217,17 +194,13 @@ const doubleInequalityRuleParser: TokenParser<MediaAndRules> =
   )
     .separatedBy(TokenParser.tokens.Whitespace.optional)
     .map(([_openParen, lower, op, eq, key, op2, eq2, upper, _closeParen]) => {
-      const lowerKey = op === '>' ? `max-${key}` : `min-${key}`;
-      const upperKey = op2 === '>' ? `min-${key}` : `max-${key}`;
-      const lowerIsMaxWidth = lowerKey.startsWith('max-');
-      const upperIsMaxWidth = upperKey.startsWith('max-');
-      const lowerValue = adjustDimension(lower, op, eq, lowerIsMaxWidth);
-      const upperValue = adjustDimension(upper, op2, eq2, upperIsMaxWidth);
+      const lowerOp = (op === '>' ? '<' : '>') + (eq || '');
+      const upperOp = op2 + (eq2 || '');
       return {
         type: 'and',
         rules: [
-          { type: 'pair', key: lowerKey, value: lowerValue },
-          { type: 'pair', key: upperKey, value: upperValue },
+          { type: 'pair', key, value: lower, operator: lowerOp },
+          { type: 'pair', key, value: upper, operator: upperOp },
         ],
       };
     });
@@ -358,13 +331,29 @@ function mergeIntervalsForAnd(
 ): Array<MediaQueryRule> {
   const epsilon: number = 0.01;
   const dimensions = ['width', 'height'];
-  const intervals: { [dim: string]: Array<[number, number]> } = {
+
+  const useRangeSyntax = rules.some((rule) => {
+    let target = rule;
+    if (rule.type === 'not') {
+      target = rule.rule;
+    }
+    return target && target.type === 'pair' && target.operator != null;
+  });
+
+  const lowerBounds: {
+    [dim: string]: Array<{ value: number, inclusive: boolean }>,
+  } = {
+    width: [],
+    height: [],
+  };
+  const upperBounds: {
+    [dim: string]: Array<{ value: number, inclusive: boolean }>,
+  } = {
     width: [],
     height: [],
   };
 
   const units: { [dim: string]: string } = {};
-
   let hasAnyUnitConflicts = false;
 
   for (const rule of rules) {
@@ -399,65 +388,69 @@ function mergeIntervalsForAnd(
   }
 
   for (const rule: MediaQueryRule of rules) {
-    for (const dim of dimensions) {
-      if (
-        rule.type === 'pair' &&
-        (rule.key === `min-${dim}` || rule.key === `max-${dim}`) &&
-        isNumericLength(rule.value)
-      ) {
-        const val = rule.value as any;
+    let isHandled = false;
+    let dim: ?string = null;
+    let val: ?any = null;
+    let op: ?string = null;
+    let isNot = false;
 
-        if (intervals[dim].length === 0) {
-          units[dim] = val.unit;
-        } else if (units[dim] !== val.unit) {
-          hasAnyUnitConflicts = true;
-        }
-        intervals[dim].push(
-          rule.key === `min-${dim}`
-            ? [val.value, Infinity]
-            : [-Infinity, val.value],
-        );
-        break;
-      } else if (
-        rule.type === 'not' &&
-        rule.rule &&
-        rule.rule.type === 'pair' &&
-        (rule.rule.key === `min-${dim}` || rule.rule.key === `max-${dim}`) &&
-        isNumericLength(rule.rule.value)
+    let targetRule = rule;
+    if (rule.type === 'not') {
+      isNot = true;
+      targetRule = rule.rule;
+    }
+
+    if (
+      targetRule &&
+      targetRule.type === 'pair' &&
+      isNumericLength(targetRule.value)
+    ) {
+      val = targetRule.value;
+      const key = targetRule.key;
+      if (
+        key === 'min-width' ||
+        key === 'max-width' ||
+        key === 'min-height' ||
+        key === 'max-height'
       ) {
-        const val = rule.rule.value as any;
-        if (intervals[dim].length === 0) {
-          units[dim] = val.unit;
-        } else if (units[dim] !== val.unit) {
-          hasAnyUnitConflicts = true;
-        }
-        if (rule.rule.key === `min-${dim}`) {
-          intervals[dim].push([-Infinity, val.value - epsilon]);
-        } else {
-          intervals[dim].push([val.value + epsilon, Infinity]);
-        }
-        break;
+        dim = key.split('-')[1];
+        op = key.startsWith('min-') ? '>=' : '<=';
+        isHandled = true;
+      } else if ((key === 'width' || key === 'height') && targetRule.operator) {
+        dim = key;
+        op = targetRule.operator;
+        isHandled = true;
       }
     }
-    if (
-      !(
-        (rule.type === 'pair' &&
-          (rule.key === 'min-width' ||
-            rule.key === 'max-width' ||
-            rule.key === 'min-height' ||
-            rule.key === 'max-height') &&
-          isNumericLength(rule.value)) ||
-        (rule.type === 'not' &&
-          rule.rule &&
-          rule.rule.type === 'pair' &&
-          (rule.rule.key === 'min-width' ||
-            rule.rule.key === 'max-width' ||
-            rule.rule.key === 'min-height' ||
-            rule.rule.key === 'max-height') &&
-          isNumericLength(rule.rule.value))
-      )
-    ) {
+
+    if (!isHandled || dim == null || val == null || op == null) {
       return rules;
+    }
+
+    if (units[dim] === undefined) {
+      units[dim] = val.unit;
+    } else if (units[dim] !== val.unit) {
+      hasAnyUnitConflicts = true;
+    }
+
+    let effectiveOp = op;
+    if (isNot) {
+      if (op === '>=') effectiveOp = '<';
+      else if (op === '>') effectiveOp = '<=';
+      else if (op === '<=') effectiveOp = '>';
+      else if (op === '<') effectiveOp = '>=';
+    }
+
+    if (effectiveOp === '>=' || effectiveOp === '>') {
+      lowerBounds[dim].push({
+        value: val.value,
+        inclusive: effectiveOp === '>=',
+      });
+    } else if (effectiveOp === '<=' || effectiveOp === '<') {
+      upperBounds[dim].push({
+        value: val.value,
+        inclusive: effectiveOp === '<=',
+      });
     }
   }
 
@@ -468,33 +461,98 @@ function mergeIntervalsForAnd(
   }
 
   for (const dim of dimensions) {
-    const dimIntervals = intervals[dim];
-    if (dimIntervals.length === 0) continue;
+    const dimLower = lowerBounds[dim];
+    const dimUpper = upperBounds[dim];
+    if (dimLower.length === 0 && dimUpper.length === 0) continue;
 
-    let lower: number = -Infinity;
-    let upper: number = Infinity;
-    for (const [l, u]: [number, number] of dimIntervals) {
-      if (l > lower) lower = l;
-      if (u < upper) upper = u;
+    let lowerValue = -Infinity;
+    let lowerInclusive = false;
+    if (dimLower.length > 0) {
+      lowerValue = -Infinity;
+      lowerInclusive = false;
+      for (const b of dimLower) {
+        if (b.value > lowerValue) {
+          lowerValue = b.value;
+          lowerInclusive = b.inclusive;
+        } else if (b.value === lowerValue) {
+          lowerInclusive = lowerInclusive && b.inclusive;
+        }
+      }
     }
-    if (lower > upper) {
+
+    let upperValue = Infinity;
+    let upperInclusive = false;
+    if (dimUpper.length > 0) {
+      upperValue = Infinity;
+      upperInclusive = false;
+      for (const b of dimUpper) {
+        if (b.value < upperValue) {
+          upperValue = b.value;
+          upperInclusive = b.inclusive;
+        } else if (b.value === upperValue) {
+          upperInclusive = upperInclusive && b.inclusive;
+        }
+      }
+    }
+
+    if (lowerValue > upperValue) {
       return [];
     }
-    if (lower !== -Infinity) {
-      result.push({
-        type: 'pair',
-        key: `min-${dim}`,
-        value: { value: lower, unit: units[dim], type: 'integer' } as any,
-      });
+    if (lowerValue === upperValue && (!lowerInclusive || !upperInclusive)) {
+      return [];
     }
-    if (upper !== Infinity) {
-      result.push({
-        type: 'pair',
-        key: `max-${dim}`,
-        value: { value: upper, unit: units[dim], type: 'integer' } as any,
-      });
+
+    if (useRangeSyntax) {
+      if (lowerValue !== -Infinity) {
+        result.push({
+          type: 'pair',
+          key: dim,
+          value: {
+            value: lowerValue,
+            unit: units[dim],
+            type: 'integer',
+          } as any,
+          operator: lowerInclusive ? '>=' : '>',
+        });
+      }
+      if (upperValue !== Infinity) {
+        result.push({
+          type: 'pair',
+          key: dim,
+          value: {
+            value: upperValue,
+            unit: units[dim],
+            type: 'integer',
+          } as any,
+          operator: upperInclusive ? '<=' : '<',
+        });
+      }
+    } else {
+      if (lowerValue !== -Infinity) {
+        result.push({
+          type: 'pair',
+          key: `min-${dim}`,
+          value: {
+            value: lowerValue + (lowerInclusive ? 0 : epsilon),
+            unit: units[dim],
+            type: 'integer',
+          } as any,
+        });
+      }
+      if (upperValue !== Infinity) {
+        result.push({
+          type: 'pair',
+          key: `max-${dim}`,
+          value: {
+            value: upperValue - (upperInclusive ? 0 : epsilon),
+            unit: units[dim],
+            type: 'integer',
+          } as any,
+        });
+      }
     }
   }
+
   return result.length > 0 ? result : rules;
 }
 
@@ -531,7 +589,23 @@ export class MediaQuery {
       case 'word-rule':
         return `(${queries.keyValue})`;
       case 'pair': {
-        const { key, value } = queries;
+        const { key, value, operator } = queries;
+
+        if (operator != null) {
+          if (
+            value != null &&
+            typeof value === 'object' &&
+            typeof (value as any).value === 'number' &&
+            typeof (value as any).unit === 'string'
+          ) {
+            const len = value as Length;
+            return `(${key} ${operator} ${len.value}${len.unit})`;
+          }
+          if (value != null && typeof value.toString === 'function') {
+            return `(${key} ${operator} ${value.toString()})`;
+          }
+          return `(${key} ${operator} ${String(value)})`;
+        }
 
         if (Array.isArray(value)) {
           return `(${key}: ${value[0]} / ${value[2]})`;


### PR DESCRIPTION
## What changed / motivation ?
When StyleX compiles overlapping media query breakpoints using strict range syntax (e.g. `@media (width >= 48rem)` and `@media (width >= 64rem)`), it previously transformed the lower breakpoint into an epsilon-adjusted upper bound like `(width <= 63.99rem)`. This left a small gap between 63.99rem and 64rem where neither breakpoint applied.

This PR changes the merge logic to track exact interval bounds with inclusivity, so it emits a strict comparison like `(width < 64rem)` instead of a rounded `<=` value — eliminating the gap entirely. Legacy `min-width` / `max-width` syntax keeps its existing epsilon fallback for backward compatibility.

## Linked PR/Issues
Fixes #1793

## Additional Context
- Modified `packages/style-value-parser/src/at-queries/media-query.js` to track bounds with inclusivity and emit strict `<`/`>` operators for range syntax.
- Added a regression test in `media-query-transform-test.js` matching the exact example from the issue.
- Updated snapshot tests in `parse-media-query-test.js` to reflect the new AST (operator + exact value instead of epsilon-adjusted value).

Before:
`@media (width >= 48rem) and (width <= 63.99rem)`

After:
`@media (width >= 48rem) and (width < 64rem)`

## Pre-flight checklist
- [x] I have read the contributing guidelines
- [x] Performed a self-review of my code