### PR TITLE
[unplugin] Support unplugin v3 in the peer dependency range

### DIFF
--- a/packages/@stylexjs/unplugin/package.json
+++ b/packages/@stylexjs/unplugin/package.json
@@ -75,7 +75,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "unplugin": "^2.3.11"
+    "unplugin": "^2.3.11 || ^3.0.0"
   },
   "dependencies": {
     "@babel/core": "^7.26.8",


### PR DESCRIPTION
## What changed / motivation ?

`@stylexjs/unplugin` pins its `unplugin` peer dependency to `^2.3.11`. unplugin v3 shipped in January 2026 (latest is `3.3.0`), so projects already on v3 — or pulling it in through another plugin — hit a peer dependency conflict. This widens the range to `^2.3.11 || ^3.0.0`. No source changes were needed.

## End-to-end builds

The unit suite in `packages/@stylexjs/unplugin/__tests__` calls the plugin factory directly and never runs a real bundler, so I built the examples on both versions and compared the emitted CSS byte for byte:

| example | adapter | build @2.3.11 | build @3.3.0 | StyleX atomic classes | emitted CSS |
|---|---|---|---|---|---|
| example-vite | vite | OK | OK | 16 | byte-identical |
| example-vite-react | vite | OK | OK | 48 | byte-identical |
| example-webpack | webpack | OK | OK | 40 | byte-identical |
| example-esbuild | esbuild | OK | OK | 14 | byte-identical |
| example-rspack | rspack | OK | OK | 0 | byte-identical |
| example-bun | bun | OK | OK | 0 | byte-identical |

Caveats, stated plainly: `example-rspack` and `example-bun` emit no StyleX atomic CSS at all in this environment — on `2.3.11` as much as on `3.3.0` — so they show no regression but do not exercise the CSS path (cf. #1390, #1745). `example-react-router` fails to build for me on both versions, i.e. before this change. The four examples that do emit StyleX CSS cover the vite, webpack, and esbuild adapters.

## Why v3's breaking changes don't affect this package

**1. ESM-only (CJS build dropped), `engines: ^20.19.0 || >=22.12.0`.**

This package ships both a CJS and an ESM build. Node's `require(esm)` resolves unplugin's single `./dist/index.mjs` export (no top-level await), so `require('@stylexjs/unplugin/webpack')` from a CommonJS `webpack.config.js` keeps working — but only on Node versions that have `require(esm)`. Measured, requiring the built `lib/webpack.js` against `unplugin@3.3.0`:

| Node | result |
|---|---|
| 18.20.8 | `ERR_REQUIRE_ESM` |
| 20.18.0 | `ERR_REQUIRE_ESM` |
| **20.19.0** | ok |
| 22.11.0 | `ERR_REQUIRE_ESM` |
| **22.12.0** | ok, with `ExperimentalWarning: CommonJS module … is loading ES Module … using require()` |
| 22.22.0 | ok, no warning |
| 24.8.0 / 24.9.0 | ok |

The cutoff lands exactly on unplugin v3's declared `engines`. I also loaded all ten entry points — `index`, `vite`, `rollup`, `esbuild`, `webpack`, `rspack`, `rolldown`, `farm`, `unloader`, `bun` — from both `lib/*.js` (`require`) and `lib/es/*.mjs` (`import`) against `3.3.0`; all 20 resolve.

**Worth a maintainer decision:** `@stylexjs/unplugin` declares no `engines` field, so nothing stops a user on Node 18 / 20.18 / 22.11 from resolving the peer to v3 and getting `ERR_REQUIRE_ESM` at config load — npm only warns with `EBADENGINE`. Happy to add `"engines"` or narrow the range if you'd rather make that explicit.

**2. acorn removed; `setParseImpl` now required for `this.parse`.**

The only context-parser use is the Rollup/Vite watch-mode branch in `src/core.js`, guarded by `ctx.meta && ctx.meta.watchMode && typeof ctx.parse === 'function'`. Measured `this` inside a `transform` hook, for a plugin built with each `create*Plugin`:

| framework | `ctx.meta` | `resolve`/`load` | `parse()` @2.3.11 | `parse()` @3.3.0 |
|---|---|---|---|---|
| rollup (build) | `{rollupVersion, watchMode:false}` | present | ok | ok |
| rollup (watch) | `{rollupVersion, watchMode:true}` | present | ok | ok |
| vite | `{rollupVersion, rolldownVersion, watchMode, viteVersion}` | present | ok | ok |
| webpack | `undefined` | `undefined` | ok | throws `Parse implementation is not set` |
| rspack | `undefined` | `undefined` | ok | throws `Parse implementation is not set` |

unplugin only injects its own `parse` into the webpack and rspack contexts, and that is exactly where v3 turns it into a throwing stub — but `ctx.meta` is `undefined` there in both versions, so the branch is already unreachable (as are `ctx.resolve`/`ctx.load`, which it needs). Under Rollup/Vite, where the branch does run, `this` is the native Rollup context and `parse` is Rollup's own — unaffected by v3, including with `watchMode: true`.

## Additional Context

### Unit suite against v3

`packages/@stylexjs/unplugin` has no `jest.config.js`, so `__tests__/unplugin.test.js` runs through the CommonJS path. Jest can only `require()` an ESM-only package when `vm.SourceTextModule.prototype.hasAsyncGraph` exists — Node 24.9+ with `--experimental-vm-modules`. Measured, running the existing suite against `unplugin@3.3.0`:

| Node | no flag | `--experimental-vm-modules` |
|---|---|---|
| 20.19.0 | cannot load unplugin | cannot load unplugin |
| 22.22.0 | cannot load unplugin | cannot load unplugin |
| 24.8.0 | cannot load unplugin | cannot load unplugin |
| **24.9.0** | cannot load unplugin | **9/9 passing** |

So the suite does pass against v3, but only on a Node newer than CI's.

### CI stays on v2, lockfile unchanged

`packages/docs` depends on `unplugin@^2.3.10`, and Yarn 1 does not install peer dependencies, so the hoisted `unplugin` stays at `2.3.11` and `yarn.lock` needs no change. `yarn install --frozen-lockfile` passes with this diff.

Bumping `packages/docs` is deliberately out of scope: it would put an ESM-only dependency in Jest's resolution path, which per the table above would need `tests.yml`/`.nvmrc` moved to Node 24.9+ plus `--experimental-vm-modules`.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
