### PR TITLE
Add opt-in compressed class names

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-create-test.js
@@ -5318,6 +5318,128 @@ describe('@stylexjs/babel-plugin', () => {
       });
     });
 
+    describe('options `enableCompressedClassnames:true`', () => {
+      test('uses short names for simple declarations and hashes the rest', () => {
+        const { code, metadata } = transform(
+          `
+            import * as stylex from '@stylexjs/stylex';
+            export const styles = stylex.create({
+              root: {
+                margin: 0,
+                marginTop: '4px',
+                paddingTop: '16px',
+                display: 'flex',
+                position: 'absolute',
+                opacity: 0.5,
+                color: '#fff',
+                animationTimeline: 'auto',
+                ':hover': {
+                  marginBottom: 0,
+                },
+              },
+            });
+          `,
+          { enableCompressedClassnames: true },
+        );
+
+        expect(code).toMatchInlineSnapshot(`
+          "import * as stylex from '@stylexjs/stylex';
+          export const styles = {
+            root: {
+              m: "m0",
+              mt: "mt4",
+              pt: "pt16",
+              d: "d-f",
+              po: "po-a",
+              op: "op0d5",
+              c: "c-fff",
+              kjjejL: "xyuw9oy",
+              kCBjJz: "x2xz49s",
+              $$css: true
+            }
+          };"
+        `);
+        expect(metadata).toMatchInlineSnapshot(`
+          {
+            "stylex": [
+              [
+                "m0",
+                {
+                  "ltr": ".m0{margin:0}",
+                  "rtl": null,
+                },
+                1000,
+              ],
+              [
+                "mt4",
+                {
+                  "ltr": ".mt4{margin-top:4px}",
+                  "rtl": null,
+                },
+                4000,
+              ],
+              [
+                "pt16",
+                {
+                  "ltr": ".pt16{padding-top:16px}",
+                  "rtl": null,
+                },
+                4000,
+              ],
+              [
+                "d-f",
+                {
+                  "ltr": ".d-f{display:flex}",
+                  "rtl": null,
+                },
+                3000,
+              ],
+              [
+                "po-a",
+                {
+                  "ltr": ".po-a{position:absolute}",
+                  "rtl": null,
+                },
+                3000,
+              ],
+              [
+                "op0d5",
+                {
+                  "ltr": ".op0d5{opacity:.5}",
+                  "rtl": null,
+                },
+                3000,
+              ],
+              [
+                "c-fff",
+                {
+                  "ltr": ".c-fff{color:#fff}",
+                  "rtl": null,
+                },
+                3000,
+              ],
+              [
+                "xyuw9oy",
+                {
+                  "ltr": ".xyuw9oy{animation-timeline:auto}",
+                  "rtl": null,
+                },
+                3000,
+              ],
+              [
+                "x2xz49s",
+                {
+                  "ltr": ".x2xz49s:hover{margin-bottom:0}",
+                  "rtl": null,
+                },
+                4130,
+              ],
+            ],
+          }
+        `);
+      });
+    });
+
     describe('options `debug:true`', () => {
       test('adds debug data', () => {
         const options = {

--- a/packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts
+++ b/packages/@stylexjs/babel-plugin/src/shared/common-types.d.ts
@@ -43,6 +43,7 @@ export type StyleXOptions = Readonly<{
   env?: Readonly<{ [$$Key$$: string]: any }>;
   dev: boolean;
   propertyValidationMode?: 'throw' | 'warn' | 'silent';
+  enableCompressedClassnames?: null | undefined | boolean;
   enableDebugDataProp?: null | undefined | boolean;
   enableDevClassNames?: null | undefined | boolean;
   enableFontSizePxToRem?: null | undefined | boolean;

--- a/packages/@stylexjs/babel-plugin/src/shared/common-types.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/common-types.js
@@ -50,6 +50,7 @@ export type StyleXOptions = $ReadOnly<{
   env?: $ReadOnly<{ [string]: any }>,
   dev: boolean,
   propertyValidationMode?: 'throw' | 'warn' | 'silent',
+  enableCompressedClassnames?: ?boolean,
   enableDebugDataProp?: ?boolean,
   enableDevClassNames?: ?boolean,
   enableFontSizePxToRem?: ?boolean,

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/__tests__/compressed-class-name-test.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/__tests__/compressed-class-name-test.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import getCompressedClassName, {
+  valueShorthands,
+} from '../compressed-class-name';
+import { propertyShorthands } from '../../property-shorthands';
+
+const compress = (
+  property: string,
+  value: string | $ReadOnlyArray<string>,
+  hasModifiers: boolean = false,
+  classNamePrefix: string = 'x',
+) => getCompressedClassName(property, value, hasModifiers, classNamePrefix);
+
+describe('compressed class names', () => {
+  test('compresses common numeric declarations', () => {
+    expect(compress('margin', '0')).toBe('m0');
+    expect(compress('margin', '4px')).toBe('m4');
+    expect(compress('paddingTop', '16px')).toBe('pt16');
+    expect(compress('width', '100%')).toBe('w100p');
+    expect(compress('opacity', '.5')).toBe('op0d5');
+    expect(compress('margin', '-4px')).toBe('m-4');
+  });
+
+  test('compresses common keyword declarations', () => {
+    expect(compress('display', 'flex')).toBe('d-f');
+    expect(compress('position', 'absolute')).toBe('po-a');
+    expect(compress('flexDirection', 'column-reverse')).toBe('fd-cr');
+    expect(compress('backgroundColor', 'red')).toBe('bg-r');
+    expect(compress('color', '#fff')).toBe('c-fff');
+  });
+
+  test('does not compress names longer than six characters', () => {
+    expect(compress('paddingTop', '1234px')).toBe('pt1234');
+    expect(compress('paddingTop', '12345px')).toBeNull();
+    expect(compress('backgroundColor', '#ffff')).toBeNull();
+  });
+
+  test('falls back for complex or potentially conflicting declarations', () => {
+    expect(compress('animationTimeline', 'auto')).toBeNull();
+    expect(compress('margin', 'var(--spacing)')).toBeNull();
+    expect(compress('margin', ['0', '4px'])).toBeNull();
+    expect(compress('margin', '4px', true)).toBeNull();
+    expect(compress('margin', '4')).toBeNull();
+    expect(compress('lineHeight', '4px')).toBeNull();
+    expect(compress('margin', '0', false, 'm')).toBeNull();
+    expect(compress('margin', '0', false, '')).toBeNull();
+  });
+
+  test('hardcoded names are unique and never longer than six characters', () => {
+    for (const [property, values] of Object.entries(valueShorthands)) {
+      const propertyShorthand = propertyShorthands[property];
+      expect(propertyShorthand).toBeDefined();
+
+      const suffixes = Object.values(values);
+      expect(new Set(suffixes).size).toBe(suffixes.length);
+      for (const suffix of suffixes) {
+        expect(`${propertyShorthand}-${suffix}`).toMatch(/^[a-z-]+$/);
+        expect(`${propertyShorthand}-${suffix}`.length).toBeLessThanOrEqual(6);
+      }
+    }
+  });
+});

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/__tests__/convert-to-className-test.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/__tests__/convert-to-className-test.js
@@ -41,6 +41,31 @@ describe('convert-to-className test', () => {
     expect(debugClassName.startsWith('x')).toBe(true);
     expect(debugClassName.startsWith('margin-x')).toBe(false);
   });
+  test('uses a compressed classname when enabled and available', () => {
+    const options = {
+      classNamePrefix: 'x',
+      dev: false,
+      debug: false,
+      enableCompressedClassnames: true,
+      styleResolution: 'property-specificity',
+      test: false,
+    } as const;
+    const result = convertStyleToClassName(['margin', 4], [], [], [], options);
+    expect(result[1]).toBe('m4');
+    expect(result[2].ltr).toBe('.m4{margin:4px}');
+  });
+  test('uses compressed classnames in debug mode', () => {
+    const options = {
+      classNamePrefix: 'x',
+      dev: false,
+      debug: true,
+      enableCompressedClassnames: true,
+      styleResolution: 'property-specificity',
+      test: false,
+    } as const;
+    const result = convertStyleToClassName(['margin', 4], [], [], [], options);
+    expect(result[1]).toBe('m4');
+  });
   test('converts margin number to px', () => {
     expect(convert(['margin', 10])).toEqual('margin:10px');
   });

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/compressed-class-name.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/compressed-class-name.js
@@ -1,0 +1,463 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import { propertyShorthands } from '../property-shorthands';
+import { getNumberSuffix, lengthUnits, timeUnits } from './transform-value';
+
+const MAX_COMPRESSED_CLASS_NAME_LENGTH = 6;
+
+const alignment = Object.freeze({
+  baseline: 'b',
+  center: 'c',
+  end: 'e',
+  'flex-end': 'fe',
+  'flex-start': 'fs',
+  normal: 'n',
+  'space-around': 'sa',
+  'space-between': 'sb',
+  'space-evenly': 'se',
+  start: 's',
+  stretch: 'st',
+});
+
+const itemAlignment = Object.freeze({
+  baseline: 'b',
+  center: 'c',
+  end: 'e',
+  'flex-end': 'fe',
+  'flex-start': 'fs',
+  normal: 'n',
+  'self-end': 'se',
+  'self-start': 'ss',
+  start: 'st',
+  stretch: 's',
+});
+
+const selfAlignment = Object.freeze({
+  ...itemAlignment,
+  auto: 'a',
+});
+
+const color = Object.freeze({
+  black: 'b',
+  blue: 'bl',
+  currentColor: 'c',
+  gray: 'gy',
+  green: 'g',
+  orange: 'o',
+  purple: 'p',
+  red: 'r',
+  transparent: 't',
+  white: 'w',
+  yellow: 'y',
+});
+
+const overflow = Object.freeze({
+  auto: 'a',
+  clip: 'c',
+  hidden: 'h',
+  scroll: 's',
+  visible: 'v',
+});
+
+const borderStyle = Object.freeze({
+  dashed: 'd',
+  dotted: 'dt',
+  double: 'db',
+  hidden: 'h',
+  none: 'n',
+  solid: 's',
+});
+
+const timingFunction = Object.freeze({
+  ease: 'e',
+  'ease-in': 'ei',
+  'ease-in-out': 'io',
+  'ease-out': 'eo',
+  linear: 'l',
+  'step-end': 'se',
+  'step-start': 'ss',
+});
+
+export const valueShorthands: $ReadOnly<{
+  [string]: $ReadOnly<{ [string]: string }>,
+}> = Object.freeze({
+  accentColor: color,
+  alignContent: alignment,
+  alignItems: itemAlignment,
+  alignSelf: selfAlignment,
+  animationDirection: {
+    alternate: 'a',
+    'alternate-reverse': 'ar',
+    normal: 'n',
+    reverse: 'r',
+  },
+  animationFillMode: {
+    backwards: 'b',
+    both: 'bt',
+    forwards: 'f',
+    none: 'n',
+  },
+  animationIterationCount: { infinite: 'i' },
+  animationName: { none: 'n' },
+  animationPlayState: { paused: 'p', running: 'r' },
+  animationTimingFunction: timingFunction,
+  appearance: { auto: 'a', none: 'n' },
+  backgroundColor: color,
+  backgroundImage: { none: 'n' },
+  backgroundPosition: {
+    bottom: 'b',
+    center: 'c',
+    left: 'l',
+    right: 'r',
+    top: 't',
+  },
+  backgroundRepeat: {
+    'no-repeat': 'n',
+    repeat: 'r',
+    'repeat-x': 'rx',
+    'repeat-y': 'ry',
+    round: 'rd',
+    space: 's',
+  },
+  backgroundSize: { auto: 'a', contain: 'ct', cover: 'c' },
+  borderBlockColor: color,
+  borderBlockStyle: borderStyle,
+  borderBottomColor: color,
+  borderBottomStyle: borderStyle,
+  borderColor: color,
+  borderInlineColor: color,
+  borderInlineEndColor: color,
+  borderInlineEndStyle: borderStyle,
+  borderInlineStartColor: color,
+  borderInlineStartStyle: borderStyle,
+  borderInlineStyle: borderStyle,
+  borderLeftColor: color,
+  borderLeftStyle: borderStyle,
+  borderRightColor: color,
+  borderRightStyle: borderStyle,
+  borderStyle,
+  borderTopColor: color,
+  borderTopStyle: borderStyle,
+  boxShadow: { none: 'n' },
+  boxSizing: { 'border-box': 'b', 'content-box': 'c' },
+  clear: {
+    both: 'b',
+    'inline-end': 'ie',
+    'inline-start': 'is',
+    left: 'l',
+    none: 'n',
+    right: 'r',
+  },
+  color,
+  content: { none: 'no', normal: 'n' },
+  cursor: {
+    auto: 'a',
+    crosshair: 'c',
+    default: 'd',
+    grab: 'g',
+    grabbing: 'gb',
+    help: 'h',
+    move: 'm',
+    'not-allowed': 'na',
+    pointer: 'p',
+    text: 't',
+    wait: 'w',
+    'zoom-in': 'zi',
+    'zoom-out': 'zo',
+  },
+  display: {
+    block: 'b',
+    contents: 'c',
+    flex: 'f',
+    'flow-root': 'fr',
+    grid: 'g',
+    inline: 'i',
+    'inline-block': 'ib',
+    'inline-flex': 'if',
+    'inline-grid': 'ig',
+    none: 'n',
+    table: 't',
+  },
+  fill: color,
+  filter: { none: 'n' },
+  flexDirection: {
+    column: 'c',
+    'column-reverse': 'cr',
+    row: 'r',
+    'row-reverse': 'rr',
+  },
+  flexWrap: { nowrap: 'n', wrap: 'w', 'wrap-reverse': 'wr' },
+  float: {
+    'inline-end': 'ie',
+    'inline-start': 'is',
+    left: 'l',
+    none: 'n',
+    right: 'r',
+  },
+  fontFamily: {
+    monospace: 'm',
+    'sans-serif': 'ss',
+    serif: 'sr',
+    'system-ui': 'sy',
+  },
+  fontStyle: { italic: 'i', normal: 'n', oblique: 'o' },
+  fontWeight: {
+    bold: 'b',
+    bolder: 'br',
+    lighter: 'l',
+    normal: 'n',
+  },
+  justifyContent: alignment,
+  justifyItems: itemAlignment,
+  justifySelf: selfAlignment,
+  letterSpacing: { normal: 'n' },
+  lineHeight: { normal: 'n' },
+  listStyleType: { none: 'n' },
+  margin: { auto: 'a' },
+  marginBlock: { auto: 'a' },
+  marginBlockEnd: { auto: 'a' },
+  marginBlockStart: { auto: 'a' },
+  marginBottom: { auto: 'a' },
+  marginInline: { auto: 'a' },
+  marginInlineEnd: { auto: 'a' },
+  marginInlineStart: { auto: 'a' },
+  marginLeft: { auto: 'a' },
+  marginRight: { auto: 'a' },
+  marginTop: { auto: 'a' },
+  maxHeight: { none: 'n' },
+  maxWidth: { none: 'n' },
+  objectFit: {
+    contain: 'ct',
+    cover: 'cv',
+    fill: 'f',
+    none: 'n',
+    'scale-down': 'sd',
+  },
+  objectPosition: {
+    bottom: 'b',
+    center: 'c',
+    left: 'l',
+    right: 'r',
+    top: 't',
+  },
+  outlineColor: color,
+  outlineStyle: borderStyle,
+  overflow,
+  overflowWrap: { anywhere: 'a', 'break-word': 'bw', normal: 'n' },
+  overflowX: overflow,
+  overflowY: overflow,
+  placeContent: alignment,
+  placeItems: itemAlignment,
+  placeSelf: selfAlignment,
+  pointerEvents: { auto: 'a', none: 'n' },
+  position: {
+    absolute: 'a',
+    fixed: 'f',
+    relative: 'r',
+    static: 's',
+    sticky: 'st',
+  },
+  resize: {
+    block: 'bk',
+    both: 'b',
+    horizontal: 'h',
+    inline: 'i',
+    none: 'n',
+    vertical: 'v',
+  },
+  stroke: color,
+  textAlign: {
+    center: 'c',
+    end: 'e',
+    justify: 'j',
+    left: 'l',
+    'match-parent': 'mp',
+    right: 'r',
+    start: 's',
+  },
+  textDecoration: {
+    blink: 'b',
+    'line-through': 'lt',
+    none: 'n',
+    overline: 'o',
+    underline: 'u',
+  },
+  textOverflow: { clip: 'c', ellipsis: 'e' },
+  textTransform: {
+    capitalize: 'c',
+    lowercase: 'l',
+    none: 'n',
+    uppercase: 'u',
+  },
+  transform: { none: 'n' },
+  transformOrigin: {
+    bottom: 'b',
+    center: 'c',
+    left: 'l',
+    right: 'r',
+    top: 't',
+  },
+  transitionProperty: {
+    all: 'a',
+    'background-color': 'bg',
+    color: 'c',
+    none: 'n',
+    opacity: 'o',
+    transform: 't',
+  },
+  transitionTimingFunction: timingFunction,
+  userSelect: { all: 'al', auto: 'a', contain: 'c', none: 'n', text: 't' },
+  verticalAlign: {
+    baseline: 'b',
+    bottom: 'bt',
+    middle: 'm',
+    sub: 's',
+    super: 'sp',
+    'text-bottom': 'tb',
+    'text-top': 'tt',
+    top: 't',
+  },
+  visibility: { collapse: 'c', hidden: 'h', visible: 'v' },
+  whiteSpace: {
+    'break-spaces': 'bs',
+    normal: 'n',
+    nowrap: 'nw',
+    pre: 'p',
+    'pre-line': 'pl',
+    'pre-wrap': 'pw',
+  },
+  willChange: {
+    auto: 'a',
+    contents: 'c',
+    opacity: 'o',
+    'scroll-position': 'sp',
+    transform: 't',
+  },
+  wordBreak: {
+    'break-all': 'ba',
+    'break-word': 'bw',
+    'keep-all': 'ka',
+    normal: 'n',
+  },
+  wordSpacing: { normal: 'n' },
+  zIndex: { auto: 'a' },
+});
+
+const simpleUnitShorthands: $ReadOnly<{ [string]: string }> = Object.freeze({
+  '%': 'p',
+  em: 'e',
+  rem: 'r',
+});
+
+function encodeNumber(value: string): ?string {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return null;
+  }
+
+  const normalized = String(number);
+  if (!/^-?(?:\d+|\d+\.\d+)$/.test(normalized)) {
+    return null;
+  }
+  return normalized.replace('.', 'd');
+}
+
+function getNumericClassName(
+  property: string,
+  propertyShorthand: string,
+  value: string,
+): ?string {
+  if (value === '0') {
+    return propertyShorthand + '0';
+  }
+
+  const dimension = value.match(/^(-?(?:\d+|\d*\.\d+))(px|%|rem|em|ms|s)?$/);
+  if (dimension == null) {
+    return null;
+  }
+
+  const number = encodeNumber(dimension[1]);
+  const unit = dimension[2] ?? '';
+  if (number == null) {
+    return null;
+  }
+
+  if (unit === '' && getNumberSuffix(property) === '') {
+    return propertyShorthand + number;
+  }
+  if (
+    unit === 'px' &&
+    lengthUnits.has(property) &&
+    getNumberSuffix(property) !== ''
+  ) {
+    return propertyShorthand + number;
+  }
+  if ((unit === 'ms' || unit === 's') && timeUnits.has(property)) {
+    return propertyShorthand + number + unit[0];
+  }
+
+  const unitShorthand = simpleUnitShorthands[unit];
+  return unitShorthand == null
+    ? null
+    : propertyShorthand + number + unitShorthand;
+}
+
+function getKeywordClassName(
+  property: string,
+  propertyShorthand: string,
+  value: string,
+): ?string {
+  const valueShorthand = valueShorthands[property]?.[value];
+  return valueShorthand == null
+    ? null
+    : `${propertyShorthand}-${valueShorthand}`;
+}
+
+function getHexColorClassName(
+  property: string,
+  propertyShorthand: string,
+  value: string,
+): ?string {
+  if (valueShorthands[property] !== color || !/^#[0-9a-f]{3,4}$/i.test(value)) {
+    return null;
+  }
+  return `${propertyShorthand}-${value.slice(1).toLowerCase()}`;
+}
+
+export default function getCompressedClassName(
+  property: string,
+  value: string | $ReadOnlyArray<string>,
+  hasModifiers: boolean,
+  classNamePrefix: string,
+): ?string {
+  const propertyShorthand = propertyShorthands[property];
+  if (
+    propertyShorthand == null ||
+    Array.isArray(value) ||
+    hasModifiers ||
+    classNamePrefix === ''
+  ) {
+    return null;
+  }
+
+  const candidate =
+    getNumericClassName(property, propertyShorthand, value) ??
+    getKeywordClassName(property, propertyShorthand, value) ??
+    getHexColorClassName(property, propertyShorthand, value);
+
+  if (
+    candidate == null ||
+    candidate.length > MAX_COMPRESSED_CLASS_NAME_LENGTH ||
+    candidate.startsWith(classNamePrefix)
+  ) {
+    return null;
+  }
+  return candidate;
+}

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/convert-to-className.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/convert-to-className.js
@@ -10,6 +10,7 @@
 import type { TRawValue, StyleRule, StyleXOptions } from '../common-types';
 
 import createHash from '../hash';
+import getCompressedClassName from './compressed-class-name';
 import dashify from './dashify';
 import transformValue from './transform-value';
 import { generateCSSRule } from './generate-css-rule';
@@ -31,7 +32,7 @@ export function convertStyleToClassName(
   constRules: $ReadOnlyArray<string>,
   options: StyleXOptions = defaultOptions,
 ): StyleRule {
-  const { classNamePrefix = 'x' } = options;
+  const { classNamePrefix = 'x', enableCompressedClassnames = false } = options;
   const [key, rawValue] = objEntry;
   const dashedKey = key.startsWith('--') ? key : dashify(key);
 
@@ -60,7 +61,16 @@ export function convertStyleToClassName(
 
   // NOTE: '<>' is used to keep existing hashes stable.
   // This should be removed in a future version.
-  const className = classNamePrefix + createHash('<>' + stringToHash);
+  const hashedClassName = classNamePrefix + createHash('<>' + stringToHash);
+  const compressedClassName = enableCompressedClassnames
+    ? getCompressedClassName(
+        key,
+        value,
+        modifierHashString !== 'null',
+        classNamePrefix,
+      )
+    : null;
+  const className = compressedClassName ?? hashedClassName;
 
   const cssRules = generateCSSRule(
     className,

--- a/packages/@stylexjs/babel-plugin/src/shared/utils/default-options.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/utils/default-options.js
@@ -14,6 +14,7 @@ export const defaultOptions: StyleXOptions = {
   dev: false,
   debug: false,
   propertyValidationMode: 'silent',
+  enableCompressedClassnames: false,
   enableDevClassNames: false,
   enableDebugDataProp: true,
   enableFontSizePxToRem: false,

--- a/packages/@stylexjs/babel-plugin/src/utils/__tests__/state-manager-test.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/__tests__/state-manager-test.js
@@ -132,6 +132,36 @@ describe('StateManager config parsing', () => {
     });
   });
 
+  describe('"enableCompressedClassnames" option (boolean)', () => {
+    test('logs errors if invalid', () => {
+      const stateManager = makeState({ enableCompressedClassnames: 'true' });
+      expect(stateManager.options.enableCompressedClassnames).toBe(false);
+      expect(warnings).toEqual([
+        [
+          '[@stylexjs/babel-plugin]',
+          'Expected (options.enableCompressedClassnames) to be a boolean, but got `"true"`.',
+        ],
+      ]);
+    });
+
+    test('default value', () => {
+      const stateManager = makeState();
+      expect(stateManager.options.enableCompressedClassnames).toBe(false);
+      expect(warnings).toEqual([]);
+    });
+
+    test('false value', () => {
+      const stateManager = makeState({ enableCompressedClassnames: false });
+      expect(stateManager.options.enableCompressedClassnames).toBe(false);
+      expect(warnings).toEqual([]);
+    });
+
+    test('true value', () => {
+      const stateManager = makeState({ enableCompressedClassnames: true });
+      expect(stateManager.options.enableCompressedClassnames).toBe(true);
+      expect(warnings).toEqual([]);
+    });
+  });
   describe('"enableDebugDataProp" option (boolean)', () => {
     test('logs errors if invalid', () => {
       const stateManager = makeState({

--- a/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/state-manager.js
@@ -95,6 +95,7 @@ export type StyleXOptions = $ReadOnly<{
   ...RuntimeOptions,
   aliases?: ?$ReadOnly<{ [string]: string | $ReadOnlyArray<string> }>,
   propertyValidationMode?: 'throw' | 'warn' | 'silent',
+  enableCompressedClassnames?: boolean,
   enableDebugDataProp?: boolean,
   enableDevClassNames?: boolean,
   enableInlinedConditionalMerge?: boolean,
@@ -227,6 +228,14 @@ export default class StateManager {
       'options.debug',
     );
 
+    const enableCompressedClassnames: StyleXStateOptions['enableCompressedClassnames'] =
+      z.logAndDefault(
+        z.boolean(),
+        options.enableCompressedClassnames ??
+          defaultOptions.enableCompressedClassnames,
+        false,
+        'options.enableCompressedClassnames',
+      );
     const enableDebugDataProp: StyleXStateOptions['enableDebugDataProp'] =
       z.logAndDefault(
         z.boolean(),
@@ -436,6 +445,7 @@ export default class StateManager {
       dev,
       propertyValidationMode,
       env,
+      enableCompressedClassnames,
       enableDebugDataProp,
       enableDevClassNames,
       enableFontSizePxToRem,

--- a/packages/docs/content/docs/api/configuration/babel-plugin.mdx
+++ b/packages/docs/content/docs/api/configuration/babel-plugin.mdx
@@ -23,7 +23,25 @@ Example: `'@/components/*': [path.join(__dirname, './src/components/*')]`
 classNamePrefix: string; // Default: 'x'
 ```
 
-Prefix to be applied to every generated className.
+Prefix applied to hashed class names. When `enableCompressedClassnames` is
+enabled, readable compressed names use their property shorthand instead.
+
+---
+
+### `enableCompressedClassnames`
+
+```ts
+enableCompressedClassnames: boolean; // Default: false
+```
+
+When `true`, StyleX uses short, deterministic class names for common properties
+with simple values. For example, `margin: 0` becomes `m0`, `paddingTop: 16`
+becomes `pt16`, `display: 'flex'` becomes `d-f`, and `position: 'absolute'`
+becomes `po-a`.
+
+Compressed names are never longer than six characters. Declarations with
+complex values, conditions, or no safe short form continue to use hashing and
+the configured `classNamePrefix`.
 
 ---
 

--- a/packages/docs/static/llm/stylex-installation.md
+++ b/packages/docs/static/llm/stylex-installation.md
@@ -196,7 +196,8 @@ import './index.css';
 | `treeshakeCompensation` | boolean | false | Prevent tree-shaking from removing styles |
 | `aliases` | object | {} | Path aliases matching your bundler config |
 | `unstable_moduleResolution` | object | undefined | Module resolution strategy for theming APIs |
-| `classNamePrefix` | string | 'x' | Prefix for generated class names |
+| `classNamePrefix` | string | 'x' | Prefix for hashed generated class names |
+| `enableCompressedClassnames` | boolean | false | Use class names of six characters or fewer for common simple declarations |
 | `importSources` | array | ['@stylexjs/stylex'] | Custom import sources for StyleX |
 | `styleResolution` | string | 'property-specificity' | Style merge strategy: 'application-order' (last style wins) or 'property-specificity' (more specific property wins) |
 


### PR DESCRIPTION
## Summary

- add the `enableCompressedClassnames` compiler option, disabled by default
- generate short class names for common simple declarations using the property prefixes introduced in #1839
- cap readable class names at six characters and preserve hashing for complex, conditional, conflicting, or uncommon cases
- add Flow and TypeScript config types, validation, documentation, and end-to-end coverage

## Examples

- `margin: 0` → `m0`
- `margin: 4px` → `m4`
- `paddingTop: 16px` → `pt16`
- `display: flex` → `d-f`
- `position: absolute` → `po-a`

Stacked on #1839.

## Test plan

- `npm run build`
- `npm run docs:build`
- `npm run flow -- --show-all-errors`
- `npm run typescript`
- `npm run prettier:report`
- `npm run lint:report`
- `npm run test:packages`
