### PR TITLE
fix(unplugin): transform .astro files that arrive already compiled

### DIFF
--- a/packages/@stylexjs/unplugin/__tests__/unplugin.test.js
+++ b/packages/@stylexjs/unplugin/__tests__/unplugin.test.js
@@ -26,6 +26,46 @@ describe('@stylexjs/unplugin', () => {
     expect(result).toBeNull();
   });
 
+  test('includes .astro files', () => {
+    const plugin = unplugin.raw({});
+    expect(plugin.transformInclude('/virtual/page.astro')).toBe(true);
+    expect(
+      plugin.transformInclude('/virtual/page.astro?astro&type=script'),
+    ).toBe(true);
+  });
+
+  test('compiles StyleX in .astro modules', async () => {
+    const plugin = unplugin.rollup({
+      runtimeInjection: false,
+      devPersistToDisk: false,
+      dev: false,
+    });
+    if (typeof plugin.buildStart === 'function') {
+      plugin.buildStart();
+    }
+    // Astro hands bundler plugins the compiled module, not the `---` source
+    const source = `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({ hero: { color: 'red' } });
+      export default function $$Page() { return styles; }
+    `;
+    const result = await plugin.transform(source, '/virtual/page.astro');
+    expect(result).not.toBeNull();
+    expect(result.code).not.toContain('stylex.create');
+
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'stylex-unplugin-test-'),
+    );
+    try {
+      await plugin.writeBundle({ dir: tempDir }, {});
+      const cssPath = path.join(tempDir, 'assets', 'stylex.css');
+      expect(fs.existsSync(cssPath)).toBe(true);
+      expect(fs.readFileSync(cssPath, 'utf8')).toContain('color: red;');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test('writes fallback CSS asset when no CSS bundle entry exists', async () => {
     const plugin = unplugin.rollup({
       runtimeInjection: false,

--- a/packages/@stylexjs/unplugin/__tests__/unplugin.test.js
+++ b/packages/@stylexjs/unplugin/__tests__/unplugin.test.js
@@ -47,7 +47,7 @@ describe('@stylexjs/unplugin', () => {
     const source = `
       import * as stylex from '@stylexjs/stylex';
       const styles = stylex.create({ hero: { color: 'red' } });
-      export default function $$Page() { return styles; }
+      export default styles;
     `;
     const result = await plugin.transform(source, '/virtual/page.astro');
     expect(result).not.toBeNull();

--- a/packages/@stylexjs/unplugin/src/core.js
+++ b/packages/@stylexjs/unplugin/src/core.js
@@ -210,6 +210,9 @@ function discoverStylexPackages({
 
 const JS_LIKE_RE = /\.[cm]?[jt]sx?(\?|$)/;
 const SVELTE_LIKE_RE = /\.svelte(\?|$)/;
+// Astro compiles `.astro` to JavaScript before any bundler plugin runs, so these
+// arrive here as plain modules and are handled like any other JS-like file.
+const ASTRO_LIKE_RE = /\.astro(\?|$)/;
 
 export const unpluginFactory = (userOptions = {}, metaOptions) => {
   // framework :: 'rollup' | 'vite' | 'rolldown' | 'farm' | 'unloader'
@@ -406,13 +409,20 @@ export const unpluginFactory = (userOptions = {}, metaOptions) => {
     },
 
     transformInclude(id) {
-      return JS_LIKE_RE.test(id) || SVELTE_LIKE_RE.test(id);
+      return (
+        JS_LIKE_RE.test(id) || SVELTE_LIKE_RE.test(id) || ASTRO_LIKE_RE.test(id)
+      );
     },
 
     // Core code transform
     async transform(code, id) {
       // Only handle JS-like files; avoid parsing CSS/JSON/etc
-      if (!JS_LIKE_RE.test(id) && !SVELTE_LIKE_RE.test(id)) return null;
+      if (
+        !JS_LIKE_RE.test(id) &&
+        !SVELTE_LIKE_RE.test(id) &&
+        !ASTRO_LIKE_RE.test(id)
+      )
+        return null;
       if (!shouldHandle(code)) return null;
 
       // Extract the pure filename by removing everything after '?' (e.g., handling Vite's '?v=' cache busting).

--- a/packages/@stylexjs/unplugin/src/core.js
+++ b/packages/@stylexjs/unplugin/src/core.js
@@ -210,9 +210,13 @@ function discoverStylexPackages({
 
 const JS_LIKE_RE = /\.[cm]?[jt]sx?(\?|$)/;
 const SVELTE_LIKE_RE = /\.svelte(\?|$)/;
-// Astro compiles `.astro` to JavaScript before any bundler plugin runs, so these
-// arrive here as plain modules and are handled like any other JS-like file.
 const ASTRO_LIKE_RE = /\.astro(\?|$)/;
+
+function isTransformableId(id) {
+  return (
+    JS_LIKE_RE.test(id) || SVELTE_LIKE_RE.test(id) || ASTRO_LIKE_RE.test(id)
+  );
+}
 
 export const unpluginFactory = (userOptions = {}, metaOptions) => {
   // framework :: 'rollup' | 'vite' | 'rolldown' | 'farm' | 'unloader'
@@ -409,20 +413,13 @@ export const unpluginFactory = (userOptions = {}, metaOptions) => {
     },
 
     transformInclude(id) {
-      return (
-        JS_LIKE_RE.test(id) || SVELTE_LIKE_RE.test(id) || ASTRO_LIKE_RE.test(id)
-      );
+      return isTransformableId(id);
     },
 
     // Core code transform
     async transform(code, id) {
       // Only handle JS-like files; avoid parsing CSS/JSON/etc
-      if (
-        !JS_LIKE_RE.test(id) &&
-        !SVELTE_LIKE_RE.test(id) &&
-        !ASTRO_LIKE_RE.test(id)
-      )
-        return null;
+      if (!isTransformableId(id)) return null;
       if (!shouldHandle(code)) return null;
 
       // Extract the pure filename by removing everything after '?' (e.g., handling Vite's '?v=' cache busting).


### PR DESCRIPTION
## What changed / motivation ?

I wanted to try StyleX in an Astro app and couldn't get it working. Any style I declared inside a `.astro` file was ignored, and the build failed with:

```
Error: Unexpected 'stylex.create' call at runtime.
Styles must be compiled by '@stylexjs/babel-plugin'.
```

It turned out the plugin picks which files to handle by file extension, and `.astro` isn't on the list, so those files get skipped entirely.

Supporting them doesn't need anything special. Astro turns `.astro` files into plain JavaScript before any bundler plugin runs, so by the time this plugin sees them they're ordinary modules. Adding the extension is enough.

## Linked PR/Issues

Fixes # (issue)

## Additional Context

Two new ones. Both fail on `main` and pass with this change:

- one checks `.astro` files are picked up
-  one compiles a real `.astro` module and checks the CSS actually comes out

I also created a sample app with a patched `@stylexjs/unplugin` package ([repo](https://github.com/wobsoriano/astro-stylex-example), [demo](https://astro-stylex-example.vercel.app))

**NOTE:** Even with the fix, an Astro app still needs a little glue to get the stylesheet onto the page. In dev the plugin adds its styles through a hook Astro doesn't use, and in a build it appends its rules to an existing stylesheet, so a site without one ends up with a CSS file nothing links to. Neither fails loudly, you just get an unstyled page.

Happy to follow up with an `@stylexjs/unplugin/astro` entry, or add an example in the examples folder, or I can just release a community astro-stylex integration ([ref](https://github.com/wobsoriano/astro-stylex-example/blob/main/stylex-astro.mjs))

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code