### PR TITLE
[eslint-plugin] Fix formatting for outlineWidth rule

### DIFF
--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -2094,7 +2094,11 @@ const CSSProperties = {
     'inset',
     'outset',
   ) as RuleCheck,
-  outlineWidth: makeUnionRule(isNumber, isLength, isNonNumericString) as RuleCheck,
+  outlineWidth: makeUnionRule(
+    isNumber,
+    isLength,
+    isNonNumericString,
+  ) as RuleCheck,
   blockOverflow: overflow, // TODO - Add support to Babel Plugin
   inlineOverflow: overflow, // TODO - Add support to Babel Plugin
   overflow: overflow,


### PR DESCRIPTION
## Summary

- format the `outlineWidth` validation rule added in #1760
- restore the Prettier job on `main`

## Test plan

- `prettier --check "**/*.{js,flow,mjs,tsx,ts}"`
- ESLint on `cssProperties.js`