### PR TITLE
[rollup-plugin][unplugin] Honor custom importSources without dropping the built-in ones

### DIFF
--- a/packages/@stylexjs/rollup-plugin/__tests__/__fixtures__/customSource.js
+++ b/packages/@stylexjs/rollup-plugin/__tests__/__fixtures__/customSource.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import * as stylex from 'custom-stylex';
+
+export const styles = stylex.create({
+  red: {
+    color: 'red',
+  },
+});

--- a/packages/@stylexjs/rollup-plugin/__tests__/index-test.js
+++ b/packages/@stylexjs/rollup-plugin/__tests__/index-test.js
@@ -60,6 +60,37 @@ describe('rollup-plugin-stylex', () => {
     return { css, js, output };
   }
 
+  it('still transforms built-in imports when a custom importSource is set', async () => {
+    const { css } = await runStylex({
+      fileName: 'stylex.css',
+      importSources: ['custom-stylex'],
+    });
+    expect(css).toContain('display: flex;');
+  });
+
+  it('transforms a module that imports from a custom importSource', async () => {
+    const bundle = await rollup.rollup({
+      external: ['custom-stylex', '@stylexjs/stylex/lib/stylex-inject'],
+      input: path.resolve(__dirname, '__fixtures__/customSource.js'),
+      plugins: [
+        babel({
+          babelHelpers: 'bundled',
+          configFile: path.resolve(__dirname, '__fixtures__/.babelrc.json'),
+        }),
+        stylexPlugin({
+          fileName: 'stylex.css',
+          importSources: ['custom-stylex'],
+          lightningcssOptions: { minify: false },
+        }),
+      ],
+    });
+    const { output } = await bundle.generate({
+      file: path.resolve(__dirname, '/__builds__/bundle.js'),
+    });
+    const css = output.find((o) => o.fileName === 'stylex.css')?.source;
+    expect(css).toContain('color: red;');
+  });
+
   it('extracts CSS and removes stylex.inject calls', async () => {
     const { css, js } = await runStylex({ fileName: 'stylex.css' });
 

--- a/packages/@stylexjs/rollup-plugin/src/index.js
+++ b/packages/@stylexjs/rollup-plugin/src/index.js
@@ -30,6 +30,9 @@ const IS_DEV_ENV =
   process.env.NODE_ENV === 'development' ||
   process.env.BABEL_ENV === 'development';
 
+// The babel plugin always recognises these on top of any configured source.
+const BUILT_IN_IMPORT_SOURCES = ['stylex', '@stylexjs/stylex'];
+
 export type PluginOptions = $ReadOnly<{
   ...Partial<Options>,
   fileName?: string,
@@ -68,11 +71,12 @@ export default function stylexPlugin({
   unstable_moduleResolution = { type: 'commonJS', rootDir: process.cwd() },
   fileName = 'stylex.css',
   babelConfig: { plugins = [], presets = [] } = {},
-  importSources = ['stylex', '@stylexjs/stylex'],
+  importSources = BUILT_IN_IMPORT_SOURCES,
   useCSSLayers = false,
   lightningcssOptions,
   ...options
 }: PluginOptions = {}): Plugin<> {
+  const gateImportSources = [...BUILT_IN_IMPORT_SOURCES, ...importSources];
   let stylexRules: { [string]: $ReadOnlyArray<Rule> } = {};
   return {
     name: 'rollup-plugin-stylex',
@@ -117,7 +121,7 @@ export default function stylexPlugin({
       id: string,
     ): Promise<null | TransformResult> {
       if (
-        !importSources.some((importName) =>
+        !gateImportSources.some((importName) =>
           typeof importName === 'string'
             ? inputCode.includes(importName)
             : inputCode.includes(importName.from),
@@ -140,6 +144,7 @@ export default function stylexPlugin({
           jsxSyntaxPlugin,
           stylexBabelPlugin.withOptions({
             ...options,
+            importSources,
             dev,
             unstable_moduleResolution,
           }),

--- a/packages/@stylexjs/unplugin/__tests__/unplugin.test.js
+++ b/packages/@stylexjs/unplugin/__tests__/unplugin.test.js
@@ -29,6 +29,20 @@ describe('@stylexjs/unplugin', () => {
     expect(result).toBeNull();
   });
 
+  test('still transforms built-in imports when a custom importSource is set', async () => {
+    const plugin = unplugin.raw({ importSources: ['custom-stylex'] });
+    if (typeof plugin.buildStart === 'function') {
+      plugin.buildStart();
+    }
+    const source = `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({ foo: { color: 'red' } });
+      export default styles;
+    `;
+    const result = await plugin.transform(source, '/virtual/example.js');
+    expect(result).not.toBeNull();
+  });
+
   test('writes fallback CSS asset when no CSS bundle entry exists', async () => {
     const plugin = unplugin.rollup({
       runtimeInjection: false,

--- a/packages/@stylexjs/unplugin/src/core.js
+++ b/packages/@stylexjs/unplugin/src/core.js
@@ -21,6 +21,9 @@ import { transform as lightningTransform } from 'lightningcss';
 import browserslist from 'browserslist';
 import { browserslistToTargets } from 'lightningcss';
 
+// The babel plugin always recognises these on top of any configured source.
+const BUILT_IN_IMPORT_SOURCES = ['stylex', '@stylexjs/stylex'];
+
 // Vite and Rollup hash asset file names by default, so `index.css` reaches the
 // output directory as e.g. `assets/index-B5Jdbbfd.css`. Both patterns therefore
 // allow an optional content hash.
@@ -231,7 +234,7 @@ export const unpluginFactory = (userOptions = {}, metaOptions) => {
       process.env.BABEL_ENV === 'development',
     unstable_moduleResolution = { type: 'commonJS', rootDir: process.cwd() },
     babelConfig: { plugins = [], presets = [] } = {},
-    importSources = ['stylex', '@stylexjs/stylex'],
+    importSources = BUILT_IN_IMPORT_SOURCES,
     useCSSLayers = false,
     lightningcssOptions,
     cssInjectionTarget,
@@ -244,6 +247,8 @@ export const unpluginFactory = (userOptions = {}, metaOptions) => {
     treeshakeCompensation = ['vite', 'rollup', 'rolldown'].includes(framework),
     ...stylexOptions
   } = userOptions;
+
+  const gateImportSources = [...BUILT_IN_IMPORT_SOURCES, ...importSources];
 
   // Shared state across a single compilation (used for builds)
   const stylexRulesById = new Map(); // id -> Rule[]
@@ -342,7 +347,7 @@ export const unpluginFactory = (userOptions = {}, metaOptions) => {
 
   function shouldHandle(code) {
     if (!code) return false;
-    return importSources.some((src) => containsStylexImport(code, src));
+    return gateImportSources.some((src) => containsStylexImport(code, src));
   }
 
   function resetState() {


### PR DESCRIPTION
## What changed / motivation ?

Configuring `importSources` on the rollup plugin or the unplugin integrations broke compilation in two ways.

The rollup plugin gated files on `importSources` but never forwarded the option to the babel plugin, so a module importing from a configured custom source passed the gate and was left untransformed.

Both the rollup plugin and `@stylexjs/unplugin` tested the gate against the configured list alone. The babel plugin composes its own list as the built-in sources plus the configured ones, so adding a custom source narrowed the gate and ordinary `@stylexjs/stylex` modules stopped reaching the compiler.

The gate now tests the built-in sources plus the configured ones, and the rollup plugin forwards `importSources`.

## Linked PR/Issues

None.

## Additional Context

Three tests: the two gate cases and a fixture importing from `custom-stylex`. All three fail on `main` and pass with the change.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
