### PR TITLE
[babel-plugin] Fix positionTry emitting every declaration twice

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-import-export-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-import-export-test.js
@@ -239,14 +239,14 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
-        const fallback1 = "--x5jppmd";
-        const fallback2 = "--x17pzx6";
+        const fallback1 = "--xpd0xwl";
+        const fallback2 = "--x10ycovl";
         const theme = {
           xop34xu: "xfnndu4 xop34xu",
           $$css: true
         };
         ({
-          className: "x1qar0u3 x7cint9 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
+          className: "x1qar0u3 x14dju54 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
         });"
       `);
 
@@ -262,18 +262,18 @@ describe('@stylexjs/babel-plugin', () => {
               1,
             ],
             [
-              "--x5jppmd",
+              "--xpd0xwl",
               {
-                "ltr": "@position-try --x5jppmd {anchor-name:anchor-name;anchor-name:--myAnchor;position-area:position-area;position-area:top left;}",
-                "rtl": "@position-try --x5jppmd {anchor-name:--myAnchor;position-area:top left;}",
+                "ltr": "@position-try --xpd0xwl {anchor-name:--myAnchor;position-area:top left;}",
+                "rtl": null,
               },
               0,
             ],
             [
-              "--x17pzx6",
+              "--x10ycovl",
               {
-                "ltr": "@position-try --x17pzx6 {anchor-name:anchor-name;anchor-name:--otherAnchor;inset-inline-start:inset-inline-start;inset-inline-start:anchor(start);top:top;top:anchor(bottom);}",
-                "rtl": "@position-try --x17pzx6 {anchor-name:--otherAnchor;inset-inline-start:anchor(start);top:anchor(bottom);}",
+                "ltr": "@position-try --x10ycovl {anchor-name:--otherAnchor;inset-inline-start:anchor(start);top:anchor(bottom);}",
+                "rtl": null,
               },
               0,
             ],
@@ -294,9 +294,9 @@ describe('@stylexjs/babel-plugin', () => {
               3000,
             ],
             [
-              "x7cint9",
+              "x14dju54",
               {
-                "ltr": ".x7cint9{position-try-fallbacks:--x5jppmd,--x17pzx6}",
+                "ltr": ".x14dju54{position-try-fallbacks:--xpd0xwl,--x10ycovl}",
                 "rtl": null,
               },
               3000,
@@ -367,14 +367,14 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
-        const fallback1 = "--x5jppmd";
-        const fallback2 = "--x17pzx6";
+        const fallback1 = "--xpd0xwl";
+        const fallback2 = "--x10ycovl";
         const theme = {
           xop34xu: "xfnndu4 xop34xu",
           $$css: true
         };
         ({
-          className: "x1qar0u3 x7cint9 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
+          className: "x1qar0u3 x14dju54 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
         });"
       `);
 
@@ -410,14 +410,14 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
-        const fallback1 = "--x5jppmd";
-        const fallback2 = "--x17pzx6";
+        const fallback1 = "--xpd0xwl";
+        const fallback2 = "--x10ycovl";
         const theme = {
           xop34xu: "xfnndu4 xop34xu",
           $$css: true
         };
         ({
-          className: "x1qar0u3 x7cint9 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
+          className: "x1qar0u3 x14dju54 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
         });"
       `);
 
@@ -462,14 +462,14 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
-        const fallback1 = "--x5jppmd";
-        const fallback2 = "--x17pzx6";
+        const fallback1 = "--xpd0xwl";
+        const fallback2 = "--x10ycovl";
         const theme = {
           xop34xu: "xfnndu4 xop34xu",
           $$css: true
         };
         ({
-          className: "x1qar0u3 x7cint9 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
+          className: "x1qar0u3 x14dju54 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
         });"
       `);
 
@@ -496,14 +496,14 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
-        const fallback1 = "--x5jppmd";
-        const fallback2 = "--x17pzx6";
+        const fallback1 = "--xpd0xwl";
+        const fallback2 = "--x10ycovl";
         const theme = {
           xop34xu: "xfnndu4 xop34xu",
           $$css: true
         };
         ({
-          className: "x1qar0u3 x7cint9 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
+          className: "x1qar0u3 x14dju54 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
         });"
       `);
 
@@ -543,14 +543,14 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
-        const fallback1 = "--x5jppmd";
-        const fallback2 = "--x17pzx6";
+        const fallback1 = "--xpd0xwl";
+        const fallback2 = "--x10ycovl";
         const theme = {
           xop34xu: "xfnndu4 xop34xu",
           $$css: true
         };
         ({
-          className: "x1qar0u3 x7cint9 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
+          className: "x1qar0u3 x14dju54 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
         });"
       `);
 
@@ -577,14 +577,14 @@ describe('@stylexjs/babel-plugin', () => {
           __varGroupHash__: "xop34xu"
         };
         const viewTransition1 = "xchu1hv";
-        const fallback1 = "--x5jppmd";
-        const fallback2 = "--x17pzx6";
+        const fallback1 = "--xpd0xwl";
+        const fallback2 = "--x10ycovl";
         const theme = {
           xop34xu: "xfnndu4 xop34xu",
           $$css: true
         };
         ({
-          className: "x1qar0u3 x7cint9 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
+          className: "x1qar0u3 x14dju54 x1e2nbdu x14693no x15oojuh xfnndu4 xop34xu"
         });"
       `);
 

--- a/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-positionTry-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-stylex-positionTry-test.js
@@ -40,17 +40,17 @@ describe('@stylexjs/babel-plugin', () => {
 
       expect(code).toMatchInlineSnapshot(`
         "import * as stylex from '@stylexjs/stylex';
-        export const name = "--xhs37kq";"
+        export const name = "--x1v351di";"
       `);
 
       expect(metadata).toMatchInlineSnapshot(`
         {
           "stylex": [
             [
-              "--xhs37kq",
+              "--x1v351di",
               {
-                "ltr": "@position-try --xhs37kq {height:height;height:100px;left:left;left:0;position-anchor:position-anchor;position-anchor:--anchor;top:top;top:0;width:width;width:100px;}",
-                "rtl": "@position-try --xhs37kq {height:100px;left:0;position-anchor:--anchor;top:0;width:100px;}",
+                "ltr": "@position-try --x1v351di {height:100px;left:0;position-anchor:--anchor;top:0;width:100px;}",
+                "rtl": null,
               },
               0,
             ],
@@ -75,17 +75,17 @@ describe('@stylexjs/babel-plugin', () => {
       expect(code).toMatchInlineSnapshot(`
         "import * as stylex from '@stylexjs/stylex';
         const SIZE = '100px';
-        export const name = "--xhs37kq";"
+        export const name = "--x1v351di";"
       `);
 
       expect(metadata).toMatchInlineSnapshot(`
         {
           "stylex": [
             [
-              "--xhs37kq",
+              "--x1v351di",
               {
-                "ltr": "@position-try --xhs37kq {height:height;height:100px;left:left;left:0;position-anchor:position-anchor;position-anchor:--anchor;top:top;top:0;width:width;width:100px;}",
-                "rtl": "@position-try --xhs37kq {height:100px;left:0;position-anchor:--anchor;top:0;width:100px;}",
+                "ltr": "@position-try --x1v351di {height:100px;left:0;position-anchor:--anchor;top:0;width:100px;}",
+                "rtl": null,
               },
               0,
             ],
@@ -114,10 +114,10 @@ describe('@stylexjs/babel-plugin', () => {
       expect(code).toMatchInlineSnapshot(`
         "import * as stylex from '@stylexjs/stylex';
         const SIZE = '100px';
-        const name = "--x1oyda6q";
+        const name = "--x1lerlyv";
         export const styles = {
           root: {
-            k9M3vk: "x4uh2cz",
+            k9M3vk: "x188f6ho",
             $$css: true
           }
         };"
@@ -127,17 +127,17 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
-              "--x1oyda6q",
+              "--x1lerlyv",
               {
-                "ltr": "@position-try --x1oyda6q {height:height;height:100px;left:left;left:0;top:top;top:0;width:width;width:100px;}",
-                "rtl": "@position-try --x1oyda6q {height:100px;left:0;top:0;width:100px;}",
+                "ltr": "@position-try --x1lerlyv {height:100px;left:0;top:0;width:100px;}",
+                "rtl": null,
               },
               0,
             ],
             [
-              "x4uh2cz",
+              "x188f6ho",
               {
-                "ltr": ".x4uh2cz{position-try-fallbacks:--x1oyda6q}",
+                "ltr": ".x188f6ho{position-try-fallbacks:--x1lerlyv}",
                 "rtl": null,
               },
               3000,
@@ -167,7 +167,7 @@ describe('@stylexjs/babel-plugin', () => {
         "import * as stylex from '@stylexjs/stylex';
         export const styles = {
           root: {
-            k9M3vk: "xlj2pck",
+            k9M3vk: "x1kvy05d",
             $$css: true
           }
         };"
@@ -177,17 +177,17 @@ describe('@stylexjs/babel-plugin', () => {
         {
           "stylex": [
             [
-              "--xhs37kq",
+              "--x1v351di",
               {
-                "ltr": "@position-try --xhs37kq {height:height;height:100px;left:left;left:0;position-anchor:position-anchor;position-anchor:--anchor;top:top;top:0;width:width;width:100px;}",
-                "rtl": "@position-try --xhs37kq {height:100px;left:0;position-anchor:--anchor;top:0;width:100px;}",
+                "ltr": "@position-try --x1v351di {height:100px;left:0;position-anchor:--anchor;top:0;width:100px;}",
+                "rtl": null,
               },
               0,
             ],
             [
-              "xlj2pck",
+              "x1kvy05d",
               {
-                "ltr": ".xlj2pck{position-try-fallbacks:--xhs37kq}",
+                "ltr": ".x1kvy05d{position-try-fallbacks:--x1v351di}",
                 "rtl": null,
               },
               3000,

--- a/packages/@stylexjs/babel-plugin/src/shared/stylex-position-try.js
+++ b/packages/@stylexjs/babel-plugin/src/shared/stylex-position-try.js
@@ -20,6 +20,7 @@ import {
   objEntries,
   objMapKeys,
   objMap,
+  objMapEntry,
   Pipe,
 } from './utils/object-utils';
 import { defaultOptions } from './utils/default-options';
@@ -38,12 +39,13 @@ export default function styleXPositionTry(
     .pipe((x) => objMap(x, (value, key) => transformValue(key, value, options)))
     .done();
 
-  const ltrStyles = objMap(expandedObject, (value, key) =>
-    generateLtr([key, value]),
+  // The generators return a `[key, value]` pair; a direction flip can rewrite the key.
+  const ltrStyles = objMapEntry(expandedObject, (entry) =>
+    generateLtr(entry, options),
   );
-  const rtlStyles = objMap(
+  const rtlStyles = objMapEntry(
     expandedObject,
-    (value, key) => generateRtl([key, value]) ?? value,
+    (entry) => generateRtl(entry, options) ?? entry,
   );
 
   const ltrString = constructPositionTryObj(ltrStyles);


### PR DESCRIPTION
## What changed / motivation ?

`stylex.positionTry` emitted every declaration twice, once with the property name as its own value, and produced an RTL variant for every rule. `generateLtr` and `generateRtl` take and return a `[key, value]` pair, but the code mapped only the value, so the returned pair was spliced in as the value: `anchor-name:anchor-name;anchor-name:--myAnchor`. The generators are now applied to the whole entry with `objMapEntry`, the same way the other transforms use them.

## Linked PR/Issues

None.

## Additional Context

The existing snapshots recorded the doubled output; they are updated to the corrected rules and the RTL variant is `null` where nothing flips.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code
