### PR TITLE
[unplugin] Preserve Vite plugin return types

### DIFF
--- a/packages/@stylexjs/unplugin/src/index.d.ts
+++ b/packages/@stylexjs/unplugin/src/index.d.ts
@@ -6,6 +6,7 @@
  */
 
 import type { UserOptions } from './core';
+import type vite from './vite';
 
 export { unpluginFactory } from './core';
 export type { UserOptions } from './core';
@@ -19,7 +20,7 @@ declare const stylex: {
   rollup: (options?: Partial<UserOptions>) => any;
   rspack: (options?: Partial<UserOptions>) => any;
   unloader: (options?: Partial<UserOptions>) => any;
-  vite: (options?: Partial<UserOptions>) => any;
+  vite: typeof vite;
   webpack: (options?: Partial<UserOptions>) => any;
   raw: typeof import('./core').unpluginFactory;
 };

--- a/packages/@stylexjs/unplugin/src/vite.d.ts
+++ b/packages/@stylexjs/unplugin/src/vite.d.ts
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type { VitePlugin } from 'unplugin';
 import type { UserOptions } from './core';
 
-declare const plugin: (options?: Partial<UserOptions>) => any;
+declare const plugin: (options?: Partial<UserOptions>) => VitePlugin;
 
 export default plugin;


### PR DESCRIPTION
## What changed / motivation ?

The Vite adapter declares its return value as `any`, so adding it to a Vite configuration loses plugin type information and triggers `typescript/no-unsafe-assignment` in projects using type-aware linting.

Use the `VitePlugin` type exported by the existing `unplugin` peer dependency, and share the Vite factory declaration with `stylex.vite()` and the named `unplugin` export. The runtime behaviour and optional configuration argument remain unchanged.

## Linked PR/Issues

N/A

## Additional Context

This change only updates the two Vite-related declarations.

Validation:

- `yarn test` passed (build, Flow, package tests, TypeScript, Prettier and ESLint).
- Existing TypeScript tests and targeted Prettier checks passed for the final diff.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
