### PR TITLE
[babel-plugin] quote content values that contain quote characters

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-value-normalization-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-value-normalization-test.js
@@ -325,6 +325,76 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
+    test('"content" property values containing quotes are wrapped in quotes', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            apostrophes: {
+              content: "Bob's and Jim's",
+            },
+            embeddedQuote: {
+              content: 'He said "hello"',
+            },
+            quoteKeywords: {
+              content: 'open-quote "hello" close-quote',
+            }
+          });
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2({
+          ltr: ".x5jgoue{content:\\"Bob's and Jim's\\"}",
+          priority: 3000
+        });
+        _inject2({
+          ltr: ".x1ooro1k{content:\\"He said \\\\\\"hello\\\\\\"\\"}",
+          priority: 3000
+        });
+        _inject2({
+          ltr: ".x1iyhvvg{content:open-quote \\"hello\\" close-quote}",
+          priority: 3000
+        });"
+      `);
+    });
+
+    test('"content" property values keep their CSS escape sequences', () => {
+      expect(
+        transform(`
+          import stylex from 'stylex';
+          const styles = stylex.create({
+            emDash: {
+              content: '\\\\2014',
+            },
+            curlyQuotes: {
+              content: '\\\\201C hello \\\\201D',
+            },
+            trailingBackslash: {
+              content: '50% off \\\\',
+            },
+          });
+        `),
+      ).toMatchInlineSnapshot(`
+        "import _inject from "@stylexjs/stylex/lib/stylex-inject";
+        var _inject2 = _inject;
+        import stylex from 'stylex';
+        _inject2({
+          ltr: ".x1v4x2nj{content:\\"\\\\2014\\"}",
+          priority: 3000
+        });
+        _inject2({
+          ltr: ".x1uxbif5{content:\\"\\\\201C hello \\\\201D\\"}",
+          priority: 3000
+        });
+        _inject2({
+          ltr: ".x1y6ogk6{content:\\"50% off \\\\\\\\\\"}",
+          priority: 3000
+        });"
+      `);
+    });
+
     test('[legacy] no space before "!important"', () => {
       expect(
         transform(`

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/__tests__/transform-value-test.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/__tests__/transform-value-test.js
@@ -75,6 +75,57 @@ describe('transformValue content property tests', () => {
     });
   });
 
+  test('adds quotes to plain strings containing quote characters', () => {
+    const strings = [
+      ["Bob's and Jim's", '"Bob\'s and Jim\'s"'],
+      ["It's a test, isn't it", '"It\'s a test, isn\'t it"'],
+      ['He said "hello"', '"He said \\"hello\\""'],
+      ['say "hi" now', '"say \\"hi\\" now"'],
+      ['"hello" is what he said', '"\\"hello\\" is what he said"'],
+    ];
+
+    strings.forEach(([input, expected]) => {
+      expect(transformValue('content', input, {})).toBe(expected);
+    });
+  });
+
+  test('preserves CSS escape sequences when adding quotes', () => {
+    const strings = [
+      // Inside a CSS string a backslash starts an escape sequence. `\2014` is
+      // the escape for an em dash and `\201C` for a left double quotation
+      // mark, so escaping the backslash would print the digits instead.
+      ['\\2014', '"\\2014"'],
+      ['\\201C hello \\201D', '"\\201C hello \\201D"'],
+      ['back\\slash', '"back\\slash"'],
+      // `\\` is the escape for a literal backslash and stays one escape.
+      ['C:\\\\Users', '"C:\\\\Users"'],
+      // A double quote the author already escaped is escaped once, not twice.
+      ['He said \\"hello\\"', '"He said \\"hello\\""'],
+      // A trailing backslash would escape the closing quote, so it is doubled
+      // into the escape for a literal backslash.
+      ['50% off \\', '"50% off \\\\"'],
+      // A CSS string cannot hold a line break, so it is written as `\A`.
+      ['line one\nline two', '"line one\\A line two"'],
+    ];
+
+    strings.forEach(([input, expected]) => {
+      expect(transformValue('content', input, {})).toBe(expected);
+    });
+  });
+
+  test('preserves quote keywords combined with strings', () => {
+    const values = [
+      '"a" "b"',
+      'open-quote "hello"',
+      '"prefix" no-close-quote',
+      'open-quote "text" close-quote',
+    ];
+
+    values.forEach((input) => {
+      expect(transformValue('content', input, {})).toBe(input);
+    });
+  });
+
   test('preserve units in zero values CSS variables', () => {
     const variables = [
       ['--test', '0px', '0px'],

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/transform-value.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/transform-value.js
@@ -10,6 +10,7 @@
 import type { StyleXOptions } from '../common-types';
 
 import normalizeValue from './normalize-value';
+import parser from 'postcss-value-parser';
 
 /**
  * Convert a CSS value in JS to the final CSS string value
@@ -60,14 +61,46 @@ export default function transformValue(
       val.includes(func),
     );
     const isKeyword = cssContentKeywords.has(val);
-    const hasMatchingQuotes =
-      (val.match(/"/g)?.length ?? 0) >= 2 ||
-      (val.match(/'/g)?.length ?? 0) >= 2;
 
-    if (isCssFunction || isKeyword || hasMatchingQuotes) {
+    // A value the author already wrote as CSS is a list of content components:
+    // quoted strings, functions and quote keywords. Counting quote characters
+    // is not enough to detect that, because ordinary text can contain a pair of
+    // them, as in "Bob's and Jim's" or 'He said "hello"'. Such a value is not a
+    // CSS string, so the browser drops the whole declaration.
+    const contentNodes = parser(val).nodes.filter(
+      (node) => node.type !== 'space' && node.type !== 'div',
+    );
+    const isQuotedContentList =
+      contentNodes.some((node) => node.type === 'string' && !node.unclosed) &&
+      contentNodes.every((node) => {
+        if (node.type === 'string' || node.type === 'function') {
+          return !node.unclosed;
+        }
+        return node.type === 'word' && cssContentKeywords.has(node.value);
+      });
+
+    if (isCssFunction || isKeyword || isQuotedContentList) {
       return val;
     }
-    return `"${val}"`;
+
+    // Inside a CSS string a backslash starts an escape sequence, so an escape
+    // the author wrote, such as `\2014` for an em dash, is left as it is. Only
+    // what would end the string early is escaped: a double quote that is not
+    // already escaped, a trailing backslash that would otherwise escape the
+    // closing quote, and a line break, which a CSS string writes as `\A`.
+    const escaped = val.replace(
+      /\\(?:\r\n|[\s\S])|\r\n|[\n\r\f]|["\\]/g,
+      (match) => {
+        if (match.length > 1 && match[0] === '\\') {
+          return match;
+        }
+        if (match === '"' || match === '\\') {
+          return `\\${match}`;
+        }
+        return '\\A ';
+      },
+    );
+    return `"${escaped}"`;
   }
 
   return normalizeValue(value, key, options);


### PR DESCRIPTION
## What changed / motivation ?

There is no issue open for this, so here is the reproduction. On `main`:

```js
const styles = stylex.create({
  apostrophes: {content: "Bob's and Jim's"},
  embedded: {content: 'He said "hello"'},
});
```

compiles, with no warning, to `content:Bob's and Jim's` and `content:He said "hello"`. Neither is a CSS string. I served both in Chrome and read `getComputedStyle(el, '::before').content`: both come back as `none`, so the browser threw the declaration away and nothing renders.

The cause is in `transformValue`, which decides whether a `content` value is already CSS by counting quote characters:

```js
const hasMatchingQuotes =
  (val.match(/"/g)?.length ?? 0) >= 2 ||
  (val.match(/'/g)?.length ?? 0) >= 2;
```

The intent is to leave a value alone when the author already quoted it, but what it asks is whether a quote character appears twice anywhere, and ordinary prose satisfies that.

### The fix

The value is parsed with the `postcss-value-parser` that `normalize-value.js` next door already imports. It passes through only when every part is a closed string, a closed function or a quote keyword, and at least one part is a string. Anything else is wrapped in one quoted string, escaping only what would end that string early: an unescaped double quote, a trailing backslash, and a line break as `\A`.

A backslash that opens an escape sequence is left alone. Inside a CSS string a backslash means an escape, so `content: '\2014'` is the author asking for an em dash and still compiles to `content:"\2014"`. Escaping every backslash would emit `content:"\\2014"` and render the literal characters instead.

## Behavior change

I ran each case through Chrome, one declaration per stylesheet, reading the computed `content` before and after. Fourteen inputs emit byte identical CSS, including `\2014`, `\201C hello \201D`, `C:\\Users`, `back\slash`, `open-quote "hello" close-quote`, `"icon" / "Alt text"`, `attr()`, `counter()` and any value already written as a string.

Six change, and all six were broken before:

* prose with quotes in it (`Bob's and Jim's`, `He said "hello"`, `say "hi`, and quotes the author escaped) computed `none` and now renders the sentence.
* a value ending in a backslash emitted an unterminated string on `main`, so Chrome swallowed the rule's closing brace and painted `50% off "}`. It now renders `50% off \`.
* a value holding a line break computed `none` and is now written with `\A`.

Two inputs that are invalid CSS either way also change what the page shows, and I would rather state them than bury them: `"a" contents` uses a content list keyword that is in the spec but not in this file's keyword set, and `"a" 5px` is not a valid content value. Both computed `none` and painted nothing; each now paints its text literally. Neither ever produced what its author wanted, but if you would rather `contents` keep passing through I am happy to add it to the keyword set.

Nothing that renders correctly on `main` renders differently. Accepting a value requires at least one closed string, so the check can only accept what it accepted before, and for a value that was already quoted the new escaping is the identity unless it holds an unescaped quote, a trailing backslash or a line break.

## Linked PR/Issues

No open issue. The quote counting arrived in #782, whose description says it "Only adds quotes for plain text strings"; `Bob's and Jim's` is plain text, so this closes that gap rather than changing the intent.

## Additional Context

Tests cover apostrophes, an embedded quoted word, the keyword and string combinations that must keep passing through, and a case per escape rule, plus two snapshot cases beside the existing `content` test so the emitted CSS is visible.

Reverting only `transform-value.js` and keeping the tests fails four of them, reporting `Expected: "\"Bob's and Jim's\"" / Received: "Bob's and Jim's"` among them; restoring it passes all 26. `test:packages` is 1993 passed and 77 skipped across 87 suites with 1173 snapshots, `flow` reports no errors, `prettier:report` is clean, and `eslint` is clean on the three changed files.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
