### PR TITLE
[breaking] Remove property-prefixed debug class names

### DIFF
--- a/examples/example-react-router/vite.config.ts
+++ b/examples/example-react-router/vite.config.ts
@@ -13,7 +13,6 @@ export default defineConfig({
   plugins: [
     stylex.vite({
       useCSSLayers: true,
-      enableDebugClassNames: false,
       runtimeInjection: false,
     }),
     react(),

--- a/examples/example-waku/waku.config.ts
+++ b/examples/example-waku/waku.config.ts
@@ -10,7 +10,6 @@ import { defineConfig } from 'waku/config';
 
 const stylexPlugin = stylex.vite({
   debug: process.env.NODE_ENV === 'development',
-  enableDebugClassNames: false,
   enableDevClassNames: false,
   useCSSLayers: true,
   devMode: 'css-only',

--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-call-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-call-test.js
@@ -1179,7 +1179,6 @@ describe('@stylexjs/babel-plugin', () => {
           filename: '/html/js/FooBar.react.js',
           dev: true,
           enableDevClassNames: false,
-          enableDebugClassNames: true,
           enableInlinedConditionalMerge: false,
         };
         expect(
@@ -1200,10 +1199,10 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
-          "color-x1e2nbdu";"
+          "x1e2nbdu";"
         `);
 
         expect(
@@ -1229,22 +1228,22 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           const styles = {
             default: {
-              "color-kMwMTN": "color-x1e2nbdu",
+              "color-kMwMTN": "x1e2nbdu",
               $$css: "js/FooBar.react.js:4"
             }
           };
           _inject2({
-            ltr: ".backgroundColor-x1t391ir{background-color:blue}",
+            ltr: ".x1t391ir{background-color:blue}",
             priority: 3000
           });
           const otherStyles = {
             default: {
-              "backgroundColor-kWkggS": "backgroundColor-x1t391ir",
+              "backgroundColor-kWkggS": "x1t391ir",
               $$css: "js/FooBar.react.js:9"
             }
           };
@@ -1272,20 +1271,20 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           _inject2({
-            ltr: ".color-xju2f9n{color:blue}",
+            ltr: ".xju2f9n{color:blue}",
             priority: 3000
           });
           const styles = {
             default: {
-              "color-kMwMTN": "color-x1e2nbdu",
+              "color-kMwMTN": "x1e2nbdu",
               $$css: "js/FooBar.react.js:4"
             },
             active: {
-              "color-kMwMTN": "color-xju2f9n",
+              "color-kMwMTN": "xju2f9n",
               $$css: "js/FooBar.react.js:7"
             }
           };
@@ -1297,7 +1296,6 @@ describe('@stylexjs/babel-plugin', () => {
         const options = {
           filename: '/html/js/FooBar.react.js',
           dev: true,
-          enableDebugClassNames: true,
           enableDevClassNames: false,
         };
         expect(
@@ -1323,16 +1321,16 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           _inject2({
-            ltr: ".backgroundColor-x1t391ir{background-color:blue}",
+            ltr: ".x1t391ir{background-color:blue}",
             priority: 3000
           });
           ({
-            0: "color-x1e2nbdu",
-            1: "color-x1e2nbdu backgroundColor-x1t391ir"
+            0: "x1e2nbdu",
+            1: "x1e2nbdu x1t391ir"
           })[!!isActive << 0];"
         `);
 
@@ -1357,16 +1355,16 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           _inject2({
-            ltr: ".color-xju2f9n{color:blue}",
+            ltr: ".xju2f9n{color:blue}",
             priority: 3000
           });
           ({
-            0: "color-x1e2nbdu",
-            1: "color-xju2f9n"
+            0: "x1e2nbdu",
+            1: "xju2f9n"
           })[!!isActive << 0];"
         `);
       });
@@ -1876,7 +1874,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           {
             dev: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
             filename: 'src/js/components/Foo.react.js',
           },
@@ -1890,56 +1887,56 @@ describe('@stylexjs/babel-plugin', () => {
         function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
         var _inject2 = _stylexInject.default;
         _inject2({
-          ltr: ".boxSizing-x9f619{box-sizing:border-box}",
+          ltr: ".x9f619{box-sizing:border-box}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridArea-x1yc5d2u{grid-area:sidebar}",
+          ltr: ".x1yc5d2u{grid-area:sidebar}",
           priority: 1000
         });
         _inject2({
-          ltr: ".gridArea-x1fdo2jl{grid-area:content}",
+          ltr: ".x1fdo2jl{grid-area:content}",
           priority: 1000
         });
         _inject2({
-          ltr: ".display-xrvj5dj{display:grid}",
+          ltr: ".xrvj5dj{display:grid}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateRows-x7k18q3{grid-template-rows:100%}",
+          ltr: ".x7k18q3{grid-template-rows:100%}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x5gp9wm{grid-template-areas:\\"content\\"}",
+          ltr: ".x5gp9wm{grid-template-areas:\\"content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
+          ltr: ".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x17lh93j{grid-template-areas:\\"sidebar content\\"}",
+          ltr: ".x17lh93j{grid-template-areas:\\"sidebar content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateRows-xmr4b4k.gridTemplateRows-xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
+          ltr: "@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
           priority: 3200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateAreas-xesbpuc.gridTemplateAreas-xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
+          ltr: "@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
           priority: 2200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateColumns-x15nfgh4.gridTemplateColumns-x15nfgh4{grid-template-columns:100%}}",
+          ltr: "@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}",
           priority: 3200
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
+          ltr: ".x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
           priority: 3000
         });
         ({
-          0: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
-          1: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x"
+          0: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4",
+          1: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x"
         })[!!(sidebar == null) << 0];"
       `);
     });
@@ -1982,7 +1979,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           {
             dev: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
           },
         ),
@@ -1991,57 +1987,57 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import * as stylex from '@stylexjs/stylex';
         _inject2({
-          ltr: ".boxSizing-x9f619{box-sizing:border-box}",
+          ltr: ".x9f619{box-sizing:border-box}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridArea-x1yc5d2u{grid-area:sidebar}",
+          ltr: ".x1yc5d2u{grid-area:sidebar}",
           priority: 1000
         });
         _inject2({
-          ltr: ".gridArea-x1fdo2jl{grid-area:content}",
+          ltr: ".x1fdo2jl{grid-area:content}",
           priority: 1000
         });
         _inject2({
-          ltr: ".display-xrvj5dj{display:grid}",
+          ltr: ".xrvj5dj{display:grid}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateRows-x7k18q3{grid-template-rows:100%}",
+          ltr: ".x7k18q3{grid-template-rows:100%}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x5gp9wm{grid-template-areas:\\"content\\"}",
+          ltr: ".x5gp9wm{grid-template-areas:\\"content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
+          ltr: ".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x17lh93j{grid-template-areas:\\"sidebar content\\"}",
+          ltr: ".x17lh93j{grid-template-areas:\\"sidebar content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateRows-xmr4b4k.gridTemplateRows-xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
+          ltr: "@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
           priority: 3200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateAreas-xesbpuc.gridTemplateAreas-xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
+          ltr: "@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
           priority: 2200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateColumns-x15nfgh4.gridTemplateColumns-x15nfgh4{grid-template-columns:100%}}",
+          ltr: "@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}",
           priority: 3200
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
+          ltr: ".x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
           priority: 3000
         });
         export const styles = {
           sidebar: {
-            "boxSizing-kB7OPa": "boxSizing-x9f619",
-            "gridArea-kJuA4N": "gridArea-x1yc5d2u",
+            "boxSizing-kB7OPa": "x9f619",
+            "gridArea-kJuA4N": "x1yc5d2u",
             "gridRow-kbNqZ1": null,
             "gridRowStart-k1lYIM": null,
             "gridRowEnd-kpJH7q": null,
@@ -2051,7 +2047,7 @@ describe('@stylexjs/babel-plugin', () => {
             $$css: "@stylexjs/babel-plugin::4"
           },
           content: {
-            "gridArea-kJuA4N": "gridArea-x1fdo2jl",
+            "gridArea-kJuA4N": "x1fdo2jl",
             "gridRow-kbNqZ1": null,
             "gridRowStart-k1lYIM": null,
             "gridRowEnd-kpJH7q": null,
@@ -2061,28 +2057,28 @@ describe('@stylexjs/babel-plugin', () => {
             $$css: "@stylexjs/babel-plugin::8"
           },
           root: {
-            "display-k1xSpc": "display-xrvj5dj",
-            "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
-            "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
+            "display-k1xSpc": "xrvj5dj",
+            "gridTemplateRows-k9llMU": "x7k18q3",
+            "gridTemplateAreas-kC13JO": "x5gp9wm",
             $$css: "@stylexjs/babel-plugin::11"
           },
           withSidebar: {
-            "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
-            "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
-            "gridTemplateAreas-kC13JO": "gridTemplateAreas-x17lh93j",
-            "@media (max-width: 640px)_gridTemplateRows-k9pwkU": "gridTemplateRows-xmr4b4k",
-            "@media (max-width: 640px)_gridTemplateAreas-kOnEH4": "gridTemplateAreas-xesbpuc",
-            "@media (max-width: 640px)_gridTemplateColumns-k1JLwA": "gridTemplateColumns-x15nfgh4",
+            "gridTemplateColumns-kumcoG": "x1rkzygb",
+            "gridTemplateRows-k9llMU": "x7k18q3",
+            "gridTemplateAreas-kC13JO": "x17lh93j",
+            "@media (max-width: 640px)_gridTemplateRows-k9pwkU": "xmr4b4k",
+            "@media (max-width: 640px)_gridTemplateAreas-kOnEH4": "xesbpuc",
+            "@media (max-width: 640px)_gridTemplateColumns-k1JLwA": "x15nfgh4",
             $$css: "@stylexjs/babel-plugin::16"
           },
           noSidebar: {
-            "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
+            "gridTemplateColumns-kumcoG": "x1mkdm3x",
             $$css: "@stylexjs/babel-plugin::26"
           }
         };
         ({
-          0: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
-          1: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x"
+          0: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4",
+          1: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x"
         })[!!(sidebar == null) << 0];"
       `);
     });
@@ -2126,7 +2122,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           {
             dev: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
             enableInlinedConditionalMerge: false,
           },
@@ -2136,57 +2131,57 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import * as stylex from '@stylexjs/stylex';
         _inject2({
-          ltr: ".boxSizing-x9f619{box-sizing:border-box}",
+          ltr: ".x9f619{box-sizing:border-box}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridArea-x1yc5d2u{grid-area:sidebar}",
+          ltr: ".x1yc5d2u{grid-area:sidebar}",
           priority: 1000
         });
         _inject2({
-          ltr: ".gridArea-x1fdo2jl{grid-area:content}",
+          ltr: ".x1fdo2jl{grid-area:content}",
           priority: 1000
         });
         _inject2({
-          ltr: ".display-xrvj5dj{display:grid}",
+          ltr: ".xrvj5dj{display:grid}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateRows-x7k18q3{grid-template-rows:100%}",
+          ltr: ".x7k18q3{grid-template-rows:100%}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x5gp9wm{grid-template-areas:\\"content\\"}",
+          ltr: ".x5gp9wm{grid-template-areas:\\"content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
+          ltr: ".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x17lh93j{grid-template-areas:\\"sidebar content\\"}",
+          ltr: ".x17lh93j{grid-template-areas:\\"sidebar content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateRows-xmr4b4k.gridTemplateRows-xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
+          ltr: "@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
           priority: 3200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateAreas-xesbpuc.gridTemplateAreas-xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
+          ltr: "@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
           priority: 2200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateColumns-x15nfgh4.gridTemplateColumns-x15nfgh4{grid-template-columns:100%}}",
+          ltr: "@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}",
           priority: 3200
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
+          ltr: ".x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
           priority: 3000
         });
         export const styles = {
           sidebar: {
-            "boxSizing-kB7OPa": "boxSizing-x9f619",
-            "gridArea-kJuA4N": "gridArea-x1yc5d2u",
+            "boxSizing-kB7OPa": "x9f619",
+            "gridArea-kJuA4N": "x1yc5d2u",
             "gridRow-kbNqZ1": null,
             "gridRowStart-k1lYIM": null,
             "gridRowEnd-kpJH7q": null,
@@ -2196,7 +2191,7 @@ describe('@stylexjs/babel-plugin', () => {
             $$css: "@stylexjs/babel-plugin::4"
           },
           content: {
-            "gridArea-kJuA4N": "gridArea-x1fdo2jl",
+            "gridArea-kJuA4N": "x1fdo2jl",
             "gridRow-kbNqZ1": null,
             "gridRowStart-k1lYIM": null,
             "gridRowEnd-kpJH7q": null,
@@ -2206,22 +2201,22 @@ describe('@stylexjs/babel-plugin', () => {
             $$css: "@stylexjs/babel-plugin::8"
           },
           root: {
-            "display-k1xSpc": "display-xrvj5dj",
-            "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
-            "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
+            "display-k1xSpc": "xrvj5dj",
+            "gridTemplateRows-k9llMU": "x7k18q3",
+            "gridTemplateAreas-kC13JO": "x5gp9wm",
             $$css: "@stylexjs/babel-plugin::11"
           },
           withSidebar: {
-            "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
-            "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
-            "gridTemplateAreas-kC13JO": "gridTemplateAreas-x17lh93j",
-            "@media (max-width: 640px)_gridTemplateRows-k9pwkU": "gridTemplateRows-xmr4b4k",
-            "@media (max-width: 640px)_gridTemplateAreas-kOnEH4": "gridTemplateAreas-xesbpuc",
-            "@media (max-width: 640px)_gridTemplateColumns-k1JLwA": "gridTemplateColumns-x15nfgh4",
+            "gridTemplateColumns-kumcoG": "x1rkzygb",
+            "gridTemplateRows-k9llMU": "x7k18q3",
+            "gridTemplateAreas-kC13JO": "x17lh93j",
+            "@media (max-width: 640px)_gridTemplateRows-k9pwkU": "xmr4b4k",
+            "@media (max-width: 640px)_gridTemplateAreas-kOnEH4": "xesbpuc",
+            "@media (max-width: 640px)_gridTemplateColumns-k1JLwA": "x15nfgh4",
             $$css: "@stylexjs/babel-plugin::16"
           },
           noSidebar: {
-            "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
+            "gridTemplateColumns-kumcoG": "x1mkdm3x",
             $$css: "@stylexjs/babel-plugin::26"
           }
         };
@@ -2270,7 +2265,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           {
             dev: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
           },
         ),
@@ -2279,62 +2273,62 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import * as stylex from '@stylexjs/stylex';
         _inject2({
-          ltr: ".boxSizing-x9f619{box-sizing:border-box}",
+          ltr: ".x9f619{box-sizing:border-box}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridArea-x1yc5d2u{grid-area:sidebar}",
+          ltr: ".x1yc5d2u{grid-area:sidebar}",
           priority: 1000
         });
         _inject2({
-          ltr: ".gridArea-x1fdo2jl{grid-area:content}",
+          ltr: ".x1fdo2jl{grid-area:content}",
           priority: 1000
         });
         _inject2({
-          ltr: ".display-xrvj5dj{display:grid}",
+          ltr: ".xrvj5dj{display:grid}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateRows-x7k18q3{grid-template-rows:100%}",
+          ltr: ".x7k18q3{grid-template-rows:100%}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x5gp9wm{grid-template-areas:\\"content\\"}",
+          ltr: ".x5gp9wm{grid-template-areas:\\"content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
+          ltr: ".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x17lh93j{grid-template-areas:\\"sidebar content\\"}",
+          ltr: ".x17lh93j{grid-template-areas:\\"sidebar content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateRows-xmr4b4k.gridTemplateRows-xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
+          ltr: "@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
           priority: 3200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateAreas-xesbpuc.gridTemplateAreas-xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
+          ltr: "@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
           priority: 2200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateColumns-x15nfgh4.gridTemplateColumns-x15nfgh4{grid-template-columns:100%}}",
+          ltr: "@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}",
           priority: 3200
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
+          ltr: ".x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
           priority: 3000
         });
         const complex = {
-          0: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
-          4: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x",
-          2: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1yc5d2u",
-          6: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1yc5d2u",
-          1: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 gridArea-x1fdo2jl",
-          5: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x gridArea-x1fdo2jl",
-          3: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1fdo2jl",
-          7: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1fdo2jl"
+          0: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4",
+          4: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x",
+          2: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1yc5d2u",
+          6: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1yc5d2u",
+          1: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x1fdo2jl",
+          5: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x1fdo2jl",
+          3: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1fdo2jl",
+          7: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1fdo2jl"
         }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];"
       `);
     });
@@ -2353,7 +2347,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           {
             dev: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
           },
         ),
@@ -2402,7 +2395,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           {
             dev: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
           },
         ),
@@ -2411,7 +2403,7 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import * as stylex from '@stylexjs/stylex';
         _inject2({
-          ltr: ".marginRight-x1wsuqlk{margin-right:12px}",
+          ltr: ".x1wsuqlk{margin-right:12px}",
           priority: 4000
         });
         const styles = {};
@@ -2432,7 +2424,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           {
             dev: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
           },
         ),
@@ -2441,7 +2432,7 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import * as stylex from '@stylexjs/stylex';
         _inject2({
-          ltr: ".marginRight-x1wsuqlk{margin-right:12px}",
+          ltr: ".x1wsuqlk{margin-right:12px}",
           priority: 4000
         });
         const styles = {};

--- a/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/legacy/stylex-transform-legacy-shorthands-test.js
@@ -471,60 +471,60 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
           stylex(styles.foo, styles.bar)
           export const string = stylex(styles.foo, styles.bar, xstyle);
         `,
-          { debug: true, enableDebugClassNames: true },
+          { debug: true },
         ),
       ).toMatchInlineSnapshot(`
         "import _inject from "@stylexjs/stylex/lib/stylex-inject";
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2({
-          ltr: ".paddingTop-x123j3cw{padding-top:5px}",
+          ltr: ".x123j3cw{padding-top:5px}",
           priority: 4000
         });
         _inject2({
-          ltr: ".paddingBottom-xs9asl8{padding-bottom:5px}",
+          ltr: ".xs9asl8{padding-bottom:5px}",
           priority: 4000
         });
         _inject2({
-          ltr: ".paddingInlineStart-xaso8d8{padding-left:5px}",
-          rtl: ".paddingInlineStart-xaso8d8{padding-right:5px}",
+          ltr: ".xaso8d8{padding-left:5px}",
+          rtl: ".xaso8d8{padding-right:5px}",
           priority: 3000
         });
         _inject2({
-          ltr: ".paddingInlineEnd-x2vl965{padding-right:10px}",
-          rtl: ".paddingInlineEnd-x2vl965{padding-left:10px}",
+          ltr: ".x2vl965{padding-right:10px}",
+          rtl: ".x2vl965{padding-left:10px}",
           priority: 3000
         });
         _inject2({
-          ltr: ".paddingTop-x1nn3v0j{padding-top:2px}",
+          ltr: ".x1nn3v0j{padding-top:2px}",
           priority: 4000
         });
         _inject2({
-          ltr: ".paddingBottom-x1120s5i{padding-bottom:2px}",
+          ltr: ".x1120s5i{padding-bottom:2px}",
           priority: 4000
         });
         _inject2({
-          ltr: ".paddingLeft-xnljgj5{padding-left:22px}",
+          ltr: ".xnljgj5{padding-left:22px}",
           priority: 4000
         });
         const styles = {
           foo: {
-            "paddingTop-kLKAdn": "paddingTop-x123j3cw",
-            "paddingBottom-kGO01o": "paddingBottom-xs9asl8",
-            "paddingInlineStart-kZCmMZ": "paddingInlineStart-xaso8d8",
-            "paddingInlineEnd-kwRFfy": "paddingInlineEnd-x2vl965",
+            "paddingTop-kLKAdn": "x123j3cw",
+            "paddingBottom-kGO01o": "xs9asl8",
+            "paddingInlineStart-kZCmMZ": "xaso8d8",
+            "paddingInlineEnd-kwRFfy": "x2vl965",
             $$css: "@stylexjs/babel-plugin::4"
           },
           bar: {
-            "paddingTop-kLKAdn": "paddingTop-x1nn3v0j",
-            "paddingBottom-kGO01o": "paddingBottom-x1120s5i",
-            "paddingLeft-kE3dHu": "paddingLeft-xnljgj5",
+            "paddingTop-kLKAdn": "x1nn3v0j",
+            "paddingBottom-kGO01o": "x1120s5i",
+            "paddingLeft-kE3dHu": "xnljgj5",
             "paddingInlineStart-kZCmMZ": null,
             "paddingInlineEnd-kwRFfy": null,
             $$css: "@stylexjs/babel-plugin::9"
           }
         };
-        "paddingTop-x1nn3v0j paddingBottom-x1120s5i paddingLeft-xnljgj5";
+        "x1nn3v0j x1120s5i xnljgj5";
         export const string = stylex(styles.foo, styles.bar, xstyle);"
       `);
     });
@@ -1118,7 +1118,6 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
         `,
           {
             debug: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
           },
         ),
@@ -1127,52 +1126,52 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2({
-          ltr: ".listStyleType-x3ct3a4{list-style-type:none}",
+          ltr: ".x3ct3a4{list-style-type:none}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStyleType-x152237o{list-style-type:square}",
+          ltr: ".x152237o{list-style-type:square}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStylePosition-x1cy9i3i{list-style-position:inside}",
+          ltr: ".x1cy9i3i{list-style-position:inside}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStyleType-x1jzm7bx{list-style-type:\\"--\\"}",
+          ltr: ".x1jzm7bx{list-style-type:\\"--\\"}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStyleType-x1tpmu87{list-style-type:'=='}",
+          ltr: ".x1tpmu87{list-style-type:'=='}",
           priority: 3000
         });
         export const styles = {
           none: {
-            "listStyleType-kH6xsr": "listStyleType-x3ct3a4",
+            "listStyleType-kH6xsr": "x3ct3a4",
             "listStylePosition-kpqbRz": null,
             "listStyleImage-khnUzm": null,
             $$css: "@stylexjs/babel-plugin::4"
           },
           square: {
-            "listStyleType-kH6xsr": "listStyleType-x152237o",
+            "listStyleType-kH6xsr": "x152237o",
             "listStylePosition-kpqbRz": null,
             "listStyleImage-khnUzm": null,
             $$css: "@stylexjs/babel-plugin::7"
           },
           inside: {
             "listStyleType-kH6xsr": null,
-            "listStylePosition-kpqbRz": "listStylePosition-x1cy9i3i",
+            "listStylePosition-kpqbRz": "x1cy9i3i",
             "listStyleImage-khnUzm": null,
             $$css: "@stylexjs/babel-plugin::10"
           },
           custom1: {
-            "listStyleType-kH6xsr": "listStyleType-x1jzm7bx",
+            "listStyleType-kH6xsr": "x1jzm7bx",
             "listStylePosition-kpqbRz": null,
             "listStyleImage-khnUzm": null,
             $$css: "@stylexjs/babel-plugin::13"
           },
           custom2: {
-            "listStyleType-kH6xsr": "listStyleType-x1tpmu87",
+            "listStyleType-kH6xsr": "x1tpmu87",
             "listStylePosition-kpqbRz": null,
             "listStyleImage-khnUzm": null,
             $$css: "@stylexjs/babel-plugin::16"
@@ -1203,7 +1202,6 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
         `,
           {
             debug: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
           },
         ),
@@ -1212,60 +1210,60 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2({
-          ltr: ".listStyleType-x3ct3a4{list-style-type:none}",
+          ltr: ".x3ct3a4{list-style-type:none}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStylePosition-x1cy9i3i{list-style-position:inside}",
+          ltr: ".x1cy9i3i{list-style-position:inside}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStyleType-x152237o{list-style-type:square}",
+          ltr: ".x152237o{list-style-type:square}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStyleImage-xnbnhf8{list-style-image:none}",
+          ltr: ".xnbnhf8{list-style-image:none}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStyleType-xl2um64{list-style-type:simp-chinese-informal}",
+          ltr: ".xl2um64{list-style-type:simp-chinese-informal}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStyleImage-x1qcowux{list-style-image:linear-gradient(90deg,white 100%)}",
+          ltr: ".x1qcowux{list-style-image:linear-gradient(90deg,white 100%)}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStyleType-xqkogtj{list-style-type:\\"+\\"}",
+          ltr: ".xqkogtj{list-style-type:\\"+\\"}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStylePosition-x43c9pm{list-style-position:outside}",
+          ltr: ".x43c9pm{list-style-position:outside}",
           priority: 3000
         });
         export const styles = {
           one: {
-            "listStyleType-kH6xsr": "listStyleType-x3ct3a4",
-            "listStylePosition-kpqbRz": "listStylePosition-x1cy9i3i",
+            "listStyleType-kH6xsr": "x3ct3a4",
+            "listStylePosition-kpqbRz": "x1cy9i3i",
             "listStyleImage-khnUzm": null,
             $$css: "@stylexjs/babel-plugin::4"
           },
           two: {
-            "listStyleType-kH6xsr": "listStyleType-x152237o",
+            "listStyleType-kH6xsr": "x152237o",
             "listStylePosition-kpqbRz": null,
-            "listStyleImage-khnUzm": "listStyleImage-xnbnhf8",
+            "listStyleImage-khnUzm": "xnbnhf8",
             $$css: "@stylexjs/babel-plugin::7"
           },
           three: {
-            "listStyleType-kH6xsr": "listStyleType-xl2um64",
+            "listStyleType-kH6xsr": "xl2um64",
             "listStylePosition-kpqbRz": null,
-            "listStyleImage-khnUzm": "listStyleImage-x1qcowux",
+            "listStyleImage-khnUzm": "x1qcowux",
             $$css: "@stylexjs/babel-plugin::10"
           },
           four: {
-            "listStyleType-kH6xsr": "listStyleType-xqkogtj",
-            "listStylePosition-kpqbRz": "listStylePosition-x43c9pm",
-            "listStyleImage-khnUzm": "listStyleImage-x1qcowux",
+            "listStyleType-kH6xsr": "xqkogtj",
+            "listStylePosition-kpqbRz": "x43c9pm",
+            "listStyleImage-khnUzm": "x1qcowux",
             $$css: "@stylexjs/babel-plugin::13"
           }
         };"
@@ -1300,7 +1298,6 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
         `,
           {
             debug: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
           },
         ),
@@ -1309,52 +1306,52 @@ describe('legacy-shorthand-expansion style resolution (enableLogicalStylesPolyfi
         var _inject2 = _inject;
         import stylex from 'stylex';
         _inject2({
-          ltr: ".listStylePosition-x1cy9i3i{list-style-position:inside}",
+          ltr: ".x1cy9i3i{list-style-position:inside}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStyleType-x152237o{list-style-type:square}",
+          ltr: ".x152237o{list-style-type:square}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStyleType-x12kno0j{list-style-type:georgian}",
+          ltr: ".x12kno0j{list-style-type:georgian}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStyleImage-xnbnhf8{list-style-image:none}",
+          ltr: ".xnbnhf8{list-style-image:none}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStylePosition-x43c9pm{list-style-position:outside}",
+          ltr: ".x43c9pm{list-style-position:outside}",
           priority: 3000
         });
         _inject2({
-          ltr: ".listStyleImage-x1qcowux{list-style-image:linear-gradient(90deg,white 100%)}",
+          ltr: ".x1qcowux{list-style-image:linear-gradient(90deg,white 100%)}",
           priority: 3000
         });
         export const styles = {
           one: {
-            "listStylePosition-kpqbRz": "listStylePosition-x1cy9i3i",
+            "listStylePosition-kpqbRz": "x1cy9i3i",
             "listStyleImage-khnUzm": null,
-            "listStyleType-kH6xsr": "listStyleType-x152237o",
+            "listStyleType-kH6xsr": "x152237o",
             $$css: "@stylexjs/babel-plugin::4"
           },
           two: {
-            "listStyleType-kH6xsr": "listStyleType-x12kno0j",
-            "listStyleImage-khnUzm": "listStyleImage-xnbnhf8",
-            "listStylePosition-kpqbRz": "listStylePosition-x43c9pm",
+            "listStyleType-kH6xsr": "x12kno0j",
+            "listStyleImage-khnUzm": "xnbnhf8",
+            "listStylePosition-kpqbRz": "x43c9pm",
             $$css: "@stylexjs/babel-plugin::8"
           },
           three: {
-            "listStyleImage-khnUzm": "listStyleImage-x1qcowux",
-            "listStylePosition-kpqbRz": "listStylePosition-x43c9pm",
-            "listStyleType-kH6xsr": "listStyleType-x152237o",
+            "listStyleImage-khnUzm": "x1qcowux",
+            "listStylePosition-kpqbRz": "x43c9pm",
+            "listStyleType-kH6xsr": "x152237o",
             $$css: "@stylexjs/babel-plugin::12"
           },
           four: {
-            "listStyleImage-khnUzm": "listStyleImage-x1qcowux",
-            "listStylePosition-kpqbRz": "listStylePosition-x43c9pm",
-            "listStyleType-kH6xsr": "listStyleType-x152237o",
+            "listStyleImage-khnUzm": "x1qcowux",
+            "listStylePosition-kpqbRz": "x43c9pm",
+            "listStyleType-kH6xsr": "x152237o",
             $$css: "@stylexjs/babel-plugin::17"
           }
         };"

--- a/packages/@stylexjs/babel-plugin/__tests__/shared-stylex-nested-transforms-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/shared-stylex-nested-transforms-test.js
@@ -22,7 +22,6 @@ const defaultOptions = {
   classNamePrefix: 'x',
   dev: false,
   debug: false,
-  enableDebugClassNames: true,
   test: false,
   useRemForFontSize: false,
   enableFontSizePxToRem: false,

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -15,7 +15,6 @@ import stylexPlugin from '../src/index';
 function transform(source, opts = {}) {
   const pluginOpts = {
     debug: true,
-    enableDebugClassNames: true,
     styleResolution: 'property-specificity',
     unstable_moduleResolution: {
       rootDir: '/src/app/',
@@ -165,15 +164,15 @@ describe('@stylexjs/babel-plugin', () => {
           mediaSmall: "@media (max-width: 500px)"
         };
         export const vars = {
-          blue: "var(--blue-xpqh4lw)",
-          marginTokens: "var(--marginTokens-x8nt2k2)",
-          colorTokens: "var(--colorTokens-xkxfyv)",
+          blue: "var(--xpqh4lw)",
+          marginTokens: "var(--x8nt2k2)",
+          colorTokens: "var(--xkxfyv)",
           __varGroupHash__: "xsg933n"
         };
         export const spacing = {
-          small: "var(--small-x19twipt)",
-          medium: "var(--medium-xypjos2)",
-          large: "var(--large-x1ec7iuc)",
+          small: "var(--x19twipt)",
+          medium: "var(--xypjos2)",
+          large: "var(--x1ec7iuc)",
           __varGroupHash__: "xbiwvf9"
         };"
       `);
@@ -183,11 +182,11 @@ describe('@stylexjs/babel-plugin', () => {
           enableLTRRTLComments: false,
         }),
       ).toMatchInlineSnapshot(`
-        ":root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}"
+        ":root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}"
       `);
     });
 
@@ -204,43 +203,43 @@ describe('@stylexjs/babel-plugin', () => {
           mediaSmall: "@media (max-width: 500px)"
         };
         export const vars = {
-          blue: "var(--blue-xpqh4lw)",
-          marginTokens: "var(--marginTokens-x8nt2k2)",
-          colorTokens: "var(--colorTokens-xkxfyv)",
+          blue: "var(--xpqh4lw)",
+          marginTokens: "var(--x8nt2k2)",
+          colorTokens: "var(--xkxfyv)",
           __varGroupHash__: "xsg933n"
         };
         export const spacing = {
-          small: "var(--small-x19twipt)",
-          medium: "var(--medium-xypjos2)",
-          large: "var(--large-x1ec7iuc)",
+          small: "var(--x19twipt)",
+          medium: "var(--xypjos2)",
+          large: "var(--x1ec7iuc)",
           __varGroupHash__: "xbiwvf9"
         };
         export const themeColor = {
-          xsg933n: "x6xqkwy xsg933n",
+          xsg933n: "x1coplze xsg933n",
           $$css: true
         };
         export const themeSpacing = {
-          xbiwvf9: "x57uvma xbiwvf9",
+          xbiwvf9: "x4hn0rr xbiwvf9",
           $$css: true
         };
         export const styles = {
           root: {
-            "animationName-kKVMdj": "animationName-x13ah0pd",
-            "backgroundColor-kWkggS": "backgroundColor-xrkmrrc backgroundColor-xbrh7vm backgroundColor-xfy810d backgroundColor-xahc4vn backgroundColor-x1t4kl4c backgroundColor-x975j7z",
-            "margin-kogj98": "margin-xymmreb",
-            "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
-            "outlineColor-kjBf7l": "outlineColor-x184ctg8",
-            "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-xtj17id",
-            "padding-kmVPX3": "padding-xss17vw",
-            "float-kyUFMd": "float-x1kmio9f",
+            "animationName-kKVMdj": "x13ah0pd",
+            "backgroundColor-kWkggS": "xrkmrrc xbrh7vm xfy810d xahc4vn x1t4kl4c x975j7z",
+            "margin-kogj98": "xymmreb",
+            "borderColor-kVAM5u": "x1bg2uv5 xio2edn xqiy1ys",
+            "outlineColor-kjBf7l": "x18abd1y",
+            "textShadow-kKMj4B": "x1skrh0i xtj17id",
+            "padding-kmVPX3": "x1s2izit",
+            "float-kyUFMd": "x1kmio9f",
             $$css: "components/main.js:33"
           },
           overrideColor: {
-            "--orange-theme-color": "--orange-theme-color-xufgesz",
+            "--orange-theme-color": "xufgesz",
             $$css: "components/main.js:71"
           },
           dynamic: color => [{
-            "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
+            "color-kMwMTN": color != null ? "x14rh7hd" : color,
             $$css: "components/main.js:74"
           }, {
             "--x-color": color != null ? color : undefined
@@ -255,32 +254,32 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "@property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
-        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
-        .--orange-theme-color-xufgesz{--orange-theme-color:red}
-        .margin-xymmreb:not(#\\#){margin:10px 20px}
-        .padding-xss17vw:not(#\\#){padding:var(--large-x1ec7iuc)}
-        .borderColor-x1bg2uv5:not(#\\#):not(#\\#){border-color:green}
-        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c:not(#\\#):not(#\\#){border-color:var(--blue-xpqh4lw)}}
-        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys:not(#\\#):not(#\\#){border-color:yellow}}}
-        .animationName-x13ah0pd:not(#\\#):not(#\\#):not(#\\#){animation-name:x35atj5-B}
-        .backgroundColor-xrkmrrc:not(#\\#):not(#\\#):not(#\\#){background-color:red}
-        .color-x14rh7hd:not(#\\#):not(#\\#):not(#\\#){color:var(--x-color)}
-        html:not([dir='rtl']) .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:left}
-        html[dir='rtl'] .float-x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:right}
-        .outlineColor-x184ctg8:not(#\\#):not(#\\#):not(#\\#){outline-color:var(--colorTokens-xkxfyv)}
-        .textShadow-x1skrh0i:not(#\\#):not(#\\#):not(#\\#){text-shadow:1px 2px 3px 4px red}
-        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *):not(#\\#):not(#\\#):not(#\\#){background-color:green}
-        .backgroundColor-xbrh7vm:hover:not(#\\#):not(#\\#):not(#\\#){background-color:blue}
-        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn:not(#\\#):not(#\\#):not(#\\#){background-color:yellow}}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id:not(#\\#):not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}
-        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)):not(#\\#):not(#\\#):not(#\\#){background-color:purple}}
-        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)):not(#\\#):not(#\\#):not(#\\#){background-color:orange}}"
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
+        .xufgesz{--orange-theme-color:red}
+        .xymmreb:not(#\\#){margin:10px 20px}
+        .x1s2izit:not(#\\#){padding:var(--x1ec7iuc)}
+        .x1bg2uv5:not(#\\#):not(#\\#){border-color:green}
+        @media (max-width: 1000px){.xio2edn.xio2edn:not(#\\#):not(#\\#){border-color:var(--xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys:not(#\\#):not(#\\#){border-color:yellow}}}
+        .x13ah0pd:not(#\\#):not(#\\#):not(#\\#){animation-name:x35atj5-B}
+        .xrkmrrc:not(#\\#):not(#\\#):not(#\\#){background-color:red}
+        .x14rh7hd:not(#\\#):not(#\\#):not(#\\#){color:var(--x-color)}
+        html:not([dir='rtl']) .x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:left}
+        html[dir='rtl'] .x1kmio9f:not(#\\#):not(#\\#):not(#\\#){float:right}
+        .x18abd1y:not(#\\#):not(#\\#):not(#\\#){outline-color:var(--xkxfyv)}
+        .x1skrh0i:not(#\\#):not(#\\#):not(#\\#){text-shadow:1px 2px 3px 4px red}
+        .xfy810d.xfy810d:where(.x-default-marker:focus *):not(#\\#):not(#\\#):not(#\\#){background-color:green}
+        .xbrh7vm:hover:not(#\\#):not(#\\#):not(#\\#){background-color:blue}
+        @media (max-width: 1000px){.xahc4vn.xahc4vn:not(#\\#):not(#\\#):not(#\\#){background-color:yellow}}
+        @media (min-width: 320px){.xtj17id.xtj17id:not(#\\#):not(#\\#):not(#\\#){text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1t4kl4c.x1t4kl4c.x1t4kl4c:where(:has(.x-default-marker:focus)):not(#\\#):not(#\\#):not(#\\#){background-color:purple}}
+        @media (max-width: 1000px){.x975j7z.x975j7z.x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)):not(#\\#):not(#\\#):not(#\\#){background-color:orange}}"
       `);
     });
 
@@ -297,43 +296,43 @@ describe('@stylexjs/babel-plugin', () => {
           mediaSmall: "@media (max-width: 500px)"
         };
         export const vars = {
-          blue: "var(--blue-xpqh4lw)",
-          marginTokens: "var(--marginTokens-x8nt2k2)",
-          colorTokens: "var(--colorTokens-xkxfyv)",
+          blue: "var(--xpqh4lw)",
+          marginTokens: "var(--x8nt2k2)",
+          colorTokens: "var(--xkxfyv)",
           __varGroupHash__: "xsg933n"
         };
         export const spacing = {
-          small: "var(--small-x19twipt)",
-          medium: "var(--medium-xypjos2)",
-          large: "var(--large-x1ec7iuc)",
+          small: "var(--x19twipt)",
+          medium: "var(--xypjos2)",
+          large: "var(--x1ec7iuc)",
           __varGroupHash__: "xbiwvf9"
         };
         export const themeColor = {
-          xsg933n: "x6xqkwy xsg933n",
+          xsg933n: "x1coplze xsg933n",
           $$css: true
         };
         export const themeSpacing = {
-          xbiwvf9: "x57uvma xbiwvf9",
+          xbiwvf9: "x4hn0rr xbiwvf9",
           $$css: true
         };
         export const styles = {
           root: {
-            "animationName-kKVMdj": "animationName-x13ah0pd",
-            "backgroundColor-kWkggS": "backgroundColor-xrkmrrc backgroundColor-xbrh7vm backgroundColor-xfy810d backgroundColor-xahc4vn backgroundColor-x1t4kl4c backgroundColor-x975j7z",
-            "margin-kogj98": "margin-xymmreb",
-            "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
-            "outlineColor-kjBf7l": "outlineColor-x184ctg8",
-            "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-xtj17id",
-            "padding-kmVPX3": "padding-xss17vw",
-            "float-kyUFMd": "float-x1kmio9f",
+            "animationName-kKVMdj": "x13ah0pd",
+            "backgroundColor-kWkggS": "xrkmrrc xbrh7vm xfy810d xahc4vn x1t4kl4c x975j7z",
+            "margin-kogj98": "xymmreb",
+            "borderColor-kVAM5u": "x1bg2uv5 xio2edn xqiy1ys",
+            "outlineColor-kjBf7l": "x18abd1y",
+            "textShadow-kKMj4B": "x1skrh0i xtj17id",
+            "padding-kmVPX3": "x1s2izit",
+            "float-kyUFMd": "x1kmio9f",
             $$css: "main.js:33"
           },
           overrideColor: {
-            "--orange-theme-color": "--orange-theme-color-xufgesz",
+            "--orange-theme-color": "xufgesz",
             $$css: "main.js:71"
           },
           dynamic: color => [{
-            "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
+            "color-kMwMTN": color != null ? "x14rh7hd" : color,
             $$css: "main.js:74"
           }, {
             "--x-color": color != null ? color : undefined
@@ -350,37 +349,37 @@ describe('@stylexjs/babel-plugin', () => {
         @layer priority1, priority2, priority3, priority4;
         @property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
-        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
-        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
+        .xufgesz{--orange-theme-color:red}
         @layer priority2{
-        .margin-xymmreb{margin:10px 20px}
-        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        .xymmreb{margin:10px 20px}
+        .x1s2izit{padding:var(--x1ec7iuc)}
         }
         @layer priority3{
-        .borderColor-x1bg2uv5{border-color:green}
-        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
-        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        .x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.xio2edn.xio2edn{border-color:var(--xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys{border-color:yellow}}}
         }
         @layer priority4{
-        .animationName-x13ah0pd{animation-name:x35atj5-B}
-        .backgroundColor-xrkmrrc{background-color:red}
-        .color-x14rh7hd{color:var(--x-color)}
-        html:not([dir='rtl']) .float-x1kmio9f{float:left}
-        html[dir='rtl'] .float-x1kmio9f{float:right}
-        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
-        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
-        .backgroundColor-xbrh7vm:hover{background-color:blue}
-        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
-        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
-        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        .x13ah0pd{animation-name:x35atj5-B}
+        .xrkmrrc{background-color:red}
+        .x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .x1kmio9f{float:left}
+        html[dir='rtl'] .x1kmio9f{float:right}
+        .x18abd1y{outline-color:var(--xkxfyv)}
+        .x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .xfy810d.xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.xahc4vn.xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1t4kl4c.x1t4kl4c.x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.x975j7z.x975j7z.x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
         }"
       `);
     });
@@ -399,37 +398,37 @@ describe('@stylexjs/babel-plugin', () => {
         @layer reset, typography, priority1, priority2, priority3, priority4;
         @property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
-        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
-        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
+        .xufgesz{--orange-theme-color:red}
         @layer priority2{
-        .margin-xymmreb{margin:10px 20px}
-        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        .xymmreb{margin:10px 20px}
+        .x1s2izit{padding:var(--x1ec7iuc)}
         }
         @layer priority3{
-        .borderColor-x1bg2uv5{border-color:green}
-        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
-        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        .x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.xio2edn.xio2edn{border-color:var(--xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys{border-color:yellow}}}
         }
         @layer priority4{
-        .animationName-x13ah0pd{animation-name:x35atj5-B}
-        .backgroundColor-xrkmrrc{background-color:red}
-        .color-x14rh7hd{color:var(--x-color)}
-        html:not([dir='rtl']) .float-x1kmio9f{float:left}
-        html[dir='rtl'] .float-x1kmio9f{float:right}
-        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
-        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
-        .backgroundColor-xbrh7vm:hover{background-color:blue}
-        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
-        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
-        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        .x13ah0pd{animation-name:x35atj5-B}
+        .xrkmrrc{background-color:red}
+        .x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .x1kmio9f{float:left}
+        html[dir='rtl'] .x1kmio9f{float:right}
+        .x18abd1y{outline-color:var(--xkxfyv)}
+        .x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .xfy810d.xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.xahc4vn.xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1t4kl4c.x1t4kl4c.x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.x975j7z.x975j7z.x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
         }"
       `);
     });
@@ -448,37 +447,37 @@ describe('@stylexjs/babel-plugin', () => {
         @layer priority1, priority2, priority3, priority4, overrides, xds.theme;
         @property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
-        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
-        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
+        .xufgesz{--orange-theme-color:red}
         @layer priority2{
-        .margin-xymmreb{margin:10px 20px}
-        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        .xymmreb{margin:10px 20px}
+        .x1s2izit{padding:var(--x1ec7iuc)}
         }
         @layer priority3{
-        .borderColor-x1bg2uv5{border-color:green}
-        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
-        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        .x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.xio2edn.xio2edn{border-color:var(--xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys{border-color:yellow}}}
         }
         @layer priority4{
-        .animationName-x13ah0pd{animation-name:x35atj5-B}
-        .backgroundColor-xrkmrrc{background-color:red}
-        .color-x14rh7hd{color:var(--x-color)}
-        html:not([dir='rtl']) .float-x1kmio9f{float:left}
-        html[dir='rtl'] .float-x1kmio9f{float:right}
-        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
-        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
-        .backgroundColor-xbrh7vm:hover{background-color:blue}
-        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
-        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
-        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        .x13ah0pd{animation-name:x35atj5-B}
+        .xrkmrrc{background-color:red}
+        .x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .x1kmio9f{float:left}
+        html[dir='rtl'] .x1kmio9f{float:right}
+        .x18abd1y{outline-color:var(--xkxfyv)}
+        .x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .xfy810d.xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.xahc4vn.xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1t4kl4c.x1t4kl4c.x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.x975j7z.x975j7z.x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
         }"
       `);
     });
@@ -498,37 +497,37 @@ describe('@stylexjs/babel-plugin', () => {
         @layer reset, priority1, priority2, priority3, priority4, xds.theme;
         @property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
-        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
-        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
+        .xufgesz{--orange-theme-color:red}
         @layer priority2{
-        .margin-xymmreb{margin:10px 20px}
-        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        .xymmreb{margin:10px 20px}
+        .x1s2izit{padding:var(--x1ec7iuc)}
         }
         @layer priority3{
-        .borderColor-x1bg2uv5{border-color:green}
-        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
-        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        .x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.xio2edn.xio2edn{border-color:var(--xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys{border-color:yellow}}}
         }
         @layer priority4{
-        .animationName-x13ah0pd{animation-name:x35atj5-B}
-        .backgroundColor-xrkmrrc{background-color:red}
-        .color-x14rh7hd{color:var(--x-color)}
-        html:not([dir='rtl']) .float-x1kmio9f{float:left}
-        html[dir='rtl'] .float-x1kmio9f{float:right}
-        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
-        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
-        .backgroundColor-xbrh7vm:hover{background-color:blue}
-        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
-        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
-        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        .x13ah0pd{animation-name:x35atj5-B}
+        .xrkmrrc{background-color:red}
+        .x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .x1kmio9f{float:left}
+        html[dir='rtl'] .x1kmio9f{float:right}
+        .x18abd1y{outline-color:var(--xkxfyv)}
+        .x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .xfy810d.xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.xahc4vn.xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1t4kl4c.x1t4kl4c.x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.x975j7z.x975j7z.x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
         }"
       `);
     });
@@ -547,37 +546,37 @@ describe('@stylexjs/babel-plugin', () => {
         @layer stylex.priority1, stylex.priority2, stylex.priority3, stylex.priority4;
         @property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
-        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
-        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
+        .xufgesz{--orange-theme-color:red}
         @layer stylex.priority2{
-        .margin-xymmreb{margin:10px 20px}
-        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        .xymmreb{margin:10px 20px}
+        .x1s2izit{padding:var(--x1ec7iuc)}
         }
         @layer stylex.priority3{
-        .borderColor-x1bg2uv5{border-color:green}
-        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
-        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        .x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.xio2edn.xio2edn{border-color:var(--xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys{border-color:yellow}}}
         }
         @layer stylex.priority4{
-        .animationName-x13ah0pd{animation-name:x35atj5-B}
-        .backgroundColor-xrkmrrc{background-color:red}
-        .color-x14rh7hd{color:var(--x-color)}
-        html:not([dir='rtl']) .float-x1kmio9f{float:left}
-        html[dir='rtl'] .float-x1kmio9f{float:right}
-        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
-        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
-        .backgroundColor-xbrh7vm:hover{background-color:blue}
-        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
-        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
-        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        .x13ah0pd{animation-name:x35atj5-B}
+        .xrkmrrc{background-color:red}
+        .x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .x1kmio9f{float:left}
+        html[dir='rtl'] .x1kmio9f{float:right}
+        .x18abd1y{outline-color:var(--xkxfyv)}
+        .x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .xfy810d.xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.xahc4vn.xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1t4kl4c.x1t4kl4c.x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.x975j7z.x975j7z.x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
         }"
       `);
     });
@@ -598,37 +597,37 @@ describe('@stylexjs/babel-plugin', () => {
         @layer reset, typography, stylex.priority1, stylex.priority2, stylex.priority3, stylex.priority4, xds.theme;
         @property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
-        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
-        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
+        .xufgesz{--orange-theme-color:red}
         @layer stylex.priority2{
-        .margin-xymmreb{margin:10px 20px}
-        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        .xymmreb{margin:10px 20px}
+        .x1s2izit{padding:var(--x1ec7iuc)}
         }
         @layer stylex.priority3{
-        .borderColor-x1bg2uv5{border-color:green}
-        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
-        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        .x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.xio2edn.xio2edn{border-color:var(--xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys{border-color:yellow}}}
         }
         @layer stylex.priority4{
-        .animationName-x13ah0pd{animation-name:x35atj5-B}
-        .backgroundColor-xrkmrrc{background-color:red}
-        .color-x14rh7hd{color:var(--x-color)}
-        html:not([dir='rtl']) .float-x1kmio9f{float:left}
-        html[dir='rtl'] .float-x1kmio9f{float:right}
-        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
-        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
-        .backgroundColor-xbrh7vm:hover{background-color:blue}
-        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
-        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
-        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        .x13ah0pd{animation-name:x35atj5-B}
+        .xrkmrrc{background-color:red}
+        .x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .x1kmio9f{float:left}
+        html[dir='rtl'] .x1kmio9f{float:right}
+        .x18abd1y{outline-color:var(--xkxfyv)}
+        .x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .xfy810d.xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.xahc4vn.xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1t4kl4c.x1t4kl4c.x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.x975j7z.x975j7z.x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
         }"
       `);
     });
@@ -649,37 +648,37 @@ describe('@stylexjs/babel-plugin', () => {
         @layer xds.reset, xds.typography, xds.base.priority1, xds.base.priority2, xds.base.priority3, xds.base.priority4, xds.theme;
         @property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
-        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
-        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
+        .xufgesz{--orange-theme-color:red}
         @layer xds.base.priority2{
-        .margin-xymmreb{margin:10px 20px}
-        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        .xymmreb{margin:10px 20px}
+        .x1s2izit{padding:var(--x1ec7iuc)}
         }
         @layer xds.base.priority3{
-        .borderColor-x1bg2uv5{border-color:green}
-        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
-        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        .x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.xio2edn.xio2edn{border-color:var(--xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys{border-color:yellow}}}
         }
         @layer xds.base.priority4{
-        .animationName-x13ah0pd{animation-name:x35atj5-B}
-        .backgroundColor-xrkmrrc{background-color:red}
-        .color-x14rh7hd{color:var(--x-color)}
-        html:not([dir='rtl']) .float-x1kmio9f{float:left}
-        html[dir='rtl'] .float-x1kmio9f{float:right}
-        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
-        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
-        .backgroundColor-xbrh7vm:hover{background-color:blue}
-        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
-        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
-        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        .x13ah0pd{animation-name:x35atj5-B}
+        .xrkmrrc{background-color:red}
+        .x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .x1kmio9f{float:left}
+        html[dir='rtl'] .x1kmio9f{float:right}
+        .x18abd1y{outline-color:var(--xkxfyv)}
+        .x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .xfy810d.xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.xahc4vn.xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1t4kl4c.x1t4kl4c.x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.x975j7z.x975j7z.x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
         }"
       `);
     });
@@ -699,37 +698,37 @@ describe('@stylexjs/babel-plugin', () => {
         @layer priority1, priority2, priority3, priority4;
         @property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
-        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
-        .--orange-theme-color-xufgesz{--orange-theme-color:red}
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
+        .xufgesz{--orange-theme-color:red}
         @layer priority2{
-        .margin-xymmreb{margin:10px 20px}
-        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
+        .xymmreb{margin:10px 20px}
+        .x1s2izit{padding:var(--x1ec7iuc)}
         }
         @layer priority3{
-        .borderColor-x1bg2uv5{border-color:green}
-        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
-        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
+        .x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.xio2edn.xio2edn{border-color:var(--xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys{border-color:yellow}}}
         }
         @layer priority4{
-        .animationName-x13ah0pd{animation-name:x35atj5-B}
-        .backgroundColor-xrkmrrc{background-color:red}
-        .color-x14rh7hd{color:var(--x-color)}
-        html:not([dir='rtl']) .float-x1kmio9f{float:left}
-        html[dir='rtl'] .float-x1kmio9f{float:right}
-        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
-        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
-        .backgroundColor-xbrh7vm:hover{background-color:blue}
-        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
-        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
-        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
+        .x13ah0pd{animation-name:x35atj5-B}
+        .xrkmrrc{background-color:red}
+        .x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .x1kmio9f{float:left}
+        html[dir='rtl'] .x1kmio9f{float:right}
+        .x18abd1y{outline-color:var(--xkxfyv)}
+        .x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .xfy810d.xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.xahc4vn.xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1t4kl4c.x1t4kl4c.x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.x975j7z.x975j7z.x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}
         }"
       `);
     });
@@ -745,43 +744,43 @@ describe('@stylexjs/babel-plugin', () => {
           mediaSmall: "@media (max-width: 500px)"
         };
         export const vars = {
-          blue: "var(--blue-xpqh4lw)",
-          marginTokens: "var(--marginTokens-x8nt2k2)",
-          colorTokens: "var(--colorTokens-xkxfyv)",
+          blue: "var(--xpqh4lw)",
+          marginTokens: "var(--x8nt2k2)",
+          colorTokens: "var(--xkxfyv)",
           __varGroupHash__: "xsg933n"
         };
         export const spacing = {
-          small: "var(--small-x19twipt)",
-          medium: "var(--medium-xypjos2)",
-          large: "var(--large-x1ec7iuc)",
+          small: "var(--x19twipt)",
+          medium: "var(--xypjos2)",
+          large: "var(--x1ec7iuc)",
           __varGroupHash__: "xbiwvf9"
         };
         export const themeColor = {
-          xsg933n: "x6xqkwy xsg933n",
+          xsg933n: "x1coplze xsg933n",
           $$css: true
         };
         export const themeSpacing = {
-          xbiwvf9: "x57uvma xbiwvf9",
+          xbiwvf9: "x4hn0rr xbiwvf9",
           $$css: true
         };
         export const styles = {
           root: {
-            "animationName-kKVMdj": "animationName-x13ah0pd",
-            "backgroundColor-kWkggS": "backgroundColor-xrkmrrc backgroundColor-xbrh7vm backgroundColor-xfy810d backgroundColor-xahc4vn backgroundColor-x1t4kl4c backgroundColor-x975j7z",
-            "margin-kogj98": "margin-xymmreb",
-            "borderColor-kVAM5u": "borderColor-x1bg2uv5 borderColor-x5ugf7c borderColor-xqiy1ys",
-            "outlineColor-kjBf7l": "outlineColor-x184ctg8",
-            "textShadow-kKMj4B": "textShadow-x1skrh0i textShadow-xtj17id",
-            "padding-kmVPX3": "padding-xss17vw",
-            "float-kyUFMd": "float-x1kmio9f",
+            "animationName-kKVMdj": "x13ah0pd",
+            "backgroundColor-kWkggS": "xrkmrrc xbrh7vm xfy810d xahc4vn x1t4kl4c x975j7z",
+            "margin-kogj98": "xymmreb",
+            "borderColor-kVAM5u": "x1bg2uv5 xio2edn xqiy1ys",
+            "outlineColor-kjBf7l": "x18abd1y",
+            "textShadow-kKMj4B": "x1skrh0i xtj17id",
+            "padding-kmVPX3": "x1s2izit",
+            "float-kyUFMd": "x1kmio9f",
             $$css: "main.js:33"
           },
           overrideColor: {
-            "--orange-theme-color": "--orange-theme-color-xufgesz",
+            "--orange-theme-color": "xufgesz",
             $$css: "main.js:71"
           },
           dynamic: color => [{
-            "color-kMwMTN": color != null ? "color-x14rh7hd" : color,
+            "color-kMwMTN": color != null ? "x14rh7hd" : color,
             $$css: "main.js:74"
           }, {
             "--x-color": color != null ? color : undefined
@@ -797,32 +796,32 @@ describe('@stylexjs/babel-plugin', () => {
       ).toMatchInlineSnapshot(`
         "@property --x-color { syntax: "*"; inherits: false;}
         @keyframes x35atj5-B{0%{box-shadow:1px 2px 3px 4px red;color:yellow;}100%{box-shadow:10px 20px 30px 40px green;color:var(--orange-theme-color);}}
-        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
-        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}
-        .--orange-theme-color-xufgesz{--orange-theme-color:red}
-        .margin-xymmreb{margin:10px 20px}
-        .padding-xss17vw{padding:var(--large-x1ec7iuc)}
-        .borderColor-x1bg2uv5{border-color:green}
-        @media (max-width: 1000px){.borderColor-x5ugf7c.borderColor-x5ugf7c{border-color:var(--blue-xpqh4lw)}}
-        @media (max-width: 500px){@media (max-width: 1000px){.borderColor-xqiy1ys.borderColor-xqiy1ys.borderColor-xqiy1ys{border-color:yellow}}}
-        .animationName-x13ah0pd{animation-name:x35atj5-B}
-        .backgroundColor-xrkmrrc{background-color:red}
-        .color-x14rh7hd{color:var(--x-color)}
-        html:not([dir='rtl']) .float-x1kmio9f{float:left}
-        html[dir='rtl'] .float-x1kmio9f{float:right}
-        .outlineColor-x184ctg8{outline-color:var(--colorTokens-xkxfyv)}
-        .textShadow-x1skrh0i{text-shadow:1px 2px 3px 4px red}
-        .backgroundColor-xfy810d.backgroundColor-xfy810d:where(.x-default-marker:focus *){background-color:green}
-        .backgroundColor-xbrh7vm:hover{background-color:blue}
-        @media (max-width: 1000px){.backgroundColor-xahc4vn.backgroundColor-xahc4vn{background-color:yellow}}
-        @media (min-width: 320px){.textShadow-xtj17id.textShadow-xtj17id{text-shadow:10px 20px 30px 40px green}}
-        @media (max-width: 1000px){.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c.backgroundColor-x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
-        @media (max-width: 1000px){.backgroundColor-x975j7z.backgroundColor-x975j7z.backgroundColor-x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}"
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}
+        .xufgesz{--orange-theme-color:red}
+        .xymmreb{margin:10px 20px}
+        .x1s2izit{padding:var(--x1ec7iuc)}
+        .x1bg2uv5{border-color:green}
+        @media (max-width: 1000px){.xio2edn.xio2edn{border-color:var(--xpqh4lw)}}
+        @media (max-width: 500px){@media (max-width: 1000px){.xqiy1ys.xqiy1ys.xqiy1ys{border-color:yellow}}}
+        .x13ah0pd{animation-name:x35atj5-B}
+        .xrkmrrc{background-color:red}
+        .x14rh7hd{color:var(--x-color)}
+        html:not([dir='rtl']) .x1kmio9f{float:left}
+        html[dir='rtl'] .x1kmio9f{float:right}
+        .x18abd1y{outline-color:var(--xkxfyv)}
+        .x1skrh0i{text-shadow:1px 2px 3px 4px red}
+        .xfy810d.xfy810d:where(.x-default-marker:focus *){background-color:green}
+        .xbrh7vm:hover{background-color:blue}
+        @media (max-width: 1000px){.xahc4vn.xahc4vn{background-color:yellow}}
+        @media (min-width: 320px){.xtj17id.xtj17id{text-shadow:10px 20px 30px 40px green}}
+        @media (max-width: 1000px){.x1t4kl4c.x1t4kl4c.x1t4kl4c:where(:has(.x-default-marker:focus)){background-color:purple}}
+        @media (max-width: 1000px){.x975j7z.x975j7z.x975j7z:where(.x-default-marker:active ~ *, :has(~ .x-default-marker:active)){background-color:orange}}"
       `);
     });
 
@@ -853,28 +852,28 @@ describe('@stylexjs/babel-plugin', () => {
           mediaSmall: "@media (max-width: 500px)"
         };
         export const vars = {
-          blue: "var(--blue-xpqh4lw)",
-          marginTokens: "var(--marginTokens-x8nt2k2)",
-          colorTokens: "var(--colorTokens-xkxfyv)",
+          blue: "var(--xpqh4lw)",
+          marginTokens: "var(--x8nt2k2)",
+          colorTokens: "var(--xkxfyv)",
           __varGroupHash__: "xsg933n"
         };
         export const spacing = {
-          small: "var(--small-x19twipt)",
-          medium: "var(--medium-xypjos2)",
-          large: "var(--large-x1ec7iuc)",
+          small: "var(--x19twipt)",
+          medium: "var(--xypjos2)",
+          large: "var(--x1ec7iuc)",
           __varGroupHash__: "xbiwvf9"
         };
         export const styles = {
           container: {
-            "marginTop-keoZOQ": "marginTop-x1anpbxc",
-            "marginInlineEnd-k71WvV": "marginInlineEnd-x3aesyq",
-            "marginBottom-k1K539": "marginBottom-xyorhqc",
-            "marginInlineStart-keTefX": "marginInlineStart-xqsn43r",
-            "paddingTop-kLKAdn": "paddingTop-x123j3cw",
-            "paddingInlineEnd-kwRFfy": "paddingInlineEnd-x1q3ajuy",
-            "paddingBottom-kGO01o": "paddingBottom-xs9asl8",
-            "paddingInlineStart-kZCmMZ": "paddingInlineStart-x1gx403c",
-            "float-kyUFMd": "float-xj87blo",
+            "marginTop-keoZOQ": "x1anpbxc",
+            "marginInlineEnd-k71WvV": "x3aesyq",
+            "marginBottom-k1K539": "xyorhqc",
+            "marginInlineStart-keTefX": "xqsn43r",
+            "paddingTop-kLKAdn": "x123j3cw",
+            "paddingInlineEnd-kwRFfy": "x1q3ajuy",
+            "paddingBottom-kGO01o": "xs9asl8",
+            "paddingInlineStart-kZCmMZ": "x1gx403c",
+            "float-kyUFMd": "xj87blo",
             $$css: "main.js:25"
           }
         };"
@@ -894,24 +893,24 @@ describe('@stylexjs/babel-plugin', () => {
           --stylex-logical-start: right;
           --stylex-logical-end: left;
         }
-        :root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
-        .float-xj87blo:not(#\\#){float:var(--stylex-logical-start)}
-        /* @ltr begin */.marginInlineStart-xqsn43r:not(#\\#){margin-left:20px}/* @ltr end */
-        /* @rtl begin */.marginInlineStart-xqsn43r:not(#\\#){margin-right:20px}/* @rtl end */
-        /* @ltr begin */.marginInlineEnd-x3aesyq:not(#\\#){margin-right:20px}/* @ltr end */
-        /* @rtl begin */.marginInlineEnd-x3aesyq:not(#\\#){margin-left:20px}/* @rtl end */
-        /* @ltr begin */.paddingInlineStart-x1gx403c:not(#\\#){padding-left:15px}/* @ltr end */
-        /* @rtl begin */.paddingInlineStart-x1gx403c:not(#\\#){padding-right:15px}/* @rtl end */
-        /* @ltr begin */.paddingInlineEnd-x1q3ajuy:not(#\\#){padding-right:15px}/* @ltr end */
-        /* @rtl begin */.paddingInlineEnd-x1q3ajuy:not(#\\#){padding-left:15px}/* @rtl end */
-        .marginBottom-xyorhqc:not(#\\#):not(#\\#){margin-bottom:10px}
-        .marginTop-x1anpbxc:not(#\\#):not(#\\#){margin-top:10px}
-        .paddingBottom-xs9asl8:not(#\\#):not(#\\#){padding-bottom:5px}
-        .paddingTop-x123j3cw:not(#\\#):not(#\\#){padding-top:5px}"
+        :root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .xj87blo:not(#\\#){float:var(--stylex-logical-start)}
+        /* @ltr begin */.xqsn43r:not(#\\#){margin-left:20px}/* @ltr end */
+        /* @rtl begin */.xqsn43r:not(#\\#){margin-right:20px}/* @rtl end */
+        /* @ltr begin */.x3aesyq:not(#\\#){margin-right:20px}/* @ltr end */
+        /* @rtl begin */.x3aesyq:not(#\\#){margin-left:20px}/* @rtl end */
+        /* @ltr begin */.x1gx403c:not(#\\#){padding-left:15px}/* @ltr end */
+        /* @rtl begin */.x1gx403c:not(#\\#){padding-right:15px}/* @rtl end */
+        /* @ltr begin */.x1q3ajuy:not(#\\#){padding-right:15px}/* @ltr end */
+        /* @rtl begin */.x1q3ajuy:not(#\\#){padding-left:15px}/* @rtl end */
+        .xyorhqc:not(#\\#):not(#\\#){margin-bottom:10px}
+        .x1anpbxc:not(#\\#):not(#\\#){margin-top:10px}
+        .xs9asl8:not(#\\#):not(#\\#){padding-bottom:5px}
+        .x123j3cw:not(#\\#):not(#\\#){padding-top:5px}"
       `);
     });
 
@@ -939,13 +938,13 @@ describe('@stylexjs/babel-plugin', () => {
           enableLTRRTLComments: false,
         }),
       ).toMatchInlineSnapshot(`
-        ":root, .xsg933n{--blue-xpqh4lw:blue;--marginTokens-x8nt2k2:10px;--colorTokens-xkxfyv:red;}
-        :root, .xbiwvf9{--small-x19twipt:2px;--medium-xypjos2:4px;--large-x1ec7iuc:8px;}
-        @media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:lightblue;}}
-        @media (min-width: 600px){:root, .xsg933n{--marginTokens-x8nt2k2:20px;}}
-        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--colorTokens-xkxfyv:oklab(0.7 -0.3 -0.4);}}}
-        .x6xqkwy.x6xqkwy, .x6xqkwy.x6xqkwy:root{--blue-xpqh4lw:lightblue;}
-        .x57uvma.x57uvma, .x57uvma.x57uvma:root{--large-x1ec7iuc:20px;--medium-xypjos2:10px;--small-x19twipt:5px;}"
+        ":root, .xbiwvf9{--x19twipt:2px;--xypjos2:4px;--x1ec7iuc:8px;}
+        :root, .xsg933n{--xpqh4lw:blue;--x8nt2k2:10px;--xkxfyv:red;}
+        @media (min-width: 600px){:root, .xsg933n{--x8nt2k2:20px;}}
+        @media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:lightblue;}}
+        @supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xsg933n{--xkxfyv:oklab(0.7 -0.3 -0.4);}}}
+        .x4hn0rr.x4hn0rr, .x4hn0rr.x4hn0rr:root{--x1ec7iuc:20px;--xypjos2:10px;--x19twipt:5px;}
+        .x1coplze.x1coplze, .x1coplze.x1coplze:root{--xpqh4lw:lightblue;}"
       `);
     });
 
@@ -978,9 +977,7 @@ describe('@stylexjs/babel-plugin', () => {
     });
 
     test('useLegacyClassnamesSort: false (default behavior)', () => {
-      const { _code, metadata } = transform(fixture, {
-        enableDebugClassNames: false,
-      });
+      const { _code, metadata } = transform(fixture);
 
       expect(
         stylexPlugin.processStylexRules(metadata, {
@@ -1022,9 +1019,7 @@ describe('@stylexjs/babel-plugin', () => {
     });
 
     test('useLegacyClassnamesSort: true (legacy behavior)', () => {
-      const { _code, metadata } = transform(fixture, {
-        enableDebugClassNames: false,
-      });
+      const { _code, metadata } = transform(fixture);
 
       expect(
         stylexPlugin.processStylexRules(metadata, {

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -5322,7 +5322,6 @@ describe('@stylexjs/babel-plugin', () => {
       test('adds debug data', () => {
         const options = {
           debug: true,
-          enableDebugClassNames: true,
           filename: '/html/js/components/Foo.react.js',
         };
         const { code, metadata } = transform(
@@ -5346,15 +5345,15 @@ describe('@stylexjs/babel-plugin', () => {
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
             "1": {
-              "fontSize-kGuDYH": "fontSize-xrv4cvt",
+              "fontSize-kGuDYH": "xrv4cvt",
               $$css: "components/Foo.react.js:10"
             },
             foo: {
-              "color-kMwMTN": "color-x1e2nbdu",
+              "color-kMwMTN": "x1e2nbdu",
               $$css: "components/Foo.react.js:4"
             },
             "bar-baz": {
-              "display-k1xSpc": "display-x1lliihq",
+              "display-k1xSpc": "x1lliihq",
               $$css: "components/Foo.react.js:7"
             }
           };"
@@ -5363,25 +5362,25 @@ describe('@stylexjs/babel-plugin', () => {
           {
             "stylex": [
               [
-                "fontSize-xrv4cvt",
+                "xrv4cvt",
                 {
-                  "ltr": ".fontSize-xrv4cvt{font-size:1em}",
+                  "ltr": ".xrv4cvt{font-size:1em}",
                   "rtl": null,
                 },
                 3000,
               ],
               [
-                "color-x1e2nbdu",
+                "x1e2nbdu",
                 {
-                  "ltr": ".color-x1e2nbdu{color:red}",
+                  "ltr": ".x1e2nbdu{color:red}",
                   "rtl": null,
                 },
                 3000,
               ],
               [
-                "display-x1lliihq",
+                "x1lliihq",
                 {
-                  "ltr": ".display-x1lliihq{display:block}",
+                  "ltr": ".x1lliihq{display:block}",
                   "rtl": null,
                 },
                 3000,
@@ -5394,7 +5393,6 @@ describe('@stylexjs/babel-plugin', () => {
       test('adds debug data for npm packages', () => {
         const options = {
           debug: true,
-          enableDebugClassNames: true,
           filename: '/js/node_modules/npm-package/dist/components/Foo.react.js',
         };
         const { code, metadata } = transform(
@@ -5418,15 +5416,15 @@ describe('@stylexjs/babel-plugin', () => {
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
             "1": {
-              "fontSize-kGuDYH": "fontSize-xrv4cvt",
+              "fontSize-kGuDYH": "xrv4cvt",
               $$css: "npm-package:components/Foo.react.js:10"
             },
             foo: {
-              "color-kMwMTN": "color-x1e2nbdu",
+              "color-kMwMTN": "x1e2nbdu",
               $$css: "npm-package:components/Foo.react.js:4"
             },
             "bar-baz": {
-              "display-k1xSpc": "display-x1lliihq",
+              "display-k1xSpc": "x1lliihq",
               $$css: "npm-package:components/Foo.react.js:7"
             }
           };"
@@ -5435,25 +5433,25 @@ describe('@stylexjs/babel-plugin', () => {
           {
             "stylex": [
               [
-                "fontSize-xrv4cvt",
+                "xrv4cvt",
                 {
-                  "ltr": ".fontSize-xrv4cvt{font-size:1em}",
+                  "ltr": ".xrv4cvt{font-size:1em}",
                   "rtl": null,
                 },
                 3000,
               ],
               [
-                "color-x1e2nbdu",
+                "x1e2nbdu",
                 {
-                  "ltr": ".color-x1e2nbdu{color:red}",
+                  "ltr": ".x1e2nbdu{color:red}",
                   "rtl": null,
                 },
                 3000,
               ],
               [
-                "display-x1lliihq",
+                "x1lliihq",
                 {
-                  "ltr": ".display-x1lliihq{display:block}",
+                  "ltr": ".x1lliihq{display:block}",
                   "rtl": null,
                 },
                 3000,
@@ -5466,7 +5464,6 @@ describe('@stylexjs/babel-plugin', () => {
       test('adds debug data (haste)', () => {
         const options = {
           debug: true,
-          enableDebugClassNames: true,
           filename: '/html/js/components/Foo.react.js',
           unstable_moduleResolution: { type: 'haste' },
         };
@@ -5491,15 +5488,15 @@ describe('@stylexjs/babel-plugin', () => {
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
             "1": {
-              "fontSize-kGuDYH": "fontSize-xrv4cvt",
+              "fontSize-kGuDYH": "xrv4cvt",
               $$css: "Foo.react.js:10"
             },
             foo: {
-              "color-kMwMTN": "color-x1e2nbdu",
+              "color-kMwMTN": "x1e2nbdu",
               $$css: "Foo.react.js:4"
             },
             "bar-baz": {
-              "display-k1xSpc": "display-x1lliihq",
+              "display-k1xSpc": "x1lliihq",
               $$css: "Foo.react.js:7"
             }
           };"
@@ -5508,25 +5505,25 @@ describe('@stylexjs/babel-plugin', () => {
           {
             "stylex": [
               [
-                "fontSize-xrv4cvt",
+                "xrv4cvt",
                 {
-                  "ltr": ".fontSize-xrv4cvt{font-size:1em}",
+                  "ltr": ".xrv4cvt{font-size:1em}",
                   "rtl": null,
                 },
                 3000,
               ],
               [
-                "color-x1e2nbdu",
+                "x1e2nbdu",
                 {
-                  "ltr": ".color-x1e2nbdu{color:red}",
+                  "ltr": ".x1e2nbdu{color:red}",
                   "rtl": null,
                 },
                 3000,
               ],
               [
-                "display-x1lliihq",
+                "x1lliihq",
                 {
-                  "ltr": ".display-x1lliihq{display:block}",
+                  "ltr": ".x1lliihq{display:block}",
                   "rtl": null,
                 },
                 3000,
@@ -5539,7 +5536,6 @@ describe('@stylexjs/babel-plugin', () => {
       test('adds debug data for npm packages (haste)', () => {
         const options = {
           debug: true,
-          enableDebugClassNames: true,
           filename: '/node_modules/npm-package/dist/components/Foo.react.js',
           unstable_moduleResolution: { type: 'haste' },
         };
@@ -5564,15 +5560,15 @@ describe('@stylexjs/babel-plugin', () => {
           "import * as stylex from '@stylexjs/stylex';
           export const styles = {
             "1": {
-              "fontSize-kGuDYH": "fontSize-xrv4cvt",
+              "fontSize-kGuDYH": "xrv4cvt",
               $$css: "npm-package:components/Foo.react.js:10"
             },
             foo: {
-              "color-kMwMTN": "color-x1e2nbdu",
+              "color-kMwMTN": "x1e2nbdu",
               $$css: "npm-package:components/Foo.react.js:4"
             },
             "bar-baz": {
-              "display-k1xSpc": "display-x1lliihq",
+              "display-k1xSpc": "x1lliihq",
               $$css: "npm-package:components/Foo.react.js:7"
             }
           };"
@@ -5581,25 +5577,25 @@ describe('@stylexjs/babel-plugin', () => {
           {
             "stylex": [
               [
-                "fontSize-xrv4cvt",
+                "xrv4cvt",
                 {
-                  "ltr": ".fontSize-xrv4cvt{font-size:1em}",
+                  "ltr": ".xrv4cvt{font-size:1em}",
                   "rtl": null,
                 },
                 3000,
               ],
               [
-                "color-x1e2nbdu",
+                "x1e2nbdu",
                 {
-                  "ltr": ".color-x1e2nbdu{color:red}",
+                  "ltr": ".x1e2nbdu{color:red}",
                   "rtl": null,
                 },
                 3000,
               ],
               [
-                "display-x1lliihq",
+                "x1lliihq",
                 {
-                  "ltr": ".display-x1lliihq{display:block}",
+                  "ltr": ".x1lliihq{display:block}",
                   "rtl": null,
                 },
                 3000,

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineVars-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-defineVars-test.js
@@ -1004,8 +1004,8 @@ describe('@stylexjs/babel-plugin', () => {
     });
 
     describe('options `debug:true`', () => {
-      test('tokens object includes debug data', () => {
-        const options = { debug: true, enableDebugClassNames: true };
+      test('tokens object uses hashed variable names', () => {
+        const options = { debug: true };
         const { code, metadata } = transform(
           `
           import * as stylex from '@stylexjs/stylex';
@@ -1026,8 +1026,8 @@ describe('@stylexjs/babel-plugin', () => {
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const vars = {
-            color: "var(--color-xwx8imx)",
-            otherColor: "var(--otherColor-xaaua2w)",
+            color: "var(--xwx8imx)",
+            otherColor: "var(--xaaua2w)",
             __varGroupHash__: "xop34xu"
           };"
         `);
@@ -1038,7 +1038,7 @@ describe('@stylexjs/babel-plugin', () => {
               [
                 "xop34xu",
                 {
-                  "ltr": ":root, .xop34xu{--color-xwx8imx:blue;--otherColor-xaaua2w:green;}",
+                  "ltr": ":root, .xop34xu{--xwx8imx:blue;--xaaua2w:green;}",
                   "rtl": null,
                 },
                 0.1,
@@ -1046,7 +1046,7 @@ describe('@stylexjs/babel-plugin', () => {
               [
                 "xop34xu-1lveb7",
                 {
-                  "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--color-xwx8imx:lightblue;}}",
+                  "ltr": "@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:lightblue;}}",
                   "rtl": null,
                 },
                 0.2,
@@ -1054,7 +1054,7 @@ describe('@stylexjs/babel-plugin', () => {
               [
                 "xop34xu-1e6ryz3",
                 {
-                  "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xop34xu{--color-xwx8imx:oklab(0.7 -0.3 -0.4);}}}",
+                  "ltr": "@supports (color: oklab(0 0 0)){@media (prefers-color-scheme: dark){:root, .xop34xu{--xwx8imx:oklab(0.7 -0.3 -0.4);}}}",
                   "rtl": null,
                 },
                 0.3,
@@ -1064,8 +1064,8 @@ describe('@stylexjs/babel-plugin', () => {
         `);
       });
 
-      test('tokens object includes debug data (keys with special characters)', () => {
-        const options = { debug: true, enableDebugClassNames: true };
+      test('tokens with special-character keys use hashed variable names', () => {
+        const options = { debug: true };
         const { code, metadata } = transform(
           `
           import * as stylex from '@stylexjs/stylex';
@@ -1082,10 +1082,10 @@ describe('@stylexjs/babel-plugin', () => {
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const vars = {
-            "10": "var(--_10-x187fpdw)",
-            "1.5 pixels": "var(--_1_5_pixels-x15ahj5d)",
-            "corner#radius": "var(--corner_radius-x2ajqv2)",
-            "@@primary": "var(--__primary-x13tvx0f)",
+            "10": "var(--x187fpdw)",
+            "1.5 pixels": "var(--x15ahj5d)",
+            "corner#radius": "var(--x2ajqv2)",
+            "@@primary": "var(--x13tvx0f)",
             __varGroupHash__: "xop34xu"
           };"
         `);
@@ -1096,7 +1096,7 @@ describe('@stylexjs/babel-plugin', () => {
               [
                 "xop34xu",
                 {
-                  "ltr": ":root, .xop34xu{--_10-x187fpdw:green;--_1_5_pixels-x15ahj5d:blue;--corner_radius-x2ajqv2:purple;--__primary-x13tvx0f:pink;}",
+                  "ltr": ":root, .xop34xu{--x187fpdw:green;--x15ahj5d:blue;--x2ajqv2:purple;--x13tvx0f:pink;}",
                   "rtl": null,
                 },
                 0.1,
@@ -1109,7 +1109,7 @@ describe('@stylexjs/babel-plugin', () => {
 
     describe('options `dev:true`', () => {
       test('tokens object', () => {
-        const options = { dev: true, enableDebugClassNames: true };
+        const options = { dev: true };
         const { code, metadata } = transform(
           `
           import * as stylex from '@stylexjs/stylex';
@@ -1125,9 +1125,9 @@ describe('@stylexjs/babel-plugin', () => {
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const vars = {
-            color: "var(--color-xwx8imx)",
-            nextColor: "var(--nextColor-xk6xtqk)",
-            otherColor: "var(--otherColor-xaaua2w)",
+            color: "var(--xwx8imx)",
+            nextColor: "var(--xk6xtqk)",
+            otherColor: "var(--xaaua2w)",
             __varGroupHash__: "xop34xu"
           };"
         `);
@@ -1138,7 +1138,7 @@ describe('@stylexjs/babel-plugin', () => {
               [
                 "xop34xu",
                 {
-                  "ltr": ":root, .xop34xu{--color-xwx8imx:red;--nextColor-xk6xtqk:green;--otherColor-xaaua2w:blue;}",
+                  "ltr": ":root, .xop34xu{--xwx8imx:red;--xk6xtqk:green;--xaaua2w:blue;}",
                   "rtl": null,
                 },
                 0.1,
@@ -1201,7 +1201,6 @@ describe('@stylexjs/babel-plugin', () => {
       test('processes tokens in files with configured extension', () => {
         const options = {
           debug: true,
-          enableDebugClassNames: true,
           filename: '/stylex/packages/src/vars/default.cssvars.js',
           unstable_moduleResolution: {
             rootDir: '/stylex/packages/',
@@ -1222,7 +1221,7 @@ describe('@stylexjs/babel-plugin', () => {
         expect(code).toMatchInlineSnapshot(`
           "import * as stylex from '@stylexjs/stylex';
           export const vars = {
-            color: "var(--color-x1lzcbr1)",
+            color: "var(--x1lzcbr1)",
             __varGroupHash__: "x1bxutiz"
           };"
         `);
@@ -1233,7 +1232,7 @@ describe('@stylexjs/babel-plugin', () => {
               [
                 "x1bxutiz",
                 {
-                  "ltr": ":root, .x1bxutiz{--color-x1lzcbr1:red;}",
+                  "ltr": ":root, .x1bxutiz{--x1lzcbr1:red;}",
                   "rtl": null,
                 },
                 0.1,

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-props-test.js
@@ -206,7 +206,6 @@ describe('@stylexjs/babel-plugin', () => {
     describe('props calls with jsx', () => {
       const options = {
         debug: true,
-        enableDebugClassNames: true,
         dev: true,
         enableDevClassNames: false,
         filename: '/js/node_modules/npm-package/dist/components/Foo.react.js',
@@ -239,14 +238,14 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           function Foo() {
             return <>
-                            <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4">Hello World</div>
-                            <div className="test" className="color-x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4" id="test">Hello World</div>
-                            <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4" className="test">Hello World</div>
+                            <div id="test" className="x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4">Hello World</div>
+                            <div className="test" className="x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4" id="test">Hello World</div>
+                            <div id="test" className="x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4" className="test">Hello World</div>
                           </>;
           }"
         `);
@@ -279,14 +278,14 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           function Foo() {
             return <>
-                            <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4">Hello World</div>
-                            <div className="test" className="color-x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4" id="test">Hello World</div>
-                            <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4" className="test">Hello World</div>
+                            <div id="test" className="x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4">Hello World</div>
+                            <div className="test" className="x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4" id="test">Hello World</div>
+                            <div id="test" className="x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4" className="test">Hello World</div>
                           </>;
           }"
         `);
@@ -313,11 +312,11 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           function Foo() {
-            return <div className="color-x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4">Hello World</div>;
+            return <div className="x1e2nbdu" data-style-src="npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4">Hello World</div>;
           }"
         `);
       });
@@ -527,11 +526,11 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           _inject2({
-            ltr: ".opacity-xb4nw82{opacity:var(--x-opacity)}",
+            ltr: ".xb4nw82{opacity:var(--x-opacity)}",
             priority: 3000
           });
           _inject2({
@@ -540,11 +539,11 @@ describe('@stylexjs/babel-plugin', () => {
           });
           const styles = {
             red: {
-              "color-kMwMTN": "color-x1e2nbdu",
+              "color-kMwMTN": "x1e2nbdu",
               $$css: "npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4"
             },
             opacity: opacity => [{
-              "opacity-kSiTet": opacity != null ? "opacity-xb4nw82" : opacity,
+              "opacity-kSiTet": opacity != null ? "xb4nw82" : opacity,
               $$css: "npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:7"
             }, {
               "--x-opacity": opacity != null ? opacity : undefined
@@ -583,12 +582,12 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           const styles = {
             red: {
-              "color-kMwMTN": "color-x1e2nbdu",
+              "color-kMwMTN": "x1e2nbdu",
               $$css: "npm-package:js/node_modules/npm-package/dist/components/Foo.react.js:4"
             }
           };
@@ -1369,7 +1368,7 @@ describe('@stylexjs/babel-plugin', () => {
       });
 
       describe('with options', () => {
-        test('dev/debug classnames for atoms', () => {
+        test('dev classnames and debug data for atoms', () => {
           const inline = transform(
             `
               import stylex from 'stylex';
@@ -1380,7 +1379,6 @@ describe('@stylexjs/babel-plugin', () => {
               dev: true,
               debug: true,
               enableDevClassNames: true,
-              enableDebugClassNames: true,
               filename: '/tmp/Foo.js',
             },
           );
@@ -1390,11 +1388,11 @@ describe('@stylexjs/babel-plugin', () => {
             import stylex from 'stylex';
             import css from '@stylexjs/atoms';
             _inject2({
-              ltr: ".display-x78zum5{display:flex}",
+              ltr: ".x78zum5{display:flex}",
               priority: 3000
             });
             ({
-              className: "Foo____inline__ display-x78zum5"
+              className: "Foo____inline__ x78zum5"
             });"
           `);
         });
@@ -2363,7 +2361,6 @@ describe('@stylexjs/babel-plugin', () => {
           filename: '/html/js/FooBar.react.js',
           dev: true,
           enableInlinedConditionalMerge: false,
-          enableDebugClassNames: true,
           enableDevClassNames: false,
         };
         expect(
@@ -2384,11 +2381,11 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           ({
-            className: "color-x1e2nbdu",
+            className: "x1e2nbdu",
             "data-style-src": "html/js/FooBar.react.js:4"
           });"
         `);
@@ -2416,22 +2413,22 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           const styles = {
             default: {
-              "color-kMwMTN": "color-x1e2nbdu",
+              "color-kMwMTN": "x1e2nbdu",
               $$css: "html/js/FooBar.react.js:4"
             }
           };
           _inject2({
-            ltr: ".backgroundColor-x1t391ir{background-color:blue}",
+            ltr: ".x1t391ir{background-color:blue}",
             priority: 3000
           });
           const otherStyles = {
             default: {
-              "backgroundColor-kWkggS": "backgroundColor-x1t391ir",
+              "backgroundColor-kWkggS": "x1t391ir",
               $$css: "html/js/FooBar.react.js:9"
             }
           };
@@ -2443,7 +2440,6 @@ describe('@stylexjs/babel-plugin', () => {
         const options = {
           filename: '/html/js/FooBar.react.js',
           dev: true,
-          enableDebugClassNames: true,
           enableDevClassNames: false,
         };
         expect(
@@ -2469,20 +2465,20 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           _inject2({
-            ltr: ".backgroundColor-x1t391ir{background-color:blue}",
+            ltr: ".x1t391ir{background-color:blue}",
             priority: 3000
           });
           ({
             0: {
-              className: "color-x1e2nbdu",
+              className: "x1e2nbdu",
               "data-style-src": "html/js/FooBar.react.js:4"
             },
             1: {
-              className: "color-x1e2nbdu backgroundColor-x1t391ir",
+              className: "x1e2nbdu x1t391ir",
               "data-style-src": "html/js/FooBar.react.js:4; html/js/FooBar.react.js:9"
             }
           })[!!isActive << 0];"
@@ -2509,20 +2505,20 @@ describe('@stylexjs/babel-plugin', () => {
           var _inject2 = _inject;
           import stylex from 'stylex';
           _inject2({
-            ltr: ".color-x1e2nbdu{color:red}",
+            ltr: ".x1e2nbdu{color:red}",
             priority: 3000
           });
           _inject2({
-            ltr: ".color-xju2f9n{color:blue}",
+            ltr: ".xju2f9n{color:blue}",
             priority: 3000
           });
           ({
             0: {
-              className: "color-x1e2nbdu",
+              className: "x1e2nbdu",
               "data-style-src": "html/js/FooBar.react.js:4"
             },
             1: {
-              className: "color-xju2f9n",
+              className: "xju2f9n",
               "data-style-src": "html/js/FooBar.react.js:4; html/js/FooBar.react.js:7"
             }
           })[!!isActive << 0];"
@@ -2879,7 +2875,6 @@ describe('@stylexjs/babel-plugin', () => {
         `,
           {
             dev: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
           },
         ),
@@ -2888,90 +2883,90 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import * as stylex from '@stylexjs/stylex';
         _inject2({
-          ltr: ".boxSizing-x9f619{box-sizing:border-box}",
+          ltr: ".x9f619{box-sizing:border-box}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridArea-x1yc5d2u{grid-area:sidebar}",
+          ltr: ".x1yc5d2u{grid-area:sidebar}",
           priority: 1000
         });
         _inject2({
-          ltr: ".gridArea-x1fdo2jl{grid-area:content}",
+          ltr: ".x1fdo2jl{grid-area:content}",
           priority: 1000
         });
         _inject2({
-          ltr: ".display-xrvj5dj{display:grid}",
+          ltr: ".xrvj5dj{display:grid}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateRows-x7k18q3{grid-template-rows:100%}",
+          ltr: ".x7k18q3{grid-template-rows:100%}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x5gp9wm{grid-template-areas:\\"content\\"}",
+          ltr: ".x5gp9wm{grid-template-areas:\\"content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
+          ltr: ".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x17lh93j{grid-template-areas:\\"sidebar content\\"}",
+          ltr: ".x17lh93j{grid-template-areas:\\"sidebar content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateRows-xmr4b4k.gridTemplateRows-xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
+          ltr: "@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
           priority: 3200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateAreas-xesbpuc.gridTemplateAreas-xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
+          ltr: "@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
           priority: 2200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateColumns-x15nfgh4.gridTemplateColumns-x15nfgh4{grid-template-columns:100%}}",
+          ltr: "@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}",
           priority: 3200
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
+          ltr: ".x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
           priority: 3000
         });
         export const styles = {
           sidebar: {
-            "boxSizing-kB7OPa": "boxSizing-x9f619",
-            "gridArea-kJuA4N": "gridArea-x1yc5d2u",
+            "boxSizing-kB7OPa": "x9f619",
+            "gridArea-kJuA4N": "x1yc5d2u",
             $$css: "@stylexjs/babel-plugin::4"
           },
           content: {
-            "gridArea-kJuA4N": "gridArea-x1fdo2jl",
+            "gridArea-kJuA4N": "x1fdo2jl",
             $$css: "@stylexjs/babel-plugin::8"
           },
           root: {
-            "display-k1xSpc": "display-xrvj5dj",
-            "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
-            "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
+            "display-k1xSpc": "xrvj5dj",
+            "gridTemplateRows-k9llMU": "x7k18q3",
+            "gridTemplateAreas-kC13JO": "x5gp9wm",
             $$css: "@stylexjs/babel-plugin::11"
           },
           withSidebar: {
-            "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
-            "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
-            "gridTemplateAreas-kC13JO": "gridTemplateAreas-x17lh93j",
-            "@media (max-width: 640px)_gridTemplateRows-k9pwkU": "gridTemplateRows-xmr4b4k",
-            "@media (max-width: 640px)_gridTemplateAreas-kOnEH4": "gridTemplateAreas-xesbpuc",
-            "@media (max-width: 640px)_gridTemplateColumns-k1JLwA": "gridTemplateColumns-x15nfgh4",
+            "gridTemplateColumns-kumcoG": "x1rkzygb",
+            "gridTemplateRows-k9llMU": "x7k18q3",
+            "gridTemplateAreas-kC13JO": "x17lh93j",
+            "@media (max-width: 640px)_gridTemplateRows-k9pwkU": "xmr4b4k",
+            "@media (max-width: 640px)_gridTemplateAreas-kOnEH4": "xesbpuc",
+            "@media (max-width: 640px)_gridTemplateColumns-k1JLwA": "x15nfgh4",
             $$css: "@stylexjs/babel-plugin::16"
           },
           noSidebar: {
-            "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
+            "gridTemplateColumns-kumcoG": "x1mkdm3x",
             $$css: "@stylexjs/babel-plugin::26"
           }
         };
         ({
           0: {
-            className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
+            className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4",
             "data-style-src": "@stylexjs/babel-plugin::11; @stylexjs/babel-plugin::16"
           },
           1: {
-            className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x",
+            className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x",
             "data-style-src": "@stylexjs/babel-plugin::11; @stylexjs/babel-plugin::26"
           }
         })[!!(sidebar == null) << 0];"
@@ -3020,7 +3015,6 @@ describe('@stylexjs/babel-plugin', () => {
           {
             filename: '/html/js/FooBar.react.js',
             dev: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
           },
         ),
@@ -3029,84 +3023,84 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import * as stylex from '@stylexjs/stylex';
         _inject2({
-          ltr: ".boxSizing-x9f619{box-sizing:border-box}",
+          ltr: ".x9f619{box-sizing:border-box}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridArea-x1yc5d2u{grid-area:sidebar}",
+          ltr: ".x1yc5d2u{grid-area:sidebar}",
           priority: 1000
         });
         _inject2({
-          ltr: ".gridArea-x1fdo2jl{grid-area:content}",
+          ltr: ".x1fdo2jl{grid-area:content}",
           priority: 1000
         });
         _inject2({
-          ltr: ".display-xrvj5dj{display:grid}",
+          ltr: ".xrvj5dj{display:grid}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateRows-x7k18q3{grid-template-rows:100%}",
+          ltr: ".x7k18q3{grid-template-rows:100%}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x5gp9wm{grid-template-areas:\\"content\\"}",
+          ltr: ".x5gp9wm{grid-template-areas:\\"content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
+          ltr: ".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x17lh93j{grid-template-areas:\\"sidebar content\\"}",
+          ltr: ".x17lh93j{grid-template-areas:\\"sidebar content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateRows-xmr4b4k.gridTemplateRows-xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
+          ltr: "@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
           priority: 3200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateAreas-xesbpuc.gridTemplateAreas-xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
+          ltr: "@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
           priority: 2200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateColumns-x15nfgh4.gridTemplateColumns-x15nfgh4{grid-template-columns:100%}}",
+          ltr: "@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}",
           priority: 3200
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
+          ltr: ".x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
           priority: 3000
         });
         const complex = {
           0: {
-            className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
+            className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:16"
           },
           4: {
-            className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x",
+            className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:26"
           },
           2: {
-            className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1yc5d2u",
+            className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1yc5d2u",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:16; html/js/FooBar.react.js:4"
           },
           6: {
-            className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1yc5d2u",
+            className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1yc5d2u",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:26; html/js/FooBar.react.js:4"
           },
           1: {
-            className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 gridArea-x1fdo2jl",
+            className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x1fdo2jl",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:16; html/js/FooBar.react.js:8"
           },
           5: {
-            className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x gridArea-x1fdo2jl",
+            className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x1fdo2jl",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:26; html/js/FooBar.react.js:8"
           },
           3: {
-            className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1fdo2jl",
+            className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1fdo2jl",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:16; html/js/FooBar.react.js:4; html/js/FooBar.react.js:8"
           },
           7: {
-            className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1fdo2jl",
+            className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1fdo2jl",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:26; html/js/FooBar.react.js:4; html/js/FooBar.react.js:8"
           }
         }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];"
@@ -3156,7 +3150,6 @@ describe('@stylexjs/babel-plugin', () => {
             filename: '/html/js/FooBar.react.js',
             dev: true,
             debug: true,
-            enableDebugClassNames: true,
             enableDevClassNames: false,
           },
         ),
@@ -3165,91 +3158,91 @@ describe('@stylexjs/babel-plugin', () => {
         var _inject2 = _inject;
         import * as stylex from '@stylexjs/stylex';
         _inject2({
-          ltr: ".boxSizing-x9f619{box-sizing:border-box}",
+          ltr: ".x9f619{box-sizing:border-box}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridArea-x1yc5d2u{grid-area:sidebar}",
+          ltr: ".x1yc5d2u{grid-area:sidebar}",
           priority: 1000
         });
         _inject2({
-          ltr: ".gridArea-x1fdo2jl{grid-area:content}",
+          ltr: ".x1fdo2jl{grid-area:content}",
           priority: 1000
         });
         _inject2({
-          ltr: ".display-xrvj5dj{display:grid}",
+          ltr: ".xrvj5dj{display:grid}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateRows-x7k18q3{grid-template-rows:100%}",
+          ltr: ".x7k18q3{grid-template-rows:100%}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x5gp9wm{grid-template-areas:\\"content\\"}",
+          ltr: ".x5gp9wm{grid-template-areas:\\"content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
+          ltr: ".x1rkzygb{grid-template-columns:auto minmax(0,1fr)}",
           priority: 3000
         });
         _inject2({
-          ltr: ".gridTemplateAreas-x17lh93j{grid-template-areas:\\"sidebar content\\"}",
+          ltr: ".x17lh93j{grid-template-areas:\\"sidebar content\\"}",
           priority: 2000
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateRows-xmr4b4k.gridTemplateRows-xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
+          ltr: "@media (max-width: 640px){.xmr4b4k.xmr4b4k{grid-template-rows:minmax(0,1fr) auto}}",
           priority: 3200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateAreas-xesbpuc.gridTemplateAreas-xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
+          ltr: "@media (max-width: 640px){.xesbpuc.xesbpuc{grid-template-areas:\\"content\\" \\"sidebar\\"}}",
           priority: 2200
         });
         _inject2({
-          ltr: "@media (max-width: 640px){.gridTemplateColumns-x15nfgh4.gridTemplateColumns-x15nfgh4{grid-template-columns:100%}}",
+          ltr: "@media (max-width: 640px){.x15nfgh4.x15nfgh4{grid-template-columns:100%}}",
           priority: 3200
         });
         _inject2({
-          ltr: ".gridTemplateColumns-x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
+          ltr: ".x1mkdm3x{grid-template-columns:minmax(0,1fr)}",
           priority: 3000
         });
         const complex = {
           0: {
-            className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
+            className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:16"
           },
           4: {
-            className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x",
+            className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:26"
           },
           2: {
-            className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1yc5d2u",
+            className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1yc5d2u",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:16; html/js/FooBar.react.js:4"
           },
           6: {
-            className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1yc5d2u",
+            className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1yc5d2u",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:26; html/js/FooBar.react.js:4"
           },
           1: {
-            className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 gridArea-x1fdo2jl",
+            className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x1fdo2jl",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:16; html/js/FooBar.react.js:8"
           },
           5: {
-            className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x gridArea-x1fdo2jl",
+            className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x1fdo2jl",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:26; html/js/FooBar.react.js:8"
           },
           3: {
-            className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1fdo2jl",
+            className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1fdo2jl",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:16; html/js/FooBar.react.js:4; html/js/FooBar.react.js:8"
           },
           7: {
-            className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1fdo2jl",
+            className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1fdo2jl",
             "data-style-src": "html/js/FooBar.react.js:11; html/js/FooBar.react.js:26; html/js/FooBar.react.js:4; html/js/FooBar.react.js:8"
           }
         }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];"
       `);
     });
 
-    test('Stylex call with debug on and debug classnames off', () => {
+    test('Stylex call with debug on uses hashed classnames', () => {
       expect(
         transform(
           `
@@ -3292,7 +3285,6 @@ describe('@stylexjs/babel-plugin', () => {
             filename: '/html/js/FooBar.react.js',
             dev: true,
             debug: true,
-            enableDebugClassNames: false,
             enableDevClassNames: false,
           },
         ),

--- a/packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts
@@ -43,7 +43,6 @@ export type StyleXOptions = Readonly<{
   env?: Readonly<{ [$$Key$$: string]: any }>;
   dev: boolean;
   propertyValidationMode?: 'throw' | 'warn' | 'silent';
-  enableDebugClassNames?: null | undefined | boolean;
   enableDebugDataProp?: null | undefined | boolean;
   enableDevClassNames?: null | undefined | boolean;
   enableFontSizePxToRem?: null | undefined | boolean;

--- a/packages/@stylexjs/babel-plugin/src/shared/common-types.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/common-types.js
@@ -50,7 +50,6 @@ export type StyleXOptions = $ReadOnly<{
   env?: $ReadOnly<{ [string]: any }>,
   dev: boolean,
   propertyValidationMode?: 'throw' | 'warn' | 'silent',
-  enableDebugClassNames?: ?boolean,
   enableDebugDataProp?: ?boolean,
   enableDevClassNames?: ?boolean,
   enableFontSizePxToRem?: ?boolean,

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-define-consts.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-define-consts.js
@@ -20,7 +20,7 @@ export default function styleXDefineConsts<Vars: ConstsConfig>(
   { [string]: string | number }, // jsOutput JS output
   { [string]: InjectableConstStyle }, // metadata for registerinjectableStyles
 ] {
-  const { classNamePrefix, exportId, debug, enableDebugClassNames } = {
+  const { classNamePrefix, exportId } = {
     ...defaultOptions,
     ...options,
   };
@@ -29,15 +29,9 @@ export default function styleXDefineConsts<Vars: ConstsConfig>(
   const injectableStyles: { [string]: InjectableConstStyle } = {};
 
   for (const [key, value] of Object.entries(constants)) {
-    const varSafeKey = (
-      key[0] >= '0' && key[0] <= '9' ? `_${key}` : key
-    ).replace(/[^a-zA-Z0-9]/g, '_');
-
     const constKey = key.startsWith('--')
       ? key.slice(2)
-      : debug && enableDebugClassNames
-        ? `${varSafeKey}-${classNamePrefix}${createHash(`${exportId}.${key}`)}`
-        : `${classNamePrefix}${createHash(`${exportId}.${key}`)}`;
+      : `${classNamePrefix}${createHash(`${exportId}.${key}`)}`;
 
     jsOutput[key] = value;
     injectableStyles[constKey] = {

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-define-vars.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-define-vars.js
@@ -36,7 +36,7 @@ export default function styleXDefineVars<Vars: VarsConfig>(
   variables: Vars,
   options: $ReadOnly<{ ...Partial<StyleXOptions>, exportId: string, ... }>,
 ): [VarsObject<Vars>, { [string]: InjectableStyle }] {
-  const { classNamePrefix, exportId, debug, enableDebugClassNames } = {
+  const { classNamePrefix, exportId } = {
     ...defaultOptions,
     ...options,
   };
@@ -53,14 +53,9 @@ export default function styleXDefineVars<Vars: VarsConfig>(
   const variablesMap: {
     +[string]: { +nameHash: string, +value: VarsConfigValue },
   } = objMap(variables, (value, key) => {
-    const varSafeKey = (
-      key[0] >= '0' && key[0] <= '9' ? `_${key}` : key
-    ).replace(/[^a-zA-Z0-9]/g, '_');
     const nameHash = key.startsWith('--')
       ? key.slice(2)
-      : debug && enableDebugClassNames
-        ? varSafeKey + '-' + classNamePrefix + createHash(`${exportId}.${key}`)
-        : classNamePrefix + createHash(`${exportId}.${key}`);
+      : classNamePrefix + createHash(`${exportId}.${key}`);
 
     if (isCSSType(value)) {
       const v: CSSType<> = value;

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/__tests__/convert-to-className-test.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/__tests__/convert-to-className-test.js
@@ -18,44 +18,28 @@ describe('convert-to-className test', () => {
   test('converts style to className', () => {
     expect(convert(['margin', 10])).toEqual('margin:10px');
   });
-  test('prefixes classname with property name when options.debug is true', () => {
-    const options = {
+  test('generates the same classname in debug and production modes', () => {
+    const baseOptions = {
       classNamePrefix: 'x',
       dev: false,
+      styleResolution: 'property-specificity',
+      test: false,
+    } as const;
+    const debugClassName = convertStyleToClassName(['margin', 10], [], [], [], {
+      ...baseOptions,
       debug: true,
-      styleResolution: 'property-specificity',
-      test: false,
-    } as const;
-    const result = convertStyleToClassName(['margin', 10], [], [], [], options);
-    const className = result[1];
-    expect(className.startsWith('margin-x')).toBe(true);
-  });
-  test('prefixes classname with prefix only when options.enableDebugClassNames is false', () => {
-    const options = {
-      classNamePrefix: 'x',
-      dev: false,
-      debug: true,
-      enableDebugClassNames: false,
-      styleResolution: 'property-specificity',
-      test: false,
-    } as const;
-    const result = convertStyleToClassName(['margin', 10], [], [], [], options);
-    const className = result[1];
-    expect(className.startsWith('x')).toBe(true);
-    expect(className.startsWith('margin-x')).toBe(false);
-  });
-  test('prefixes classname with prefix only when options.debug is false', () => {
-    const options = {
-      classNamePrefix: 'x',
-      dev: false,
-      debug: false,
-      styleResolution: 'property-specificity',
-      test: false,
-    } as const;
-    const result = convertStyleToClassName(['margin', 10], [], [], [], options);
-    const className = result[1];
-    expect(className.startsWith('x')).toBe(true);
-    expect(className.startsWith('margin-x')).toBe(false);
+    })[1];
+    const productionClassName = convertStyleToClassName(
+      ['margin', 10],
+      [],
+      [],
+      [],
+      { ...baseOptions, debug: false },
+    )[1];
+
+    expect(debugClassName).toBe(productionClassName);
+    expect(debugClassName.startsWith('x')).toBe(true);
+    expect(debugClassName.startsWith('margin-x')).toBe(false);
   });
   test('converts margin number to px', () => {
     expect(convert(['margin', 10])).toEqual('margin:10px');

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/convert-to-className.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/convert-to-className.js
@@ -31,11 +31,7 @@ export function convertStyleToClassName(
   constRules: $ReadOnlyArray<string>,
   options: StyleXOptions = defaultOptions,
 ): StyleRule {
-  const {
-    classNamePrefix = 'x',
-    debug = false,
-    enableDebugClassNames = true,
-  } = options;
+  const { classNamePrefix = 'x' } = options;
   const [key, rawValue] = objEntry;
   const dashedKey = key.startsWith('--') ? key : dashify(key);
 
@@ -64,10 +60,7 @@ export function convertStyleToClassName(
 
   // NOTE: '<>' is used to keep existing hashes stable.
   // This should be removed in a future version.
-  const className =
-    debug && enableDebugClassNames
-      ? `${key}-${classNamePrefix}${createHash('<>' + stringToHash)}`
-      : classNamePrefix + createHash('<>' + stringToHash);
+  const className = classNamePrefix + createHash('<>' + stringToHash);
 
   const cssRules = generateCSSRule(
     className,

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/default-options.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/default-options.js
@@ -14,7 +14,6 @@ export const defaultOptions: StyleXOptions = {
   dev: false,
   debug: false,
   propertyValidationMode: 'silent',
-  enableDebugClassNames: false,
   enableDevClassNames: false,
   enableDebugDataProp: true,
   enableFontSizePxToRem: false,

--- a/packages/@stylexjs/babel-plugin/src/utils/__tests__/state-manager-test.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/__tests__/state-manager-test.js
@@ -92,8 +92,6 @@ describe('StateManager config parsing', () => {
     test('true value', () => {
       const stateManager = makeState({ debug: true });
       expect(stateManager.options.debug).toBe(true);
-      // automatically enabled in 'debug'
-      expect(stateManager.options.enableDebugClassNames).toBe(false);
       expect(stateManager.options.enableDebugDataProp).toBe(true);
       expect(warnings).toEqual([]);
     });
@@ -130,43 +128,6 @@ describe('StateManager config parsing', () => {
       expect(stateManager.options.debug).toBe(true);
       // enableDevClassNames is disabled by default in 'dev'
       expect(stateManager.options.enableDevClassNames).toBe(true);
-      expect(warnings).toEqual([]);
-    });
-  });
-
-  describe('"enableDebugClassNames" option (boolean)', () => {
-    test('logs errors if invalid', () => {
-      const stateManager = makeState({ enableDebugClassNames: 'false' });
-      expect(stateManager.options.enableDebugClassNames).toBe(true);
-      expect(warnings).toEqual([
-        [
-          '[@stylexjs/babel-plugin]',
-          'Expected (options.enableDebugClassNames) to be a boolean, but got `"false"`.',
-        ],
-      ]);
-    });
-
-    test('default value', () => {
-      const stateManager = makeState();
-      expect(stateManager.options.enableDebugClassNames).toBe(false);
-      expect(warnings).toEqual([]);
-    });
-
-    test('false value', () => {
-      const stateManager = makeState({
-        debug: true,
-        enableDebugClassNames: false,
-      });
-      expect(stateManager.options.enableDebugClassNames).toBe(false);
-      expect(warnings).toEqual([]);
-    });
-
-    test('true value', () => {
-      const stateManager = makeState({
-        debug: true,
-        enableDebugClassNames: true,
-      });
-      expect(stateManager.options.enableDebugClassNames).toBe(true);
       expect(warnings).toEqual([]);
     });
   });

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
@@ -309,18 +309,8 @@ function resolveVarGroupKey(
   }
 
   const strToHash = utils.genFileBasedIdentifier({ fileName, exportName, key });
-  const { debug, enableDebugClassNames, classNamePrefix } =
-    traversalState.options;
-
-  const varSafeKey = (key[0] >= '0' && key[0] <= '9' ? `_${key}` : key).replace(
-    /[^a-zA-Z0-9]/g,
-    '_',
-  );
-
-  const varName =
-    debug && enableDebugClassNames
-      ? `${varSafeKey}-${classNamePrefix}${utils.hash(strToHash)}`
-      : classNamePrefix + utils.hash(strToHash);
+  const { classNamePrefix } = traversalState.options;
+  const varName = classNamePrefix + utils.hash(strToHash);
 
   return `var(--${varName})`;
 }

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -95,7 +95,6 @@ export type StyleXOptions = $ReadOnly<{
   ...RuntimeOptions,
   aliases?: ?$ReadOnly<{ [string]: string | $ReadOnlyArray<string> }>,
   propertyValidationMode?: 'throw' | 'warn' | 'silent',
-  enableDebugClassNames?: boolean,
   enableDebugDataProp?: boolean,
   enableDevClassNames?: boolean,
   enableInlinedConditionalMerge?: boolean,
@@ -227,14 +226,6 @@ export default class StateManager {
       false,
       'options.debug',
     );
-
-    const enableDebugClassNames: StyleXStateOptions['enableDebugClassNames'] =
-      z.logAndDefault(
-        z.boolean(),
-        options.enableDebugClassNames ?? defaultOptions.enableDebugClassNames,
-        true,
-        'options.enableDebugClassNames',
-      );
 
     const enableDebugDataProp: StyleXStateOptions['enableDebugDataProp'] =
       z.logAndDefault(
@@ -445,7 +436,6 @@ export default class StateManager {
       dev,
       propertyValidationMode,
       env,
-      enableDebugClassNames,
       enableDebugDataProp,
       enableDevClassNames,
       enableFontSizePxToRem,

--- a/packages/@stylexjs/rollup-plugin/__tests__/index-test.js
+++ b/packages/@stylexjs/rollup-plugin/__tests__/index-test.js
@@ -192,7 +192,6 @@ describe('rollup-plugin-stylex', () => {
     it('preserves stylex.inject calls and does not extract CSS', async () => {
       const { css, js } = await runStylex({
         debug: true,
-        enableDebugClassNames: true,
         runtimeInjection: true,
       });
 
@@ -211,17 +210,17 @@ describe('rollup-plugin-stylex', () => {
 
         var _inject2$2 = _inject;
         _inject2$2({
-          ltr: ".display-x1lliihq{display:block}",
+          ltr: ".x1lliihq{display:block}",
           priority: 3000
         });
         _inject2$2({
-          ltr: ".width-xh8yej3{width:100%}",
+          ltr: ".xh8yej3{width:100%}",
           priority: 4000
         });
         var styles$2 = {
           bar: {
-            "display-k1xSpc": "display-x1lliihq",
-            "width-kzqmXN": "width-xh8yej3",
+            "display-k1xSpc": "x1lliihq",
+            "width-kzqmXN": "xh8yej3",
             $$css: "@stylexjs/rollup-plugin:__tests__/__fixtures__/otherStyles.js:14"
           }
         };
@@ -235,22 +234,22 @@ describe('rollup-plugin-stylex', () => {
 
         var _inject2$1 = _inject;
         _inject2$1({
-          ltr: ".display-xt0psk2{display:inline}",
+          ltr: ".xt0psk2{display:inline}",
           priority: 3000
         });
         _inject2$1({
-          ltr: ".height-x1egiwwb{height:500px}",
+          ltr: ".x1egiwwb{height:500px}",
           priority: 4000
         });
         _inject2$1({
-          ltr: ".width-x3hqpx7{width:50%}",
+          ltr: ".x3hqpx7{width:50%}",
           priority: 4000
         });
         const styles$1 = {
           baz: {
-            "display-k1xSpc": "display-xt0psk2",
-            "height-kZKoxP": "height-x1egiwwb",
-            "width-kzqmXN": "width-x3hqpx7",
+            "display-k1xSpc": "xt0psk2",
+            "height-kZKoxP": "x1egiwwb",
+            "width-kzqmXN": "x3hqpx7",
             $$css: "@stylexjs/rollup-plugin:__tests__/__fixtures__/npmStyles.js:15"
           }
         };
@@ -268,42 +267,42 @@ describe('rollup-plugin-stylex', () => {
           priority: 0
         });
         _inject2({
-          ltr: ".animationName-xeuoslp{animation-name:xgnty7z-B}",
+          ltr: ".xeuoslp{animation-name:xgnty7z-B}",
           priority: 3000
         });
         _inject2({
-          ltr: ".backgroundColor-x1gykpug:hover{background-color:red}",
+          ltr: ".x1gykpug:hover{background-color:red}",
           priority: 3130
         });
         _inject2({
-          ltr: ".borderStartStartRadius-xu4yf9m{border-start-start-radius:7.5px}",
+          ltr: ".xu4yf9m{border-start-start-radius:7.5px}",
           priority: 3000
         });
         _inject2({
-          ltr: ".display-x78zum5{display:flex}",
+          ltr: ".x78zum5{display:flex}",
           priority: 3000
         });
         _inject2({
-          ltr: ".height-x1egiwwb{height:500px}",
+          ltr: ".x1egiwwb{height:500px}",
           priority: 4000
         });
         _inject2({
-          ltr: ".marginInlineStart-x1hm9lzh{margin-inline-start:10px}",
+          ltr: ".x1hm9lzh{margin-inline-start:10px}",
           priority: 3000
         });
         _inject2({
-          ltr: ".marginTop-xlrshdv{margin-top:99px}",
+          ltr: ".xlrshdv{margin-top:99px}",
           priority: 4000
         });
         var styles = {
           foo: {
-            "animationName-kKVMdj": "animationName-xeuoslp",
-            "backgroundColor-kWkggS": "backgroundColor-x1gykpug",
-            "borderStartStartRadius-krdFHd": "borderStartStartRadius-xu4yf9m",
-            "display-k1xSpc": "display-x78zum5",
-            "height-kZKoxP": "height-x1egiwwb",
-            "marginInlineStart-keTefX": "marginInlineStart-x1hm9lzh",
-            "marginTop-keoZOQ": "marginTop-xlrshdv",
+            "animationName-kKVMdj": "xeuoslp",
+            "backgroundColor-kWkggS": "x1gykpug",
+            "borderStartStartRadius-krdFHd": "xu4yf9m",
+            "display-k1xSpc": "x78zum5",
+            "height-kZKoxP": "x1egiwwb",
+            "marginInlineStart-keTefX": "x1hm9lzh",
+            "marginTop-keoZOQ": "xlrshdv",
             $$css: "@stylexjs/rollup-plugin:__tests__/__fixtures__/index.js:24"
           }
         };

--- a/packages/docs/content/docs/api/configuration/babel-plugin.mdx
+++ b/packages/docs/content/docs/api/configuration/babel-plugin.mdx
@@ -33,8 +33,9 @@ Prefix to be applied to every generated className.
 debug: boolean; // Default: false
 ```
 
-When `true`, StyleX will use debug class names and insert `data-style-src` props
-to help identify the source of the styles.
+When `true`, StyleX will make compiled style keys easier to read and insert
+`data-style-src` props to help identify the source of the styles. Generated
+atomic class names remain hashed.
 
 ---
 

--- a/packages/docs/waku.config.ts
+++ b/packages/docs/waku.config.ts
@@ -88,7 +88,6 @@ export default defineConfig({
       stylex.vite({
         debug: process.env.NODE_ENV === 'development',
         treeshakeCompensation: true,
-        enableDebugClassNames: false,
         enableDevClassNames: false,
         useCSSLayers: true,
         devMode: 'css-only',


### PR DESCRIPTION
## What changed / motivation ?

Remove the enableDebugClassNames configuration and the code paths that prefix generated atomic class names and variable or constant identifiers with source property names.

Atomic class names now remain stable hashes in debug and production builds. Existing debug and dev behavior remains, including readable compiled keys, data-style-src metadata, developer-origin class names, runtime injection, and debug file path handling.

## Linked PR/Issues

N/A

## Additional Context

This is a breaking configuration change.

Tests:
- npm test -- --runInBand in @stylexjs/babel-plugin: 970 passed
- npm test -- --runInBand in @stylexjs/rollup-plugin: 3 passed
- npm run flow
- ESLint
- Prettier
- Babel plugin build

## Pre-flight checklist

- [x] I have read the contributing guidelines
- [x] Performed a self-review of my code