### PR TITLE
[babel-plugin] (edge case) Insert constant values verbatim, not as replacement patterns

### DIFF
--- a/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
+++ b/packages/@stylexjs/babel-plugin/__tests__/transform-process-test.js
@@ -944,6 +944,75 @@ describe('@stylexjs/babel-plugin', () => {
       `);
     });
 
+    // A constant's value is data, not a replacement pattern. Substituting it
+    // with a string replacement made `String.prototype.replace`/`replaceAll`
+    // expand its `$` sequences: `$&` re-inserted the matched text, `$$`
+    // collapsed to one `$`, and `` $` ``/`$'` inserted the text around the
+    // match. Both the alias pre-collapse and the per-rule substitution have
+    // to insert values verbatim.
+    test('substitutes a constant value containing `$&` verbatim', () => {
+      // `$&` re-inserted `var(--b)` over itself, so the pre-collapse loop made
+      // no progress and rescanned from the start forever -- a hung build, not
+      // a thrown error.
+      const rules = [
+        ['a', { constKey: 'a', constVal: 'var(--b)', ltr: '', rtl: null }, 0],
+        ['b', { constKey: 'b', constVal: '$&', ltr: '', rtl: null }, 0],
+        ['x1', { ltr: '.x1{content:var(--a)}', rtl: null }, 3000],
+      ];
+
+      expect(
+        stylexPlugin.processStylexRules(rules, { useLayers: false }),
+      ).toMatchInlineSnapshot('".x1{content:$&}"');
+    });
+
+    test('substitutes a constant value containing `$&` with no alias chain', () => {
+      // Without a chain the pre-collapse loop never runs, but the per-rule
+      // substitution still expanded `$&` -- leaving the `var()` unsubstituted.
+      const rules = [
+        ['b', { constKey: 'b', constVal: '$&', ltr: '', rtl: null }, 0],
+        ['x1', { ltr: '.x1{content:var(--b)}', rtl: null }, 3000],
+      ];
+
+      expect(
+        stylexPlugin.processStylexRules(rules, { useLayers: false }),
+      ).toMatchInlineSnapshot('".x1{content:$&}"');
+    });
+
+    test('substitutes constant values containing other `$` sequences verbatim', () => {
+      const rules = [
+        [
+          'a1',
+          { constKey: 'a1', constVal: 'var(--b1)', ltr: '', rtl: null },
+          0,
+        ],
+        ['b1', { constKey: 'b1', constVal: '$$', ltr: '', rtl: null }, 0],
+        [
+          'a2',
+          { constKey: 'a2', constVal: 'var(--b2)', ltr: '', rtl: null },
+          0,
+        ],
+        ['b2', { constKey: 'b2', constVal: '$`', ltr: '', rtl: null }, 0],
+        [
+          'a3',
+          { constKey: 'a3', constVal: 'var(--b3)', ltr: '', rtl: null },
+          0,
+        ],
+        ['b3', { constKey: 'b3', constVal: "$'", ltr: '', rtl: null }, 0],
+        [
+          'x1',
+          {
+            ltr: '.x1{--p1:var(--a1);--p2:var(--a2);--p3:var(--a3)}',
+            rtl: null,
+          },
+          3000,
+        ],
+      ];
+
+      expect(
+        stylexPlugin.processStylexRules(rules, { useLayers: false }),
+      ).toMatchInlineSnapshot('".x1{--p1:$$;--p2:$`;--p3:$\'}"');
+    });
+
     test('legacy-expand-shorthands duplicates theme selectors for higher precedence', () => {
       const { _code, metadata } = transform(
         `

--- a/packages/@stylexjs/babel-plugin/src/index.js
+++ b/packages/@stylexjs/babel-plugin/src/index.js
@@ -749,7 +749,7 @@ function processStylexRules(
       if (refValue == null) continue;
       visited.add(ref);
       const replacement = resolveConstant(refValue, visited);
-      result = result.replace(match[0], replacement.toString());
+      result = result.replace(match[0], () => replacement.toString());
       visited.delete(ref);
       regex.lastIndex = 0;
     }
@@ -788,7 +788,7 @@ function processStylexRules(
         for (const [varRef, constValue] of constsMap.entries()) {
           if (typeof original !== 'string') continue;
           const replacement = String(constValue);
-          original = original.replaceAll(varRef, replacement);
+          original = original.replaceAll(varRef, () => replacement);
           if (replacement.startsWith('var(') && replacement.endsWith(')')) {
             const inside = replacement.slice(4, -1).trim();
             const commaIdx = inside.indexOf(',');


### PR DESCRIPTION
## What changed / motivation ?

**This came out of an agentic code review of #1700.** The review flagged that constant values are substituted with a *string* replacement; checking the claim against `main` confirmed it's a pre-existing bug, that it affects a second call site as well, and that in one case it hangs the build. It's independent of #1700, so it's split out here.

**This is an edge case: it only affects a `defineConsts` value that contains a `$`.** Nothing else changes. But within that narrow case the output is silently wrong, and one shape hangs the build outright — so it seems worth fixing even though most codebases will never hit it.

The cause: values are substituted with a string replacement, so `String.prototype.replace`/`replaceAll` expand the `$` sequences inside them. A constant's value is data, never a replacement pattern. Per [MDN — specifying a string as the replacement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement), `$&` inserts the matched substring, `$$` inserts a literal `$`, and `` $` ``/`$'` insert the portion before/after the match. Two call sites are affected — the alias pre-collapse in `resolveConstant`, and the per-rule substitution — and both switch to function replacers, which are not subject to that expansion. Two lines, no other behavior change.

**The plausible case: `$$` in a `content` string.** A price-range indicator, the familiar `$` / `$$` / `$$$` scale:

```js
// tokens.stylex.js
export const price = stylex.defineConsts({
  cheap: '"$"',
  moderate: '"$$"',
  expensive: '"$$$"',
});

// App.js
export const styles = stylex.create({
  cheap: { content: price.cheap },
  moderate: { content: price.moderate },
  expensive: { content: price.expensive },
});
```

Before, every tier past the first loses exactly one `$`, because `$$` is the escape for a literal `$`:

```css
.x1l6mih1{content:"$"}    /* cheap     — correct  */
.xgdktg8{content:"$"}     /* moderate  — lost a $ */
.xxyzbk8{content:"$$"}    /* expensive — lost a $ */
```

After:

```css
.x1l6mih1{content:"$"}
.xgdktg8{content:"$$"}
.xxyzbk8{content:"$$$"}
```

So the UI renders `$`, `$`, `$$` — "cheap" and "moderate" become visually identical and the whole scale shifts down one, with no error or warning. Any doubled dollar hits this: currency labels, `content` strings, tokens exported from a spreadsheet or design tool.

**The contrived case: `$&` hangs the build.** Replacing `var(--b)` with `$&` re-inserts `var(--b)` over itself, so the pre-collapse loop makes no progress and — having already cleared `visited` and reset `lastIndex` — rescans from the start forever. The `circular reference detected` guard can't catch it: it detects a cycle within one recursive descent, not a substitution that fails to advance.

These definitions alone hang the build, because the pre-collapse walks every entry in `constsMap` whether or not anything references it. No usage of `prefix` is required:

```js
export const label = stylex.defineConsts({
  '--currency': '"$&"',
  prefix: 'var(--currency)',
});
```

After this change that compiles to `.x11xwbpo{content:"$&"}`. The alias chain needs a verbatim `--` key (#1460) for one const to name another; a plain `$&` value doesn't hang, but is still silently left unsubstituted.

## Linked PR/Issues

No tracking issue. Relates to #1460 (verbatim `--` const keys, which make const→const aliasing possible) and #1700, where this was found — that PR rewrites the per-rule substitution loop and already uses function replacers there, so it independently fixes one of these two sites. Whichever lands second has a one-hunk conflict on the `replaceAll` line, resolved by taking the newer side. The `resolveConstant` fix doesn't conflict.

## Additional Context

Verified against unfixed `main` (`ee1d8a91`): each of the three added tests fails, and the `$&` chain case hangs (killed by a 30s watchdog; the suite otherwise finishes in ~0.7s). The price-tier CSS above is real output from the transform on both sides.

Note the `$&` regression test *hangs* rather than fails if the fix regresses, since it's a synchronous loop Jest can't interrupt. The other two fail cleanly.

**Tests:** three cases in `transform-process-test.js` — a `$&` value reached through an alias chain (the hang), a `$&` value with no chain (silently unsubstituted by the per-rule site), and `$$`/`` $` ``/`$'` values preserved verbatim.

## Pre-flight checklist

- [x] I have read the contributing guidelines
- [x] Performed a self-review of my code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
