### PR TITLE
Allow stylex.env keys in the valid styles lint rule

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -355,6 +355,51 @@ eslintTester.run('stylex-valid-styles', rule.default, {
       `,
       options: [{ allowOuterPseudoAndMedia: true }],
     },
+    // stylex.env member keys are compile time literals (issue 1764)
+    `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        hideBelowSmall: {
+          display: {
+            [stylex.env.responsive.belowSmall]: 'none',
+          },
+        },
+      });
+    `,
+    `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        hideBelowSmall: {
+          display: {
+            default: 'block',
+            [stylex.env.responsive.belowSmall]: 'none',
+          },
+        },
+      });
+    `,
+    `
+      import { create, env } from '@stylexjs/stylex';
+      const styles = create({
+        hideBelowSmall: {
+          display: {
+            [env.responsive.belowSmall]: 'none',
+          },
+        },
+      });
+    `,
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          hideBelowSmall: {
+            [stylex.env.responsive.belowSmall]: {
+              display: 'none',
+            },
+          },
+        });
+      `,
+      options: [{ allowOuterPseudoAndMedia: true }],
+    },
     // test for positive numbers
     "import * as stylex from '@stylexjs/stylex'; stylex.create({default: {marginInlineStart: 5}});",
     // test for literals as namespaces
@@ -2935,6 +2980,24 @@ revert`,
         },
         {
           message: 'Keys must be strings',
+        },
+      ],
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        import { env } from 'some-other-library';
+        const styles = stylex.create({
+          hideBelowSmall: {
+            display: {
+              [env.responsive.belowSmall]: 'none',
+            },
+          },
+        });
+      `,
+      errors: [
+        {
+          message: 'All keys in a stylex object must be static literal values.',
         },
       ],
     },

--- a/packages/@stylexjs/eslint-plugin/src/rules/isStylexEnvMember.js
+++ b/packages/@stylexjs/eslint-plugin/src/rules/isStylexEnvMember.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+import type { Expression, Pattern } from 'estree';
+
+type ASTNode = {
+  +type: string,
+  +name?: string,
+  +computed?: boolean,
+  +object?: ASTNode,
+  +property?: ASTNode,
+  ...
+};
+
+/**
+ * True when `node` is a compile time `stylex.env` member chain, e.g.
+ * `stylex.env.responsive.belowSmall` or a named import `env.responsive.belowSmall`.
+ * Those values are interpolated as literals by the compiler, so they are valid
+ * object keys (typically media queries).
+ */
+export default function isStylexEnvMember(
+  node: Expression | Pattern,
+  styleXDefaultImports: Set<string>,
+  styleXEnvImports: Set<string>,
+): boolean {
+  if (node == null || node.type !== 'MemberExpression') {
+    return false;
+  }
+
+  const properties: Array<string> = [];
+  let current: ASTNode = node;
+  while (current.type === 'MemberExpression') {
+    if (current.computed === true || current.property?.type !== 'Identifier') {
+      return false;
+    }
+    if (typeof current.property.name !== 'string') {
+      return false;
+    }
+    properties.unshift(current.property.name);
+    if (current.object == null) {
+      return false;
+    }
+    current = current.object;
+  }
+
+  if (current.type !== 'Identifier' || typeof current.name !== 'string') {
+    return false;
+  }
+
+  if (styleXEnvImports.has(current.name)) {
+    return properties.length > 0;
+  }
+
+  return (
+    styleXDefaultImports.has(current.name) &&
+    properties[0] === 'env' &&
+    properties.length >= 1
+  );
+}

--- a/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
+++ b/packages/@stylexjs/eslint-plugin/src/stylex-valid-styles.js
@@ -38,6 +38,7 @@ import isNumber from './rules/isNumber';
 import isAnimationName from './rules/isAnimationName';
 import isPositionTryFallbacks from './rules/isPositionTryFallbacks';
 import isStylexResolvedVarsToken from './rules/isStylexResolvedVarsToken';
+import isStylexEnvMember from './rules/isStylexEnvMember';
 import isCSSVariable from './rules/isCSSVariable';
 import evaluate from './utils/evaluate';
 import resolveKey from './utils/resolveKey';
@@ -381,6 +382,7 @@ const stylexValidStyles = {
     const styleXKeyframesImports = new Set<string>();
     const styleXPositionTryImports = new Set<string>();
     const styleXWhenImports = new Set<string>();
+    const styleXEnvImports = new Set<string>();
 
     const overrides: PropLimits = {
       ...(isLegacyExpandShorthands ? legacyProps : {}),
@@ -647,6 +649,16 @@ const stylexValidStyles = {
           if (isStylexResolvedVarsToken(key, stylexResolvedVarsTokenImports)) {
             return undefined;
           }
+          if (isStylexEnvMember(key, styleXDefaultImports, styleXEnvImports)) {
+            return styleValue.properties.forEach((prop) =>
+              checkStyleProperty(
+                prop,
+                level + 1,
+                propName,
+                outerIsPseudoElement,
+              ),
+            );
+          }
           if (
             typeof keyName !== 'string' ||
             (key.type !== 'Literal' && key.type !== 'Identifier')
@@ -721,6 +733,11 @@ const stylexValidStyles = {
           return undefined;
         }
 
+        const isStylexEnvKey = isStylexEnvMember(
+          styleKey,
+          styleXDefaultImports,
+          styleXEnvImports,
+        );
         let isStylexWhenCall = false;
         if (style.computed && styleKey.type !== 'Literal') {
           if (
@@ -764,7 +781,8 @@ const stylexValidStyles = {
         if (
           styleKey.type !== 'Literal' &&
           styleKey.type !== 'Identifier' &&
-          !isStylexWhenCall
+          !isStylexWhenCall &&
+          !isStylexEnvKey
         ) {
           return context.report({
             node: styleKey,
@@ -1124,6 +1142,12 @@ const stylexValidStyles = {
                 specifier.imported.name === 'when'
               ) {
                 styleXWhenImports.add(specifier.local.name);
+              }
+              if (
+                specifier.type === 'ImportSpecifier' &&
+                specifier.imported.name === 'env'
+              ) {
+                styleXEnvImports.add(specifier.local.name);
               }
             });
           }


### PR DESCRIPTION
Fixes #1764

valid styles currently reports stylex.env member expressions used as object keys. The compiler already treats those as compile time literals, the same way it treats string media queries.

This change recognizes stylex.env chains and named env imports so the rule no longer flags them. Nested CSS values are still checked as usual.