### PR TITLE
docs: fix dead links to the shared package

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This is the development monorepo for StyleX.
   - [postcss-plugin](https://github.com/facebook/stylex/blob/main/packages/@stylexjs/postcss-plugin)
   - [rollup-plugin](https://github.com/facebook/stylex/blob/main/packages/@stylexjs/rollup-plugin)
   - [scripts](https://github.com/facebook/stylex/blob/main/packages/scripts)
-  - [shared](https://github.com/facebook/stylex/blob/main/packages/@stylexjs/babel-plugin/shared)
+  - [shared](https://github.com/facebook/stylex/tree/main/packages/@stylexjs/shared)
   - [style-value-parser](https://github.com/facebook/stylex/blob/main/packages/style-value-parser)
   - [stylex](https://github.com/facebook/stylex/blob/main/packages/@stylexjs/stylex)
 

--- a/packages/@stylexjs/eslint-plugin/README.md
+++ b/packages/@stylexjs/eslint-plugin/README.md
@@ -53,7 +53,7 @@ their **suggested replacements**.
 ### @stylexjs/sort-keys
 
 This rule helps to sort the StyleX property keys according to
-[property priorities](https://github.com/facebook/stylex/blob/main/packages/%40stylexjs/babel-plugin/src/shared/utils/property-priorities.js).
+[property priorities](https://github.com/facebook/stylex/blob/main/packages/%40stylexjs/shared/src/utils/property-priorities.js).
 
 #### Config options
 


### PR DESCRIPTION
Two README links to the `@stylexjs/shared` package 404, both treating `shared` as a directory inside `babel-plugin` when it's actually a sibling package:

| File | Old (404) | New (200) |
| --- | --- | --- |
| `README.md` | `blob/main/packages/@stylexjs/babel-plugin/shared` | [`tree/main/packages/@stylexjs/shared`](https://github.com/facebook/stylex/tree/main/packages/%40stylexjs/shared) |
| `packages/@stylexjs/eslint-plugin/README.md` | `.../babel-plugin/src/shared/utils/property-priorities.js` | [`.../shared/src/utils/property-priorities.js`](https://github.com/facebook/stylex/blob/main/packages/%40stylexjs/shared/src/utils/property-priorities.js) |

The root README one also used `/blob/` for a directory; that's now `/tree/`.

The eslint-plugin link matters most — it's the reference readers follow to understand the `sort-keys` rule's property ordering, and right now it goes nowhere.