### PR TITLE
fix(unplugin): do not let Vite dev polling timer keep the process alive

### DIFF
--- a/packages/@stylexjs/unplugin/__tests__/unplugin.test.js
+++ b/packages/@stylexjs/unplugin/__tests__/unplugin.test.js
@@ -477,24 +477,43 @@ describe('@stylexjs/unplugin', () => {
     });
 
     test('is cleared when the httpServer closes', () => {
-      const plugin = unplugin.vite({ dev: true });
-      const closeListeners = [];
-      const httpServer = {
-        once(event, fn) {
-          if (event === 'close') closeListeners.push(fn);
-        },
-      };
-      const server = makeServer(httpServer);
-      plugin.configureServer(server);
+      jest.useFakeTimers();
+      try {
+        const plugin = unplugin.vite({ dev: true });
+        const closeListeners = [];
+        const httpServer = {
+          once(event, fn) {
+            if (event === 'close') closeListeners.push(fn);
+          },
+        };
+        const sent = [];
+        const server = {
+          middlewares: { use: () => {} },
+          ws: { send: (msg) => sent.push(msg) },
+          httpServer,
+        };
+        plugin.configureServer(server);
+        expect(server.__stylexSharedPollingInterval).toBeDefined();
+        expect(closeListeners).toHaveLength(1);
 
-      const interval = server.__stylexSharedPollingInterval;
-      expect(interval).toBeDefined();
-      expect(closeListeners.length).toBe(1);
-      // Simulate the server closing.
-      closeListeners[0]();
-      // After close the timer is cleared: calling clearInterval again is safe,
-      // and the interval no longer has a ref either way.
-      expect(() => clearInterval(interval)).not.toThrow();
+        const shared = plugin.__stylexGetSharedStore();
+        const updates = () =>
+          sent.filter((m) => m && m.event === 'stylex:css-update');
+
+        // A version bump is picked up on the next poll.
+        shared.version += 1;
+        jest.advanceTimersByTime(150);
+        expect(updates()).toHaveLength(1);
+
+        // Simulate the server closing: the timer is cleared, so later bumps
+        // are never broadcast.
+        closeListeners[0]();
+        shared.version += 1;
+        jest.advanceTimersByTime(1500);
+        expect(updates()).toHaveLength(1);
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/packages/@stylexjs/unplugin/__tests__/unplugin.test.js
+++ b/packages/@stylexjs/unplugin/__tests__/unplugin.test.js
@@ -447,4 +447,54 @@ describe('@stylexjs/unplugin', () => {
       expect(css).toContain('.x1aif7nf');
     });
   });
+
+  // Regression: https://github.com/facebook/stylex/issues/1836
+  // The Vite adapter's shared-store polling timer must never keep the process
+  // alive. Vitest's Vite server has no `httpServer`, so the `close` cleanup is
+  // skipped and a still-referenced interval would hang `vitest run` on exit.
+  describe('Vite dev shared-store polling timer', () => {
+    function makeServer(httpServer) {
+      return {
+        middlewares: { use: () => {} },
+        ws: { send: () => {} },
+        httpServer,
+      };
+    }
+
+    test('is unref’d when the server has no httpServer (Vitest)', () => {
+      const plugin = unplugin.vite({ dev: true });
+      expect(typeof plugin.configureServer).toBe('function');
+
+      const server = makeServer(null);
+      plugin.configureServer(server);
+
+      const interval = server.__stylexSharedPollingInterval;
+      expect(interval).toBeDefined();
+      // The timer must not hold the event loop open.
+      expect(typeof interval.hasRef).toBe('function');
+      expect(interval.hasRef()).toBe(false);
+      clearInterval(interval);
+    });
+
+    test('is cleared when the httpServer closes', () => {
+      const plugin = unplugin.vite({ dev: true });
+      const closeListeners = [];
+      const httpServer = {
+        once(event, fn) {
+          if (event === 'close') closeListeners.push(fn);
+        },
+      };
+      const server = makeServer(httpServer);
+      plugin.configureServer(server);
+
+      const interval = server.__stylexSharedPollingInterval;
+      expect(interval).toBeDefined();
+      expect(closeListeners.length).toBe(1);
+      // Simulate the server closing.
+      closeListeners[0]();
+      // After close the timer is cleared: calling clearInterval again is safe,
+      // and the interval no longer has a ref either way.
+      expect(() => clearInterval(interval)).not.toThrow();
+    });
+  });
 });

--- a/packages/@stylexjs/unplugin/src/vite.js
+++ b/packages/@stylexjs/unplugin/src/vite.js
@@ -89,7 +89,18 @@ function attachViteHooks(plugin) {
             } catch {}
           }
         }, 150);
+        // This dev-only polling timer must never keep the process alive. Under
+        // Vitest (and Vite middleware mode) the server has no `httpServer`, so
+        // the `close` cleanup below is skipped; a still-referenced interval
+        // would then leak and hang the process on exit (~10s under
+        // `vitest run`) (#1836).
+        if (typeof interval.unref === 'function') {
+          interval.unref();
+        }
         server.httpServer?.once('close', () => clearInterval(interval));
+        // Exposed so tests (and hosts that tear the server down without an
+        // `httpServer` close event) can observe/clear the timer.
+        server.__stylexSharedPollingInterval = interval;
       }
     },
     resolveId(id) {


### PR DESCRIPTION
## What changed / motivation ?

`@stylexjs/unplugin`'s Vite adapter keeps Node alive after tests finish when used under Vitest. In `configureServer`, when the shared store is active the plugin starts a 150 ms `setInterval` to broadcast `stylex:css-update`, but clears it only via `server.httpServer?.once('close', ...)`. Vitest's Vite server has **no `httpServer`**, so the cleanup listener is skipped and the interval is never cleared — every `vitest run` ends with `close timed out after 10000ms` and suite wall time jumps from ~4.5 s to ~15 s (#1836).

This change calls `interval.unref()` so the dev-only polling timer can never hold the event loop open, while keeping the existing `httpServer` `close` cleanup for normal dev servers. The interval is also exposed on the server (`__stylexSharedPollingInterval`) so hosts that tear down a server without an `httpServer` close event (and tests) can observe/clear it. Behavior is unchanged for real dev servers (the timer still fires and is cleared on close); it only stops blocking process exit when there is no `httpServer`.

## Linked PR/Issues

Fixes #1836

## Additional Context

- Added two regression tests in `__tests__/unplugin.test.js`:
  - the interval is `unref`'d ( `hasRef() === false` ) when the server has no `httpServer` (the Vitest case);
  - the interval is cleared when the `httpServer` emits `close`.
- This corresponds to the issue's suggested fix of using `interval.unref?.()` so a leaked timer cannot keep Node alive.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
