### PR TITLE
[docs] recover from stale client chunks

### DIFF
--- a/packages/docs/src/components/SiteErrorBoundary.tsx
+++ b/packages/docs/src/components/SiteErrorBoundary.tsx
@@ -13,10 +13,10 @@ const DEFAULT_DESCRIPTION = 'The styling system that powers Meta.';
 const RELOAD_KEY_PREFIX = 'stylex:chunk-reload:';
 const RELOAD_WINDOW_MS = 60_000;
 const DYNAMIC_IMPORT_ERROR =
-  /chunkloaderror|failed to fetch dynamically imported module|importing a module script failed|loading chunk .* failed/i;
+  /chunkloaderror|failed to fetch dynamically imported module|error loading dynamically imported module|importing a module script failed|loading chunk .* failed/i;
 
 type State = {
-  error: unknown | null;
+  hasError: boolean;
 };
 
 function getReloadKey(): string {
@@ -47,10 +47,10 @@ export class SiteErrorBoundary extends Component<
   { children: ReactNode },
   State
 > {
-  state: State = { error: null };
+  state: State = { hasError: false };
 
-  static getDerivedStateFromError(error: unknown): State {
-    return { error };
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
   }
 
   componentDidCatch(error: unknown): void {
@@ -58,43 +58,40 @@ export class SiteErrorBoundary extends Component<
   }
 
   render(): ReactNode {
-    if (this.state.error == null) {
+    if (!this.state.hasError) {
       return this.props.children;
     }
 
     return (
-      <>
-        <title>{DEFAULT_TITLE}</title>
-        <meta content={DEFAULT_DESCRIPTION} name="description" />
-        <meta content="noindex" name="robots" />
-        <main
-          data-nosnippet=""
-          style={{
-            alignItems: 'center',
-            display: 'flex',
-            flexDirection: 'column',
-            fontFamily: 'system-ui, sans-serif',
-            height: '100dvh',
-            justifyContent: 'center',
-            padding: 24,
-            textAlign: 'center',
-          }}
-        >
-          <h1>StyleX is temporarily unavailable</h1>
-          <p>Refresh the page to try again.</p>
-          <button
-            onClick={() => {
-              try {
-                window.sessionStorage.removeItem(getReloadKey());
-              } catch {}
-              window.location.reload();
+      <html lang="en">
+        <head>
+          <title>{DEFAULT_TITLE}</title>
+          <meta charSet="utf-8" />
+          <meta content="width=device-width, initial-scale=1" name="viewport" />
+          <meta content={DEFAULT_DESCRIPTION} name="description" />
+        </head>
+        <body>
+          <main
+            data-nosnippet=""
+            style={{
+              alignItems: 'center',
+              display: 'flex',
+              flexDirection: 'column',
+              fontFamily: 'system-ui, sans-serif',
+              height: '100dvh',
+              justifyContent: 'center',
+              padding: 24,
+              textAlign: 'center',
             }}
-            type="button"
           >
-            Refresh
-          </button>
-        </main>
-      </>
+            <h1>StyleX is temporarily unavailable</h1>
+            <p>Refresh the page to try again.</p>
+            <button onClick={() => window.location.reload()} type="button">
+              Refresh
+            </button>
+          </main>
+        </body>
+      </html>
     );
   }
 }

--- a/packages/docs/src/components/SiteErrorBoundary.tsx
+++ b/packages/docs/src/components/SiteErrorBoundary.tsx
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use client';
+
+import { Component, type ReactNode } from 'react';
+
+const DEFAULT_TITLE = 'StyleX — The styling system for ambitious interfaces';
+const DEFAULT_DESCRIPTION = 'The styling system that powers Meta.';
+const RELOAD_KEY_PREFIX = 'stylex:chunk-reload:';
+const RELOAD_WINDOW_MS = 60_000;
+const DYNAMIC_IMPORT_ERROR =
+  /chunkloaderror|failed to fetch dynamically imported module|importing a module script failed|loading chunk .* failed/i;
+
+type State = {
+  error: unknown | null;
+};
+
+function getReloadKey(): string {
+  return `${RELOAD_KEY_PREFIX}${window.location.pathname}`;
+}
+
+function reloadAfterDynamicImportError(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!DYNAMIC_IMPORT_ERROR.test(message)) {
+    return;
+  }
+
+  try {
+    const key = getReloadKey();
+    const lastReload = Number(window.sessionStorage.getItem(key) ?? 0);
+    if (Date.now() - lastReload < RELOAD_WINDOW_MS) {
+      return;
+    }
+    window.sessionStorage.setItem(key, String(Date.now()));
+  } catch {
+    return;
+  }
+
+  window.location.reload();
+}
+
+export class SiteErrorBoundary extends Component<
+  { children: ReactNode },
+  State
+> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: unknown): State {
+    return { error };
+  }
+
+  componentDidCatch(error: unknown): void {
+    reloadAfterDynamicImportError(error);
+  }
+
+  render(): ReactNode {
+    if (this.state.error == null) {
+      return this.props.children;
+    }
+
+    return (
+      <>
+        <title>{DEFAULT_TITLE}</title>
+        <meta content={DEFAULT_DESCRIPTION} name="description" />
+        <meta content="noindex" name="robots" />
+        <main
+          data-nosnippet=""
+          style={{
+            alignItems: 'center',
+            display: 'flex',
+            flexDirection: 'column',
+            fontFamily: 'system-ui, sans-serif',
+            height: '100dvh',
+            justifyContent: 'center',
+            padding: 24,
+            textAlign: 'center',
+          }}
+        >
+          <h1>StyleX is temporarily unavailable</h1>
+          <p>Refresh the page to try again.</p>
+          <button
+            onClick={() => {
+              try {
+                window.sessionStorage.removeItem(getReloadKey());
+              } catch {}
+              window.location.reload();
+            }}
+            type="button"
+          >
+            Refresh
+          </button>
+        </main>
+      </>
+    );
+  }
+}

--- a/packages/docs/src/pages/_layout.tsx
+++ b/packages/docs/src/pages/_layout.tsx
@@ -8,7 +8,6 @@ import type { ReactNode } from 'react';
 import { Provider } from '@/components/provider';
 import '@/styles/globals.css';
 import DevStyleXHMR from '@/components/DevStyleXHMR';
-import { SiteErrorBoundary } from '@/components/SiteErrorBoundary';
 import { SidebarProvider } from '@/contexts/SidebarContext';
 import coverImageUrl from '@/static/img/stylex-cover-photo.png';
 
@@ -16,31 +15,10 @@ const faviconUrl = '/favicon.svg';
 
 const DEFAULT_TITLE = 'StyleX — The styling system for ambitious interfaces';
 const DEFAULT_DESCRIPTION = 'The styling system that powers Meta.';
-const CHUNK_RECOVERY_SCRIPT = `
-(() => {
-  const key = 'stylex:chunk-reload:' + window.location.pathname;
-  const retryWindow = 60_000;
-
-  window.addEventListener('vite:preloadError', (event) => {
-    try {
-      const lastReload = Number(window.sessionStorage.getItem(key) || 0);
-      if (Date.now() - lastReload < retryWindow) {
-        return;
-      }
-      window.sessionStorage.setItem(key, String(Date.now()));
-    } catch {
-      return;
-    }
-
-    event.preventDefault();
-    window.location.reload();
-  });
-})();
-`;
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <SiteErrorBoundary>
+    <>
       <head>
         <meta charSet="utf-8" />
         <meta content="width=device-width, initial-scale=1" name="viewport" />
@@ -56,12 +34,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <link href={faviconUrl} rel="icon" sizes="any" />
         <link href={faviconUrl} rel="icon" type="image/svg+xml" />
         <link href={faviconUrl} rel="shortcut icon" />
-        <script dangerouslySetInnerHTML={{ __html: CHUNK_RECOVERY_SCRIPT }} />
       </head>
       <DevStyleXHMR />
       <Provider>
         <SidebarProvider>{children}</SidebarProvider>
       </Provider>
-    </SiteErrorBoundary>
+    </>
   );
 }

--- a/packages/docs/src/pages/_layout.tsx
+++ b/packages/docs/src/pages/_layout.tsx
@@ -8,6 +8,7 @@ import type { ReactNode } from 'react';
 import { Provider } from '@/components/provider';
 import '@/styles/globals.css';
 import DevStyleXHMR from '@/components/DevStyleXHMR';
+import { SiteErrorBoundary } from '@/components/SiteErrorBoundary';
 import { SidebarProvider } from '@/contexts/SidebarContext';
 import coverImageUrl from '@/static/img/stylex-cover-photo.png';
 
@@ -15,10 +16,37 @@ const faviconUrl = '/favicon.svg';
 
 const DEFAULT_TITLE = 'StyleX — The styling system for ambitious interfaces';
 const DEFAULT_DESCRIPTION = 'The styling system that powers Meta.';
+const CHUNK_RECOVERY_SCRIPT = `
+(() => {
+  const key = 'stylex:chunk-reload:' + window.location.pathname;
+  const retryWindow = 60_000;
+
+  window.setTimeout(() => {
+    try {
+      window.sessionStorage.removeItem(key);
+    } catch {}
+  }, 10_000);
+
+  window.addEventListener('vite:preloadError', (event) => {
+    try {
+      const lastReload = Number(window.sessionStorage.getItem(key) || 0);
+      if (Date.now() - lastReload < retryWindow) {
+        return;
+      }
+      window.sessionStorage.setItem(key, String(Date.now()));
+    } catch {
+      return;
+    }
+
+    event.preventDefault();
+    window.location.reload();
+  });
+})();
+`;
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <>
+    <SiteErrorBoundary>
       <head>
         <meta charSet="utf-8" />
         <meta content="width=device-width, initial-scale=1" name="viewport" />
@@ -34,11 +62,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <link href={faviconUrl} rel="icon" sizes="any" />
         <link href={faviconUrl} rel="icon" type="image/svg+xml" />
         <link href={faviconUrl} rel="shortcut icon" />
+        <script dangerouslySetInnerHTML={{ __html: CHUNK_RECOVERY_SCRIPT }} />
       </head>
       <DevStyleXHMR />
       <Provider>
         <SidebarProvider>{children}</SidebarProvider>
       </Provider>
-    </>
+    </SiteErrorBoundary>
   );
 }

--- a/packages/docs/src/pages/_layout.tsx
+++ b/packages/docs/src/pages/_layout.tsx
@@ -21,12 +21,6 @@ const CHUNK_RECOVERY_SCRIPT = `
   const key = 'stylex:chunk-reload:' + window.location.pathname;
   const retryWindow = 60_000;
 
-  window.setTimeout(() => {
-    try {
-      window.sessionStorage.removeItem(key);
-    } catch {}
-  }, 10_000);
-
   window.addEventListener('vite:preloadError', (event) => {
     try {
       const lastReload = Number(window.sessionStorage.getItem(key) || 0);

--- a/packages/docs/src/pages/_root.tsx
+++ b/packages/docs/src/pages/_root.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import type { ReactNode } from 'react';
+import { SiteErrorBoundary } from '@/components/SiteErrorBoundary';
+
+// Backport Waku's version-skew recovery while the site is on v1.0.0-alpha.0.
+// https://github.com/wakujs/waku/pull/2240
+const VERSION_SKEW_RECOVERY_SCRIPT = `
+(() => {
+  const key = 'stylex:chunk-reload:' + window.location.pathname;
+  const retryWindowMs = 60_000;
+  const dynamicImportError =
+    /failed to fetch dynamically imported module|error loading dynamically imported module|importing a module script failed/i;
+
+  const recover = (event) => {
+    try {
+      const lastReload = Number(window.sessionStorage.getItem(key) || 0);
+      if (Date.now() - lastReload < retryWindowMs) {
+        return;
+      }
+      window.sessionStorage.setItem(key, String(Date.now()));
+    } catch {
+      return;
+    }
+
+    event.preventDefault();
+    const reload = () => window.location.reload();
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', reload, { once: true });
+    } else {
+      reload();
+    }
+  };
+
+  window.addEventListener('vite:preloadError', recover);
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason;
+    const message =
+      reason && typeof reason === 'object' && 'message' in reason
+        ? String(reason.message)
+        : String(reason);
+    if (dynamicImportError.test(message)) {
+      recover(event);
+    }
+  });
+})();
+`;
+
+export default function RootElement({ children }: { children: ReactNode }) {
+  return (
+    <SiteErrorBoundary>
+      <html lang="en">
+        <head>
+          <script>{VERSION_SKEW_RECOVERY_SCRIPT}</script>
+        </head>
+        <body>{children}</body>
+      </html>
+    </SiteErrorBoundary>
+  );
+}


### PR DESCRIPTION
## Context

- Backport [Waku’s upstream version-skew recovery](https://github.com/wakujs/waku/pull/2240), which installs recovery before bootstrap and covers entry-chunk failures.
- Retry stale chunk loads once per 60-second window while preserving search metadata if recovery fails.
- This is a temporary mitigation while StyleX uses Waku 1.0.0-alpha.0; remove it after upgrading to 1.0.0-rc.0 or newer.