### PR TITLE
[eslint-plugin] allow the CSS `page` property

### DIFF
--- a/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
+++ b/packages/@stylexjs/eslint-plugin/__tests__/stylex-valid-styles-test.js
@@ -36,6 +36,21 @@ eslintTester.run('stylex-valid-styles', rule.default, {
         }
       });
     `,
+    // issue #1861 — the `page` property binds an element to a named `@page`
+    `
+      import * as stylex from '@stylexjs/stylex';
+      const styles = stylex.create({
+        staticPage: {
+          page: 'bincard',
+        },
+        autoPage: {
+          page: 'auto',
+        },
+        conditionalPage: {
+          page: { default: null, '@media print': 'bincard' },
+        },
+      });
+    `,
     // test for local static variables
     `
       import * as stylex from '@stylexjs/stylex';

--- a/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
+++ b/packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js
@@ -1128,6 +1128,8 @@ const pageBreakInside: RuleCheck = makeUnionRule(
   makeLiteralRule('auto'),
   makeLiteralRule('avoid'),
 );
+// `auto | <custom-ident>` — any string is a valid named page
+const page: RuleCheck = makeUnionRule(all, isString);
 const perspective: RuleCheck = makeUnionRule(
   makeLiteralRule('none'),
   isNumber,
@@ -2139,6 +2141,7 @@ const CSSProperties = {
   paddingRight: length,
   paddingTop: length,
 
+  page: page,
   pageBreakAfter: pageBreak,
   pageBreakBefore: pageBreak,
   pageBreakInside: pageBreakInside,


### PR DESCRIPTION
## What changed / motivation ?

`page` was missing from the ESLint plugin's `CSSProperties` map, so `@stylexjs/valid-styles` reported "This is not a key that is allowed by stylex" for element-level named-page bindings. Added it as `makeUnionRule(all, isString)` — the property takes `auto | <custom-ident>` so any string is valid, and `all` is what lets `default: null` through for the conditional form.

We think this is only a lint gap, not a compiler one. `page` already compiles correctly and is already in both the Flow and TypeScript types (`StyleXCSSTypes.js`, `StyleXCSSTypes.d.ts`), so the global `[data-print-page]` CSS workaround in the issue shouldn't be necessary — suppressing the rule is enough in the meantime:

```ts
staticPage: {
  // eslint-disable-next-line @stylexjs/valid-styles
  page: 'bincard',
},
```

This does not add support for `@page` at-rule descriptors, which the issue also asks about, so it doesn't close the issue.

## Linked PR/Issues

Related to #1861

## Additional Context

Added the issue's snippet as a valid case in `stylex-valid-styles-test.js`. Confirmed the compiler emits the expected CSS for both forms:

```css
.x4dxuac{page:bincard}
@media print{.xpbjynu.xpbjynu{page:bincard}}
```

## Pre-flight checklist

- [x] I have read the contributing guidelines [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
