### PR TITLE
[compiler-conformance] add implementation-neutral golden fixtures

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/golden-fixtures-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/golden-fixtures-test.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import {
+  exactPart,
+  getFixtureNames,
+  isJsEquivalent,
+  jsPart,
+  loadFixture,
+  normalizeResult,
+  readExpected,
+  writeExpected,
+} from 'compiler-conformance';
+
+import { babelAdapter } from '../test-utils/babel-conformance-adapter';
+
+// Re-records every `expected.json` from the current Babel output. Only use it
+// after reviewing the resulting diff.
+const UPDATE_GOLDEN = process.env.STYLEX_UPDATE_GOLDEN === '1';
+
+describe('@stylexjs/babel-plugin golden fixtures', () => {
+  test.each(getFixtureNames())('%s', (fixtureName) => {
+    const fixture = loadFixture(fixtureName);
+    const rawResult = babelAdapter.transform(fixture);
+
+    if (UPDATE_GOLDEN) {
+      writeExpected(fixtureName, rawResult, fixture);
+    }
+
+    const actual = normalizeResult(fixture, rawResult);
+    const expected = readExpected(fixtureName, fixture);
+
+    // Transform status, StyleX metadata, generated CSS and diagnostics have to
+    // match exactly once normalized.
+    expect(exactPart(actual)).toEqual(exactPart(expected));
+
+    // Generated JavaScript is compared as a normalized AST so that an
+    // implementation is free to print it differently. When the programs really
+    // do differ, assert on the sources to get a readable diff.
+    if (!isJsEquivalent(jsPart(expected), jsPart(actual), fixture.syntax)) {
+      expect(jsPart(actual)).toBe(jsPart(expected));
+    }
+  });
+});

--- a/packages/@stylexjs/babel-plugin/__tests__/golden-fixtures-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/golden-fixtures-test.js
@@ -30,10 +30,10 @@ describe('@stylexjs/babel-plugin golden fixtures', () => {
     const rawResult = babelAdapter.transform(fixture);
 
     if (UPDATE_GOLDEN) {
-      writeExpected(fixtureName, rawResult, fixture);
+      writeExpected(fixtureName, rawResult, fixture, babelAdapter.name);
     }
 
-    const actual = normalizeResult(fixture, rawResult);
+    const actual = normalizeResult(fixture, rawResult, babelAdapter.name);
     const expected = readExpected(fixtureName, fixture);
 
     // Transform status, StyleX metadata, generated CSS and diagnostics have to

--- a/packages/@stylexjs/babel-plugin/package.json
+++ b/packages/@stylexjs/babel-plugin/package.json
@@ -35,6 +35,7 @@
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-replace": "^6.0.1",
     "babel-plugin-syntax-hermes-parser": "^0.36.1",
+    "compiler-conformance": "0.19.0",
     "path-browserify": "^1.0.1",
     "rollup": "^4.59.0",
     "scripts": "0.19.0"

--- a/packages/@stylexjs/babel-plugin/test-utils/babel-conformance-adapter.js
+++ b/packages/@stylexjs/babel-plugin/test-utils/babel-conformance-adapter.js
@@ -86,6 +86,6 @@ function transform(fixture) {
 }
 
 export const babelAdapter = {
-  name: 'babel',
+  name: '@stylexjs/babel-plugin',
   transform,
 };

--- a/packages/@stylexjs/babel-plugin/test-utils/babel-conformance-adapter.js
+++ b/packages/@stylexjs/babel-plugin/test-utils/babel-conformance-adapter.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { transformFileSync } from '@babel/core';
+
+import stylexPlugin from '../src/index';
+
+/**
+ * Adapts the StyleX Babel plugin to the `compiler-conformance` adapter
+ * contract. Everything Babel-specific lives here: parser configuration, the
+ * shape of the transform result, and capturing diagnostics off the console.
+ *
+ * See `packages/compiler-conformance/README.md` for the contract itself.
+ */
+
+function formatDiagnostic(args) {
+  return args
+    .map((value) =>
+      typeof value === 'string' ? value : JSON.stringify(value, null, 2),
+    )
+    .join(' ');
+}
+
+// The fixture `syntax` list uses the same names as `@babel/parser` plugins.
+function toParserOpts(syntax) {
+  return { plugins: [...syntax] };
+}
+
+function transform(fixture) {
+  const warnings = [];
+  const errors = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+
+  console.warn = (...args) => {
+    warnings.push(formatDiagnostic(args));
+  };
+  console.error = (...args) => {
+    errors.push(formatDiagnostic(args));
+  };
+
+  try {
+    const result = transformFileSync(fixture.entryPath, {
+      babelrc: false,
+      configFile: false,
+      filename: fixture.entryPath,
+      parserOpts: toParserOpts(fixture.syntax),
+      plugins: [[stylexPlugin, fixture.pluginOptions]],
+    });
+
+    if (result == null) {
+      throw new Error(
+        `Babel produced no result for fixture "${fixture.name}".`,
+      );
+    }
+
+    const metadata = result.metadata?.stylex ?? [];
+
+    return {
+      css: stylexPlugin.processStylexRules(metadata, fixture.processOptions),
+      errors,
+      js: result.code,
+      metadata,
+      status: 'ok',
+      warnings,
+    };
+  } catch (error) {
+    return {
+      error: {
+        message: error instanceof Error ? error.message : String(error),
+      },
+      errors,
+      status: 'error',
+      warnings,
+    };
+  } finally {
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+}
+
+export const babelAdapter = {
+  name: 'babel',
+  transform,
+};

--- a/packages/compiler-conformance/README.md
+++ b/packages/compiler-conformance/README.md
@@ -76,13 +76,15 @@ transform.
 
 **`js` is compared semantically**, as a normalized syntax tree. Ignored are
 whitespace, indentation, semicolons, comments, quote style and numeric literal
-spelling, how a non-computed property key is written (`{a: 1}`, `{'a': 1}` and
-`{1: x}` name the same properties as `{"a": 1}`, `{a: 1}` and `{"1": x}`), and
-property shorthand (`{a}` equals `{a: a}`). So an implementation only has to
-agree on the program it emits, not on how it prints it. The string stored in
-`expected.json` is one valid printing of that program; reformatting it does not
-change the outcome. When the programs genuinely differ, the Babel test falls
-back to asserting on the sources so the failure shows a readable diff.
+spelling, how a non-computed property key is written (`{a: 1}`, `{'a': 1}`,
+`{1: x}` and `{1n: x}` name the same properties as `{"a": 1}`, `{a: 1}` and
+`{"1": x}`), and property shorthand (`{a}` equals `{a: a}`). So an
+implementation only has to agree on the program it emits, not on how it prints
+it. The `__proto__` shorthand remains distinct because `{__proto__}` creates a
+data property while `{__proto__: value}` sets the object's prototype. The string
+stored in `expected.json` is one valid printing of that program; reformatting it
+does not change the outcome. When the programs genuinely differ, the Babel test
+falls back to asserting on the sources so the failure shows a readable diff.
 
 **`metadata`, `css`, `warnings`, `errors` and `status` are compared exactly**,
 after normalization:
@@ -91,8 +93,9 @@ after normalization:
   each CSS line.
 - Absolute paths become `<FIXTURE_ROOT>` and `<REPO_ROOT>`.
 - In diagnostics, terminal color escapes are removed, a leading
-  `<FIXTURE_ROOT>/<entry>: ` location prefix is dropped, a trailing source
-  excerpt (code frame) is dropped, and a leading `[implementation-name]` tag is
+  `<FIXTURE_ROOT>/<entry>: ` location prefix is dropped, and a trailing numbered
+  source excerpt (code frame) is dropped. When the adapter passes the exact text
+  of its leading `[implementation-name]` tag to `normalizeResult`, that tag is
   collapsed to `[stylex]`. What is compared is the message itself, not how an
   implementation decorates it. Color matters here in practice: Babel
   syntax-highlights a code frame whenever `CI` is set, so an uncolored message
@@ -123,6 +126,13 @@ or, when the transform fails:
 { status: 'error', error: { message: '…' }, warnings: [...], errors: [...] }
 ```
 
+Every field shown for the selected status is required. `normalizeResult` rejects
+unknown statuses, missing output, and non-string diagnostics instead of filling
+in defaults that could hide an incomplete adapter. If an implementation prefixes
+diagnostics with `[my-compiler]`, pass `my-compiler` as the third argument to
+`normalizeResult`; only that exact tag is collapsed to `[stylex]`, so semantic
+prefixes such as `[E100]` remain part of the contract.
+
 From JavaScript, drive it with the helpers this package exports:
 
 ```js
@@ -138,7 +148,11 @@ const {
 
 for (const name of getFixtureNames()) {
   const fixture = loadFixture(name);
-  const actual = normalizeResult(fixture, myAdapter.transform(fixture));
+  const actual = normalizeResult(
+    fixture,
+    myAdapter.transform(fixture),
+    myAdapter.name,
+  );
   const expected = readExpected(name, fixture);
 
   assert.deepStrictEqual(exactPart(actual), exactPart(expected));

--- a/packages/compiler-conformance/README.md
+++ b/packages/compiler-conformance/README.md
@@ -1,0 +1,174 @@
+# compiler-conformance
+
+Golden fixtures that describe what a StyleX compiler must do, independently of
+how it is implemented.
+
+Each fixture pins the four observable outputs of compiling one file: the
+generated JavaScript, the StyleX metadata, the generated CSS, and the
+diagnostics. Fixtures are plain data — an implementation written in any language
+can read them and check itself against the same contract.
+
+The StyleX Babel plugin is the first consumer, via the adapter in
+`packages/@stylexjs/babel-plugin/test-utils/babel-conformance-adapter.js` and
+the test in `packages/@stylexjs/babel-plugin/__tests__/golden-fixtures-test.js`.
+
+## Layout
+
+```
+fixtures/<fixture-name>/
+  manifest.json    how to compile the fixture
+  input.js         the entry file (name set by `entry`)
+  expected.json    the recorded result
+  ...              any extra files the entry imports
+```
+
+## `manifest.json`
+
+| Field            | Type       | Default                                               | Meaning                                                      |
+| ---------------- | ---------- | ----------------------------------------------------- | ------------------------------------------------------------ |
+| `description`    | `string`   | `""`                                                  | What behavior this fixture pins down.                        |
+| `entry`          | `string`   | `"input.js"`                                          | File in the fixture directory to compile.                    |
+| `syntax`         | `string[]` | `["flow"]`                                            | Source syntax the entry uses, e.g. `["flow", "jsx"]`.        |
+| `pluginOptions`  | `object`   | `{}`                                                  | StyleX compiler options.                                     |
+| `processOptions` | `object`   | `{"useLayers": false, "enableLTRRTLComments": false}` | Options for the step that assembles rules into a stylesheet. |
+
+`pluginOptions` and `processOptions` are StyleX's own documented options, so
+they carry over unchanged between implementations. `syntax` is deliberately
+abstract: an adapter maps it onto whatever its parser needs.
+
+Avoid options that take an absolute path. Fixture output must not depend on
+where the repository is checked out.
+
+## `expected.json`
+
+For a fixture that compiles successfully:
+
+```json
+{
+  "status": "ok",
+  "js": "…generated JavaScript…",
+  "metadata": [
+    ["x1e2nbdu", { "ltr": ".x1e2nbdu{color:red}", "rtl": null }, 3000]
+  ],
+  "css": ".x1e2nbdu{color:red}",
+  "warnings": [],
+  "errors": []
+}
+```
+
+For a fixture whose transform is expected to fail:
+
+```json
+{
+  "status": "error",
+  "error": { "message": "create() can only accept an object." },
+  "warnings": [],
+  "errors": []
+}
+```
+
+`warnings` and `errors` are non-fatal diagnostics, split by the channel they
+were reported on. A fixture can succeed and still report diagnostics —
+`options-warning` does exactly that. `error` is the fatal one that ended the
+transform.
+
+## How results are compared
+
+**`js` is compared semantically**, as a normalized syntax tree. Ignored are
+whitespace, indentation, semicolons, comments, quote style and numeric literal
+spelling, how a non-computed property key is written (`{a: 1}`, `{'a': 1}` and
+`{1: x}` name the same properties as `{"a": 1}`, `{a: 1}` and `{"1": x}`), and
+property shorthand (`{a}` equals `{a: a}`). So an implementation only has to
+agree on the program it emits, not on how it prints it. The string stored in
+`expected.json` is one valid printing of that program; reformatting it does not
+change the outcome. When the programs genuinely differ, the Babel test falls
+back to asserting on the sources so the failure shows a readable diff.
+
+**`metadata`, `css`, `warnings`, `errors` and `status` are compared exactly**,
+after normalization:
+
+- Line endings are normalized to `\n`, and trailing whitespace is stripped from
+  each CSS line.
+- Absolute paths become `<FIXTURE_ROOT>` and `<REPO_ROOT>`.
+- In diagnostics, a leading `<FIXTURE_ROOT>/<entry>: ` location prefix is
+  dropped, a trailing source excerpt (code frame) is dropped, and a leading
+  `[implementation-name]` tag is collapsed to `[stylex]`. What is compared is
+  the message itself, not how an implementation decorates it.
+- Object keys are sorted, because key order carries no meaning in JSON. **Array
+  order is preserved**, because the order of emitted rules is part of the
+  contract.
+
+## Consuming this suite from another implementation
+
+Implement an adapter — compile one fixture, return its result in the shape below
+— and the shared runner does the rest:
+
+```js
+{
+  status: 'ok',
+  js: '…',           // generated JavaScript
+  metadata: [...],   // StyleX metadata
+  css: '…',          // stylesheet assembled from the metadata
+  warnings: [...],   // non-fatal diagnostics
+  errors: [...],
+}
+```
+
+or, when the transform fails:
+
+```js
+{ status: 'error', error: { message: '…' }, warnings: [...], errors: [...] }
+```
+
+From JavaScript, drive it with the helpers this package exports:
+
+```js
+const {
+  exactPart,
+  getFixtureNames,
+  isJsEquivalent,
+  jsPart,
+  loadFixture,
+  normalizeResult,
+  readExpected,
+} = require('compiler-conformance');
+
+for (const name of getFixtureNames()) {
+  const fixture = loadFixture(name);
+  const actual = normalizeResult(fixture, myAdapter.transform(fixture));
+  const expected = readExpected(name, fixture);
+
+  assert.deepStrictEqual(exactPart(actual), exactPart(expected));
+  assert.ok(isJsEquivalent(jsPart(expected), jsPart(actual), fixture.syntax));
+}
+```
+
+From another language, read `manifest.json` and `expected.json` directly and
+apply the rules in [How results are compared](#how-results-are-compared). The
+fixtures are the contract; these helpers are only a convenience.
+
+Two things to be aware of when porting:
+
+- Some fixtures depend on their own location. `define-vars-theme` uses
+  `commonJS` module resolution, which names a file
+  `<package name>:<path within the package>` — here
+  `compiler-conformance:fixtures/define-vars-theme/input.stylex.js`. That name
+  is hashed into the generated CSS variables, so it is stable across checkouts
+  but changes if the fixture is moved or the package is renamed.
+- `props-and-merge` is the only fixture that needs JSX.
+
+## Updating the recorded output
+
+Re-record every `expected.json` from the current Babel output and review the
+diff:
+
+```
+STYLEX_UPDATE_GOLDEN=1 npx jest golden-fixtures
+```
+
+from `packages/@stylexjs/babel-plugin`. A change here is a change to the
+behavioral contract, so the diff deserves the same scrutiny as the code that
+caused it.
+
+The comparison rules above are themselves tested, independently of any compiler
+— run `npm test` in this package.

--- a/packages/compiler-conformance/README.md
+++ b/packages/compiler-conformance/README.md
@@ -90,10 +90,13 @@ after normalization:
 - Line endings are normalized to `\n`, and trailing whitespace is stripped from
   each CSS line.
 - Absolute paths become `<FIXTURE_ROOT>` and `<REPO_ROOT>`.
-- In diagnostics, a leading `<FIXTURE_ROOT>/<entry>: ` location prefix is
-  dropped, a trailing source excerpt (code frame) is dropped, and a leading
-  `[implementation-name]` tag is collapsed to `[stylex]`. What is compared is
-  the message itself, not how an implementation decorates it.
+- In diagnostics, terminal color escapes are removed, a leading
+  `<FIXTURE_ROOT>/<entry>: ` location prefix is dropped, a trailing source
+  excerpt (code frame) is dropped, and a leading `[implementation-name]` tag is
+  collapsed to `[stylex]`. What is compared is the message itself, not how an
+  implementation decorates it. Color matters here in practice: Babel
+  syntax-highlights a code frame whenever `CI` is set, so an uncolored message
+  locally and a colored one on CI have to normalize to the same text.
 - Object keys are sorted, because key order carries no meaning in JSON. **Array
   order is preserved**, because the order of emitted rules is part of the
   contract.

--- a/packages/compiler-conformance/__tests__/conformance-harness-test.js
+++ b/packages/compiler-conformance/__tests__/conformance-harness-test.js
@@ -79,6 +79,32 @@ describe('normalizeDiagnostic', () => {
       normalizeDiagnostic('bad value\n|start| is reserved.', CONTEXT),
     ).toBe('bad value\n|start| is reserved.');
   });
+
+  // Babel's code frame colorizes whenever the environment looks color-capable,
+  // which on GitHub Actions it does — so this is the shape the very same
+  // diagnostic takes on CI, and the escapes must not hide the excerpt.
+  test('drops a colorized source excerpt', () => {
+    const esc = '\u001B';
+    const message = [
+      `${FIXTURE.dir}/input.js: create() can only accept an object.`,
+      `${esc}[0m ${esc}[90m 1 |${esc}[39m ${esc}[36mimport${esc}[39m stylex${esc}[33m;${esc}[39m`,
+      `${esc}[31m${esc}[1m>${esc}[22m${esc}[39m${esc}[90m 2 |${esc}[39m stylex${esc}[33m.${esc}[39mcreate(${esc}[35m1${esc}[39m)${esc}[33m;${esc}[39m`,
+      `${esc}[90m   |${esc}[39m       ${esc}[31m${esc}[1m^${esc}[22m${esc}[39m${esc}[0m`,
+    ].join('\n');
+
+    expect(normalizeDiagnostic(message, CONTEXT)).toBe(
+      'create() can only accept an object.',
+    );
+  });
+
+  test('removes color from a message that has no source excerpt', () => {
+    expect(
+      normalizeDiagnostic(
+        '\u001B[1m\u001B[31m[@stylexjs/babel-plugin]\u001B[39m Expected a boolean.\u001B[22m',
+        CONTEXT,
+      ),
+    ).toBe('[stylex] Expected a boolean.');
+  });
 });
 
 describe('normalizeCss', () => {

--- a/packages/compiler-conformance/__tests__/conformance-harness-test.js
+++ b/packages/compiler-conformance/__tests__/conformance-harness-test.js
@@ -23,6 +23,7 @@ const {
   normalizeResult,
 } = require('../src/index');
 
+const IMPLEMENTATION_TAG = '@stylexjs/babel-plugin';
 const FIXTURE = {
   dir: '/repo/packages/compiler-conformance/fixtures/demo',
   entry: 'input.js',
@@ -31,13 +32,47 @@ const FIXTURE = {
 const CONTEXT = {
   entry: FIXTURE.entry,
   fixtureDir: FIXTURE.dir,
+  implementationTag: IMPLEMENTATION_TAG,
   repoRoot: FIXTURE.repoRoot,
 };
+const WINDOWS_CONTEXT = {
+  entry: 'input.js',
+  fixtureDir: 'C:\\repo\\packages\\compiler-conformance\\fixtures\\demo',
+  implementationTag: IMPLEMENTATION_TAG,
+  repoRoot: 'C:\\repo',
+};
+
+function validSuccess(overrides = {}) {
+  return {
+    css: '',
+    errors: [],
+    js: '',
+    metadata: [],
+    status: 'ok',
+    warnings: [],
+    ...overrides,
+  };
+}
 
 describe('normalizePaths', () => {
   test('replaces the fixture directory before the repository root', () => {
     expect(
       normalizePaths(`${FIXTURE.dir}/input.js imports /repo/other.js`, CONTEXT),
+    ).toBe('<FIXTURE_ROOT>/input.js imports <REPO_ROOT>/other.js');
+  });
+
+  test('only replaces roots at a path boundary', () => {
+    expect(normalizePaths('/repo-copy/result.js', CONTEXT)).toBe(
+      '/repo-copy/result.js',
+    );
+  });
+
+  test('normalizes Windows roots and separators', () => {
+    expect(
+      normalizePaths(
+        `${WINDOWS_CONTEXT.fixtureDir}\\input.js imports C:/repo/other.js`,
+        WINDOWS_CONTEXT,
+      ),
     ).toBe('<FIXTURE_ROOT>/input.js imports <REPO_ROOT>/other.js');
   });
 
@@ -60,12 +95,27 @@ describe('normalizeDiagnostic', () => {
     );
   });
 
-  test('collapses the implementation tag', () => {
+  test('drops a Windows location prefix with line and column coordinates', () => {
+    expect(
+      normalizeDiagnostic(
+        `${WINDOWS_CONTEXT.fixtureDir}\\input.js:12:3: bad token`,
+        WINDOWS_CONTEXT,
+      ),
+    ).toBe('bad token');
+  });
+
+  test('collapses the caller-provided implementation tag', () => {
     expect(
       normalizeDiagnostic('[@stylexjs/babel-plugin] Expected a boolean.', {
         ...CONTEXT,
       }),
     ).toBe('[stylex] Expected a boolean.');
+  });
+
+  test('preserves a semantic bracketed prefix', () => {
+    expect(normalizeDiagnostic('[E100] Expected a boolean.', CONTEXT)).toBe(
+      '[E100] Expected a boolean.',
+    );
   });
 
   test('leaves a message that merely opens with a bracket alone', () => {
@@ -78,6 +128,12 @@ describe('normalizeDiagnostic', () => {
     expect(
       normalizeDiagnostic('bad value\n|start| is reserved.', CONTEXT),
     ).toBe('bad value\n|start| is reserved.');
+  });
+
+  test('preserves pipe-prefixed alternatives in a multiline message', () => {
+    expect(
+      normalizeDiagnostic('Expected one of:\n  | string\n  | number', CONTEXT),
+    ).toBe('Expected one of:\n  | string\n  | number');
   });
 
   // Babel's code frame colorizes whenever the environment looks color-capable,
@@ -141,10 +197,24 @@ describe('isJsEquivalent', () => {
   test('ignores how a property key is spelled', () => {
     expect(isJsEquivalent('({a: 1});', '({"a": 1});', ['flow'])).toBe(true);
     expect(isJsEquivalent('({1: x});', '({"1": x});', ['flow'])).toBe(true);
+    expect(isJsEquivalent('({1n: x});', '({"1": x});', ['flow'])).toBe(true);
   });
 
   test('ignores property shorthand', () => {
     expect(isJsEquivalent('({a});', '({a: a});', ['flow'])).toBe(true);
+    expect(
+      isJsEquivalent('const {a} = x;', 'const {a: a} = x;', ['flow']),
+    ).toBe(true);
+  });
+
+  test('preserves the semantic distinction for __proto__ shorthand', () => {
+    expect(
+      isJsEquivalent(
+        'const __proto__ = null; ({__proto__});',
+        'const __proto__ = null; ({__proto__: __proto__});',
+        ['flow'],
+      ),
+    ).toBe(false);
   });
 
   test('reports a genuine difference', () => {
@@ -179,17 +249,26 @@ describe('isJsEquivalent', () => {
       isJsEquivalent('export const a = 1;', 'const = ;', ['flow']),
     ).toThrow(/Failed to parse the actual output as JavaScript/);
   });
+
+  test('fails loudly when identical output is unparseable', () => {
+    expect(() => isJsEquivalent('const = ;', 'const = ;', ['flow'])).toThrow(
+      /Failed to parse the expected output as JavaScript/,
+    );
+  });
 });
 
 describe('normalizeResult', () => {
   test('normalizes a successful transform', () => {
-    const result = normalizeResult(FIXTURE, {
-      css: '.a{color:red}  ',
-      js: '  export const a = 1;  ',
-      metadata: [['a', { rtl: null, ltr: '.a{color:red}' }, 3000]],
-      status: 'ok',
-      warnings: ['[@stylexjs/babel-plugin] heads up'],
-    });
+    const result = normalizeResult(
+      FIXTURE,
+      validSuccess({
+        css: '.a{color:red}  ',
+        js: '  export const a = 1;  ',
+        metadata: [['a', { rtl: null, ltr: '.a{color:red}' }, 3000]],
+        warnings: ['[@stylexjs/babel-plugin] heads up'],
+      }),
+      IMPLEMENTATION_TAG,
+    );
 
     expect(result).toEqual({
       css: '.a{color:red}',
@@ -208,7 +287,9 @@ describe('normalizeResult', () => {
       error: {
         message: `${FIXTURE.dir}/input.js: create() can only accept an object.\n> 1 | x\n    | ^`,
       },
+      errors: [],
       status: 'error',
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -218,6 +299,47 @@ describe('normalizeResult', () => {
       warnings: [],
     });
     expect(jsPart(result)).toBeNull();
+  });
+
+  test.each([
+    ['a missing status', { errors: [], warnings: [] }, /result.status/],
+    [
+      'an unknown status',
+      { errors: [], status: 'failed', warnings: [] },
+      /result.status/,
+    ],
+    [
+      'missing diagnostics',
+      { css: '', js: '', metadata: [], status: 'ok' },
+      /result.warnings/,
+    ],
+    [
+      'a non-string diagnostic',
+      validSuccess({ warnings: [{}] }),
+      /result.warnings/,
+    ],
+    [
+      'missing JavaScript',
+      { css: '', errors: [], metadata: [], status: 'ok', warnings: [] },
+      /result.js/,
+    ],
+    [
+      'missing metadata',
+      { css: '', errors: [], js: '', status: 'ok', warnings: [] },
+      /result.metadata/,
+    ],
+    [
+      'missing CSS',
+      { errors: [], js: '', metadata: [], status: 'ok', warnings: [] },
+      /result.css/,
+    ],
+    [
+      'a missing fatal message',
+      { error: {}, errors: [], status: 'error', warnings: [] },
+      /result.error.message/,
+    ],
+  ])('rejects %s', (_description, result, expectedError) => {
+    expect(() => normalizeResult(FIXTURE, result)).toThrow(expectedError);
   });
 });
 
@@ -231,5 +353,19 @@ describe('fixtures', () => {
       expect(fs.existsSync(fixture.entryPath)).toBe(true);
       expect(fs.existsSync(getExpectedPath(name))).toBe(true);
     }
+  });
+
+  test('default arrays and objects are isolated between loads', () => {
+    const first = loadFixture('create-basic');
+    const second = loadFixture('create-basic');
+
+    expect(first.processOptions).not.toBe(second.processOptions);
+    expect(first.syntax).not.toBe(second.syntax);
+
+    first.processOptions.useLayers = true;
+    first.syntax.push('jsx');
+
+    expect(second.processOptions.useLayers).toBe(false);
+    expect(second.syntax).toEqual(['flow']);
   });
 });

--- a/packages/compiler-conformance/__tests__/conformance-harness-test.js
+++ b/packages/compiler-conformance/__tests__/conformance-harness-test.js
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+
+const {
+  exactPart,
+  getExpectedPath,
+  getFixtureNames,
+  isJsEquivalent,
+  jsPart,
+  loadFixture,
+  normalizeCss,
+  normalizeData,
+  normalizeDiagnostic,
+  normalizePaths,
+  normalizeResult,
+} = require('../src/index');
+
+const FIXTURE = {
+  dir: '/repo/packages/compiler-conformance/fixtures/demo',
+  entry: 'input.js',
+  repoRoot: '/repo',
+};
+const CONTEXT = {
+  entry: FIXTURE.entry,
+  fixtureDir: FIXTURE.dir,
+  repoRoot: FIXTURE.repoRoot,
+};
+
+describe('normalizePaths', () => {
+  test('replaces the fixture directory before the repository root', () => {
+    expect(
+      normalizePaths(`${FIXTURE.dir}/input.js imports /repo/other.js`, CONTEXT),
+    ).toBe('<FIXTURE_ROOT>/input.js imports <REPO_ROOT>/other.js');
+  });
+
+  test('normalizes line endings', () => {
+    expect(normalizePaths('a\r\nb', CONTEXT)).toBe('a\nb');
+  });
+});
+
+describe('normalizeDiagnostic', () => {
+  test('drops the location prefix and the source excerpt', () => {
+    const message = [
+      `${FIXTURE.dir}/input.js: create() can only accept an object.`,
+      '  1 | import * as stylex from "@stylexjs/stylex";',
+      '> 2 | export const styles = stylex.create(1);',
+      '    |                       ^^^^^^^^^^^^^^^^',
+    ].join('\n');
+
+    expect(normalizeDiagnostic(message, CONTEXT)).toBe(
+      'create() can only accept an object.',
+    );
+  });
+
+  test('collapses the implementation tag', () => {
+    expect(
+      normalizeDiagnostic('[@stylexjs/babel-plugin] Expected a boolean.', {
+        ...CONTEXT,
+      }),
+    ).toBe('[stylex] Expected a boolean.');
+  });
+
+  test('leaves a message that merely opens with a bracket alone', () => {
+    expect(normalizeDiagnostic('[1, 2] is not a valid value.', CONTEXT)).toBe(
+      '[1, 2] is not a valid value.',
+    );
+  });
+
+  test('leaves a pipe that is not a source excerpt alone', () => {
+    expect(
+      normalizeDiagnostic('bad value\n|start| is reserved.', CONTEXT),
+    ).toBe('bad value\n|start| is reserved.');
+  });
+});
+
+describe('normalizeCss', () => {
+  test('strips trailing whitespace from every line and trims', () => {
+    expect(
+      normalizeCss('\n.a{color:red}   \n.b{color:blue}\t\n\n', CONTEXT),
+    ).toBe('.a{color:red}\n.b{color:blue}');
+  });
+});
+
+describe('normalizeData', () => {
+  test('sorts object keys', () => {
+    expect(JSON.stringify(normalizeData({ b: 1, a: 2 }, CONTEXT))).toBe(
+      '{"a":2,"b":1}',
+    );
+  });
+
+  test('preserves array order, because rule order is part of the contract', () => {
+    expect(normalizeData(['z', 'a'], CONTEXT)).toEqual(['z', 'a']);
+  });
+});
+
+describe('isJsEquivalent', () => {
+  test('ignores formatting, quote style and comments', () => {
+    expect(
+      isJsEquivalent(
+        'export const a = {x: 1};',
+        '// a comment\nexport const a = {\n  "x": 1,\n}\n',
+        ['flow'],
+      ),
+    ).toBe(true);
+  });
+
+  test('ignores how a property key is spelled', () => {
+    expect(isJsEquivalent('({a: 1});', '({"a": 1});', ['flow'])).toBe(true);
+    expect(isJsEquivalent('({1: x});', '({"1": x});', ['flow'])).toBe(true);
+  });
+
+  test('ignores property shorthand', () => {
+    expect(isJsEquivalent('({a});', '({a: a});', ['flow'])).toBe(true);
+  });
+
+  test('reports a genuine difference', () => {
+    expect(
+      isJsEquivalent('export const a = 1;', 'export const a = 2;', ['flow']),
+    ).toBe(false);
+  });
+
+  test('still reports a differently named property', () => {
+    expect(isJsEquivalent('({a: 1});', '({b: 1});', ['flow'])).toBe(false);
+  });
+
+  test('still reports a computed key', () => {
+    expect(isJsEquivalent('({a: 1});', '({[a]: 1});', ['flow'])).toBe(false);
+  });
+
+  test('honors the requested syntax', () => {
+    expect(
+      isJsEquivalent('const a = <div />;', 'const a = <div/>;', [
+        'flow',
+        'jsx',
+      ]),
+    ).toBe(true);
+  });
+
+  test('reports a difference when only one side produced output', () => {
+    expect(isJsEquivalent(null, 'export const a = 1;', ['flow'])).toBe(false);
+  });
+
+  test('fails loudly on unparseable output', () => {
+    expect(() =>
+      isJsEquivalent('export const a = 1;', 'const = ;', ['flow']),
+    ).toThrow(/Failed to parse the actual output as JavaScript/);
+  });
+});
+
+describe('normalizeResult', () => {
+  test('normalizes a successful transform', () => {
+    const result = normalizeResult(FIXTURE, {
+      css: '.a{color:red}  ',
+      js: '  export const a = 1;  ',
+      metadata: [['a', { rtl: null, ltr: '.a{color:red}' }, 3000]],
+      status: 'ok',
+      warnings: ['[@stylexjs/babel-plugin] heads up'],
+    });
+
+    expect(result).toEqual({
+      css: '.a{color:red}',
+      errors: [],
+      js: 'export const a = 1;',
+      metadata: [['a', { ltr: '.a{color:red}', rtl: null }, 3000]],
+      status: 'ok',
+      warnings: ['[stylex] heads up'],
+    });
+    expect(exactPart(result)).not.toHaveProperty('js');
+    expect(jsPart(result)).toBe('export const a = 1;');
+  });
+
+  test('normalizes a failed transform', () => {
+    const result = normalizeResult(FIXTURE, {
+      error: {
+        message: `${FIXTURE.dir}/input.js: create() can only accept an object.\n> 1 | x\n    | ^`,
+      },
+      status: 'error',
+    });
+
+    expect(result).toEqual({
+      error: { message: 'create() can only accept an object.' },
+      errors: [],
+      status: 'error',
+      warnings: [],
+    });
+    expect(jsPart(result)).toBeNull();
+  });
+});
+
+describe('fixtures', () => {
+  test('every fixture ships an entry file and a recorded result', () => {
+    const names = getFixtureNames();
+    expect(names.length).toBeGreaterThan(0);
+
+    for (const name of names) {
+      const fixture = loadFixture(name);
+      expect(fs.existsSync(fixture.entryPath)).toBe(true);
+      expect(fs.existsSync(getExpectedPath(name))).toBe(true);
+    }
+  });
+});

--- a/packages/compiler-conformance/fixtures/create-basic/expected.json
+++ b/packages/compiler-conformance/fixtures/create-basic/expected.json
@@ -1,0 +1,25 @@
+{
+  "css": ".xrkmrrc{background-color:red}\n.xju2f9n{color:blue}",
+  "errors": [],
+  "js": "/**\n * Copyright (c) Meta Platforms, Inc. and affiliates.\n *\n * This source code is licensed under the MIT license found in the\n * LICENSE file in the root directory of this source tree.\n */\n\nimport * as stylex from '@stylexjs/stylex';\nexport const styles = {\n  root: {\n    kWkggS: \"xrkmrrc\",\n    kMwMTN: \"xju2f9n\",\n    $$css: true\n  }\n};",
+  "metadata": [
+    [
+      "xrkmrrc",
+      {
+        "ltr": ".xrkmrrc{background-color:red}",
+        "rtl": null
+      },
+      3000
+    ],
+    [
+      "xju2f9n",
+      {
+        "ltr": ".xju2f9n{color:blue}",
+        "rtl": null
+      },
+      3000
+    ]
+  ],
+  "status": "ok",
+  "warnings": []
+}

--- a/packages/compiler-conformance/fixtures/create-basic/input.js
+++ b/packages/compiler-conformance/fixtures/create-basic/input.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+
+export const styles = stylex.create({
+  root: {
+    backgroundColor: 'red',
+    color: 'blue',
+  },
+});

--- a/packages/compiler-conformance/fixtures/create-basic/manifest.json
+++ b/packages/compiler-conformance/fixtures/create-basic/manifest.json
@@ -1,0 +1,4 @@
+{
+  "description": "stylex.create() with static declarations compiles to a style object and two atomic CSS rules.",
+  "entry": "input.js"
+}

--- a/packages/compiler-conformance/fixtures/define-vars-theme/expected.json
+++ b/packages/compiler-conformance/fixtures/define-vars-theme/expected.json
@@ -1,0 +1,33 @@
+{
+  "css": ":root, .xnsr5hh{--xkoxvr5:red;--x19047mj:white;}\n@media (prefers-color-scheme: dark){:root, .xnsr5hh{--x19047mj:black;}}\n.x19gg9ko.x19gg9ko, .x19gg9ko.x19gg9ko:root{--x19047mj:yellow;--xkoxvr5:blue;}",
+  "errors": [],
+  "js": "/**\n * Copyright (c) Meta Platforms, Inc. and affiliates.\n *\n * This source code is licensed under the MIT license found in the\n * LICENSE file in the root directory of this source tree.\n */\n\nimport * as stylex from '@stylexjs/stylex';\nexport const vars = {\n  fg: \"var(--xkoxvr5)\",\n  bg: \"var(--x19047mj)\",\n  __varGroupHash__: \"xnsr5hh\"\n};\nexport const theme = {\n  xnsr5hh: \"x19gg9ko xnsr5hh\",\n  $$css: true\n};",
+  "metadata": [
+    [
+      "xnsr5hh",
+      {
+        "ltr": ":root, .xnsr5hh{--xkoxvr5:red;--x19047mj:white;}",
+        "rtl": null
+      },
+      0.1
+    ],
+    [
+      "xnsr5hh-1lveb7",
+      {
+        "ltr": "@media (prefers-color-scheme: dark){:root, .xnsr5hh{--x19047mj:black;}}",
+        "rtl": null
+      },
+      0.2
+    ],
+    [
+      "x19gg9ko",
+      {
+        "ltr": ".x19gg9ko, .x19gg9ko:root{--x19047mj:yellow;--xkoxvr5:blue;}",
+        "rtl": null
+      },
+      0.5
+    ]
+  ],
+  "status": "ok",
+  "warnings": []
+}

--- a/packages/compiler-conformance/fixtures/define-vars-theme/input.stylex.js
+++ b/packages/compiler-conformance/fixtures/define-vars-theme/input.stylex.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+
+export const vars = stylex.defineVars({
+  fg: 'red',
+  bg: {
+    default: 'white',
+    '@media (prefers-color-scheme: dark)': 'black',
+  },
+});
+
+export const theme = stylex.createTheme(vars, {
+  fg: 'blue',
+  bg: 'yellow',
+});

--- a/packages/compiler-conformance/fixtures/define-vars-theme/manifest.json
+++ b/packages/compiler-conformance/fixtures/define-vars-theme/manifest.json
@@ -1,0 +1,9 @@
+{
+  "description": "stylex.defineVars() and stylex.createTheme() emit CSS custom properties, including a media-query override. The entry is a `.stylex.js` file so that `commonJS` module resolution derives a canonical name for it; that name is `<package name>:<path within the package>`, so the generated hashes depend on the fixture's location inside this package but not on where the repository is checked out.",
+  "entry": "input.stylex.js",
+  "pluginOptions": {
+    "unstable_moduleResolution": {
+      "type": "commonJS"
+    }
+  }
+}

--- a/packages/compiler-conformance/fixtures/keyframes-and-when/expected.json
+++ b/packages/compiler-conformance/fixtures/keyframes-and-when/expected.json
@@ -1,0 +1,41 @@
+{
+  "css": "@keyframes xekv6nw-B{0%{opacity:0;}100%{opacity:1;}}\n.x127lhb5:not(#\\#){animation-name:xekv6nw-B}\n.x1e2nbdu:not(#\\#){color:red}\n.x1tavwxn.x1tavwxn:where(.x-default-marker:focus *):not(#\\#){color:blue}",
+  "errors": [],
+  "js": "/**\n * Copyright (c) Meta Platforms, Inc. and affiliates.\n *\n * This source code is licensed under the MIT license found in the\n * LICENSE file in the root directory of this source tree.\n */\n\nimport * as stylex from '@stylexjs/stylex';\nexport const styles = {\n  root: {\n    kKVMdj: \"x127lhb5\",\n    kMwMTN: \"x1e2nbdu x1tavwxn\",\n    $$css: true\n  }\n};",
+  "metadata": [
+    [
+      "xekv6nw-B",
+      {
+        "ltr": "@keyframes xekv6nw-B{0%{opacity:0;}100%{opacity:1;}}",
+        "rtl": null
+      },
+      0
+    ],
+    [
+      "x127lhb5",
+      {
+        "ltr": ".x127lhb5{animation-name:xekv6nw-B}",
+        "rtl": null
+      },
+      3000
+    ],
+    [
+      "x1e2nbdu",
+      {
+        "ltr": ".x1e2nbdu{color:red}",
+        "rtl": null
+      },
+      3000
+    ],
+    [
+      "x1tavwxn",
+      {
+        "ltr": ".x1tavwxn.x1tavwxn:where(.x-default-marker:focus *){color:blue}",
+        "rtl": null
+      },
+      3011.5
+    ]
+  ],
+  "status": "ok",
+  "warnings": []
+}

--- a/packages/compiler-conformance/fixtures/keyframes-and-when/input.js
+++ b/packages/compiler-conformance/fixtures/keyframes-and-when/input.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+
+export const styles = stylex.create({
+  root: {
+    animationName: stylex.keyframes({
+      '0%': {
+        opacity: 0,
+      },
+      '100%': {
+        opacity: 1,
+      },
+    }),
+    color: {
+      default: 'red',
+      [stylex.when.ancestor(':focus')]: 'blue',
+    },
+  },
+});

--- a/packages/compiler-conformance/fixtures/keyframes-and-when/manifest.json
+++ b/packages/compiler-conformance/fixtures/keyframes-and-when/manifest.json
@@ -1,0 +1,4 @@
+{
+  "description": "stylex.keyframes() emits an @keyframes rule at priority 0 and stylex.when.ancestor() emits a conditional rule with raised specificity.",
+  "entry": "input.js"
+}

--- a/packages/compiler-conformance/fixtures/options-warning/expected.json
+++ b/packages/compiler-conformance/fixtures/options-warning/expected.json
@@ -1,0 +1,10 @@
+{
+  "css": "",
+  "errors": [
+    "[stylex] Expected (options.enableFontSizePxToRem) to be a boolean, but got `\"true\"`."
+  ],
+  "js": "/**\n * Copyright (c) Meta Platforms, Inc. and affiliates.\n *\n * This source code is licensed under the MIT license found in the\n * LICENSE file in the root directory of this source tree.\n */\n\nexport const value = 1;",
+  "metadata": [],
+  "status": "ok",
+  "warnings": []
+}

--- a/packages/compiler-conformance/fixtures/options-warning/input.js
+++ b/packages/compiler-conformance/fixtures/options-warning/input.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const value = 1;

--- a/packages/compiler-conformance/fixtures/options-warning/manifest.json
+++ b/packages/compiler-conformance/fixtures/options-warning/manifest.json
@@ -1,0 +1,7 @@
+{
+  "description": "An option of the wrong type reports a non-fatal diagnostic on the error channel while the transform still succeeds.",
+  "entry": "input.js",
+  "pluginOptions": {
+    "enableFontSizePxToRem": "true"
+  }
+}

--- a/packages/compiler-conformance/fixtures/props-and-merge/expected.json
+++ b/packages/compiler-conformance/fixtures/props-and-merge/expected.json
@@ -1,0 +1,25 @@
+{
+  "css": ".x1e2nbdu{color:red}\n.x17z2mba:hover{color:blue}",
+  "errors": [],
+  "js": "/**\n * Copyright (c) Meta Platforms, Inc. and affiliates.\n *\n * This source code is licensed under the MIT license found in the\n * LICENSE file in the root directory of this source tree.\n */\n\nimport * as stylex from '@stylexjs/stylex';\nimport React from 'react';\nexport function Button(props) {\n  return <button {...{\n    0: {\n      className: \"x1e2nbdu\"\n    },\n    1: {\n      className: \"x1e2nbdu x17z2mba\"\n    }\n  }[!!props.active << 0]} />;\n}",
+  "metadata": [
+    [
+      "x1e2nbdu",
+      {
+        "ltr": ".x1e2nbdu{color:red}",
+        "rtl": null
+      },
+      3000
+    ],
+    [
+      "x17z2mba",
+      {
+        "ltr": ".x17z2mba:hover{color:blue}",
+        "rtl": null
+      },
+      3130
+    ]
+  ],
+  "status": "ok",
+  "warnings": []
+}

--- a/packages/compiler-conformance/fixtures/props-and-merge/input.jsx
+++ b/packages/compiler-conformance/fixtures/props-and-merge/input.jsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import React from 'react';
+
+const styles = stylex.create({
+  base: {
+    color: 'red',
+  },
+  hover: {
+    ':hover': {
+      color: 'blue',
+    },
+  },
+});
+
+export function Button(props) {
+  return <button {...stylex.props(styles.base, props.active && styles.hover)} />;
+}

--- a/packages/compiler-conformance/fixtures/props-and-merge/manifest.json
+++ b/packages/compiler-conformance/fixtures/props-and-merge/manifest.json
@@ -1,0 +1,5 @@
+{
+  "description": "stylex.props() with a conditionally applied style compiles to a lookup table indexed by the runtime condition.",
+  "entry": "input.jsx",
+  "syntax": ["flow", "jsx"]
+}

--- a/packages/compiler-conformance/fixtures/rewrite-theme-extension/expected.json
+++ b/packages/compiler-conformance/fixtures/rewrite-theme-extension/expected.json
@@ -1,0 +1,8 @@
+{
+  "css": "",
+  "errors": [],
+  "js": "/**\n * Copyright (c) Meta Platforms, Inc. and affiliates.\n *\n * This source code is licensed under the MIT license found in the\n * LICENSE file in the root directory of this source tree.\n */\n\nimport { tokens } from \"./tokens.stylex\";\nexport { tokens };",
+  "metadata": [],
+  "status": "ok",
+  "warnings": []
+}

--- a/packages/compiler-conformance/fixtures/rewrite-theme-extension/input.js
+++ b/packages/compiler-conformance/fixtures/rewrite-theme-extension/input.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { tokens } from './tokens.stylex.js';
+
+export { tokens };

--- a/packages/compiler-conformance/fixtures/rewrite-theme-extension/manifest.json
+++ b/packages/compiler-conformance/fixtures/rewrite-theme-extension/manifest.json
@@ -1,0 +1,10 @@
+{
+  "description": "With `rewriteAliases`, an import of a `.stylex.js` module has its file extension stripped from the emitted specifier.",
+  "entry": "input.js",
+  "pluginOptions": {
+    "rewriteAliases": true,
+    "unstable_moduleResolution": {
+      "type": "commonJS"
+    }
+  }
+}

--- a/packages/compiler-conformance/fixtures/rewrite-theme-extension/tokens.stylex.js
+++ b/packages/compiler-conformance/fixtures/rewrite-theme-extension/tokens.stylex.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const tokens = {
+  color: 'red',
+};

--- a/packages/compiler-conformance/fixtures/runtime-injection/expected.json
+++ b/packages/compiler-conformance/fixtures/runtime-injection/expected.json
@@ -1,0 +1,17 @@
+{
+  "css": ".x1e2nbdu{color:red}",
+  "errors": [],
+  "js": "import _inject from \"@stylexjs/stylex/lib/stylex-inject\";\nvar _inject2 = _inject;\n/**\n * Copyright (c) Meta Platforms, Inc. and affiliates.\n *\n * This source code is licensed under the MIT license found in the\n * LICENSE file in the root directory of this source tree.\n */\n\nimport * as stylex from '@stylexjs/stylex';\n_inject2({\n  ltr: \".x1e2nbdu{color:red}\",\n  priority: 3000\n});\nexport const styles = {\n  root: {\n    kMwMTN: \"x1e2nbdu\",\n    $$css: true\n  }\n};",
+  "metadata": [
+    [
+      "x1e2nbdu",
+      {
+        "ltr": ".x1e2nbdu{color:red}",
+        "rtl": null
+      },
+      3000
+    ]
+  ],
+  "status": "ok",
+  "warnings": []
+}

--- a/packages/compiler-conformance/fixtures/runtime-injection/input.js
+++ b/packages/compiler-conformance/fixtures/runtime-injection/input.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+
+export const styles = stylex.create({
+  root: {
+    color: 'red',
+  },
+});

--- a/packages/compiler-conformance/fixtures/runtime-injection/manifest.json
+++ b/packages/compiler-conformance/fixtures/runtime-injection/manifest.json
@@ -1,0 +1,7 @@
+{
+  "description": "With `runtimeInjection`, generated rules are also injected at runtime through an imported inject helper.",
+  "entry": "input.js",
+  "pluginOptions": {
+    "runtimeInjection": true
+  }
+}

--- a/packages/compiler-conformance/fixtures/validation-error/expected.json
+++ b/packages/compiler-conformance/fixtures/validation-error/expected.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "message": "create() can only accept an object."
+  },
+  "errors": [],
+  "status": "error",
+  "warnings": []
+}

--- a/packages/compiler-conformance/fixtures/validation-error/input.js
+++ b/packages/compiler-conformance/fixtures/validation-error/input.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+
+export const styles = stylex.create(1);

--- a/packages/compiler-conformance/fixtures/validation-error/manifest.json
+++ b/packages/compiler-conformance/fixtures/validation-error/manifest.json
@@ -1,0 +1,4 @@
+{
+  "description": "Calling stylex.create() with a non-object argument fails the transform with a validation error.",
+  "entry": "input.js"
+}

--- a/packages/compiler-conformance/jest.config.cjs
+++ b/packages/compiler-conformance/jest.config.cjs
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+module.exports = {
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
+  // Fixture inputs are compiler test data, never test suites.
+  testPathIgnorePatterns: ['/fixtures/'],
+  verbose: true,
+};

--- a/packages/compiler-conformance/package.json
+++ b/packages/compiler-conformance/package.json
@@ -1,0 +1,18 @@
+{
+  "private": true,
+  "name": "compiler-conformance",
+  "version": "0.19.0",
+  "description": "Implementation-neutral golden fixtures describing the StyleX compiler contract.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebook/stylex.git"
+  },
+  "license": "MIT",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "@babel/parser": "^7.29.0"
+  }
+}

--- a/packages/compiler-conformance/src/ast.js
+++ b/packages/compiler-conformance/src/ast.js
@@ -12,7 +12,8 @@ const { parse } = require('@babel/parser');
 // Node properties that describe how source was written rather than what it
 // means: positions, comments, the raw text of literals (which encodes quote
 // style and numeric formatting), and whether a property used the `{a}`
-// shorthand for `{a: a}`.
+// shorthand for `{a: a}`. The `__proto__` shorthand is handled separately
+// because it has different semantics from an explicit `__proto__` property.
 const IGNORED_NODE_KEYS = new Set([
   'comments',
   'end',
@@ -47,7 +48,11 @@ function propertyKeyName(key) {
   if (key.type === 'Identifier') {
     return key.name;
   }
-  if (key.type === 'StringLiteral' || key.type === 'NumericLiteral') {
+  if (
+    key.type === 'StringLiteral' ||
+    key.type === 'NumericLiteral' ||
+    key.type === 'BigIntLiteral'
+  ) {
     return String(key.value);
   }
   return null;
@@ -65,9 +70,9 @@ function parseProgram(code, syntax, label) {
   }
 }
 
-function canonicalize(value) {
+function canonicalize(value, parentType = null) {
   if (Array.isArray(value)) {
-    return value.map(canonicalize);
+    return value.map((item) => canonicalize(item, parentType));
   }
   if (value == null || typeof value !== 'object') {
     return value;
@@ -76,16 +81,25 @@ function canonicalize(value) {
     KEYED_NODE_TYPES.has(value.type) && value.computed === false
       ? propertyKeyName(value.key)
       : null;
+  const shorthandIsSemantic =
+    parentType === 'ObjectExpression' &&
+    value.type === 'ObjectProperty' &&
+    value.computed === false &&
+    keyName === '__proto__';
 
   const output = {};
   for (const key of Object.keys(value).sort()) {
-    if (IGNORED_NODE_KEYS.has(key) || value[key] === undefined) {
+    if (
+      (IGNORED_NODE_KEYS.has(key) &&
+        !(key === 'shorthand' && shorthandIsSemantic)) ||
+      value[key] === undefined
+    ) {
       continue;
     }
     output[key] =
       key === 'key' && keyName != null
         ? { name: keyName, type: 'PropertyKey' }
-        : canonicalize(value[key]);
+        : canonicalize(value[key], value.type ?? parentType);
   }
   return output;
 }
@@ -104,11 +118,8 @@ function normalizeAst(code, syntax, label = 'JavaScript') {
  * agree on the program they emit and not on how they print it.
  */
 function isJsEquivalent(expectedJs, actualJs, syntax) {
-  if (expectedJs === actualJs) {
-    return true;
-  }
   if (typeof expectedJs !== 'string' || typeof actualJs !== 'string') {
-    return false;
+    return expectedJs === actualJs;
   }
   const expectedAst = normalizeAst(expectedJs, syntax, 'the expected output');
   const actualAst = normalizeAst(actualJs, syntax, 'the actual output');

--- a/packages/compiler-conformance/src/ast.js
+++ b/packages/compiler-conformance/src/ast.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { parse } = require('@babel/parser');
+
+// Node properties that describe how source was written rather than what it
+// means: positions, comments, the raw text of literals (which encodes quote
+// style and numeric formatting), and whether a property used the `{a}`
+// shorthand for `{a: a}`.
+const IGNORED_NODE_KEYS = new Set([
+  'comments',
+  'end',
+  'errors',
+  'extra',
+  'innerComments',
+  'leadingComments',
+  'loc',
+  'parenStart',
+  'parenthesized',
+  'range',
+  'shorthand',
+  'start',
+  'tokens',
+  'trailingComments',
+]);
+
+// Nodes whose `key` names a fixed property when `computed` is false. How that
+// name is spelled — `{a: 1}`, `{'a': 1}`, `{1: x}` — is formatting, so the key
+// is reduced to the name it denotes.
+const KEYED_NODE_TYPES = new Set([
+  'ClassMethod',
+  'ClassProperty',
+  'ObjectMethod',
+  'ObjectProperty',
+]);
+
+function propertyKeyName(key) {
+  if (key == null || typeof key !== 'object') {
+    return null;
+  }
+  if (key.type === 'Identifier') {
+    return key.name;
+  }
+  if (key.type === 'StringLiteral' || key.type === 'NumericLiteral') {
+    return String(key.value);
+  }
+  return null;
+}
+
+function parseProgram(code, syntax, label) {
+  try {
+    return parse(code, {
+      plugins: [...syntax],
+      sourceType: 'module',
+    }).program;
+  } catch (error) {
+    error.message = `Failed to parse ${label} as JavaScript: ${error.message}`;
+    throw error;
+  }
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value == null || typeof value !== 'object') {
+    return value;
+  }
+  const keyName =
+    KEYED_NODE_TYPES.has(value.type) && value.computed === false
+      ? propertyKeyName(value.key)
+      : null;
+
+  const output = {};
+  for (const key of Object.keys(value).sort()) {
+    if (IGNORED_NODE_KEYS.has(key) || value[key] === undefined) {
+      continue;
+    }
+    output[key] =
+      key === 'key' && keyName != null
+        ? { name: keyName, type: 'PropertyKey' }
+        : canonicalize(value[key]);
+  }
+  return output;
+}
+
+/**
+ * Parses JavaScript and returns a canonical, JSON-serializable syntax tree with
+ * all formatting information removed.
+ */
+function normalizeAst(code, syntax, label = 'JavaScript') {
+  return canonicalize(parseProgram(code, syntax, label));
+}
+
+/**
+ * Compares two JavaScript sources semantically. Whitespace, indentation, quote
+ * style, semicolons and comments are ignored, so implementations only have to
+ * agree on the program they emit and not on how they print it.
+ */
+function isJsEquivalent(expectedJs, actualJs, syntax) {
+  if (expectedJs === actualJs) {
+    return true;
+  }
+  if (typeof expectedJs !== 'string' || typeof actualJs !== 'string') {
+    return false;
+  }
+  const expectedAst = normalizeAst(expectedJs, syntax, 'the expected output');
+  const actualAst = normalizeAst(actualJs, syntax, 'the actual output');
+  return JSON.stringify(expectedAst) === JSON.stringify(actualAst);
+}
+
+module.exports = {
+  isJsEquivalent,
+  normalizeAst,
+};

--- a/packages/compiler-conformance/src/fixtures.js
+++ b/packages/compiler-conformance/src/fixtures.js
@@ -56,9 +56,9 @@ function loadFixture(name) {
     entryPath: path.join(dir, entry),
     name,
     pluginOptions: manifest.pluginOptions ?? {},
-    processOptions: manifest.processOptions ?? DEFAULT_PROCESS_OPTIONS,
+    processOptions: manifest.processOptions ?? { ...DEFAULT_PROCESS_OPTIONS },
     repoRoot: REPO_ROOT,
-    syntax: manifest.syntax ?? DEFAULT_SYNTAX,
+    syntax: manifest.syntax ?? [...DEFAULT_SYNTAX],
   };
 }
 
@@ -72,8 +72,16 @@ function readExpected(name, fixture = loadFixture(name)) {
 }
 
 /** Records a result as the new expectation for a fixture. */
-function writeExpected(name, result, fixture = loadFixture(name)) {
-  writeJson(getExpectedPath(name), normalizeResult(fixture, result));
+function writeExpected(
+  name,
+  result,
+  fixture = loadFixture(name),
+  implementationTag,
+) {
+  writeJson(
+    getExpectedPath(name),
+    normalizeResult(fixture, result, implementationTag),
+  );
 }
 
 module.exports = {

--- a/packages/compiler-conformance/src/fixtures.js
+++ b/packages/compiler-conformance/src/fixtures.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { normalizeResult } = require('./result');
+
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+const MANIFEST_FILE = 'manifest.json';
+const EXPECTED_FILE = 'expected.json';
+
+const DEFAULT_ENTRY = 'input.js';
+const DEFAULT_SYNTAX = ['flow'];
+const DEFAULT_PROCESS_OPTIONS = {
+  enableLTRRTLComments: false,
+  useLayers: false,
+};
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+/** Every fixture directory that contains a manifest, in stable order. */
+function getFixtureNames() {
+  return fs
+    .readdirSync(FIXTURES_DIR)
+    .filter((entry) =>
+      fs.existsSync(path.join(FIXTURES_DIR, entry, MANIFEST_FILE)),
+    )
+    .sort();
+}
+
+/** Reads a fixture manifest and resolves it against the filesystem. */
+function loadFixture(name) {
+  const dir = path.join(FIXTURES_DIR, name);
+  const manifest = readJson(path.join(dir, MANIFEST_FILE));
+  const entry = manifest.entry ?? DEFAULT_ENTRY;
+
+  return {
+    description: manifest.description ?? '',
+    dir,
+    entry,
+    entryPath: path.join(dir, entry),
+    name,
+    pluginOptions: manifest.pluginOptions ?? {},
+    processOptions: manifest.processOptions ?? DEFAULT_PROCESS_OPTIONS,
+    repoRoot: REPO_ROOT,
+    syntax: manifest.syntax ?? DEFAULT_SYNTAX,
+  };
+}
+
+function getExpectedPath(name) {
+  return path.join(FIXTURES_DIR, name, EXPECTED_FILE);
+}
+
+/** The recorded result for a fixture, normalized the same way live output is. */
+function readExpected(name, fixture = loadFixture(name)) {
+  return normalizeResult(fixture, readJson(getExpectedPath(name)));
+}
+
+/** Records a result as the new expectation for a fixture. */
+function writeExpected(name, result, fixture = loadFixture(name)) {
+  writeJson(getExpectedPath(name), normalizeResult(fixture, result));
+}
+
+module.exports = {
+  EXPECTED_FILE,
+  FIXTURES_DIR,
+  MANIFEST_FILE,
+  REPO_ROOT,
+  getExpectedPath,
+  getFixtureNames,
+  loadFixture,
+  readExpected,
+  writeExpected,
+};

--- a/packages/compiler-conformance/src/index.js
+++ b/packages/compiler-conformance/src/index.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { isJsEquivalent, normalizeAst } = require('./ast');
+const {
+  EXPECTED_FILE,
+  FIXTURES_DIR,
+  MANIFEST_FILE,
+  REPO_ROOT,
+  getExpectedPath,
+  getFixtureNames,
+  loadFixture,
+  readExpected,
+  writeExpected,
+} = require('./fixtures');
+const {
+  FIXTURE_ROOT_TOKEN,
+  REPO_ROOT_TOKEN,
+  normalizeCss,
+  normalizeData,
+  normalizeDiagnostic,
+  normalizePaths,
+} = require('./normalize');
+const { exactPart, jsPart, normalizeResult } = require('./result');
+
+module.exports = {
+  EXPECTED_FILE,
+  FIXTURES_DIR,
+  FIXTURE_ROOT_TOKEN,
+  MANIFEST_FILE,
+  REPO_ROOT,
+  REPO_ROOT_TOKEN,
+  exactPart,
+  getExpectedPath,
+  getFixtureNames,
+  isJsEquivalent,
+  jsPart,
+  loadFixture,
+  normalizeAst,
+  normalizeCss,
+  normalizeData,
+  normalizeDiagnostic,
+  normalizePaths,
+  normalizeResult,
+  readExpected,
+  writeExpected,
+};

--- a/packages/compiler-conformance/src/normalize.js
+++ b/packages/compiler-conformance/src/normalize.js
@@ -12,21 +12,16 @@ const path = require('node:path');
 const FIXTURE_ROOT_TOKEN = '<FIXTURE_ROOT>';
 const REPO_ROOT_TOKEN = '<REPO_ROOT>';
 
-// The bracketed tag implementations put in front of non-fatal diagnostics,
-// e.g. `[@stylexjs/babel-plugin] `. The tag names the implementation, so it is
-// collapsed to a single neutral tag before comparing. Tags never contain
-// whitespace, which keeps a message that merely opens with a bracket — say
-// `[1, 2] is not a valid value` — from being mistaken for one.
-const IMPLEMENTATION_TAG = /^\[[^\]\s]+\]\s*/;
-
 // A source excerpt appended to a diagnostic by `@babel/code-frame` and its
 // equivalents:
 //
 //   ` 3 | export const styles = stylex.create(1);`
 //   `   |                       ^^^^^^^^^^^^^^^^`
 //
-// The exact rendering is implementation-specific, so it is dropped.
-const CODE_FRAME_LINE = /^\s*(?:>\s*)?(?:\d+\s*)?\|(?:\s|$)/;
+// The exact rendering is implementation-specific, so it is dropped. Requiring
+// a numbered source line prevents a pipe-prefixed list in the message itself
+// from being mistaken for a code frame.
+const CODE_FRAME_LINE = /^\s*(?:>\s*)?\d+\s*\|(?:\s|$)/;
 
 // Terminal escape sequences. A diagnostic is syntax-highlighted whenever the
 // implementation thinks the environment supports color, and that decision is
@@ -38,12 +33,43 @@ const CODE_FRAME_LINE = /^\s*(?:>\s*)?(?:\d+\s*)?\|(?:\s|$)/;
 // eslint-disable-next-line no-control-regex -- ESC is what this matches.
 const ANSI_ESCAPE = /\u001B\[[0-9;]*[A-Za-z]/g;
 
-function splitJoin(value, search, replacement) {
-  return search === '' ? value : value.split(search).join(replacement);
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function toPosixPath(value) {
   return value.split(path.win32.sep).join(path.posix.sep);
+}
+
+function resolvePath(root) {
+  const value = String(root);
+  const isWindowsPath =
+    path.sep === path.win32.sep ||
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    value.startsWith('\\\\');
+  return (isWindowsPath ? path.win32 : path).resolve(value);
+}
+
+function replacePathRoot(value, root, token) {
+  const absolute = resolvePath(root);
+  const variants = new Set([absolute, toPosixPath(absolute)]);
+  let output = value;
+
+  for (const variant of variants) {
+    const withoutTrailingSeparator = variant.replace(/[\\/]+$/, '');
+    if (withoutTrailingSeparator === '') {
+      continue;
+    }
+    const rootPattern = new RegExp(
+      `${escapeRegExp(withoutTrailingSeparator)}([\\\\/]|$)`,
+      'g',
+    );
+    output = output.replace(rootPattern, (_match, separator) =>
+      separator === '' ? token : `${token}/`,
+    );
+  }
+
+  return output;
 }
 
 /**
@@ -57,12 +83,9 @@ function normalizePaths(value, context) {
     [context.repoRoot, REPO_ROOT_TOKEN],
   ];
   for (const [root, token] of roots) {
-    if (root == null) {
-      continue;
+    if (root != null) {
+      output = replacePathRoot(output, root, token);
     }
-    const absolute = path.resolve(root);
-    output = splitJoin(output, absolute, token);
-    output = splitJoin(output, toPosixPath(absolute), token);
   }
   return output;
 }
@@ -78,6 +101,14 @@ function stripCodeFrame(message) {
   return kept.join('\n');
 }
 
+function normalizeImplementationTag(message, implementationTag) {
+  if (typeof implementationTag !== 'string' || implementationTag === '') {
+    return message;
+  }
+  const prefix = new RegExp(`^\\[${escapeRegExp(implementationTag)}\\]\\s*`);
+  return message.replace(prefix, '[stylex] ');
+}
+
 /**
  * Normalizes a single warning, error or fatal message so that the same
  * behavior reported by two implementations compares equal:
@@ -86,17 +117,19 @@ function stripCodeFrame(message) {
  * - absolute paths become `<FIXTURE_ROOT>` / `<REPO_ROOT>`
  * - a leading `<FIXTURE_ROOT>/<entry>: ` location prefix is dropped
  * - a trailing source excerpt (code frame) is dropped
- * - a leading `[implementation]` tag becomes `[stylex]`
+ * - the caller's exact leading implementation tag becomes `[stylex]`
  */
 function normalizeDiagnostic(message, context) {
   let output = stripCodeFrame(normalizePaths(stripAnsi(message), context));
 
-  const locationPrefix = `${FIXTURE_ROOT_TOKEN}/${context.entry}: `;
-  if (output.startsWith(locationPrefix)) {
-    output = output.slice(locationPrefix.length);
-  }
+  const entry = toPosixPath(context.entry);
+  const locationPrefix = new RegExp(
+    `^${escapeRegExp(`${FIXTURE_ROOT_TOKEN}/${entry}`)}` +
+      '(?::\\d+(?::\\d+)?)?:\\s*',
+  );
+  output = output.replace(locationPrefix, '');
 
-  return output.replace(IMPLEMENTATION_TAG, '[stylex] ').trim();
+  return normalizeImplementationTag(output, context.implementationTag).trim();
 }
 
 /**
@@ -104,7 +137,7 @@ function normalizeDiagnostic(message, context) {
  * so only line endings and trailing whitespace are touched.
  */
 function normalizeCss(css, context) {
-  return normalizePaths(css ?? '', context)
+  return normalizePaths(css, context)
     .split('\n')
     .map((line) => line.replace(/\s+$/, ''))
     .join('\n')

--- a/packages/compiler-conformance/src/normalize.js
+++ b/packages/compiler-conformance/src/normalize.js
@@ -28,6 +28,16 @@ const IMPLEMENTATION_TAG = /^\[[^\]\s]+\]\s*/;
 // The exact rendering is implementation-specific, so it is dropped.
 const CODE_FRAME_LINE = /^\s*(?:>\s*)?(?:\d+\s*)?\|(?:\s|$)/;
 
+// Terminal escape sequences. A diagnostic is syntax-highlighted whenever the
+// implementation thinks the environment supports color, and that decision is
+// made from the environment rather than from the code under test: Babel's code
+// frame colorizes whenever `CI` is set, so the very same error arrives plain on
+// a developer's machine and colorized on CI. Color is presentation, so it is
+// removed before anything else — otherwise the escapes also hide the code frame
+// from the matcher above, and hide absolute paths from the path tokenizer.
+// eslint-disable-next-line no-control-regex -- ESC is what this matches.
+const ANSI_ESCAPE = /\u001B\[[0-9;]*[A-Za-z]/g;
+
 function splitJoin(value, search, replacement) {
   return search === '' ? value : value.split(search).join(replacement);
 }
@@ -57,6 +67,10 @@ function normalizePaths(value, context) {
   return output;
 }
 
+function stripAnsi(value) {
+  return String(value).replace(ANSI_ESCAPE, '');
+}
+
 function stripCodeFrame(message) {
   const lines = message.split('\n');
   const frameStart = lines.findIndex((line) => CODE_FRAME_LINE.test(line));
@@ -68,13 +82,14 @@ function stripCodeFrame(message) {
  * Normalizes a single warning, error or fatal message so that the same
  * behavior reported by two implementations compares equal:
  *
+ * - terminal color escapes are removed
  * - absolute paths become `<FIXTURE_ROOT>` / `<REPO_ROOT>`
  * - a leading `<FIXTURE_ROOT>/<entry>: ` location prefix is dropped
  * - a trailing source excerpt (code frame) is dropped
  * - a leading `[implementation]` tag becomes `[stylex]`
  */
 function normalizeDiagnostic(message, context) {
-  let output = stripCodeFrame(normalizePaths(message, context));
+  let output = stripCodeFrame(normalizePaths(stripAnsi(message), context));
 
   const locationPrefix = `${FIXTURE_ROOT_TOKEN}/${context.entry}: `;
   if (output.startsWith(locationPrefix)) {

--- a/packages/compiler-conformance/src/normalize.js
+++ b/packages/compiler-conformance/src/normalize.js
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const path = require('node:path');
+
+const FIXTURE_ROOT_TOKEN = '<FIXTURE_ROOT>';
+const REPO_ROOT_TOKEN = '<REPO_ROOT>';
+
+// The bracketed tag implementations put in front of non-fatal diagnostics,
+// e.g. `[@stylexjs/babel-plugin] `. The tag names the implementation, so it is
+// collapsed to a single neutral tag before comparing. Tags never contain
+// whitespace, which keeps a message that merely opens with a bracket — say
+// `[1, 2] is not a valid value` — from being mistaken for one.
+const IMPLEMENTATION_TAG = /^\[[^\]\s]+\]\s*/;
+
+// A source excerpt appended to a diagnostic by `@babel/code-frame` and its
+// equivalents:
+//
+//   ` 3 | export const styles = stylex.create(1);`
+//   `   |                       ^^^^^^^^^^^^^^^^`
+//
+// The exact rendering is implementation-specific, so it is dropped.
+const CODE_FRAME_LINE = /^\s*(?:>\s*)?(?:\d+\s*)?\|(?:\s|$)/;
+
+function splitJoin(value, search, replacement) {
+  return search === '' ? value : value.split(search).join(replacement);
+}
+
+function toPosixPath(value) {
+  return value.split(path.win32.sep).join(path.posix.sep);
+}
+
+/**
+ * Replaces absolute filesystem paths with stable tokens. The fixture directory
+ * is replaced first because it is nested inside the repository root.
+ */
+function normalizePaths(value, context) {
+  let output = String(value).split('\r\n').join('\n');
+  const roots = [
+    [context.fixtureDir, FIXTURE_ROOT_TOKEN],
+    [context.repoRoot, REPO_ROOT_TOKEN],
+  ];
+  for (const [root, token] of roots) {
+    if (root == null) {
+      continue;
+    }
+    const absolute = path.resolve(root);
+    output = splitJoin(output, absolute, token);
+    output = splitJoin(output, toPosixPath(absolute), token);
+  }
+  return output;
+}
+
+function stripCodeFrame(message) {
+  const lines = message.split('\n');
+  const frameStart = lines.findIndex((line) => CODE_FRAME_LINE.test(line));
+  const kept = frameStart === -1 ? lines : lines.slice(0, frameStart);
+  return kept.join('\n');
+}
+
+/**
+ * Normalizes a single warning, error or fatal message so that the same
+ * behavior reported by two implementations compares equal:
+ *
+ * - absolute paths become `<FIXTURE_ROOT>` / `<REPO_ROOT>`
+ * - a leading `<FIXTURE_ROOT>/<entry>: ` location prefix is dropped
+ * - a trailing source excerpt (code frame) is dropped
+ * - a leading `[implementation]` tag becomes `[stylex]`
+ */
+function normalizeDiagnostic(message, context) {
+  let output = stripCodeFrame(normalizePaths(message, context));
+
+  const locationPrefix = `${FIXTURE_ROOT_TOKEN}/${context.entry}: `;
+  if (output.startsWith(locationPrefix)) {
+    output = output.slice(locationPrefix.length);
+  }
+
+  return output.replace(IMPLEMENTATION_TAG, '[stylex] ').trim();
+}
+
+/**
+ * Normalizes generated CSS. Rule order and rule text are part of the contract,
+ * so only line endings and trailing whitespace are touched.
+ */
+function normalizeCss(css, context) {
+  return normalizePaths(css ?? '', context)
+    .split('\n')
+    .map((line) => line.replace(/\s+$/, ''))
+    .join('\n')
+    .trim();
+}
+
+/**
+ * Normalizes structured data (StyleX metadata). Object keys are sorted because
+ * their order carries no meaning in JSON; array order is preserved because rule
+ * order is part of the contract.
+ */
+function normalizeData(value, context) {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeData(item, context));
+  }
+  if (value != null && typeof value === 'object') {
+    const entries = Object.keys(value)
+      .sort()
+      .map((key) => [key, normalizeData(value[key], context)]);
+    return Object.fromEntries(entries);
+  }
+  return typeof value === 'string' ? normalizePaths(value, context) : value;
+}
+
+module.exports = {
+  FIXTURE_ROOT_TOKEN,
+  REPO_ROOT_TOKEN,
+  normalizeCss,
+  normalizeData,
+  normalizeDiagnostic,
+  normalizePaths,
+};

--- a/packages/compiler-conformance/src/result.js
+++ b/packages/compiler-conformance/src/result.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const {
+  normalizeCss,
+  normalizeData,
+  normalizeDiagnostic,
+  normalizePaths,
+} = require('./normalize');
+
+/**
+ * Shapes an adapter result — or a previously recorded `expected.json` — into
+ * the canonical form the two are compared in. Both sides go through this
+ * function so that recorded fixtures and live output are normalized
+ * identically.
+ *
+ * See `README.md` for the adapter contract and the fixture schema.
+ */
+function normalizeResult(fixture, result) {
+  const context = {
+    entry: fixture.entry,
+    fixtureDir: fixture.dir,
+    repoRoot: fixture.repoRoot,
+  };
+  const toDiagnostics = (values) =>
+    (values ?? []).map((value) => normalizeDiagnostic(value, context));
+
+  const warnings = toDiagnostics(result.warnings);
+  const errors = toDiagnostics(result.errors);
+
+  if (result.status === 'error') {
+    const message = result.error?.message ?? '';
+    return {
+      error: { message: normalizeDiagnostic(message, context) },
+      errors,
+      status: 'error',
+      warnings,
+    };
+  }
+
+  return {
+    css: normalizeCss(result.css, context),
+    errors,
+    js: normalizePaths(result.js ?? '', context).trim(),
+    metadata: normalizeData(result.metadata ?? [], context),
+    status: 'ok',
+    warnings,
+  };
+}
+
+/**
+ * The part of a result that must match byte-for-byte after normalization:
+ * transform status, StyleX metadata, generated CSS and diagnostics.
+ */
+function exactPart(result) {
+  const { js: _js, ...rest } = result;
+  return rest;
+}
+
+/**
+ * The generated JavaScript, which is compared semantically rather than
+ * exactly. `null` for fixtures whose transform is expected to fail.
+ */
+function jsPart(result) {
+  return result.js ?? null;
+}
+
+module.exports = {
+  exactPart,
+  jsPart,
+  normalizeResult,
+};

--- a/packages/compiler-conformance/src/result.js
+++ b/packages/compiler-conformance/src/result.js
@@ -14,6 +14,48 @@ const {
   normalizePaths,
 } = require('./normalize');
 
+function assertDiagnosticList(result, field) {
+  const value = result[field];
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new TypeError(`Adapter result.${field} must be an array of strings.`);
+  }
+}
+
+function validateResult(result) {
+  if (result == null || typeof result !== 'object' || Array.isArray(result)) {
+    throw new TypeError('Adapter result must be an object.');
+  }
+  if (result.status !== 'ok' && result.status !== 'error') {
+    throw new TypeError('Adapter result.status must be "ok" or "error".');
+  }
+
+  assertDiagnosticList(result, 'warnings');
+  assertDiagnosticList(result, 'errors');
+
+  if (result.status === 'ok') {
+    if (typeof result.js !== 'string') {
+      throw new TypeError('Successful adapter result.js must be a string.');
+    }
+    if (!Array.isArray(result.metadata)) {
+      throw new TypeError(
+        'Successful adapter result.metadata must be an array.',
+      );
+    }
+    if (typeof result.css !== 'string') {
+      throw new TypeError('Successful adapter result.css must be a string.');
+    }
+  } else if (
+    result.error == null ||
+    typeof result.error !== 'object' ||
+    Array.isArray(result.error) ||
+    typeof result.error.message !== 'string'
+  ) {
+    throw new TypeError(
+      'Failed adapter result.error.message must be a string.',
+    );
+  }
+}
+
 /**
  * Shapes an adapter result — or a previously recorded `expected.json` — into
  * the canonical form the two are compared in. Both sides go through this
@@ -22,22 +64,26 @@ const {
  *
  * See `README.md` for the adapter contract and the fixture schema.
  */
-function normalizeResult(fixture, result) {
+function normalizeResult(fixture, result, implementationTag) {
+  validateResult(result);
+
   const context = {
     entry: fixture.entry,
     fixtureDir: fixture.dir,
+    implementationTag,
     repoRoot: fixture.repoRoot,
   };
   const toDiagnostics = (values) =>
-    (values ?? []).map((value) => normalizeDiagnostic(value, context));
+    values.map((value) => normalizeDiagnostic(value, context));
 
   const warnings = toDiagnostics(result.warnings);
   const errors = toDiagnostics(result.errors);
 
   if (result.status === 'error') {
-    const message = result.error?.message ?? '';
     return {
-      error: { message: normalizeDiagnostic(message, context) },
+      error: {
+        message: normalizeDiagnostic(result.error.message, context),
+      },
       errors,
       status: 'error',
       warnings,
@@ -47,8 +93,8 @@ function normalizeResult(fixture, result) {
   return {
     css: normalizeCss(result.css, context),
     errors,
-    js: normalizePaths(result.js ?? '', context).trim(),
-    metadata: normalizeData(result.metadata ?? [], context),
+    js: normalizePaths(result.js, context).trim(),
+    metadata: normalizeData(result.metadata, context),
     status: 'ok',
     warnings,
   };


### PR DESCRIPTION
## What changed / motivation ?

Extracted the implementation-neutral golden test suite from #1623 (commit
`2f2281bcc9adae76929c2c7a32a5e03e2aa45640`) so the behavioral contract can land
independently of the Rust implementation.

Nothing here adds or depends on the Rust/SWC plugin. No changes to
`packages/@stylexjs/swc-plugin`, no Rust configuration or dependencies, no Rust
CI jobs, and none of the unrelated tests from that PR.

### The shared suite

`packages/compiler-conformance` is a new private workspace package holding eight
golden fixtures as plain data. Each fixture is a directory with:

- `manifest.json` — how to compile the entry (`entry`, `syntax`,
  `pluginOptions`, `processOptions`)
- the entry file, plus anything it imports
- `expected.json` — the recorded result

The recorded result pins all four observable outputs: generated JavaScript,
StyleX metadata, generated CSS, and diagnostics. Nothing in the package is
Babel-specific, so a compiler written in any language can read the fixtures and
check itself against the same contract. `README.md` documents the schema and
what an adapter has to provide.

### Babel as the first consumer

- `packages/@stylexjs/babel-plugin/test-utils/babel-conformance-adapter.js`
  compiles one fixture and returns the result in the shared shape. Parser
  configuration, console capture and `processStylexRules` all stay here.
- `packages/@stylexjs/babel-plugin/__tests__/golden-fixtures-test.js` runs every
  fixture through that adapter.

Re-record with `STYLEX_UPDATE_GOLDEN=1 npx jest golden-fixtures` from the
babel-plugin package.

### Coverage

| Fixture                   | Covers                                                            |
| ------------------------- | ----------------------------------------------------------------- |
| `create-basic`            | `stylex.create`                                                    |
| `define-vars-theme`       | `defineVars` + `createTheme`, incl. a `prefers-color-scheme` override |
| `keyframes-and-when`      | `keyframes` and `when.ancestor`                                    |
| `options-warning`         | a transform that succeeds and still reports a diagnostic           |
| `props-and-merge`         | `props` with merged styles, in JSX                                 |
| `rewrite-theme-extension` | `rewriteAliases` with a cross-file theme                           |
| `runtime-injection`       | `runtimeInjection`                                                 |
| `validation-error`        | a failed transform                                                 |

Between them: generated JavaScript, metadata, CSS, warnings, errors, and both
successful and failed transforms.

### How results are compared

**Generated JavaScript is compared semantically**, as a normalized syntax tree
(`@babel/parser`; positions, comments and raw literal text stripped, keys
sorted). Whitespace, quote style, semicolons, comments, how a non-computed
property key is spelled, and property shorthand (except the semantic
`__proto__` case) are all ignored, so no implementation has to match another's
printer. When the programs genuinely
differ, the test falls back to asserting on the sources so the failure shows a
readable diff.

**Metadata, CSS, diagnostics and status are compared exactly**, after
deterministic normalization: line endings normalized, trailing whitespace
stripped from each CSS line, absolute paths replaced with `<FIXTURE_ROOT>` /
`<REPO_ROOT>`, and — in diagnostics — the location prefix and numbered
source excerpt dropped and the adapter's declared leading implementation tag
collapsed to
`[stylex]`.
Object keys are sorted; array order is preserved, because rule order is part of
the contract.

These rules are themselves tested, without involving any compiler, in
`packages/compiler-conformance/__tests__/conformance-harness-test.js`.

### `define-vars-theme`

In #1623 this fixture recorded a module-resolution error, which pinned a
misconfiguration rather than any behavior. It now exercises a **successful**
`defineVars`/`createTheme` transform: the entry is a `.stylex.js` file and the
fixture sets `unstable_moduleResolution: {"type": "commonJS"}`. Failed-transform
coverage is still provided by `validation-error`.

The canonical name `commonJS` resolution derives for it —
`compiler-conformance:fixtures/define-vars-theme/input.stylex.js` — is hashed
into the generated variables. It is stable across checkouts (verified by copying
the package elsewhere and recompiling), but changes if the fixture moves or the
package is renamed. The README says so.

## Linked PR/Issues

Extracted from #1623.

## Additional Context

**On the recorded output.** The `expected.json` files are regenerated from
current `main` rather than copied from #1623. The ones in that PR look stale —
their recorded `js` is missing the copyright header that their own `input.js`
files carry. Regenerating avoids importing a stale baseline; it changes nothing
about the comparison, since the AST normalizer ignores comments.

**Validation**, run locally on Node 24:

- `yarn build` — pass
- `yarn test:packages` — pass, including the 8 golden fixtures and the 39
  harness tests
- `yarn prettier:report` — pass
- `yarn lint:report` — pass

`yarn.lock` is unchanged: `@babel/parser@^7.29.0` resolves to an entry the
lockfile already has.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code



