### PR TITLE
Accept Marker type in `StyleXStyles` for passing between component prop boundaries

### DIFF
--- a/packages/@stylexjs/stylex/src/stylex.js
+++ b/packages/@stylexjs/stylex/src/stylex.js
@@ -26,7 +26,7 @@ import type {
   StyleX$DefineConsts,
   StyleXArray,
   StyleXClassNameFor,
-  StyleXMarkerToken,
+  StyleXMarker,
   StyleXStyles,
   StyleXStylesWithout,
   StyleXVar,
@@ -35,7 +35,6 @@ import type {
   PositionTry,
   ViewTransitionClass,
   StyleX$When,
-  MapNamespace,
   StyleX$DefaultMarker,
   StyleX$DefineMarker,
   StyleX$Env,
@@ -53,7 +52,7 @@ export type {
   StaticStylesWithout,
   StyleXArray,
   StyleXClassNameFor,
-  StyleXMarkerToken,
+  StyleXMarker,
   StyleXStyles,
   StyleXStylesWithout,
   StyleXVar,
@@ -211,11 +210,7 @@ export const viewTransitionClass = (
   throw errorForFn('viewTransitionClass');
 };
 
-export const defaultMarker = (): MapNamespace<
-  Readonly<{
-    marker: 'default-marker',
-  }>,
-> => {
+export const defaultMarker: StyleX$DefaultMarker = () => {
   throw errorForFn('defaultMarker');
 };
 

--- a/packages/@stylexjs/stylex/src/stylex.js
+++ b/packages/@stylexjs/stylex/src/stylex.js
@@ -26,6 +26,7 @@ import type {
   StyleX$DefineConsts,
   StyleXArray,
   StyleXClassNameFor,
+  StyleXMarkerToken,
   StyleXStyles,
   StyleXStylesWithout,
   StyleXVar,
@@ -35,6 +36,7 @@ import type {
   ViewTransitionClass,
   StyleX$When,
   MapNamespace,
+  StyleX$DefaultMarker,
   StyleX$DefineMarker,
   StyleX$Env,
 } from './types/StyleXTypes';
@@ -51,6 +53,7 @@ export type {
   StaticStylesWithout,
   StyleXArray,
   StyleXClassNameFor,
+  StyleXMarkerToken,
   StyleXStyles,
   StyleXStylesWithout,
   StyleXVar,
@@ -313,11 +316,7 @@ type IStyleX = {
   defineConsts: StyleX$DefineConsts,
   defineVars: StyleX$DefineVars,
   env: StyleX$Env,
-  defaultMarker: () => MapNamespace<
-    Readonly<{
-      marker: 'default-marker',
-    }>,
-  >,
+  defaultMarker: StyleX$DefaultMarker,
   defineMarker: StyleX$DefineMarker,
   firstThatWorks: <T extends string | number>(
     ...v: ReadonlyArray<T>

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
@@ -230,6 +230,7 @@ export type StyleXStyles<
   | false
   | GenStylePropType<CSS>
   | Readonly<[GenStylePropType<CSS>, InlineStyles]>
+  | StyleXMarkerToken
 >;
 export type StyleXStylesWithout<CSS extends UserAuthoredStyles> = StyleXStyles<
   Omit<CSSPropertiesWithExtras, keyof CSS>
@@ -317,6 +318,14 @@ export type StyleX$CreateTheme = <
 export type StyleX$DefineMarker = () => MapNamespace<{
   readonly marker: symbol;
 }>;
+
+export type StyleX$DefaultMarker = () => MapNamespace<{
+  readonly marker: 'default-marker';
+}>;
+
+export type StyleXMarkerToken =
+  | ReturnType<StyleX$DefineMarker>
+  | ReturnType<StyleX$DefaultMarker>;
 
 export type StyleX$When = {
   ancestor: <

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.d.ts
@@ -230,7 +230,7 @@ export type StyleXStyles<
   | false
   | GenStylePropType<CSS>
   | Readonly<[GenStylePropType<CSS>, InlineStyles]>
-  | StyleXMarkerToken
+  | StyleXMarker
 >;
 export type StyleXStylesWithout<CSS extends UserAuthoredStyles> = StyleXStyles<
   Omit<CSSPropertiesWithExtras, keyof CSS>
@@ -315,17 +315,13 @@ export type StyleX$CreateTheme = <
   overrides: OverridesForTokenType<TokensFromVarGroup<TVars>>,
 ) => Theme<TVars, ThemeID>;
 
-export type StyleX$DefineMarker = () => MapNamespace<{
+export type StyleXMarker = MapNamespace<{
   readonly marker: symbol;
 }>;
 
-export type StyleX$DefaultMarker = () => MapNamespace<{
-  readonly marker: 'default-marker';
-}>;
+export type StyleX$DefineMarker = () => StyleXMarker;
 
-export type StyleXMarkerToken =
-  | ReturnType<StyleX$DefineMarker>
-  | ReturnType<StyleX$DefaultMarker>;
+export type StyleX$DefaultMarker = () => StyleXMarker;
 
 export type StyleX$When = {
   ancestor: <

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.js
@@ -188,7 +188,8 @@ export type StyleXStyles<
 > = StyleXArray<
   | ?false
   | GenStylePropType<Readonly<CSS>>
-  | Readonly<[GenStylePropType<Readonly<CSS>>, InlineStyles]>,
+  | Readonly<[GenStylePropType<Readonly<CSS>>, InlineStyles]>
+  | StyleXMarkerToken,
 >;
 
 export type StyleXStylesWithout<
@@ -297,6 +298,14 @@ export type StyleX$CreateTheme = <
 export type StyleX$DefineMarker = () => MapNamespace<{
   readonly marker: 'custom-marker',
 }>;
+
+export type StyleX$DefaultMarker = () => MapNamespace<{
+  readonly marker: 'default-marker',
+}>;
+
+export type StyleXMarkerToken =
+  | ReturnType<StyleX$DefineMarker>
+  | ReturnType<StyleX$DefaultMarker>;
 
 export type StyleX$When = {
   ancestor: (

--- a/packages/@stylexjs/stylex/src/types/StyleXTypes.js
+++ b/packages/@stylexjs/stylex/src/types/StyleXTypes.js
@@ -189,7 +189,7 @@ export type StyleXStyles<
   | ?false
   | GenStylePropType<Readonly<CSS>>
   | Readonly<[GenStylePropType<Readonly<CSS>>, InlineStyles]>
-  | StyleXMarkerToken,
+  | StyleXMarker,
 >;
 
 export type StyleXStylesWithout<
@@ -295,38 +295,34 @@ export type StyleX$CreateTheme = <
   overrides: OverridesForTokenType<TokensFromVarGroup<BaseTokens>>,
 ) => Theme<BaseTokens, ID>;
 
-export type StyleX$DefineMarker = () => MapNamespace<{
+export type StyleXMarker = MapNamespace<{
   readonly marker: 'custom-marker',
 }>;
 
-export type StyleX$DefaultMarker = () => MapNamespace<{
-  readonly marker: 'default-marker',
-}>;
+export type StyleX$DefineMarker = () => StyleXMarker;
 
-export type StyleXMarkerToken =
-  | ReturnType<StyleX$DefineMarker>
-  | ReturnType<StyleX$DefaultMarker>;
+export type StyleX$DefaultMarker = () => StyleXMarker;
 
 export type StyleX$When = {
   ancestor: (
     _pseudo?: StringPrefix<':'> | StringPrefix<'['>,
-    _customMarker?: MapNamespace<{ readonly marker: 'custom-marker' }>,
+    _customMarker?: StyleXMarker,
   ) => ':where-ancestor',
   descendant: (
     _pseudo?: StringPrefix<':'> | StringPrefix<'['>,
-    _customMarker?: MapNamespace<{ readonly marker: 'custom-marker' }>,
+    _customMarker?: StyleXMarker,
   ) => ':where-descendant',
   siblingBefore: (
     _pseudo?: StringPrefix<':'> | StringPrefix<'['>,
-    _customMarker?: MapNamespace<{ readonly marker: 'custom-marker' }>,
+    _customMarker?: StyleXMarker,
   ) => ':where-sibling-before',
   siblingAfter: (
     _pseudo?: StringPrefix<':'> | StringPrefix<'['>,
-    _customMarker?: MapNamespace<{ readonly marker: 'custom-marker' }>,
+    _customMarker?: StyleXMarker,
   ) => ':where-sibling-after',
   anySibling: (
     _pseudo?: StringPrefix<':'> | StringPrefix<'['>,
-    _customMarker?: MapNamespace<{ readonly marker: 'custom-marker' }>,
+    _customMarker?: StyleXMarker,
   ) => ':where-any-sibling',
 };
 

--- a/packages/typescript-tests/src/typetests.ts
+++ b/packages/typescript-tests/src/typetests.ts
@@ -10,6 +10,7 @@
 import * as stylex from '@stylexjs/stylex';
 import type {
   StaticStyles,
+  StyleXMarkerToken,
   StyleXStyles,
   StaticStylesWithout,
   StyleXStylesWithout,
@@ -317,3 +318,35 @@ const styles9 = stylex.create({
   // @ts-expect-error - `undefined` is not a valid style value
   bar: (height: number, width?: number) => ({ height, width }),
 });
+
+/**
+ * MARKER STYLES
+ *
+ * stylex.defaultMarker() and stylex.defineMarker() should be accepted by
+ * StyleXStyles<T> for any T, enabling the marker API at component prop boundaries.
+ */
+
+const defaultMarkerToken = stylex.defaultMarker();
+const customMarkerToken = stylex.defineMarker();
+
+// Marker tokens satisfy StyleXMarkerToken
+defaultMarkerToken satisfies StyleXMarkerToken;
+customMarkerToken satisfies StyleXMarkerToken;
+
+// Marker tokens are accepted by constrained StyleXStyles<T>
+defaultMarkerToken satisfies StyleXStyles<{ margin?: string }>;
+customMarkerToken satisfies StyleXStyles<{ margin?: string }>;
+
+// Mixed array: layout styles + marker token through a constrained prop type
+const layoutStyles = stylex.create({ base: { margin: '8px' } });
+[layoutStyles.base, defaultMarkerToken] satisfies StyleXStyles<{
+  margin?: string;
+}>;
+[layoutStyles.base, customMarkerToken] satisfies StyleXStyles<{
+  margin?: string;
+}>;
+
+// CSS constraints are still enforced — this doesn't weaken StyleXStyles<T>
+const opacityStyle = stylex.create({ foo: { opacity: 0 } });
+// @ts-expect-error — opacity is not in the constraint
+opacityStyle.foo satisfies StyleXStyles<{ margin?: string }>;

--- a/packages/typescript-tests/src/typetests.ts
+++ b/packages/typescript-tests/src/typetests.ts
@@ -10,7 +10,7 @@
 import * as stylex from '@stylexjs/stylex';
 import type {
   StaticStyles,
-  StyleXMarkerToken,
+  StyleXMarker,
   StyleXStyles,
   StaticStylesWithout,
   StyleXStylesWithout,
@@ -322,27 +322,28 @@ const styles9 = stylex.create({
 /**
  * MARKER STYLES
  *
- * stylex.defaultMarker() and stylex.defineMarker() should be accepted by
- * StyleXStyles<T> for any T, enabling the marker API at component prop boundaries.
+ * `stylex.defaultMarker()` and `stylex.defineMarker()` both return a
+ * `StyleXMarker` which `StyleXStyles<T>` accepts for any `T`, so that markers
+ * can be passed across component prop boundaries.
  */
 
-const defaultMarkerToken = stylex.defaultMarker();
-const customMarkerToken = stylex.defineMarker();
+const defaultMarker = stylex.defaultMarker();
+const customMarker = stylex.defineMarker();
 
-// Marker tokens satisfy StyleXMarkerToken
-defaultMarkerToken satisfies StyleXMarkerToken;
-customMarkerToken satisfies StyleXMarkerToken;
+// Markers satisfy StyleXMarker
+defaultMarker satisfies StyleXMarker;
+customMarker satisfies StyleXMarker;
 
-// Marker tokens are accepted by constrained StyleXStyles<T>
-defaultMarkerToken satisfies StyleXStyles<{ margin?: string }>;
-customMarkerToken satisfies StyleXStyles<{ margin?: string }>;
+// Marker are accepted by constrained StyleXStyles<T>
+defaultMarker satisfies StyleXStyles<{ margin?: string }>;
+customMarker satisfies StyleXStyles<{ margin?: string }>;
 
 // Mixed array: layout styles + marker token through a constrained prop type
 const layoutStyles = stylex.create({ base: { margin: '8px' } });
-[layoutStyles.base, defaultMarkerToken] satisfies StyleXStyles<{
+[layoutStyles.base, defaultMarker] satisfies StyleXStyles<{
   margin?: string;
 }>;
-[layoutStyles.base, customMarkerToken] satisfies StyleXStyles<{
+[layoutStyles.base, customMarker] satisfies StyleXStyles<{
   margin?: string;
 }>;
 


### PR DESCRIPTION
## What changed / motivation ?

In our Design System, we follow [StyleX's docs recommend pattern](https://stylexjs.com/docs/api/types/StyleXStyles) for constraining component style props using `StyleXStyles<T>`:

```ts
// Design system component
type BoxProps = {
  /** Only layout properties allowed, other styles are intentionally blocked */
  xstyle?: StyleXStyles<{
    margin?: CSSProperties['margin'];
    padding?: CSSProperties['padding'];
    flexGrow?: CSSProperties['flexGrow'];
  }>;
};
```

This pattern works for style overrides but consumers also need to use the marker API to implement ancestor-state patterns, for example, revealing a child element when a parent is hovered, entirely in CSS:

```tsx
const styles = stylex.create({
  actions: {
    opacity: {
      default: 0,
      [stylex.when.ancestor(':hover')]: 1,
    },
  },
});

// Mark the parent component as the hover anchor...
<Box xstyle={stylex.defaultMarker()}>  {/* ❌ Type error */}
  <ChildComponent xstyle={styles.actions} />
</Box>

// ...or compose layout styles and a marker together
<Box xstyle={[styles.layout, stylex.defaultMarker()]}>  {/* ❌ Type error */}
  <ChildComponent xstyle={styles.actions} />
</Box>
```

Because `StyleXStyles<T>` has no way to express "a marker token is also valid here", in our DS, we've created an internal `XStyle` type which is essentially a union of `StylexStyles<T> | StyleXMarkerToken` (which we've just created internally from the `ReturnType`'s as in this PR), which does _work_ & without that our DS consumers are forced to either add additional wrapping elements, or are generally unable to use our components for their use-case.

_But_ it would be nice to not have to manage this at the DS level & could live in the library instead to pass between component prop boundaries easier.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code