### PR TITLE
[babel-plugin] use globalThis in the compile-time evaluator

### DIFF
--- a/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
@@ -159,7 +159,7 @@ function isBlockedFunction(fn: mixed): boolean {
     Object.getPrototypeOf(callable) === Function ||
     // Referenced, never called: this is a value the evaluator refuses to run.
     // eslint-disable-next-line no-eval
-    callable === globalThis.eval
+    callable === (globalThis as $FlowFixMe).eval
   );
 }
 
@@ -1078,7 +1078,7 @@ function _evaluate(path: NodePath<>, state: State): any {
       !path.scope.getBinding(callee.node.name) &&
       isValidCallee(callee.node.name)
     ) {
-      func = globalThis[callee.node.name];
+      func = (globalThis as $FlowFixMe)[callee.node.name];
     } else if (
       callee.isIdentifier() &&
       getOwnProperty(state.functions.identifiers, callee.node.name)
@@ -1103,7 +1103,7 @@ function _evaluate(path: NodePath<>, state: State): any {
           isValidCallee(object.node.name) &&
           isValidCalleeMethod(object.node.name, property.node.name)
         ) {
-          context = globalThis[object.node.name];
+          context = (globalThis as $FlowFixMe)[object.node.name];
           // @ts-expect-error property may not exist in context object
           func = context[property.node.name];
         } else {

--- a/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
+++ b/packages/@stylexjs/babel-plugin/src/utils/evaluate-path.js
@@ -159,7 +159,7 @@ function isBlockedFunction(fn: mixed): boolean {
     Object.getPrototypeOf(callable) === Function ||
     // Referenced, never called: this is a value the evaluator refuses to run.
     // eslint-disable-next-line no-eval
-    callable === global.eval
+    callable === globalThis.eval
   );
 }
 
@@ -1078,7 +1078,7 @@ function _evaluate(path: NodePath<>, state: State): any {
       !path.scope.getBinding(callee.node.name) &&
       isValidCallee(callee.node.name)
     ) {
-      func = global[callee.node.name];
+      func = globalThis[callee.node.name];
     } else if (
       callee.isIdentifier() &&
       getOwnProperty(state.functions.identifiers, callee.node.name)
@@ -1103,7 +1103,7 @@ function _evaluate(path: NodePath<>, state: State): any {
           isValidCallee(object.node.name) &&
           isValidCalleeMethod(object.node.name, property.node.name)
         ) {
-          context = global[object.node.name];
+          context = globalThis[object.node.name];
           // @ts-expect-error property may not exist in context object
           func = context[property.node.name];
         } else {


### PR DESCRIPTION
## What changed / motivation ?

**This only affects the playground.** It's a bug in the browser build of the plugin (`lib/index.browser.js`), which the playground is the only known consumer of. Node builds were never affected, since `global` exists there.

The compile-time evaluator read globals off Node's `global` object in three places in `src/utils/evaluate-path.js`. `global` doesn't exist in browsers, so those reads throw `ReferenceError: global is not defined` when the plugin runs client-side, as it does in the docs playground. Babel prefixes the filename, giving the reported `/App.tsx: global is not defined`.

Swapped all three to `globalThis`, which is equivalent in Node and available in browsers.

It broke now because of the read added in #1818: `isBlockedFunction` compares against `global.eval` and runs for every call expression, which is why removing the `stylex.when(...)` call from the example works around it. The other two reads are older and equally broken in a browser, but sit behind the `isValidCallee` allowlist (`String`, `Number`, `Math`, `Object`, `Array`) that no playground example hits.

## Linked PR/Issues

Fixes #1838

## Additional Context

`globalThis` behaves identically to `global` in Node, so this is strictly a widening. No behavior change for any Node consumer of the plugin.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
