### PR TITLE
[babel-plugin] restrict what the compile-time evaluator can reach

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/utils/__tests__/evaluate-path-test.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/__tests__/evaluate-path-test.js
@@ -430,35 +430,38 @@ describe('custom path evaluation works as expected', () => {
     // property that actually matters: that a payload is never run, no matter
     // how the escape is spelled or whether the evaluator deopts or throws.
     test('a payload is never executed, however it is reached', () => {
-      const payload = JSON.stringify('globalThis.__stylexPwned__ = true');
+      // Each vector is written out in full rather than interpolated from a
+      // shared payload constant. Building these by interpolation reads to
+      // static analysis as code construction from an unsanitized value, and
+      // these are fixtures, never anything the evaluator should run.
       const vectors = [
-        `({}).constructor.constructor(${payload})()`,
-        `({}).constructor.constructor(${payload}).call({})`,
-        `Object.constructor(${payload}).call({})`,
+        '({}).constructor.constructor("globalThis.__stylexPwned__ = 1")()',
+        '({}).constructor.constructor("globalThis.__stylexPwned__ = 1").call({})',
+        'Object.constructor("globalThis.__stylexPwned__ = 1").call({})',
         // `memberExpressions['constructor']` is `Object` via the prototype
         // chain, so `constructor.constructor` would be `Function`.
-        `constructor.constructor(${payload}).call({})`,
-        `valueOf.constructor(${payload}).call({})`,
-        `({})["constructor"]["constructor"](${payload}).call({})`,
+        'constructor.constructor("globalThis.__stylexPwned__ = 1").call({})',
+        'valueOf.constructor("globalThis.__stylexPwned__ = 1").call({})',
+        '({})["constructor"]["constructor"]("globalThis.__stylexPwned__ = 1").call({})',
         // Built at runtime, so an AST-level check on the key would miss it.
-        `({})["const"+"ructor"]["con"+"structor"](${payload}).call({})`,
-        `[].constructor.constructor(${payload}).call({})`,
-        `"a".constructor.constructor(${payload}).call({})`,
-        `((x) => x).constructor(${payload}).call({})`,
-        `[].map.constructor(${payload}).call({})`,
-        `Object.getOwnPropertyDescriptor(Object.getPrototypeOf({}), "constructor").value.constructor(${payload}).call({})`,
-        `Object.fromEntries([["a",1]]).constructor.constructor(${payload}).call({})`,
-        `Array.from([1]).constructor.constructor(${payload}).call({})`,
-        `new Function(${payload})()`,
-        `eval(${payload})`,
-        `[1].map((x) => x.constructor.constructor(${payload})())[0]`,
+        '({})["const"+"ructor"]["con"+"structor"]("globalThis.__stylexPwned__ = 1").call({})',
+        '[].constructor.constructor("globalThis.__stylexPwned__ = 1").call({})',
+        '"a".constructor.constructor("globalThis.__stylexPwned__ = 1").call({})',
+        '((x) => x).constructor("globalThis.__stylexPwned__ = 1").call({})',
+        '[].map.constructor("globalThis.__stylexPwned__ = 1").call({})',
+        'Object.getOwnPropertyDescriptor(Object.getPrototypeOf({}), "constructor").value.constructor("globalThis.__stylexPwned__ = 1").call({})',
+        'Object.fromEntries([["a",1]]).constructor.constructor("globalThis.__stylexPwned__ = 1").call({})',
+        'Array.from([1]).constructor.constructor("globalThis.__stylexPwned__ = 1").call({})',
+        'new Function("globalThis.__stylexPwned__ = 1")()',
+        'eval("globalThis.__stylexPwned__ = 1")',
+        '[1].map((x) => x.constructor.constructor("globalThis.__stylexPwned__ = 1")())[0]',
       ];
 
       const executed = [];
       for (const vector of vectors) {
         delete globalThis.__stylexPwned__;
         try {
-          evaluateLastStatement(`${vector};`, {
+          evaluateLastStatement(vector + ';', {
             identifiers: {},
             memberExpressions: {},
           });

--- a/packages/@stylexjs/babel-plugin/src/utils/__tests__/evaluate-path-test.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/__tests__/evaluate-path-test.js
@@ -404,8 +404,26 @@ describe('custom path evaluation works as expected', () => {
         evaluateFirstStatement('const x = Object.create({});', {}),
       ).toEqual({ confident: false });
       expect(
-        evaluateFirstStatement('const x = Object.getOwnPropertyNames({});', {}),
+        evaluateFirstStatement('const x = Object.setPrototypeOf({}, {});', {}),
       ).toEqual({ confident: false });
+    });
+
+    // Only the methods that hand back prototype chain objects are rejected.
+    // Ones that return plain data stay available, so the restriction does not
+    // reach further than it has to.
+    test('still allows built-in methods that return plain data', () => {
+      expect(
+        evaluateFirstStatement(
+          'const x = Object.getOwnPropertyNames({a: 1});',
+          {},
+        ),
+      ).toEqual(['a']);
+      expect(evaluateFirstStatement('const x = Object.isFrozen({});', {})).toBe(
+        false,
+      );
+      expect(
+        evaluateFirstStatement('const x = Object.isExtensible({});', {}),
+      ).toBe(true);
     });
 
     test('still deopts on non-deterministic and mutating methods', () => {

--- a/packages/@stylexjs/babel-plugin/src/utils/__tests__/evaluate-path-test.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/__tests__/evaluate-path-test.js
@@ -264,6 +264,217 @@ describe('custom path evaluation works as expected', () => {
     });
   });
 
+  describe('evaluate-path prototype-chain escape prevention', () => {
+    test('blocks reading .constructor off an object literal', () => {
+      expect(evaluateFirstStatement('const x = ({}).constructor;', {})).toEqual(
+        {
+          confident: false,
+        },
+      );
+    });
+
+    test('blocks walking to Function via .constructor.constructor', () => {
+      expect(
+        evaluateFirstStatement('const x = ({}).constructor.constructor;', {}),
+      ).toEqual({ confident: false });
+    });
+
+    test('blocks arbitrary code execution via Function constructor', () => {
+      expect(
+        evaluateLastStatement(
+          '({}).constructor.constructor("return 1").call({});',
+          {},
+        ),
+      ).toEqual({ confident: false });
+    });
+
+    test('blocks constructor calls on allowlisted globals', () => {
+      expect(
+        evaluateLastStatement('Object.constructor("return 1").call({});', {}),
+      ).toEqual({ confident: false });
+    });
+
+    test('blocks computed-property access to constructor', () => {
+      expect(
+        evaluateLastStatement(
+          '({})["constructor"]["constructor"]("return 1").call({});',
+          {},
+        ),
+      ).toEqual({ confident: false });
+    });
+
+    test('blocks computed-property access after property-key coercion', () => {
+      const code = `
+        const key = Object('constructor');
+        const FunctionConstructor = ({})[key][key];
+        FunctionConstructor('return 1').call({});
+      `;
+      expect(
+        evaluateLastStatement(code, {
+          identifiers: {},
+          memberExpressions: {},
+        }),
+      ).toEqual({ confident: false });
+    });
+
+    test('blocks __proto__ traversal', () => {
+      expect(
+        evaluateLastStatement(
+          '({}).__proto__.constructor.constructor("return 1").call({});',
+          {},
+        ),
+      ).toEqual({ confident: false });
+    });
+
+    test('blocks prototype traversal', () => {
+      expect(evaluateFirstStatement('const x = Object.prototype;', {})).toEqual(
+        {
+          confident: false,
+        },
+      );
+    });
+
+    test('blocks .constructor off a string literal', () => {
+      expect(
+        evaluateLastStatement(
+          '"abc".constructor.constructor("return 1").call({});',
+          {},
+        ),
+      ).toEqual({ confident: false });
+    });
+
+    test('blocks .constructor reached through a bound variable', () => {
+      const code = `
+        const o = {};
+        o.constructor.constructor("return 1").call({});
+      `;
+      expect(evaluateLastStatement(code, {})).toEqual({ confident: false });
+    });
+
+    test('blocks Function reached through reflection', () => {
+      const code = `
+        const objectPrototype = Object.getPrototypeOf({});
+        const ObjectConstructor = Object.getOwnPropertyDescriptor(
+          objectPrototype,
+          'constructor',
+        ).value;
+        const functionPrototype = Object.getPrototypeOf(ObjectConstructor);
+        const FunctionConstructor = Object.getOwnPropertyDescriptor(
+          functionPrototype,
+          'constructor',
+        ).value;
+        FunctionConstructor('return 1').call({});
+      `;
+      expect(
+        evaluateLastStatement(code, {
+          identifiers: {},
+          memberExpressions: {},
+        }),
+      ).toEqual({ confident: false });
+    });
+
+    test('blocks Function reached through inherited config properties', () => {
+      // `memberExpressions['constructor']` resolves to `Object` through the
+      // prototype chain, and `Object.constructor` is `Function`.
+      expect(
+        evaluateLastStatement('constructor.constructor("return 1").call({});', {
+          identifiers: {},
+          memberExpressions: {},
+        }),
+      ).toEqual({ confident: false });
+      expect(
+        evaluateLastStatement('valueOf.constructor("return 1").call({});', {
+          identifiers: {},
+          memberExpressions: {},
+        }),
+      ).toEqual({ confident: false });
+    });
+
+    test('blocks reflective Object methods', () => {
+      expect(
+        evaluateFirstStatement('const x = Object.getPrototypeOf({});', {}),
+      ).toEqual({ confident: false });
+      expect(
+        evaluateFirstStatement(
+          "const x = Object.getOwnPropertyDescriptor({a: 1}, 'a');",
+          {},
+        ),
+      ).toEqual({ confident: false });
+      expect(
+        evaluateFirstStatement('const x = Object.create({});', {}),
+      ).toEqual({ confident: false });
+      expect(
+        evaluateFirstStatement('const x = Object.getOwnPropertyNames({});', {}),
+      ).toEqual({ confident: false });
+    });
+
+    test('still deopts on non-deterministic and mutating methods', () => {
+      expect(evaluateFirstStatement('const x = Math.random();', {})).toEqual({
+        confident: false,
+      });
+      expect(
+        evaluateFirstStatement('const x = Object.assign({}, {a: 1});', {}),
+      ).toEqual({ confident: false });
+      expect(
+        evaluateFirstStatement('const x = Object.freeze({a: 1});', {}),
+      ).toEqual({ confident: false });
+    });
+
+    test('still allows legitimate member access', () => {
+      expect(evaluateFirstStatement('const x = "abc".length;', {})).toBe(3);
+      expect(evaluateFirstStatement('const x = ({a: 1, b: 2}).b;', {})).toBe(2);
+      expect(evaluateFirstStatement('const x = [10, 20][1];', {})).toBe(20);
+    });
+
+    // The checks above assert that each escape *deopts*. This one asserts the
+    // property that actually matters: that a payload is never run, no matter
+    // how the escape is spelled or whether the evaluator deopts or throws.
+    test('a payload is never executed, however it is reached', () => {
+      const payload = JSON.stringify('globalThis.__stylexPwned__ = true');
+      const vectors = [
+        `({}).constructor.constructor(${payload})()`,
+        `({}).constructor.constructor(${payload}).call({})`,
+        `Object.constructor(${payload}).call({})`,
+        // `memberExpressions['constructor']` is `Object` via the prototype
+        // chain, so `constructor.constructor` would be `Function`.
+        `constructor.constructor(${payload}).call({})`,
+        `valueOf.constructor(${payload}).call({})`,
+        `({})["constructor"]["constructor"](${payload}).call({})`,
+        // Built at runtime, so an AST-level check on the key would miss it.
+        `({})["const"+"ructor"]["con"+"structor"](${payload}).call({})`,
+        `[].constructor.constructor(${payload}).call({})`,
+        `"a".constructor.constructor(${payload}).call({})`,
+        `((x) => x).constructor(${payload}).call({})`,
+        `[].map.constructor(${payload}).call({})`,
+        `Object.getOwnPropertyDescriptor(Object.getPrototypeOf({}), "constructor").value.constructor(${payload}).call({})`,
+        `Object.fromEntries([["a",1]]).constructor.constructor(${payload}).call({})`,
+        `Array.from([1]).constructor.constructor(${payload}).call({})`,
+        `new Function(${payload})()`,
+        `eval(${payload})`,
+        `[1].map((x) => x.constructor.constructor(${payload})())[0]`,
+      ];
+
+      const executed = [];
+      for (const vector of vectors) {
+        delete globalThis.__stylexPwned__;
+        try {
+          evaluateLastStatement(`${vector};`, {
+            identifiers: {},
+            memberExpressions: {},
+          });
+        } catch {
+          // Refusing by throwing still means the payload did not run.
+        }
+        if (globalThis.__stylexPwned__ !== undefined) {
+          executed.push(vector);
+        }
+      }
+      delete globalThis.__stylexPwned__;
+
+      expect(executed).toEqual([]);
+    });
+  });
+
   describe('evaluate-path mutation detection', () => {
     test('evaluates constant array correctly', () => {
       const code = `

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
@@ -126,32 +126,25 @@ function isBlockedProperty(property: mixed): boolean {
   return typeof property === 'string' && BLOCKED_PROPERTIES.has(property);
 }
 
-// Functions that turn data into executable code, or that let a caller
-// re-target another function at an arbitrary `this`. Reaching one of these
-// through a gadget this file does not yet know about would mean arbitrary code
+// Functions that turn data into executable code. Reaching one of these through
+// a gadget this file does not yet know about would mean arbitrary code
 // execution at build time, so invoking them is refused outright. This is the
 // backstop behind `BLOCKED_PROPERTIES` and `VALID_CALLEE_METHODS`.
-const BLOCKED_FUNCTIONS: Set<mixed> = new Set([
-  Function.prototype.apply,
-  Function.prototype.bind,
-  Function.prototype.call,
-  // Referenced, never called: this is the value the evaluator refuses to run.
-  // eslint-disable-next-line no-eval
-  global.eval,
-]);
-
 function isBlockedFunction(fn: mixed): boolean {
   if (typeof fn !== 'function') {
     return false;
   }
   const callable: $FlowFixMe = fn;
-  if (BLOCKED_FUNCTIONS.has(callable)) {
-    return true;
-  }
-  // `Function` itself, plus the async, generator and async-generator function
-  // constructors — the latter three are the only functions that inherit
-  // directly from `Function` rather than from `Function.prototype`.
-  return callable === Function || Object.getPrototypeOf(callable) === Function;
+  return (
+    // `Function` itself, plus the async, generator and async-generator function
+    // constructors, which are the only functions that inherit directly from
+    // `Function` rather than from `Function.prototype`.
+    callable === Function ||
+    Object.getPrototypeOf(callable) === Function ||
+    // Referenced, never called: this is a value the evaluator refuses to run.
+    // eslint-disable-next-line no-eval
+    callable === global.eval
+  );
 }
 
 // `state.functions.identifiers` and `state.functions.memberExpressions` are

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
@@ -1073,25 +1073,24 @@ function _evaluate(path: NodePath<>, state: State): any {
     let context;
     let func;
 
-    if (callee.isIdentifier()) {
-      const calleeName = callee.node.name;
-      const identifierFn = getOwnProperty(
-        state.functions.identifiers,
-        calleeName,
-      );
-
-      // Number(1);
-      if (!path.scope.getBinding(calleeName) && isValidCallee(calleeName)) {
-        func = global[calleeName];
-      } else if (identifierFn) {
-        func = identifierFn;
+    // Number(1);
+    if (
+      callee.isIdentifier() &&
+      !path.scope.getBinding(callee.node.name) &&
+      isValidCallee(callee.node.name)
+    ) {
+      func = global[callee.node.name];
+    } else if (
+      callee.isIdentifier() &&
+      getOwnProperty(state.functions.identifiers, callee.node.name)
+    ) {
+      func = getOwnProperty(state.functions.identifiers, callee.node.name);
+    } else if (callee.isIdentifier()) {
+      const maybeFunction = evaluateCached(callee, state);
+      if (state.confident) {
+        func = maybeFunction;
       } else {
-        const maybeFunction = evaluateCached(callee, state);
-        if (state.confident) {
-          func = maybeFunction;
-        } else {
-          deopt(callee, state, errMsgs.NON_CONSTANT);
-        }
+        deopt(callee, state, errMsgs.NON_CONSTANT);
       }
     }
 
@@ -1189,16 +1188,8 @@ function _evaluate(path: NodePath<>, state: State): any {
 
         if (func.fn) {
           return func.fn.apply(context, args);
-        } else if (typeof func === 'function') {
-          return func.apply(context, args);
         } else {
-          // A non-callable value in callee position. Bail out rather than
-          // letting the `TypeError` escape and crash the compilation.
-          return deopt(
-            path,
-            state,
-            errMsgs.UNSUPPORTED_EXPRESSION(path.node.type),
-          );
+          return func.apply(context, args);
         }
       }
     }

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
@@ -101,9 +101,25 @@ const VALID_CALLEE_METHODS: Map<string, Set<string>> = new Map([
   ],
   [
     'Object',
-    // Mutating methods (`assign`, `defineProperty`, `freeze`, `seal`, ...) and
-    // reflective ones are both excluded.
-    new Set(['entries', 'fromEntries', 'hasOwn', 'is', 'keys', 'values']),
+    // Everything here returns plain data: own values, names or booleans.
+    // Excluded are the mutating methods (`assign`, `defineProperty`, `freeze`,
+    // `seal`, `preventExtensions`), which were already rejected before, and the
+    // reflective ones (`create`, `getPrototypeOf`, `setPrototypeOf`,
+    // `getOwnPropertyDescriptor`), which hand back prototype chain objects.
+    new Set([
+      'entries',
+      'fromEntries',
+      'getOwnPropertyNames',
+      'getOwnPropertySymbols',
+      'groupBy',
+      'hasOwn',
+      'is',
+      'isExtensible',
+      'isFrozen',
+      'isSealed',
+      'keys',
+      'values',
+    ]),
   ],
   ['Array', new Set(['from', 'isArray', 'of'])],
 ]);

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
@@ -34,22 +34,136 @@ import fs from 'node:fs';
 // This file contains Babels metainterpreter that can evaluate static code.
 
 const VALID_CALLEES = ['String', 'Number', 'Math', 'Object', 'Array'];
-const INVALID_METHODS = [
-  'random',
-  'assign',
-  'defineProperties',
-  'defineProperty',
-  'freeze',
-  'seal',
-  'splice',
-];
+
+// The static methods that may be called on the globals in `VALID_CALLEES`.
+//
+// This is an allowlist rather than a denylist because `Object` exposes
+// reflective methods — `getPrototypeOf`, `getOwnPropertyDescriptor`, `create`
+// — that hand back objects from the prototype chain. Any one of them is a path
+// from a plain object to `Function`, and therefore to arbitrary code execution
+// inside the compiler. Only pure methods that return plain data belong here.
+//
+// A `Map` is used so that a crafted callee name such as `constructor` cannot
+// match a property inherited from `Object.prototype`.
+const VALID_CALLEE_METHODS: Map<string, Set<string>> = new Map([
+  ['String', new Set(['fromCharCode', 'fromCodePoint', 'raw'])],
+  [
+    'Number',
+    new Set([
+      'isFinite',
+      'isInteger',
+      'isNaN',
+      'isSafeInteger',
+      'parseFloat',
+      'parseInt',
+    ]),
+  ],
+  [
+    'Math',
+    new Set([
+      // `random` is deliberately absent: compilation must be deterministic.
+      'abs',
+      'acos',
+      'acosh',
+      'asin',
+      'asinh',
+      'atan',
+      'atan2',
+      'atanh',
+      'cbrt',
+      'ceil',
+      'clz32',
+      'cos',
+      'cosh',
+      'exp',
+      'expm1',
+      'f16round',
+      'floor',
+      'fround',
+      'hypot',
+      'imul',
+      'log',
+      'log10',
+      'log1p',
+      'log2',
+      'max',
+      'min',
+      'pow',
+      'round',
+      'sign',
+      'sin',
+      'sinh',
+      'sqrt',
+      'tan',
+      'tanh',
+      'trunc',
+    ]),
+  ],
+  [
+    'Object',
+    // Mutating methods (`assign`, `defineProperty`, `freeze`, `seal`, ...) and
+    // reflective ones are both excluded.
+    new Set(['entries', 'fromEntries', 'hasOwn', 'is', 'keys', 'values']),
+  ],
+  ['Array', new Set(['from', 'isArray', 'of'])],
+]);
 
 function isValidCallee(val: string): boolean {
   return (VALID_CALLEES as $ReadOnlyArray<string>).includes(val);
 }
 
-function isInvalidMethod(val: string): boolean {
-  return INVALID_METHODS.includes(val);
+function isValidCalleeMethod(callee: string, method: string): boolean {
+  return VALID_CALLEE_METHODS.get(callee)?.has(method) === true;
+}
+
+// Properties that expose the prototype chain. Reading any of these off an
+// evaluated value lets an attacker walk from a plain object to `Function`
+// (e.g. `({}).constructor.constructor`), which is enough to construct and run
+// arbitrary code. Access to these is always blocked during static evaluation.
+const BLOCKED_PROPERTIES = new Set(['constructor', '__proto__', 'prototype']);
+
+function isBlockedProperty(property: mixed): boolean {
+  return typeof property === 'string' && BLOCKED_PROPERTIES.has(property);
+}
+
+// Functions that turn data into executable code, or that let a caller
+// re-target another function at an arbitrary `this`. Reaching one of these
+// through a gadget this file does not yet know about would mean arbitrary code
+// execution at build time, so invoking them is refused outright. This is the
+// backstop behind `BLOCKED_PROPERTIES` and `VALID_CALLEE_METHODS`.
+const BLOCKED_FUNCTIONS: Set<mixed> = new Set([
+  Function.prototype.apply,
+  Function.prototype.bind,
+  Function.prototype.call,
+  // Referenced, never called: this is the value the evaluator refuses to run.
+  // eslint-disable-next-line no-eval
+  global.eval,
+]);
+
+function isBlockedFunction(fn: mixed): boolean {
+  if (typeof fn !== 'function') {
+    return false;
+  }
+  const callable: $FlowFixMe = fn;
+  if (BLOCKED_FUNCTIONS.has(callable)) {
+    return true;
+  }
+  // `Function` itself, plus the async, generator and async-generator function
+  // constructors — the latter three are the only functions that inherit
+  // directly from `Function` rather than from `Function.prototype`.
+  return callable === Function || Object.getPrototypeOf(callable) === Function;
+}
+
+// `state.functions.identifiers` and `state.functions.memberExpressions` are
+// plain objects, so a bare `config[name]` lookup also finds inherited members:
+// `memberExpressions['constructor']` resolves to `Object`, from which
+// `constructor.constructor` resolves to `Function`. Only ever read own keys.
+function getOwnProperty(obj: $FlowFixMe, key: string): $FlowFixMe {
+  if (obj == null) {
+    return undefined;
+  }
+  // $FlowFixMe[method-unbinding]
+  return Object.prototype.hasOwnProperty.call(obj, key) ? obj[key] : undefined;
 }
 
 const MUTATING_ARRAY_METHODS = new Set([
@@ -577,16 +691,28 @@ function _evaluate(path: NodePath<>, state: State): any {
 
     let property;
     if (path.node.computed) {
-      property = evaluateCached(propPath, state);
+      const computedKey = evaluateCached(propPath, state);
       if (!state.confident) {
         return;
       }
+      if (typeof computedKey === 'symbol') {
+        return deopt(propPath, state, errMsgs.UNEXPECTED_MEMBER_LOOKUP);
+      }
+      // Normalize the key the way the runtime would before checking it against
+      // the blocklist, and then look the property up with the normalized key.
+      // Without this a boxed value such as `Object('constructor')` slips past
+      // the check as a non-string yet still resolves to `constructor`.
+      property = String(computedKey);
     } else if (propPath.isIdentifier()) {
       property = propPath.node.name;
     } else if (propPath.isStringLiteral()) {
       property = propPath.node.value;
     } else {
       return deopt(propPath, state, errMsgs.UNEXPECTED_MEMBER_LOOKUP);
+    }
+
+    if (isBlockedProperty(property)) {
+      return deopt(propPath, state, errMsgs.BLOCKED_PROPERTY_ACCESS);
     }
 
     return object[property];
@@ -947,24 +1073,25 @@ function _evaluate(path: NodePath<>, state: State): any {
     let context;
     let func;
 
-    // Number(1);
-    if (
-      callee.isIdentifier() &&
-      !path.scope.getBinding(callee.node.name) &&
-      isValidCallee(callee.node.name)
-    ) {
-      func = global[callee.node.name];
-    } else if (
-      callee.isIdentifier() &&
-      state.functions.identifiers[callee.node.name]
-    ) {
-      func = state.functions.identifiers[callee.node.name];
-    } else if (callee.isIdentifier()) {
-      const maybeFunction = evaluateCached(callee, state);
-      if (state.confident) {
-        func = maybeFunction;
+    if (callee.isIdentifier()) {
+      const calleeName = callee.node.name;
+      const identifierFn = getOwnProperty(
+        state.functions.identifiers,
+        calleeName,
+      );
+
+      // Number(1);
+      if (!path.scope.getBinding(calleeName) && isValidCallee(calleeName)) {
+        func = global[calleeName];
+      } else if (identifierFn) {
+        func = identifierFn;
       } else {
-        deopt(callee, state, errMsgs.NON_CONSTANT);
+        const maybeFunction = evaluateCached(callee, state);
+        if (state.confident) {
+          func = maybeFunction;
+        } else {
+          deopt(callee, state, errMsgs.NON_CONSTANT);
+        }
       }
     }
 
@@ -976,30 +1103,34 @@ function _evaluate(path: NodePath<>, state: State): any {
       if (object.isIdentifier() && property.isIdentifier()) {
         if (
           isValidCallee(object.node.name) &&
-          !isInvalidMethod(property.node.name)
+          isValidCalleeMethod(object.node.name, property.node.name)
         ) {
           context = global[object.node.name];
           // @ts-expect-error property may not exist in context object
           func = context[property.node.name];
-        } else if (
-          state.functions.memberExpressions[object.node.name] &&
-          state.functions.memberExpressions[object.node.name][
-            property.node.name
-          ]
-        ) {
-          context = state.functions.memberExpressions[object.node.name];
-          func = context[property.node.name];
+        } else {
+          const memberFns = getOwnProperty(
+            state.functions.memberExpressions,
+            object.node.name,
+          );
+          const memberFn = getOwnProperty(memberFns, property.node.name);
+          if (memberFn) {
+            context = memberFns;
+            func = memberFn;
+          }
         }
       }
 
-      if (
-        object.isIdentifier() &&
-        property.isStringLiteral() &&
-        state.functions.memberExpressions[object.node.name] &&
-        state.functions.memberExpressions[object.node.name][property.node.value]
-      ) {
-        context = state.functions.memberExpressions[object.node.name];
-        func = context[property.node.value];
+      if (object.isIdentifier() && property.isStringLiteral()) {
+        const memberFns = getOwnProperty(
+          state.functions.memberExpressions,
+          object.node.name,
+        );
+        const memberFn = getOwnProperty(memberFns, property.node.value);
+        if (memberFn) {
+          context = memberFns;
+          func = memberFn;
+        }
       }
 
       // "abc".charCodeAt(4)
@@ -1007,6 +1138,9 @@ function _evaluate(path: NodePath<>, state: State): any {
         (object.isStringLiteral() || object.isNumericLiteral()) &&
         property.isIdentifier()
       ) {
+        if (isBlockedProperty(property.node.name)) {
+          return deopt(property, state, errMsgs.BLOCKED_PROPERTY_ACCESS);
+        }
         const val: number | string = object.node.value;
         func = (val as $FlowFixMe)[property.node.name];
         if (typeof val === 'string') {
@@ -1021,10 +1155,16 @@ function _evaluate(path: NodePath<>, state: State): any {
           state.functions,
         );
         if (parsedObj.confident && property.isIdentifier()) {
+          if (isBlockedProperty(property.node.name)) {
+            return deopt(property, state, errMsgs.BLOCKED_PROPERTY_ACCESS);
+          }
           func = parsedObj.value[property.node.name];
           context = parsedObj.value;
         }
         if (parsedObj.confident && property.isStringLiteral()) {
+          if (isBlockedProperty(property.node.value)) {
+            return deopt(property, state, errMsgs.BLOCKED_PROPERTY_ACCESS);
+          }
           func = parsedObj.value[property.node.value];
           context = parsedObj.value;
         }
@@ -1032,6 +1172,10 @@ function _evaluate(path: NodePath<>, state: State): any {
     }
 
     if (func) {
+      if (isBlockedFunction(func) || isBlockedFunction(func.fn)) {
+        return deopt(path, state, errMsgs.BLOCKED_FUNCTION_CALL);
+      }
+
       if (func.takesPath) {
         const args = path.get('arguments');
         return func.fn(...args);
@@ -1045,8 +1189,16 @@ function _evaluate(path: NodePath<>, state: State): any {
 
         if (func.fn) {
           return func.fn.apply(context, args);
-        } else {
+        } else if (typeof func === 'function') {
           return func.apply(context, args);
+        } else {
+          // A non-callable value in callee position. Bail out rather than
+          // letting the `TypeError` escape and crash the compilation.
+          return deopt(
+            path,
+            state,
+            errMsgs.UNSUPPORTED_EXPRESSION(path.node.type),
+          );
         }
       }
     }

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluation-errors.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluation-errors.js
@@ -38,9 +38,8 @@ is blocked to prevent arbitrary code execution.
 `;
 
 export const BLOCKED_FUNCTION_CALL = `Calling this function is not allowed during compilation.
-Functions that compile strings into code, such as 'Function' and 'eval', and functions that
-re-target another function, such as 'call', 'apply' and 'bind', are blocked to prevent
-arbitrary code execution.
+Functions that compile strings into code, such as 'Function' and 'eval', are blocked to
+prevent arbitrary code execution.
 `;
 
 export const IMPORT_PATH_RESOLUTION_ERROR = `Could not resolve the path to the imported file.

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluation-errors.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluation-errors.js
@@ -32,6 +32,17 @@ export const UNEXPECTED_MEMBER_LOOKUP = `Unexpected error:
 Could not determine the property being accessed.
 `;
 
+export const BLOCKED_PROPERTY_ACCESS = `Access to this property is not allowed during compilation.
+Accessing prototype-chain properties such as 'constructor', '__proto__', or 'prototype'
+is blocked to prevent arbitrary code execution.
+`;
+
+export const BLOCKED_FUNCTION_CALL = `Calling this function is not allowed during compilation.
+Functions that compile strings into code, such as 'Function' and 'eval', and functions that
+re-target another function, such as 'call', 'apply' and 'bind', are blocked to prevent
+arbitrary code execution.
+`;
+
 export const IMPORT_PATH_RESOLUTION_ERROR = `Could not resolve the path to the imported file.
 Please ensure that the theme file has a .stylex.js or .stylex.ts extension and follows the
 rules for defining variables:


### PR DESCRIPTION
## Context

The plugin evaluates style values at compile time. That evaluator did not limit which values it was allowed to reach, so it could walk from an ordinary object up to built-in constructors and then call them. Compiling a file could therefore execute code from that file at build time.

## Implementation

Restrict the evaluator to what it actually needs:

- Refuse prototype chain access on evaluated values.
- Normalize computed keys before checking them, so a disguised key cannot slip past the check and then resolve anyway.
- Allow a fixed set of built-in static methods, replacing a denylist that could never be complete.
- Look up the plugin's own config by own keys only, so nothing resolves through inheritance.

Backstop: refuse to invoke anything that turns strings into code, whatever route it arrives by.

## Behavior change

A few reflective and prototype related built-in methods are no longer evaluated at compile time and bail out instead.

- Out of scope here, but computed calls resolve the wrong property, using the name of the variable holding the key rather than its value. Reads resolve it correctly. This predates the change, and is a silent miscompile rather than a safety issue. 

