### PR TITLE
fix(unplugin): serialize concurrent CSS writes in Bun plugin

### DIFF
--- a/packages/@stylexjs/unplugin/src/bun.js
+++ b/packages/@stylexjs/unplugin/src/bun.js
@@ -28,18 +28,22 @@ export const createStylexBunPlugin = (userOptions = {}) => {
     options.bunDevCssOutput ||
     path.resolve(process.cwd(), 'dist', 'stylex.dev.css');
   let lastCss = null;
+  let writeQueue = Promise.resolve();
 
-  const writeCss = async () => {
+  const writeCss = (force = false) => {
     const css = plugin.__stylexCollectCss?.() || '';
     const next = css
       ? `:root { --stylex-injection: 0; }\n${css}`
       : ':root { --stylex-injection: 0; }';
-    if (next === lastCss) return;
+    if (!force && next === lastCss) return writeQueue;
     lastCss = next;
-    try {
-      await fsp.mkdir(path.dirname(cssOutput), { recursive: true });
-      await fsp.writeFile(cssOutput, next, 'utf8');
-    } catch {}
+    writeQueue = writeQueue
+      .then(async () => {
+        await fsp.mkdir(path.dirname(cssOutput), { recursive: true });
+        await fsp.writeFile(cssOutput, next, 'utf8');
+      })
+      .catch(() => {});
+    return writeQueue;
   };
 
   return {
@@ -59,11 +63,11 @@ export const createStylexBunPlugin = (userOptions = {}) => {
       if (plugin.buildEnd) {
         build.onEnd(async () => {
           await plugin.buildEnd();
-          await writeCss();
+          await writeCss(true);
         });
       } else {
         build.onEnd(async () => {
-          await writeCss();
+          await writeCss(true);
         });
       }
 


### PR DESCRIPTION
## Summary

When building multi-file projects with Bun, StyleX transforms run concurrently via `onLoad`. Each transform triggers an asynchronous `writeCss` call against the shared `cssOutput` file.

Previously, those writes were not queued. `lastCss` was updated before `fsp.writeFile` completed, and callers did not wait on any in-flight write. Concurrent races could therefore produce out-of-order disk writes (an earlier partial CSS snapshot overwriting a later complete one). Separately, if `onEnd` observed `next === lastCss`, it skipped rewriting even when the file on disk still held a stale or incomplete result from an unfinished earlier write.

## Solution

- Serialize CSS writes through a Promise queue (`writeQueue`) so each write waits for the previous one to finish.
- Keep the `lastCss` short-circuit for intermediate updates, but return the in-flight queue so callers still await completion.
- Pass `force: true` from `build.onEnd` so the final collected CSS is always flushed after transforms finish.

## Test plan

- [x] `packages/@stylexjs/unplugin` Jest suite (`yarn test`) — 17/17 passed
- [ ] Manual Bun multi-file build: confirm `stylex.dev.css` (or configured `bunDevCssOutput`) ends with the complete StyleX CSS after parallel `onLoad` transforms