### PR TITLE
docs: fix last-wins wording after property-specificity default

### DIFF
--- a/packages/docs/content/docs/learn/index.mdx
+++ b/packages/docs/content/docs/learn/index.mdx
@@ -31,7 +31,7 @@ superior to what could be authored and maintained by hand.
     <ul>
       <li>No "style at a distance"</li>
       <li>No specificity issues</li>
-      <li>“The last style applied always wins!”</li>
+      <li>Last applied style wins for the same property</li>
     </ul>
   }
 />

--- a/packages/docs/content/docs/learn/styling-ui/using-styles.mdx
+++ b/packages/docs/content/docs/learn/styling-ui/using-styles.mdx
@@ -16,9 +16,14 @@ use them conditionally, or even compose styles across module boundaries.
 ## Merging styles
 
 The `props` function can take a list of styles and merge them in a deterministic
-way, where the last style applied always wins. The order in which the styles are
-defined does not affect the resulting styles, only the order in which they are
-applied to the HTML element.
+way. When two styles set the same property, the last style applied always wins.
+The order in which the styles are defined does not affect the resulting styles,
+only the order in which they are applied to the HTML element.
+
+Shorthand and longhand properties are different keys (`margin` vs `marginTop`).
+By default (`styleResolution: 'property-specificity'`), the longhand wins even
+if the shorthand is applied later. See
+[`styleResolution`](/docs/api/configuration/babel-plugin/#styleresolution).
 
 Using `props` is only required when styles are set on React DOM host elements
 like `<div>`.

--- a/packages/docs/content/docs/learn/thinking-in-stylex.mdx
+++ b/packages/docs/content/docs/learn/thinking-in-stylex.mdx
@@ -30,8 +30,11 @@ the expressive power available. We believe this is possible through build-tools.
 
 StyleX provides a completely predictable and deterministic styling system that
 works across files. It produces deterministic results not only when merging
-multiple selectors, but also when merging multiple shorthand and longhand
-properties (e.g. `margin` vs `margin-top`). The last style applied always wins.
+multiple selectors, but also when merging shorthand and longhand properties
+(e.g. `margin` vs `margin-top`). By default, the more specific property wins
+(`margin-top` over `margin`) regardless of application order. When two styles
+set the same property, the last style applied wins. See
+[`styleResolution`](/docs/api/configuration/babel-plugin/#styleresolution).
 
 ### Low-cost abstractions
 


### PR DESCRIPTION
## What changed / motivation ?

Since [0.14.0](https://stylexjs.com/blog/v0.14.0/), the default `styleResolution` is `property-specificity`: a longhand such as `margin-top` wins over `margin` regardless of `props()` order. “Last style applied always wins” is `application-order`.

The default-switch commit ([58a569eaac](https://github.com/facebook/stylex/commit/58a569eaacfd380668bc8bb120309fca79f4c01e)) updated the babel-plugin config page, but the learn pages still used the old wording — including the `margin` vs `margin-top` example, which is the case where last-applied does *not* win under the default.

This PR:

- Corrects [Thinking in StyleX](https://stylexjs.com/docs/learn/thinking-in-stylex/)
- Adds the same-property vs shorthand/longhand distinction on [Using styles](https://stylexjs.com/docs/learn/styling-ui/using-styles/)
- Softens the intro feature bullet so it doesn’t overclaim last-wins

Historical blog posts are left as they were when `application-order` was the default.

## Linked PR/Issues

Related to #1064 (default switch).

## Additional Context

Verified against `@stylexjs/babel-plugin` 0.19.0: compiling `stylex.props({marginTop: 0, …}, {margin: 8})` keeps all four longhand classes plus the shorthand; the longhands get extra `:not(#\#)` specificity, so computed margin stays `0`.

## Pre-flight checklist

- [x] I have read the contributing guidelines
- [x] Performed a self-review of my code

Made with [Cursor](https://cursor.com)