### PR TITLE
[docs] keep the playground up when the initial code fails to compile

### DIFF
--- a/packages/docs/src/components/Playground/index.tsx
+++ b/packages/docs/src/components/Playground/index.tsx
@@ -556,7 +556,19 @@ export const vars = stylex.defineVars({
   useEffect(() => {
     let mounted = true;
 
-    const { transformedFiles, generatedCSS } = transformSourceFiles(inputFiles);
+    // The initial files come from the URL, so they are not guaranteed to
+    // compile. Surface the failure the same way editing does, instead of
+    // letting it escape the effect and take down the page. Sandpack still
+    // has to load, otherwise the editor stays read only and there is no way
+    // to correct the code.
+    let transformedFiles: Record<string, string> = {};
+    let generatedCSS = '';
+    try {
+      ({ transformedFiles, generatedCSS } = transformSourceFiles(inputFiles));
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    }
+
     setTransformedFiles(transformedFiles);
     setCssOutput(generatedCSS);
     loadSandpackClient(


### PR DESCRIPTION
## Context

The playground compiles the files it takes from the URL. Editing already handles a compile failure and shows the error inline. The initial load did not, so a shared link whose code does not compile threw during mount and took the whole page down.

## Implementation

Handle the failure on load the same way editing does. Fall back to an empty bundle and show the error.

The preview still has to initialize even when compilation fails, because the editor stays read only until it does. Bailing out early would leave broken code on screen with no way to correct it.

## Testing

Loaded a link whose code does not compile. Before, the page failed to render at all. Now the playground loads with the error shown and the editor usable.
