### PR TITLE
[types] Validate CSSProperties against the CSS grammar, Baseline, and Flow

### DIFF
--- a/packages/@stylexjs/stylex/__tests__/css-types-test.js
+++ b/packages/@stylexjs/stylex/__tests__/css-types-test.js
@@ -1,0 +1,910 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+/**
+ * Keeps `CSSProperties` honest.
+ *
+ * Two things are hand-maintained and can drift:
+ *
+ *   1. `StyleXCSSTypes.d.ts` duplicates `StyleXCSSTypes.js`, because a Flow
+ *      union containing `string` collapses to `string` and loses its literals,
+ *      so TypeScript needs `(string & {})` instead. Nothing stops the two
+ *      files diverging apart from this test.
+ *   2. The property values themselves are written by hand, so a typo or an
+ *      invented keyword goes unnoticed. `css-tree` ships the CSS value
+ *      definition grammar, so it can say whether a keyword is real.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { parse } = require('@babel/parser');
+const { lexer } = require('css-tree');
+// `web-features` itself is ESM; its data is exported as JSON.
+const { features } = require('web-features/data.json');
+const { generate } = require('css-tree/definition-syntax');
+
+const TYPES_DIR = path.resolve(__dirname, '../src/types');
+const FLOW_FILE = path.join(TYPES_DIR, 'StyleXCSSTypes.js');
+const TS_FILE = path.join(TYPES_DIR, 'StyleXCSSTypes.d.ts');
+
+/** CSS-wide keywords, accepted by every property and never in a grammar. */
+const GLOBAL_KEYWORDS = new Set(['inherit', 'initial', 'unset']);
+
+/**
+ * Properties that do not accept the CSS-wide keywords at all.
+ *
+ * Every property is meant to compose the `all` alias. These six are instead
+ * written `null | 'a' | 'b'`, which drops `inherit`, `initial` and `unset`.
+ * They are also the only properties in the file with no named type alias --
+ * they inline their union at the property, which is what hid the slip.
+ */
+const NO_GLOBAL_KEYWORDS = new Set([
+  'colorScheme',
+  'marginTrim',
+  'paintOrder',
+  'textJustify',
+  'WebkitBackgroundClip',
+  'WebkitBoxOrient',
+]);
+
+/* ------------------------------------------------------------------ *
+ * Reading the type files
+ * ------------------------------------------------------------------ */
+
+/**
+ * What a property accepts, reduced to the three things worth comparing: the
+ * literal keywords, whether a bare number is allowed, and whether an arbitrary
+ * string is allowed.
+ */
+const blank = () => ({ literals: new Set(), open: false, numeric: false });
+
+const absorb = (into, from) => {
+  from.literals.forEach((literal) => into.literals.add(literal));
+  into.open = into.open || from.open;
+  into.numeric = into.numeric || from.numeric;
+};
+
+const finish = (value) => ({
+  literals: [...value.literals].sort(),
+  open: value.open,
+  numeric: value.numeric,
+});
+
+/** Parsing either file takes a moment, and neither changes mid-run. */
+const parsed = new Map();
+const readTypes = (file) => {
+  if (!parsed.has(file)) parsed.set(file, parseTypes(file));
+  return parsed.get(file);
+};
+
+/** A type alias, in either dialect: its name and the type it aliases. */
+function asTypeAlias(statement) {
+  const node =
+    statement.type === 'ExportNamedDeclaration'
+      ? statement.declaration
+      : statement;
+  if (!node) return null;
+  if (node.type === 'TypeAlias') return [node.id.name, node.right];
+  if (node.type === 'TSTypeAliasDeclaration') {
+    return [node.id.name, node.typeAnnotation];
+  }
+  return null;
+}
+
+/** The `[name, type]` pairs of an object type, in either dialect. */
+function objectTypeEntries(node) {
+  if (node.type === 'ObjectTypeAnnotation') {
+    return node.properties.map((property) => [
+      property.key.name,
+      property.value,
+    ]);
+  }
+  return node.members.map((member) => [
+    member.key.name,
+    member.typeAnnotation.typeAnnotation,
+  ]);
+}
+
+/** Unwraps the `Readonly<...>` around `CSSProperties`. */
+function unwrapReadonly(node) {
+  const args = node.typeParameters?.params;
+  return args?.length === 1 ? args[0] : node;
+}
+
+/**
+ * Reads `property -> { literals, open, numeric }` out of a types file.
+ *
+ * `@babel/parser` reads both dialects, so one function covers both files: the
+ * Flow types with the `flow` plugin, the TypeScript definitions with
+ * `typescript` in declaration mode. The two ASTs use disjoint node names, so a
+ * single switch can handle either.
+ */
+function parseTypes(file) {
+  const isDeclaration = file.endsWith('.d.ts');
+  const ast = parse(fs.readFileSync(file, 'utf8'), {
+    sourceType: 'module',
+    plugins: isDeclaration ? [['typescript', { dts: true }]] : ['flow'],
+  });
+
+  const aliases = new Map();
+  let cssProperties = null;
+  for (const statement of ast.program.body) {
+    const alias = asTypeAlias(statement);
+    if (!alias) continue;
+    aliases.set(alias[0], alias[1]);
+    if (alias[0] === 'CSSProperties') cssProperties = alias[1];
+  }
+
+  const resolve = (node, seen) => {
+    const result = blank();
+    if (!node) return result;
+    switch (node.type) {
+      // A parenthesised type, e.g. `(string & {})`.
+      case 'TSParenthesizedType':
+        return resolve(node.typeAnnotation, seen);
+
+      case 'UnionTypeAnnotation':
+      case 'TSUnionType':
+        for (const member of node.types) absorb(result, resolve(member, seen));
+        return result;
+
+      // `string & {}` in the TypeScript definitions: an arbitrary string that
+      // leaves sibling literals visible to autocomplete. The `{}` half
+      // contributes nothing, so this reads as a plain string.
+      case 'IntersectionTypeAnnotation':
+      case 'TSIntersectionType':
+        for (const member of node.types) absorb(result, resolve(member, seen));
+        return result;
+
+      case 'StringLiteralTypeAnnotation':
+        result.literals.add(node.value);
+        return result;
+      case 'TSLiteralType':
+        if (node.literal.type === 'StringLiteral') {
+          result.literals.add(node.literal.value);
+        } else if (node.literal.type === 'NumericLiteral') {
+          result.numeric = true;
+        }
+        return result;
+
+      case 'StringTypeAnnotation':
+      case 'TSStringKeyword':
+        result.open = true;
+        return result;
+
+      case 'NumberTypeAnnotation':
+      case 'NumberLiteralTypeAnnotation':
+      case 'TSNumberKeyword':
+        result.numeric = true;
+        return result;
+
+      // Every property accepts `null`; StyleX uses it to unset a value.
+      case 'NullLiteralTypeAnnotation':
+      case 'TSNullKeyword':
+        return result;
+
+      // The `{}` of `string & {}`, and Flow's equivalent.
+      case 'ObjectTypeAnnotation':
+      case 'TSTypeLiteral':
+        return result;
+
+      case 'GenericTypeAnnotation':
+      case 'TSTypeReference': {
+        const name =
+          node.type === 'GenericTypeAnnotation'
+            ? node.id.name
+            : node.typeName.name;
+        const args = node.typeParameters?.params ?? [];
+        // `OptionalArray<T>` is `T` or an array of `T`. It does not widen what
+        // a single value may be, so it contributes nothing of its own.
+        if (name === 'OptionalArray' || name === 'Array') {
+          for (const arg of args) absorb(result, resolve(arg, seen));
+          return result;
+        }
+        if (aliases.has(name) && !seen.has(name)) {
+          return resolve(aliases.get(name), new Set([...seen, name]));
+        }
+        // An unresolvable reference could be anything.
+        result.open = true;
+        return result;
+      }
+
+      default:
+        result.open = true;
+        return result;
+    }
+  };
+
+  const properties = {};
+  for (const [name, type] of objectTypeEntries(unwrapReadonly(cssProperties))) {
+    properties[name] = finish(resolve(type, new Set()));
+  }
+  return properties;
+}
+
+/* ------------------------------------------------------------------ *
+ * Reading the CSS grammar
+ * ------------------------------------------------------------------ */
+
+const camelToKebab = (name) =>
+  name
+    .replace(/^(Moz|Webkit|Ms|O)(?=[A-Z])/, (m) => '-' + m.toLowerCase() + '-')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase();
+
+/** Grammar types that resolve no further, so walking into them finds nothing. */
+const TERMINAL = new Set([
+  'angle',
+  'angle-percentage',
+  'basic-shape',
+  'counter-name',
+  'counter-style-name',
+  'custom-ident',
+  'dashed-ident',
+  'declaration-value',
+  'dimension',
+  'family-name',
+  'feature-tag-value',
+  'filter-function',
+  'flex',
+  'frequency',
+  'gradient',
+  'hex-color',
+  'ident',
+  'image',
+  'integer',
+  'keyframes-name',
+  'length',
+  'length-percentage',
+  'number',
+  'percentage',
+  'position',
+  'ratio',
+  'resolution',
+  'shape',
+  'string',
+  'time',
+  'transform-function',
+  'url',
+  'zero',
+]);
+
+/**
+ * Every keyword the grammar accepts for a property, or `null` when css-tree
+ * has no grammar for it at all.
+ */
+function grammarKeywords(cssName, maxDepth = 6) {
+  const descriptor = lexer.properties[cssName];
+  if (!descriptor) return null;
+
+  const keywords = new Set();
+  const seen = new Set();
+
+  const walk = (node, depth) => {
+    if (!node || depth > maxDepth) return;
+    switch (node.type) {
+      case 'Keyword':
+        keywords.add(node.name);
+        return;
+      case 'String':
+        keywords.add(node.value.replace(/^["']|["']$/g, ''));
+        return;
+      case 'Type': {
+        // Functional notations serialise to arbitrary strings; walking into
+        // them harvests nonsense from the math grammar (`e`, `pi`, `NaN`).
+        if (node.name.endsWith('()') || TERMINAL.has(node.name)) return;
+        const type = lexer.types[node.name];
+        if (!type || seen.has(node.name)) return;
+        seen.add(node.name);
+        walk(type.syntax, depth + 1);
+        seen.delete(node.name);
+        return;
+      }
+      case 'Property': {
+        // Logical properties and shorthands are defined almost entirely as
+        // `<'other-property'>` references.
+        const referenced = lexer.properties[node.name];
+        const key = `property:${node.name}`;
+        if (!referenced || seen.has(key)) return;
+        seen.add(key);
+        walk(referenced.syntax, depth + 1);
+        seen.delete(key);
+        return;
+      }
+      case 'Group':
+        for (const term of node.terms) walk(term, depth);
+        return;
+      case 'Multiplier':
+        walk(node.term, depth);
+        return;
+      default:
+        return;
+    }
+  };
+
+  walk(descriptor.syntax, 0);
+  return keywords;
+}
+
+/**
+ * Whether a property's grammar admits anything that is not a bare keyword --
+ * a function, a URL, a length, an identifier. If it does, a union of literals
+ * cannot describe the property and the type has to accept arbitrary strings.
+ */
+function needsArbitraryString(cssName) {
+  const descriptor = lexer.properties[cssName];
+  if (!descriptor) return false;
+
+  const seen = new Set();
+  const walk = (node) => {
+    if (!node) return false;
+    switch (node.type) {
+      case 'Type': {
+        if (node.name.endsWith('()') || TERMINAL.has(node.name)) return true;
+        const type = lexer.types[node.name];
+        if (!type || seen.has(node.name)) return false;
+        seen.add(node.name);
+        const found = walk(type.syntax);
+        seen.delete(node.name);
+        return found;
+      }
+      case 'Property': {
+        const referenced = lexer.properties[node.name];
+        const key = `property:${node.name}`;
+        if (!referenced || seen.has(key)) return false;
+        seen.add(key);
+        const found = walk(referenced.syntax);
+        seen.delete(key);
+        return found;
+      }
+      case 'Function':
+      case 'Token':
+        return true;
+      case 'Group':
+        return node.terms.some(walk);
+      case 'Multiplier':
+        return walk(node.term);
+      default:
+        return false;
+    }
+  };
+
+  return walk(descriptor.syntax);
+}
+
+/* ------------------------------------------------------------------ *
+ * Deliberate deviations from the grammar
+ * ------------------------------------------------------------------ */
+
+/**
+ * Properties css-tree has no grammar for. Mostly abandoned drafts
+ * (`motion-*` became `offset-*`, the CSS Display Level 3 longhands were
+ * dropped), `@font-face` descriptors that were never properties (`src`,
+ * `unicode-range`), and names that never shipped unprefixed.
+ */
+const NO_GRAMMAR = new Set([
+  'azimuth',
+  'boxSuppress',
+  'displayInside',
+  'displayList',
+  'displayOutside',
+  'end',
+  'markerOffset',
+  'motion',
+  'motionOffset',
+  'motionPath',
+  'motionRotation',
+  'overflowBlockX',
+  'src',
+  'start',
+  'textFillColor',
+  'unicodeRange',
+  'WebkitBoxOrient',
+]);
+
+/**
+ * Keywords kept even though the current grammar has dropped them. Each is a
+ * value real stylesheets still use, so removing it would break code.
+ */
+const KEPT_KEYWORDS = {
+  // The spec was rewritten to `none | in-flow | all`, but Safari ships the
+  // original `block`/`inline` syntax.
+  marginTrim: [
+    'block',
+    'block-end',
+    'block-start',
+    'inline',
+    'inline-end',
+    'inline-start',
+  ],
+  // Renamed to `inline-start`/`inline-end`.
+  float: ['end', 'start'],
+  // Renamed to `never`/`always`.
+  speak: ['none', 'normal'],
+  // Deprecated alias of `inter-character`.
+  textJustify: ['distribute'],
+  // Logical values from a dropped CSS Logical draft.
+  captionSide: ['block-end', 'block-start', 'inline-end', 'inline-start'],
+  // In the CSS UI draft, though not in css-tree.
+  userSelect: ['contain'],
+  // The one case where the grammar is stricter and correct: the spec excludes
+  // `hidden` from `outline-style`. Kept because removing it would break code.
+  outlineStyle: ['hidden'],
+  // CSS 2.1 allowed `invert`; the current spec is `auto | <color>`.
+  outlineColor: ['invert'],
+  // `-webkit-appearance` never standardised `auto`, but it is widely written.
+  WebkitAppearance: ['auto'],
+  // `mask-origin` narrowed from `<geometry-box>` to `<coord-box>`, dropping
+  // `margin-box`.
+  maskOrigin: ['margin-box'],
+  // Unprefixed intrinsic sizing keywords, which only ever shipped prefixed
+  // (`-webkit-fill-available`, `-moz-available`).
+  blockSize: ['available'],
+  inlineSize: ['available'],
+  width: ['available'],
+  maxBlockSize: ['fill-available'],
+  maxHeight: ['fill-available'],
+  maxInlineSize: ['fill-available'],
+  maxWidth: ['fill-available'],
+  minBlockSize: ['fill-available'],
+  minHeight: ['fill-available'],
+  minInlineSize: ['fill-available'],
+  minWidth: ['fill-available'],
+};
+
+/**
+ * Baseline status per CSS property, from `web-features` -- the data behind
+ * MDN's "Widely available" / "Newly available" / "Limited availability"
+ * banners. `high` means supported across the core browsers for over a year,
+ * `low` means it just got there, and `false` means it has not.
+ *
+ * css-tree carries only grammar, with no support data at all, and mdn-data's
+ * `status` describes the spec rather than browsers -- it calls `font-stretch`
+ * obsolete even though every browser has supported it since 2020, while
+ * marking its replacement `font-width` experimental. Baseline is the signal
+ * that actually says whether a property is safe to use.
+ */
+const BASELINE = new Map();
+for (const feature of Object.values(features)) {
+  for (const key of feature.compat_features ?? []) {
+    const match = key.match(/^css\.properties\.([a-z-]+)$/);
+    if (match) BASELINE.set(match[1], feature.status?.baseline);
+  }
+}
+
+const kebabToCamel = (name) =>
+  name.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+
+/**
+ * Properties that are Baseline-available but deliberately not typed.
+ *
+ * Anything Baseline `false` needs no entry here -- it is not safe to use yet,
+ * so not typing it is the default. That keeps this list to actual decisions.
+ */
+const NOT_TYPED = new Set([
+  // Shipped and worth typing -- a backlog rather than a decision.
+  // `whiteSpaceCollapse` is in fact commented out in `StyleXCSSTypes.js`
+  // awaiting exactly this, and `overflowInline` is the logical counterpart of
+  // `overflowBlock`, which is typed.
+  'fieldSizing',
+  'overflowInline',
+  'textWrapMode',
+  'textWrapStyle',
+  'transitionBehavior',
+  'viewTransitionClass',
+  'whiteSpaceCollapse',
+
+  // SVG presentation attributes, valid as CSS on SVG elements. StyleX types
+  // `fill`, `stroke`, `strokeWidth`, `fillOpacity` and `strokeOpacity`, so
+  // excluding the rest is arbitrary -- but `x`, `y`, `d` and `r` read oddly as
+  // style keys, so it stays a choice rather than an oversight.
+  'colorInterpolation',
+  'colorInterpolationFilters',
+  'cx',
+  'cy',
+  'd',
+  'floodColor',
+  'floodOpacity',
+  'lightingColor',
+  'r',
+  'rx',
+  'ry',
+  'stopColor',
+  'stopOpacity',
+  'strokeColor',
+  'vectorEffect',
+  'x',
+  'y',
+
+  // `all` resets every property at once, which styleq cannot express: it
+  // resolves overrides by deduping on the property key, so a class keyed `all`
+  // would not suppress one keyed `color`.
+  'all',
+]);
+
+/**
+ * Keywords the grammar has that the types do not -- the mirror of
+ * `KEPT_KEYWORDS`, which lists keywords the types have that the grammar does
+ * not.
+ *
+ * Only closed unions are checked. Where a property accepts an arbitrary
+ * string, every keyword is already accepted and completeness means nothing --
+ * which is most shorthands and every colour property, and is why asserting
+ * this over all properties would demand over ten thousand additions.
+ *
+ * Each of these is a value a user cannot currently write. They are listed
+ * rather than fixed so that the check can land green; emptying the list is the
+ * work it exists to prompt.
+ */
+const INCOMPLETE_UNIONS = {
+  MozOsxFontSmoothing: ['auto'],
+  WebkitBackgroundClip: ['border', 'content', 'padding'],
+  WebkitFontSmoothing: ['auto', 'none', 'subpixel-antialiased'],
+  alignItems: ['anchor-center'],
+  alignSelf: ['anchor-center'],
+  backgroundClip: ['border-area'],
+  breakAfter: ['all', 'always'],
+  breakBefore: ['all', 'always'],
+  // StyleX has `-webkit-grab` and `-webkit-grabbing` but not the `-moz-`
+  // equivalents or the zoom variants. `hand` is the pre-standard IE spelling.
+  cursor: [
+    '-moz-grab',
+    '-moz-grabbing',
+    '-moz-zoom-in',
+    '-moz-zoom-out',
+    '-webkit-zoom-in',
+    '-webkit-zoom-out',
+    'hand',
+  ],
+  display: [
+    '-moz-box',
+    '-moz-inline-box',
+    '-moz-inline-stack',
+    '-ms-grid',
+    '-ms-inline-flexbox',
+    '-ms-inline-grid',
+    '-webkit-flex',
+    '-webkit-inline-box',
+    '-webkit-inline-flex',
+    'flow',
+    'table-caption',
+  ],
+  fontSizeAdjust: [
+    'cap-height',
+    'ch-width',
+    'ex-height',
+    'from-font',
+    'ic-height',
+    'ic-width',
+  ],
+  forcedColorAdjust: ['preserve-parent-color'],
+  justifyItems: ['anchor-center'],
+  justifySelf: ['anchor-center'],
+  lineBreak: ['anywhere'],
+  marginTrim: ['all', 'in-flow'],
+  mixBlendMode: ['plus-darker', 'plus-lighter'],
+  overflow: [
+    '-moz-hidden-unscrollable',
+    '-moz-scrollbars-horizontal',
+    '-moz-scrollbars-none',
+    '-moz-scrollbars-vertical',
+    'overlay',
+  ],
+  overflowBlock: [
+    '-moz-hidden-unscrollable',
+    '-moz-scrollbars-horizontal',
+    '-moz-scrollbars-none',
+    '-moz-scrollbars-vertical',
+    'overlay',
+  ],
+  overflowX: [
+    '-moz-hidden-unscrollable',
+    '-moz-scrollbars-horizontal',
+    '-moz-scrollbars-none',
+    '-moz-scrollbars-vertical',
+    'overlay',
+  ],
+  overflowY: [
+    '-moz-hidden-unscrollable',
+    '-moz-scrollbars-horizontal',
+    '-moz-scrollbars-none',
+    '-moz-scrollbars-vertical',
+    'overlay',
+  ],
+  pageBreakAfter: ['recto', 'verso'],
+  pageBreakBefore: ['recto', 'verso'],
+  position: ['-webkit-sticky'],
+  // The full anchor-positioning grid. StyleX has a partial list.
+  positionArea: [
+    'end',
+    'none',
+    'self-block-end',
+    'self-block-start',
+    'self-end',
+    'self-inline-end',
+    'self-inline-start',
+    'self-start',
+    'span-all',
+    'span-bottom',
+    'span-end',
+    'span-left',
+    'span-right',
+    'span-self-block-end',
+    'span-self-block-start',
+    'span-self-end',
+    'span-self-inline-end',
+    'span-self-inline-start',
+    'span-self-start',
+    'span-start',
+    'span-top',
+    'span-x-end',
+    'span-x-self-end',
+    'span-x-self-start',
+    'span-x-start',
+    'span-y-end',
+    'span-y-self-end',
+    'span-y-self-start',
+    'span-y-start',
+    'start',
+    'x-end',
+    'x-self-end',
+    'x-self-start',
+    'x-start',
+    'y-end',
+    'y-self-end',
+    'y-self-start',
+    'y-start',
+  ],
+  positionVisibility: ['anchors-valid'],
+  resize: ['block', 'inline'],
+  rubyPosition: ['alternate'],
+  speak: ['always', 'never'],
+  textTransform: ['full-size-kana', 'math-auto'],
+  textWrap: ['auto'],
+  transformBox: ['content-box', 'stroke-box'],
+  unicodeBidi: [
+    '-moz-isolate',
+    '-moz-isolate-override',
+    '-moz-plaintext',
+    '-webkit-isolate',
+    '-webkit-isolate-override',
+    '-webkit-plaintext',
+  ],
+  whiteSpace: [
+    'break-spaces',
+    'collapse',
+    'preserve',
+    'preserve-breaks',
+    'preserve-spaces',
+    'wrap',
+  ],
+  wordBreak: ['auto-phrase'],
+};
+
+/**
+ * Properties whose grammar admits non-keyword values but whose type does not
+ * accept an arbitrary string.
+ *
+ * Each is a value a user cannot express. Most already accept a bare number,
+ * which covers the common case but not `calc()`, `var()`, or any unit.
+ */
+const CLOSED_DESPITE_GRAMMAR = new Set([
+  // `[ <url> [ <x> <y> ]? , ]*` -- custom cursor images cannot be written.
+  // https://github.com/facebook/stylex/issues/1463
+  'cursor',
+  // `[ light | dark | <custom-ident> ]+` -- custom scheme names.
+  'colorScheme',
+  // `oblique <angle>` -- `oblique 14deg` cannot be written.
+  'fontStyle',
+
+  // These accept a bare number, so only `calc()`, `var()` and explicit units
+  // are out of reach.
+  'animationIterationCount',
+  'fontSizeAdjust',
+  'perspective',
+  'zIndex',
+
+  // Aural properties, all `<time>` or `<number>` based.
+  'pause',
+  'pauseAfter',
+  'pauseBefore',
+  'rest',
+  'restAfter',
+  'restBefore',
+  'voiceBalance',
+]);
+
+/* ------------------------------------------------------------------ *
+ * Tests
+ * ------------------------------------------------------------------ */
+
+describe('CSSProperties', () => {
+  test('the TypeScript definitions match the Flow types', () => {
+    // `StyleXCSSTypes.d.ts` exists only to swap `string` for `(string & {})`.
+    // Normalised back, the two files must describe the same properties with
+    // the same values -- otherwise one has been edited and the other has not.
+    expect(readTypes(TS_FILE)).toEqual(readTypes(FLOW_FILE));
+  });
+
+  test('every property accepts the CSS-wide keywords', () => {
+    // `initial`, `inherit` and `unset` are valid on every property and appear
+    // in no grammar, so nothing else here can check them. Properties pick them
+    // up from the `all` alias; one written `null | 'a' | 'b'` instead of
+    // `all | 'a' | 'b'` silently rejects them.
+    const problems = [];
+    for (const [name, { literals }] of Object.entries(readTypes(FLOW_FILE))) {
+      if (NO_GLOBAL_KEYWORDS.has(name)) continue;
+      const missing = [...GLOBAL_KEYWORDS].filter((k) => !literals.includes(k));
+      if (missing.length) {
+        problems.push(
+          `${name}: does not accept ${missing.map((k) => `'${k}'`).join(', ')}. ` +
+            'Either compose the `all` alias, or add it to NO_GLOBAL_KEYWORDS ' +
+            'with a reason.',
+        );
+      }
+    }
+    expect(problems).toEqual([]);
+  });
+
+  test('every keyword is real, according to the CSS grammar', () => {
+    const types = readTypes(FLOW_FILE);
+    const invalid = [];
+
+    for (const [name, { literals }] of Object.entries(types)) {
+      if (name === 'theme' || NO_GRAMMAR.has(name)) continue;
+
+      const keywords = grammarKeywords(camelToKebab(name));
+      if (keywords == null) {
+        invalid.push(
+          `${name}: css-tree has no grammar for this property. Either drop it ` +
+            'from both type files, or add it to NO_GRAMMAR with a reason.',
+        );
+        continue;
+      }
+
+      const kept = KEPT_KEYWORDS[name] ?? [];
+      const unknown = literals.filter(
+        (l) =>
+          !keywords.has(l) &&
+          !GLOBAL_KEYWORDS.has(l) &&
+          !kept.includes(l) &&
+          // Space-separated values are combinations of single keywords.
+          !l.split(' ').every((word) => keywords.has(word)),
+      );
+
+      if (unknown.length) {
+        invalid.push(
+          `${name}: ${unknown.map((l) => `'${l}'`).join(', ')} ` +
+            'not in the CSS grammar. Either drop from both type files, or add ' +
+            'to KEPT_KEYWORDS with a reason.',
+        );
+      }
+    }
+
+    expect(invalid).toEqual([]);
+  });
+
+  test('closed unions list every keyword the grammar has', () => {
+    // The mirror of the grammar check above: that one asks whether every typed
+    // keyword is real, this one asks whether every real keyword is typed.
+    // Restricted to closed unions -- a property accepting arbitrary strings
+    // already accepts everything.
+    const problems = [];
+
+    for (const [name, type] of Object.entries(readTypes(FLOW_FILE))) {
+      if (name === 'theme' || NO_GRAMMAR.has(name) || type.open) continue;
+      const keywords = grammarKeywords(camelToKebab(name));
+      if (keywords == null) continue;
+
+      // Multi-word values are typed whole ('first baseline'), so compare words.
+      const words = new Set(type.literals.flatMap((l) => l.split(' ')));
+      const known = INCOMPLETE_UNIONS[name] ?? [];
+      const missing = [...keywords].filter(
+        (k) => !words.has(k) && !known.includes(k),
+      );
+      if (missing.length) {
+        problems.push(
+          `${name}: the grammar allows ${missing
+            .map((k) => `'${k}'`)
+            .join(', ')} but the type does not. Either add to both type ` +
+            'files, or list in INCOMPLETE_UNIONS.',
+        );
+      }
+
+      const stale = known.filter((k) => words.has(k));
+      if (stale.length) {
+        problems.push(
+          `${name}: ${stale.map((k) => `'${k}'`).join(', ')} now typed, so ` +
+            'remove from its INCOMPLETE_UNIONS entry.',
+        );
+      }
+    }
+
+    const gone = Object.keys(INCOMPLETE_UNIONS).filter(
+      (name) => !(name in readTypes(FLOW_FILE)),
+    );
+    for (const name of gone) {
+      problems.push(
+        `${name}: no longer a property, so remove it from INCOMPLETE_UNIONS.`,
+      );
+    }
+
+    expect(problems).toEqual([]);
+  });
+
+  test('properties whose grammar needs arbitrary strings accept them', () => {
+    // The other direction from the two keyword checks: not "are the literals
+    // right?" but "should this be a union of literals at all?". A grammar with
+    // a `<url>`, `<length>` or function in it cannot be expressed as literals.
+    const problems = [];
+
+    for (const [name, type] of Object.entries(readTypes(FLOW_FILE))) {
+      if (name === 'theme' || NO_GRAMMAR.has(name) || type.open) continue;
+      if (!needsArbitraryString(camelToKebab(name))) continue;
+      if (CLOSED_DESPITE_GRAMMAR.has(name)) continue;
+      problems.push(
+        `${name}: its grammar is \`${generate(
+          lexer.properties[camelToKebab(name)].syntax,
+        )}\`, which admits more than keywords, but the type accepts no ` +
+          'arbitrary string. Either add `string` in the Flow types and ' +
+          '`(string & {})` in the definitions, or list it in ' +
+          'CLOSED_DESPITE_GRAMMAR with a reason.',
+      );
+    }
+
+    const stale = [...CLOSED_DESPITE_GRAMMAR].filter((name) => {
+      const type = readTypes(FLOW_FILE)[name];
+      return type == null || type.open;
+    });
+    for (const name of stale) {
+      problems.push(
+        `${name}: now accepts an arbitrary string, so remove it from CLOSED_DESPITE_GRAMMAR.`,
+      );
+    }
+
+    expect(problems).toEqual([]);
+  });
+
+  test('every Baseline-available property is typed', () => {
+    // Bumping `web-features` is what makes this fire: a property that reaches
+    // Baseline has to be typed or listed, and one that is already typed has to
+    // come off the list. The dependency is pinned exactly so that only a
+    // deliberate bump can change the answer.
+    const typed = new Set(Object.keys(readTypes(FLOW_FILE)).map(camelToKebab));
+    const available = [...BASELINE.entries()].filter(
+      ([cssName, baseline]) =>
+        (baseline === 'high' || baseline === 'low') &&
+        // Vendor-prefixed properties are exposed case by case, and
+        // `custom-property` is a compat-data entry rather than a property.
+        !cssName.startsWith('-') &&
+        cssName !== 'custom-property',
+    );
+
+    const problems = [
+      ...available
+        .filter(
+          ([cssName]) =>
+            !typed.has(cssName) && !NOT_TYPED.has(kebabToCamel(cssName)),
+        )
+        .map(
+          ([cssName, baseline]) =>
+            `${kebabToCamel(cssName)}: Baseline ${baseline}, so it is safe to ` +
+            `use, but it is not typed. Its grammar is \`${generate(
+              lexer.properties[cssName].syntax,
+            )}\`. Either add it to both type files, or list it in NOT_TYPED ` +
+            'with a reason.',
+        ),
+      ...[...NOT_TYPED]
+        .filter((name) => typed.has(camelToKebab(name)))
+        .map((name) => `${name}: now typed, so remove it from NOT_TYPED.`),
+    ];
+
+    expect(problems).toEqual([]);
+  });
+});

--- a/packages/@stylexjs/stylex/package.json
+++ b/packages/@stylexjs/stylex/package.json
@@ -45,6 +45,7 @@
     "@babel/cli": "^7.26.4",
     "@babel/core": "^7.26.8",
     "@babel/eslint-parser": "^7.26.8",
+    "@babel/parser": "^7.29.0",
     "@babel/plugin-syntax-flow": "^7.26.0",
     "@babel/preset-env": "^7.26.8",
     "@babel/preset-flow": "^7.25.9",
@@ -59,8 +60,10 @@
     "@rollup/plugin-replace": "^6.0.1",
     "babel-plugin-syntax-hermes-parser": "^0.36.1",
     "cross-env": "^10.1.0",
+    "css-tree": "^3.2.1",
     "rollup": "^4.59.0",
-    "scripts": "0.19.0"
+    "scripts": "0.19.0",
+    "web-features": "3.37.0"
   },
   "files": [
     "lib/*"

--- a/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.d.ts
+++ b/packages/@stylexjs/stylex/src/types/StyleXCSSTypes.d.ts
@@ -1,0 +1,1527 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * TypeScript definitions for `StyleXCSSTypes.js`.
+ *
+ * !!! Keep this file in sync with `StyleXCSSTypes.js` by hand. !!!
+ *
+ * It exists because the most useful thing these types can do is only
+ * expressible in TypeScript:
+ *
+ *     Flow:       type Display = 'block' | 'flex' | string;
+ *     TypeScript: type Display = 'block' | 'flex' | (string & {});
+ *
+ * A Flow union containing `string` collapses to `string`, discarding every
+ * literal member and the editor autocomplete along with it. TypeScript's
+ * `string & {}` is mutually assignable with `string`, so any string is still
+ * accepted, but the literals survive and editors keep suggesting them.
+ *
+ * Apart from that substitution this file is a faithful translation of the Flow
+ * types. When adding or changing a property, update both files, and prefer
+ * `(string & {})` over a bare `string` in any union with other members.
+ */
+
+type CSSCursor =
+  | 'auto'
+  | 'default'
+  | 'none'
+  | 'context-menu'
+  | 'help'
+  | 'inherit'
+  | 'pointer'
+  | 'progress'
+  | 'wait'
+  | 'cell'
+  | 'crosshair'
+  | 'text'
+  | 'vertical-text'
+  | 'alias'
+  | 'copy'
+  | 'move'
+  | 'no-drop'
+  | 'not-allowed'
+  | 'e-resize'
+  | 'n-resize'
+  | 'ne-resize'
+  | 'nw-resize'
+  | 's-resize'
+  | 'se-resize'
+  | 'sw-resize'
+  | 'w-resize'
+  | 'ew-resize'
+  | 'ns-resize'
+  | 'nesw-resize'
+  | 'nwse-resize'
+  | 'col-resize'
+  | 'row-resize'
+  | 'all-scroll'
+  | 'zoom-in'
+  | 'zoom-out'
+  | 'grab'
+  | 'grabbing'
+  | '-webkit-grab'
+  | '-webkit-grabbing';
+type alignContent =
+  | 'center'
+  | 'start'
+  | 'end'
+  | 'flex-start'
+  | 'flex-end'
+  | 'normal'
+  | 'baseline'
+  | 'first baseline'
+  | 'last baseline'
+  | 'space-between'
+  | 'space-around'
+  | 'space-evenly'
+  | 'stretch'
+  | 'safe center'
+  | 'unsafe center'
+  | all;
+type alignItems =
+  | 'normal'
+  | 'stretch'
+  | 'center'
+  | 'start'
+  | 'end'
+  | 'flex-start'
+  | 'flex-end'
+  | 'self-start'
+  | 'self-end'
+  | 'baseline'
+  | 'first baseline'
+  | 'last baseline'
+  | 'safe center'
+  | 'unsafe center'
+  | all;
+type alignSelf =
+  | 'auto'
+  | 'normal'
+  | 'center'
+  | 'start'
+  | 'end'
+  | 'self-start'
+  | 'self-end'
+  | 'flex-start'
+  | 'flex-end'
+  | 'baseline'
+  | 'first baseline'
+  | 'last baseline'
+  | 'stretch'
+  | 'safe center'
+  | 'unsafe center'
+  | all;
+type all = null | 'initial' | 'inherit' | 'unset';
+type animationDelay = time;
+type animationDirection = singleAnimationDirection;
+type animationDuration = time;
+type animationFillMode = singleAnimationFillMode;
+type animationIterationCount = singleAnimationIterationCount;
+type animationName = singleAnimationName;
+type animationPlayState = singleAnimationPlayState;
+type animationTimingFunction = singleTimingFunction;
+type appearance = 'auto' | 'none' | 'textfield' | (string & {});
+type backdropFilter = 'none' | (string & {});
+type backfaceVisibility = 'visible' | 'hidden';
+type backgroundAttachment = attachment;
+type backgroundBlendMode = blendMode;
+type backgroundClip = box | 'text';
+type backgroundColor = color;
+type backgroundImage = bgImage;
+type backgroundOrigin = box;
+type backgroundPosition = string & {};
+type backgroundPositionX = string & {};
+type backgroundPositionY = string & {};
+type backgroundRepeat = repeatStyle;
+type backgroundSize = bgSize;
+type blockSize = width;
+type border = borderWidth | brStyle | color;
+type borderBlockEnd = borderWidth | borderStyle | color;
+type borderBlockEndColor = color;
+type borderBlockEndStyle = borderStyle;
+type borderBlockEndWidth = borderWidth;
+type borderBlockStart = borderWidth | borderStyle | color;
+type borderBlockStartColor = color;
+type borderBlockStartStyle = borderStyle;
+type borderBlockStartWidth = borderWidth;
+type borderBottomLeftRadius = lengthPercentage;
+type borderBottomRightRadius = lengthPercentage;
+type borderBottomStyle = brStyle;
+type borderBottomWidth = borderWidth;
+type borderCollapse = 'collapse' | 'separate';
+type borderColor = color;
+type borderImage =
+  | borderImageSource
+  | borderImageSlice
+  | (string & {})
+  | borderImageRepeat;
+type borderImageOutset = string & {};
+type borderImageRepeat = string & {};
+type borderImageSlice = (string & {}) | number | 'fill';
+type borderImageSource = 'none' | (string & {});
+type borderImageWidth = string & {};
+type borderInlineEnd = borderWidth | borderStyle | color;
+type borderInlineEndColor = color;
+type borderInlineEndStyle = borderStyle;
+type borderInlineEndWidth = borderWidth;
+type borderInlineStart = borderWidth | borderStyle | color;
+type borderInlineStartColor = color;
+type borderInlineStartStyle = borderStyle;
+type borderInlineStartWidth = borderWidth;
+type borderLeftColor = color;
+type borderLeftStyle = brStyle;
+type borderLeftWidth = borderWidth;
+type borderRightColor = color;
+type borderRightStyle = brStyle;
+type borderRightWidth = borderWidth;
+type borderRadius = lengthPercentage;
+type cornerShape =
+  | 'round'
+  | 'scoop'
+  | 'bevel'
+  | 'notch'
+  | 'square'
+  | 'squircle'
+  | (string & {});
+type cornerTopLeftShape = cornerShape;
+type cornerTopRightShape = cornerShape;
+type cornerBottomLeftShape = cornerShape;
+type cornerBottomRightShape = cornerShape;
+type borderSpacing = number | (string & {});
+type borderStyle = brStyle;
+type borderTopLeftRadius = lengthPercentage;
+type borderTopRightRadius = lengthPercentage;
+type borderTopStyle = brStyle;
+type borderTopWidth = borderWidth;
+type boxAlign = 'start' | 'center' | 'end' | 'baseline' | 'stretch';
+type boxDecorationBreak = 'slice' | 'clone';
+type boxDirection = 'normal' | 'reverse' | 'inherit';
+type boxFlex = number | (string & {});
+type boxFlexGroup = number | (string & {});
+type boxLines = 'single' | 'multiple';
+type boxOrdinalGroup = number | (string & {});
+type boxOrient =
+  | 'horizontal'
+  | 'vertical'
+  | 'inline-axis'
+  | 'block-axis'
+  | 'inherit';
+type boxShadow = 'none' | (string & {});
+type boxSizing = 'content-box' | 'border-box';
+type boxSuppress = 'show' | 'discard' | 'hide';
+type breakAfter =
+  | 'auto'
+  | 'avoid'
+  | 'avoid-page'
+  | 'page'
+  | 'left'
+  | 'right'
+  | 'recto'
+  | 'verso'
+  | 'avoid-column'
+  | 'column'
+  | 'avoid-region'
+  | 'region';
+type breakBefore =
+  | 'auto'
+  | 'avoid'
+  | 'avoid-page'
+  | 'page'
+  | 'left'
+  | 'right'
+  | 'recto'
+  | 'verso'
+  | 'avoid-column'
+  | 'column'
+  | 'avoid-region'
+  | 'region';
+type breakInside =
+  | 'auto'
+  | 'avoid'
+  | 'avoid-page'
+  | 'avoid-column'
+  | 'avoid-region';
+type captionSide =
+  | 'top'
+  | 'bottom'
+  | 'block-start'
+  | 'block-end'
+  | 'inline-start'
+  | 'inline-end';
+type clear = 'none' | 'left' | 'right' | 'both' | 'inline-start' | 'inline-end';
+type clip = (string & {}) | 'auto';
+type clipPath = (string & {}) | 'none';
+type columnCount = number | 'auto' | (string & {});
+type columnFill = 'auto' | 'balance';
+type columnGap = number | (string & {}) | 'normal';
+type columnRule = columnRuleWidth | columnRuleStyle | columnRuleColor;
+type columnRuleColor = color;
+type columnRuleStyle = brStyle;
+type columnRuleWidth = borderWidth;
+type columnSpan = 'none' | 'all';
+type columnWidth = number | 'auto' | (string & {});
+type columns = columnWidth | columnCount;
+type contain = 'none' | 'strict' | 'content' | (string & {});
+type content = string & {};
+type counterIncrement = (string & {}) | 'none';
+type counterReset = (string & {}) | 'none';
+type cursor = CSSCursor;
+type direction = 'ltr' | 'rtl' | 'inherit';
+type display =
+  | 'none'
+  | 'inherit'
+  | 'inline'
+  | 'block'
+  | 'flow-root'
+  | 'list-item'
+  | 'inline-list-item'
+  | 'inline-block'
+  | 'inline-table'
+  | 'table'
+  | 'table-cell'
+  | 'table-column'
+  | 'table-column-group'
+  | 'table-footer-group'
+  | 'table-header-group'
+  | 'table-row'
+  | 'table-row-group'
+  | 'flex'
+  | 'inline-flex'
+  | 'grid'
+  | 'inline-grid'
+  | '-webkit-box'
+  | 'run-in'
+  | 'ruby'
+  | 'ruby-base'
+  | 'ruby-text'
+  | 'ruby-base-container'
+  | 'ruby-text-container'
+  | 'contents';
+type displayInside = 'auto' | 'block' | 'table' | 'flex' | 'grid' | 'ruby';
+type displayList = 'none' | 'list-item';
+type displayOutside =
+  | 'block-level'
+  | 'inline-level'
+  | 'run-in'
+  | 'contents'
+  | 'none'
+  | 'table-row-group'
+  | 'table-header-group'
+  | 'table-footer-group'
+  | 'table-row'
+  | 'table-cell'
+  | 'table-column-group'
+  | 'table-column'
+  | 'table-caption'
+  | 'ruby-base'
+  | 'ruby-text'
+  | 'ruby-base-container'
+  | 'ruby-text-container';
+type emptyCells = 'show' | 'hide';
+type filter = 'none' | (string & {});
+type flex = 'none' | (string & {}) | number;
+type flexBasis = 'content' | number | (string & {}) | 'inherit';
+type flexDirection =
+  | 'row'
+  | 'row-reverse'
+  | 'column'
+  | 'column-reverse'
+  | 'inherit';
+type flexFlow = flexDirection | flexWrap;
+type flexGrow = all | number | (string & {});
+type flexShrink = all | number | (string & {});
+type flexWrap = 'nowrap' | 'wrap' | 'wrap-reverse' | 'inherit';
+type float =
+  | 'left'
+  | 'right'
+  | 'none'
+  | 'start'
+  | 'end'
+  | 'inline-start'
+  | 'inline-end'
+  | 'inherit';
+type fontFamily = string & {};
+type fontFeatureSettings = 'normal' | (string & {});
+type fontKerning = 'auto' | 'normal' | 'none';
+type fontLanguageOverride = 'normal' | (string & {});
+type fontSize = absoluteSize | relativeSize | lengthPercentage;
+type fontSizeAdjust = 'none' | number;
+type fontStretch =
+  | 'normal'
+  | 'ultra-condensed'
+  | 'extra-condensed'
+  | 'condensed'
+  | 'semi-condensed'
+  | 'semi-expanded'
+  | 'expanded'
+  | 'extra-expanded'
+  | 'ultra-expanded'
+  | (string & {});
+type fontStyle = 'normal' | 'italic' | 'oblique';
+type fontSynthesis = 'none' | (string & {});
+type fontVariant = 'normal' | 'none' | (string & {});
+type fontVariantAlternates = 'normal' | (string & {});
+type fontVariantCaps =
+  | 'normal'
+  | 'small-caps'
+  | 'all-small-caps'
+  | 'petite-caps'
+  | 'all-petite-caps'
+  | 'unicase'
+  | 'titling-caps';
+type fontVariantEastAsian = 'normal' | (string & {});
+type fontVariantLigatures = 'normal' | 'none' | (string & {});
+type fontVariantNumeric = 'normal' | (string & {});
+type fontVariantPosition = 'normal' | 'sub' | 'super';
+type fontWeight =
+  | 'inherit'
+  | 'normal'
+  | 'bold'
+  | 'bolder'
+  | 'lighter'
+  | 100
+  | 200
+  | 300
+  | 400
+  | 500
+  | 600
+  | 700
+  | 800
+  | 900
+  | (string & {})
+  | number;
+type gap = number | (string & {});
+type grid = gridTemplate | (string & {});
+type gridArea = gridLine | (string & {});
+type gridAutoColumns = trackSize;
+type gridAutoFlow = (string & {}) | 'dense';
+type gridAutoRows = trackSize;
+type gridColumn = gridLine | (string & {});
+type gridColumnEnd = gridLine;
+type gridColumnGap = lengthPercentage;
+type gridColumnStart = gridLine;
+type gridGap = gridRowGap | gridColumnGap;
+type gridRow = gridLine | (string & {});
+type gridRowEnd = gridLine;
+type gridRowGap = lengthPercentage;
+type gridRowStart = gridLine;
+type gridTemplate = 'none' | 'subgrid' | (string & {});
+type gridTemplateAreas = 'none' | (string & {});
+type gridTemplateColumns = 'none' | 'subgrid' | (string & {});
+type gridTemplateRows = 'none' | 'subgrid' | (string & {});
+type hyphens = 'none' | 'manual' | 'auto';
+type imageOrientation = 'from-image' | number | (string & {});
+type imageRendering =
+  | 'auto'
+  | 'crisp-edges'
+  | 'pixelated'
+  | 'optimizeSpeed'
+  | 'optimizeQuality'
+  | (string & {});
+type imageResolution = (string & {}) | 'snap';
+type imeMode = 'auto' | 'normal' | 'active' | 'inactive' | 'disabled';
+type initialLetter = 'normal' | (string & {});
+type initialLetterAlign = string & {};
+type inlineSize = width;
+type interpolateSize = 'allow-keywords' | 'numeric-only';
+type isolation = 'auto' | 'isolate';
+type justifyContent =
+  | 'center'
+  | 'start'
+  | 'end'
+  | 'flex-start'
+  | 'flex-end'
+  | 'left'
+  | 'right'
+  | 'normal'
+  | 'space-between'
+  | 'space-around'
+  | 'space-evenly'
+  | 'stretch'
+  | 'safe center'
+  | 'unsafe center'
+  | 'inherit';
+type justifyItems =
+  | 'normal'
+  | 'stretch'
+  | 'center'
+  | 'start'
+  | 'end'
+  | 'flex-start'
+  | 'flex-end'
+  | 'self-start'
+  | 'self-end'
+  | 'left'
+  | 'right'
+  | 'baseline'
+  | 'first baseline'
+  | 'last baseline'
+  | 'safe center'
+  | 'unsafe center'
+  | 'legacy right'
+  | 'legacy left'
+  | 'legacy center'
+  | all;
+type justifySelf =
+  | 'auto'
+  | 'normal'
+  | 'stretch'
+  | 'center'
+  | 'start'
+  | 'end'
+  | 'flex-start'
+  | 'flex-end'
+  | 'self-start'
+  | 'self-end'
+  | 'left'
+  | 'right'
+  | 'baseline'
+  | 'first baseline'
+  | 'last baseline'
+  | 'safe center'
+  | 'unsafe center';
+type letterSpacing = 'normal' | lengthPercentage;
+type lineBreak = 'auto' | 'loose' | 'normal' | 'strict';
+type lineHeight = 'inherit' | number | (string & {});
+type listStyle = listStyleType | listStylePosition | listStyleImage;
+type listStyleImage = (string & {}) | 'none';
+type listStylePosition = 'inside' | 'outside';
+type listStyleType = (string & {}) | 'none';
+type margin = number | (string & {});
+type marginBlockEnd = marginLeft;
+type marginBlockStart = marginLeft;
+type marginBottom = number | (string & {}) | 'auto';
+type marginInlineEnd = marginLeft;
+type marginInlineStart = marginLeft;
+type marginLeft = number | (string & {}) | 'auto';
+type marginRight = number | (string & {}) | 'auto';
+type marginTop = number | (string & {}) | 'auto';
+type markerOffset = number | 'auto' | (string & {});
+type mask = maskLayer;
+type maskClip = string & {};
+type maskComposite = compositeOperator;
+type maskMode = maskingMode;
+type maskOrigin = geometryBox;
+type maskPosition = string & {};
+type maskRepeat = repeatStyle;
+type maskSize = bgSize;
+type maskType = 'luminance' | 'alpha';
+type maxBlockSize = maxWidth;
+type maxHeight =
+  | number
+  | (string & {})
+  | 'none'
+  | 'max-content'
+  | 'min-content'
+  | 'fit-content'
+  | 'fill-available';
+type maxInlineSize = maxWidth;
+type maxWidth =
+  | number
+  | (string & {})
+  | 'none'
+  | 'max-content'
+  | 'min-content'
+  | 'fit-content'
+  | 'fill-available';
+type minBlockSize = minWidth;
+type minHeight =
+  | number
+  | (string & {})
+  | 'auto'
+  | 'max-content'
+  | 'min-content'
+  | 'fit-content'
+  | 'fill-available';
+type minInlineSize = minWidth;
+type minWidth =
+  | number
+  | (string & {})
+  | 'auto'
+  | 'max-content'
+  | 'min-content'
+  | 'fit-content'
+  | 'fill-available';
+type mixBlendMode = blendMode;
+type motion = motionPath | motionOffset | motionRotation;
+type motionOffset = lengthPercentage;
+type motionPath = (string & {}) | geometryBox | 'none';
+type motionRotation = (string & {}) | number;
+type MsOverflowStyle =
+  | 'auto'
+  | 'none'
+  | 'scrollbar'
+  | '-ms-autohiding-scrollbar';
+type objectFit = 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
+type objectPosition = string & {};
+type opacity = number | (string & {});
+type order = number | (string & {});
+type orphans = number | (string & {});
+type outline = string & {};
+type outlineColor = color | 'invert';
+type outlineOffset = number | (string & {});
+type outlineStyle = 'auto' | brStyle;
+type outlineWidth = borderWidth;
+type overflow = 'visible' | 'hidden' | 'clip' | 'scroll' | 'auto';
+type overflowAnchor = 'auto' | 'none';
+type overflowWrap = 'normal' | 'break-word' | 'anywhere';
+type overflowX = overflow;
+type overflowY = overflow;
+type overscrollBehavior = 'none' | 'contain' | 'auto';
+type overscrollBehaviorX = 'none' | 'contain' | 'auto';
+type overscrollBehaviorY = 'none' | 'contain' | 'auto';
+type padding = number | (string & {});
+type paddingBlockEnd = paddingLeft;
+type paddingBlockStart = paddingLeft;
+type paddingBottom = number | (string & {});
+type paddingLeft = number | (string & {});
+type paddingRight = number | (string & {});
+type paddingTop = number | (string & {});
+type pageBreakAfter = 'auto' | 'always' | 'avoid' | 'left' | 'right';
+type pageBreakBefore = 'auto' | 'always' | 'avoid' | 'left' | 'right';
+type pageBreakInside = 'auto' | 'avoid';
+type perspective = 'none' | number;
+type perspectiveOrigin = string & {};
+type pointerEvents =
+  | 'auto'
+  | 'none'
+  | 'visiblePainted'
+  | 'visibleFill'
+  | 'visibleStroke'
+  | 'visible'
+  | 'painted'
+  | 'fill'
+  | 'stroke'
+  | 'all'
+  | 'inherit';
+type position = 'static' | 'relative' | 'absolute' | 'sticky' | 'fixed';
+type positionArea =
+  | 'top'
+  | 'left'
+  | 'bottom'
+  | 'right'
+  | 'center'
+  | 'block-start'
+  | 'block-end'
+  | 'inline-start'
+  | 'inline-end'
+  | 'span-inline-start'
+  | 'span-inline-end'
+  | 'span-block-start'
+  | 'span-block-end';
+type positionVisibility = 'always' | 'anchors-visible' | 'no-overflow';
+type quotes = (string & {}) | 'none';
+type resize = 'none' | 'both' | 'horizontal' | 'vertical';
+type rowGap = number | (string & {});
+type rubyAlign = 'start' | 'center' | 'space-between' | 'space-around';
+type rubyMerge = 'separate' | 'collapse' | 'auto';
+type rubyPosition = 'over' | 'under' | 'inter-character';
+type scrollBehavior = 'auto' | 'smooth';
+type scrollSnapAlign = 'none' | 'start' | 'end' | 'center';
+type scrollSnapType =
+  | 'none'
+  | 'block mandatory'
+  | 'block proximity'
+  | 'block'
+  | 'both mandatory'
+  | 'both proximity'
+  | 'both'
+  | 'inline mandatory'
+  | 'inline proximity'
+  | 'inline'
+  | 'x'
+  | 'x mandatory'
+  | 'x proximity'
+  | 'y'
+  | 'y mandatory'
+  | 'y proximity';
+type shapeImageThreshold = number | (string & {});
+type shapeMargin = lengthPercentage;
+type shapeOutside = 'none' | shapeBox | (string & {});
+type tabSize = number | (string & {});
+type tableLayout = 'auto' | 'fixed';
+type textAlign =
+  | 'start'
+  | 'end'
+  | 'left'
+  | 'right'
+  | 'center'
+  | 'justify'
+  | 'match-parent'
+  | 'inherit';
+type textAlignLast =
+  | 'auto'
+  | 'start'
+  | 'end'
+  | 'left'
+  | 'right'
+  | 'center'
+  | 'justify'
+  | 'inherit';
+type textCombineUpright = 'none' | 'all' | (string & {});
+type textDecoration =
+  | textDecorationLine
+  | textDecorationStyle
+  | textDecorationColor;
+type textDecorationColor = color;
+type textDecorationLine = 'none' | (string & {});
+type textDecorationSkip = 'none' | (string & {});
+type textDecorationStyle = 'solid' | 'double' | 'dotted' | 'dashed' | 'wavy';
+type textEmphasis = textEmphasisStyle | textEmphasisColor;
+type textEmphasisColor = color;
+type textEmphasisPosition = string & {};
+type textEmphasisStyle = 'none' | (string & {});
+type textIndent = lengthPercentage | 'hanging' | 'each-line';
+type textOrientation = 'mixed' | 'upright' | 'sideways';
+type textOverflow = string & {};
+type textRendering =
+  | 'auto'
+  | 'optimizeSpeed'
+  | 'optimizeLegibility'
+  | 'geometricPrecision';
+type textShadow = 'none' | (string & {});
+type textSizeAdjust = 'none' | 'auto' | (string & {});
+type textTransform =
+  | 'none'
+  | 'capitalize'
+  | 'uppercase'
+  | 'lowercase'
+  | 'full-width';
+type textUnderlinePosition = 'auto' | (string & {});
+type touchAction = 'auto' | 'none' | (string & {}) | 'manipulation';
+type transform = 'none' | (string & {});
+type transformBox = 'border-box' | 'fill-box' | 'view-box';
+type transformOrigin = (string & {}) | number;
+type transformStyle = 'flat' | 'preserve-3d';
+type transition = singleTransition;
+type transitionDelay = time;
+type transitionDuration = time;
+type transitionProperty = 'none' | singleTransitionProperty;
+type transitionTimingFunction = singleTransitionTimingFunction;
+type unicodeBidi =
+  | 'normal'
+  | 'embed'
+  | 'isolate'
+  | 'bidi-override'
+  | 'isolate-override'
+  | 'plaintext';
+type userSelect = 'auto' | 'text' | 'none' | 'contain' | 'all';
+type verticalAlign =
+  | 'baseline'
+  | 'sub'
+  | 'super'
+  | 'text-top'
+  | 'text-bottom'
+  | 'middle'
+  | 'top'
+  | 'bottom'
+  | (string & {})
+  | number;
+type visibility = 'visible' | 'hidden' | 'collapse';
+type whiteSpace =
+  | 'normal'
+  | 'pre'
+  | 'nowrap'
+  | 'pre-wrap'
+  | 'pre-line'
+  | 'initial'
+  | 'inherit';
+type widows = number | (string & {});
+type width =
+  | (string & {})
+  | number
+  | 'available'
+  | 'min-content'
+  | 'max-content'
+  | 'fit-content'
+  | 'auto';
+type willChange = 'auto' | animatableFeature;
+type wordBreak = 'normal' | 'break-all' | 'keep-all' | nonStandardWordBreak;
+type wordSpacing = 'normal' | lengthPercentage;
+type wordWrap = 'normal' | 'break-word';
+type writingMode =
+  | 'horizontal-tb'
+  | 'vertical-rl'
+  | 'vertical-lr'
+  | 'sideways-rl'
+  | 'sideways-lr'
+  | svgWritingMode;
+type zIndex = 'auto' | number;
+type alignmentBaseline =
+  | 'auto'
+  | 'baseline'
+  | 'before-edge'
+  | 'text-before-edge'
+  | 'middle'
+  | 'central'
+  | 'after-edge'
+  | 'text-after-edge'
+  | 'ideographic'
+  | 'alphabetic'
+  | 'hanging'
+  | 'mathematical';
+type baselineShift = 'baseline' | 'sub' | 'super' | svgLength;
+type behavior = string & {};
+type clipRule = 'nonzero' | 'evenodd';
+type cue = cueBefore | cueAfter;
+type cueAfter = (string & {}) | number | 'none';
+type cueBefore = (string & {}) | number | 'none';
+type dominantBaseline =
+  | 'auto'
+  | 'use-script'
+  | 'no-change'
+  | 'reset-size'
+  | 'ideographic'
+  | 'alphabetic'
+  | 'hanging'
+  | 'mathematical'
+  | 'central'
+  | 'middle'
+  | 'text-after-edge'
+  | 'text-before-edge';
+type fill = paint;
+type fillOpacity = number | (string & {});
+type fillRule = 'nonzero' | 'evenodd';
+type glyphOrientationHorizontal = number | (string & {});
+type glyphOrientationVertical = number | (string & {});
+type kerning = 'auto' | svgLength;
+type marker = 'none' | (string & {});
+type markerEnd = 'none' | (string & {});
+type markerMid = 'none' | (string & {});
+type markerStart = 'none' | (string & {});
+type pause = pauseBefore | pauseAfter;
+type pauseAfter =
+  | number
+  | 'none'
+  | 'x-weak'
+  | 'weak'
+  | 'medium'
+  | 'strong'
+  | 'x-strong';
+type pauseBefore =
+  | number
+  | 'none'
+  | 'x-weak'
+  | 'weak'
+  | 'medium'
+  | 'strong'
+  | 'x-strong';
+type rest = restBefore | restAfter;
+type restAfter =
+  | number
+  | 'none'
+  | 'x-weak'
+  | 'weak'
+  | 'medium'
+  | 'strong'
+  | 'x-strong';
+type restBefore =
+  | number
+  | 'none'
+  | 'x-weak'
+  | 'weak'
+  | 'medium'
+  | 'strong'
+  | 'x-strong';
+type shapeRendering =
+  | 'auto'
+  | 'optimizeSpeed'
+  | 'crispEdges'
+  | 'geometricPrecision';
+type src = string & {};
+type speak = 'auto' | 'none' | 'normal';
+type speakAs = 'normal' | 'spell-out' | 'digits' | (string & {});
+type stroke = paint;
+type strokeDasharray = 'none' | (string & {});
+type strokeDashoffset = svgLength;
+type strokeLinecap = 'butt' | 'round' | 'square';
+type strokeLinejoin = 'miter' | 'round' | 'bevel';
+type strokeMiterlimit = number | (string & {});
+type strokeOpacity = number | (string & {});
+type strokeWidth = svgLength;
+type textAnchor = 'start' | 'middle' | 'end';
+type unicodeRange = string & {};
+type voiceBalance =
+  | number
+  | 'left'
+  | 'center'
+  | 'right'
+  | 'leftwards'
+  | 'rightwards';
+type voiceDuration = 'auto' | time;
+type voiceFamily = (string & {}) | 'preserve';
+type voicePitch = number | 'absolute' | (string & {});
+type voiceRange = number | 'absolute' | (string & {});
+type voiceRate = string & {};
+type voiceStress = 'normal' | 'strong' | 'moderate' | 'none' | 'reduced';
+type voiceVolume = 'silent' | (string & {});
+type absoluteSize =
+  | 'xx-small'
+  | 'x-small'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'x-large'
+  | 'xx-large';
+type animatableFeature = 'scroll-position' | 'contents' | (string & {});
+type attachment = 'scroll' | 'fixed' | 'local';
+type bgImage = 'none' | (string & {});
+type bgSize = (string & {}) | 'cover' | 'contain';
+type box = 'border-box' | 'padding-box' | 'content-box';
+type brStyle =
+  | 'none'
+  | 'hidden'
+  | 'dotted'
+  | 'dashed'
+  | 'solid'
+  | 'double'
+  | 'groove'
+  | 'ridge'
+  | 'inset'
+  | 'outset';
+type borderWidth = number | 'thin' | 'medium' | 'thick' | (string & {});
+type color = string & {};
+type compositeOperator = 'add' | 'subtract' | 'intersect' | 'exclude';
+type geometryBox = shapeBox | 'fill-box' | 'stroke-box' | 'view-box';
+type gridLine = 'auto' | (string & {});
+type lengthPercentage = number | (string & {});
+type maskLayer =
+  | maskReference
+  | maskingMode
+  | (string & {})
+  | repeatStyle
+  | geometryBox
+  | compositeOperator;
+type maskReference = 'none' | (string & {});
+type maskingMode = 'alpha' | 'luminance' | 'match-source';
+type relativeSize = 'larger' | 'smaller';
+type repeatStyle = 'repeat-x' | 'repeat-y' | (string & {});
+type shapeBox = box | 'margin-box';
+type singleAnimationDirection =
+  | 'normal'
+  | 'reverse'
+  | 'alternate'
+  | 'alternate-reverse';
+type singleAnimationFillMode = 'none' | 'forwards' | 'backwards' | 'both';
+type singleAnimationIterationCount = 'infinite' | number;
+type singleAnimationName = 'none' | (string & {});
+type singleAnimationPlayState = 'running' | 'paused';
+type singleTimingFunction = singleTransitionTimingFunction;
+type singleTransition = singleTransitionTimingFunction | (string & {}) | number;
+type singleTransitionTimingFunction =
+  | 'ease'
+  | 'linear'
+  | 'ease-in'
+  | 'ease-out'
+  | 'ease-in-out'
+  | 'step-start'
+  | 'step-end'
+  | (string & {});
+type singleTransitionProperty = 'all' | (string & {});
+type time = string & {};
+type trackBreadth =
+  | lengthPercentage
+  | (string & {})
+  | 'min-content'
+  | 'max-content'
+  | 'auto';
+type trackSize = trackBreadth | (string & {});
+type nonStandardWordBreak = 'break-word';
+type blendMode =
+  | 'normal'
+  | 'multiply'
+  | 'screen'
+  | 'overlay'
+  | 'darken'
+  | 'lighten'
+  | 'color-dodge'
+  | 'color-burn'
+  | 'hard-light'
+  | 'soft-light'
+  | 'difference'
+  | 'exclusion'
+  | 'hue'
+  | 'saturation'
+  | 'color'
+  | 'luminosity';
+type maskImage = maskReference;
+type paint = 'none' | 'currentColor' | color | (string & {});
+type svgLength = (string & {}) | number;
+type svgWritingMode = 'lr-tb' | 'rl-tb' | 'tb-rl' | 'lr' | 'rl' | 'tb';
+type top = number | (string & {});
+type OptionalArray<T> = Array<T> | T;
+export type SupportedVendorSpecificCSSProperties = Readonly<{
+  MozOsxFontSmoothing?: null | 'grayscale';
+  WebkitAppearance?: null | appearance;
+  WebkitFontSmoothing?: null | 'antialiased';
+  WebkitTapHighlightColor?: null | color;
+}>;
+export type CSSProperties = Readonly<{
+  theme?: all | (string & {});
+  MozOsxFontSmoothing?: all | 'grayscale';
+  WebkitAppearance?: all | appearance;
+  WebkitFontSmoothing?: all | 'antialiased';
+  WebkitTapHighlightColor?: all | color;
+  WebkitMaskImage?: all | maskImage;
+  WebkitTextFillColor?: all | color;
+  textFillColor?: all | color;
+  WebkitTextStrokeWidth?: all | number | (string & {});
+  WebkitTextStrokeColor?: all | color;
+  WebkitBackgroundClip?:
+    | null
+    | 'border-box'
+    | 'padding-box'
+    | 'content-box'
+    | 'text';
+  WebkitBoxOrient?:
+    | null
+    | 'vertical'
+    | 'horizontal'
+    | 'inline-axis'
+    | 'block-axis';
+  WebkitLineClamp?: all | number | (string & {});
+  accentColor?: all | color;
+  aspectRatio?: all | number | (string & {});
+  placeContent?: all | (string & {});
+  alignContent?: all | alignContent;
+  justifyContent?: all | justifyContent;
+  placeItems?: all | (string & {});
+  placeSelf?: all | (string & {});
+  alignItems?: all | alignItems;
+  justifyItems?: all | justifyItems;
+  alignSelf?: all | alignSelf;
+  justifySelf?: all | justifySelf;
+  alignmentBaseline?: all | alignmentBaseline;
+  alignTracks?: all | (string & {});
+  justifyTracks?: all | (string & {});
+  masonryAutoFlow?: all | (string & {});
+  anchorName?: all | (string & {});
+  animation?: all | (string & {});
+  animationComposition?: all | (string & {});
+  animationDelay?: all | OptionalArray<animationDelay>;
+  animationDirection?: all | OptionalArray<animationDirection>;
+  animationDuration?: all | OptionalArray<animationDuration>;
+  animationFillMode?: all | OptionalArray<animationFillMode>;
+  animationIterationCount?: all | OptionalArray<animationIterationCount>;
+  animationName?: all | OptionalArray<animationName>;
+  animationPlayState?: all | OptionalArray<animationPlayState>;
+  animationTimingFunction?: all | OptionalArray<animationTimingFunction>;
+  animationTimeline?: all | (string & {});
+  animationRange?: all | (string & {});
+  animationRangeStart?: all | (string & {});
+  animationRangeEnd?: all | (string & {});
+  appearance?: all | appearance;
+  azimuth?: all | (string & {});
+  backdropFilter?: all | backdropFilter;
+  backfaceVisibility?: all | backfaceVisibility;
+  background?: all | (string & {});
+  backgroundAttachment?: all | OptionalArray<backgroundAttachment>;
+  backgroundBlendMode?: all | OptionalArray<backgroundBlendMode>;
+  backgroundClip?: all | OptionalArray<backgroundClip>;
+  backgroundColor?: all | backgroundColor;
+  backgroundImage?: all | OptionalArray<backgroundImage>;
+  backgroundOrigin?: all | OptionalArray<backgroundOrigin>;
+  backgroundPosition?: all | OptionalArray<backgroundPosition>;
+  backgroundPositionX?: all | OptionalArray<backgroundPositionX>;
+  backgroundPositionY?: all | OptionalArray<backgroundPositionY>;
+  backgroundRepeat?: all | OptionalArray<backgroundRepeat>;
+  backgroundSize?: all | OptionalArray<backgroundSize>;
+  baselineShift?: all | baselineShift;
+  behavior?: all | behavior;
+  blockSize?: all | blockSize;
+  border?: all | border;
+  borderBlock?: all | borderBlockEnd;
+  borderBlockColor?: all | borderBlockEndColor;
+  borderBlockStyle?: all | borderBlockEndStyle;
+  borderBlockWidth?: all | borderBlockEndWidth;
+  borderBlockEnd?: all | borderBlockEnd;
+  borderBlockEndColor?: all | borderBlockEndColor;
+  borderBlockEndStyle?: all | borderBlockEndStyle;
+  borderBlockEndWidth?: all | borderBlockEndWidth;
+  borderBlockStart?: all | borderBlockStart;
+  borderBlockStartColor?: all | borderBlockStartColor;
+  borderBlockStartStyle?: all | borderBlockStartStyle;
+  borderBlockStartWidth?: all | borderBlockStartWidth;
+  borderBottom?: all | border;
+  borderBottomColor?: all | color;
+  borderBottomStyle?: all | borderBottomStyle;
+  borderBottomWidth?: all | borderBottomWidth;
+  borderCollapse?: all | borderCollapse;
+  borderColor?: all | borderColor;
+  borderImage?: all | borderImage;
+  borderImageOutset?: all | borderImageOutset;
+  borderImageRepeat?: all | borderImageRepeat;
+  borderImageSlice?: all | borderImageSlice;
+  borderImageSource?: all | borderImageSource;
+  borderImageWidth?: all | borderImageWidth;
+  borderInline?: all | borderInlineEnd;
+  borderInlineColor?: all | borderInlineEndColor;
+  borderInlineStyle?: all | borderInlineEndStyle;
+  borderInlineWidth?: all | borderInlineEndWidth;
+  borderInlineEnd?: all | borderInlineEnd;
+  borderInlineEndColor?: all | borderInlineEndColor;
+  borderInlineEndStyle?: all | borderInlineEndStyle;
+  borderInlineEndWidth?: all | borderInlineEndWidth;
+  borderInlineStart?: all | borderInlineStart;
+  borderInlineStartColor?: all | borderInlineStartColor;
+  borderInlineStartStyle?: all | borderInlineStartStyle;
+  borderInlineStartWidth?: all | borderInlineStartWidth;
+  borderLeft?: all | border;
+  borderLeftColor?: all | borderLeftColor;
+  borderLeftStyle?: all | borderLeftStyle;
+  borderLeftWidth?: all | borderLeftWidth;
+  borderRight?: all | border;
+  borderRightColor?: all | borderRightColor;
+  borderRightStyle?: all | borderRightStyle;
+  borderRightWidth?: all | borderRightWidth;
+  borderSpacing?: all | borderSpacing;
+  borderStyle?: all | borderStyle;
+  borderTop?: all | border;
+  borderTopColor?: all | color;
+  borderRadius?: all | borderRadius;
+  borderEndStartRadius?: all | borderBottomLeftRadius;
+  borderStartStartRadius?: all | borderTopLeftRadius;
+  borderStartEndRadius?: all | borderTopRightRadius;
+  borderEndEndRadius?: all | borderBottomRightRadius;
+  borderTopLeftRadius?: all | borderTopLeftRadius;
+  borderTopRightRadius?: all | borderTopRightRadius;
+  borderBottomLeftRadius?: all | borderBottomLeftRadius;
+  borderBottomRightRadius?: all | borderBottomRightRadius;
+  cornerShape?: all | cornerShape;
+  cornerStartStartShape?: all | cornerTopLeftShape;
+  cornerStartEndShape?: all | cornerTopRightShape;
+  cornerEndStartShape?: all | cornerBottomLeftShape;
+  cornerEndEndShape?: all | cornerBottomRightShape;
+  cornerTopLeftShape?: all | cornerTopLeftShape;
+  cornerTopRightShape?: all | cornerTopRightShape;
+  cornerBottomLeftShape?: all | cornerBottomLeftShape;
+  cornerBottomRightShape?: all | cornerBottomRightShape;
+  borderTopStyle?: all | borderTopStyle;
+  borderTopWidth?: all | borderTopWidth;
+  borderWidth?: all | borderWidth;
+  bottom?: all | number | (string & {});
+  boxAlign?: all | boxAlign;
+  boxDecorationBreak?: all | boxDecorationBreak;
+  boxDirection?: all | boxDirection;
+  boxFlex?: all | boxFlex;
+  boxFlexGroup?: all | boxFlexGroup;
+  boxLines?: all | boxLines;
+  boxOrdinalGroup?: all | boxOrdinalGroup;
+  boxOrient?: all | boxOrient;
+  boxShadow?: all | OptionalArray<boxShadow>;
+  boxSizing?: all | boxSizing;
+  boxSuppress?: all | boxSuppress;
+  breakAfter?: all | breakAfter;
+  breakBefore?: all | breakBefore;
+  breakInside?: all | breakInside;
+  captionSide?: all | captionSide;
+  caret?: all | (string & {});
+  caretColor?: all | color;
+  caretShape?: all | (string & {});
+  clear?: all | clear;
+  clip?: all | clip;
+  clipPath?: all | clipPath;
+  clipRule?: all | clipRule;
+  color?: all | color;
+  colorScheme?:
+    | null
+    | 'normal'
+    | 'light'
+    | 'dark'
+    | 'light dark'
+    | 'only light'
+    | 'only dark';
+  forcedColorAdjust?: all | 'auto' | 'none';
+  printColorAdjust?: all | 'economy' | 'exact';
+  columns?: all | columns;
+  columnCount?: all | columnCount;
+  columnWidth?: all | columnWidth;
+  columnRule?: all | columnRule;
+  columnRuleColor?: all | columnRuleColor;
+  columnRuleStyle?: all | columnRuleStyle;
+  columnRuleWidth?: all | columnRuleWidth;
+  columnFill?: all | columnFill;
+  columnGap?: all | columnGap;
+  columnSpan?: all | columnSpan;
+  contain?: all | contain;
+  containIntrinsicSize?: all | number | (string & {});
+  containIntrinsicBlockSize?: all | number | (string & {});
+  containIntrinsicInlineSize?: all | number | (string & {});
+  containIntrinsicHeight?: all | number | (string & {});
+  containIntrinsicWidth?: all | number | (string & {});
+  container?: all | (string & {});
+  containerName?: all | (string & {});
+  containerType?: all | 'size' | 'inline-size' | 'normal';
+  contentVisibility?: all | 'visible' | 'hidden' | 'auto';
+  content?: all | content;
+  counterIncrement?: all | counterIncrement;
+  counterReset?: all | counterReset;
+  counterSet?: all | (string & {}) | number;
+  cue?: all | cue;
+  cueAfter?: all | cueAfter;
+  cueBefore?: all | cueBefore;
+  cursor?: all | OptionalArray<cursor>;
+  direction?: all | direction;
+  display?: all | display;
+  displayInside?: all | displayInside;
+  displayList?: all | displayList;
+  displayOutside?: all | displayOutside;
+  dominantBaseline?: all | dominantBaseline;
+  emptyCells?: all | emptyCells;
+  end?: all | number | (string & {});
+  fill?: all | fill;
+  fillOpacity?: all | fillOpacity;
+  fillRule?: all | fillRule;
+  filter?: all | filter;
+  flex?: all | flex;
+  flexBasis?: all | flexBasis;
+  flexDirection?: all | flexDirection;
+  flexFlow?: all | flexFlow;
+  flexGrow?: all | flexGrow;
+  flexShrink?: all | flexShrink;
+  flexWrap?: all | flexWrap;
+  float?: all | float;
+  font?: all | (string & {});
+  fontFamily?: all | fontFamily;
+  fontFeatureSettings?: all | fontFeatureSettings;
+  fontKerning?: all | fontKerning;
+  fontLanguageOverride?: all | fontLanguageOverride;
+  fontSize?: all | fontSize;
+  fontSizeAdjust?: all | fontSizeAdjust;
+  fontStretch?: all | fontStretch;
+  fontStyle?: all | fontStyle;
+  fontSynthesis?: all | fontSynthesis;
+  fontSynthesisWeight?: all | 'auto' | 'none';
+  fontSynthesisStyle?: all | 'auto' | 'none';
+  fontSynthesisSmallCaps?: all | 'auto' | 'none';
+  fontSynthesisPosition?: all | 'auto' | 'none';
+  fontVariant?: all | fontVariant;
+  fontVariantAlternates?: all | fontVariantAlternates;
+  fontVariantCaps?: all | fontVariantCaps;
+  fontVariantEastAsian?: all | fontVariantEastAsian;
+  fontVariantLigatures?: all | fontVariantLigatures;
+  fontVariantNumeric?: all | fontVariantNumeric;
+  fontVariantPosition?: all | fontVariantPosition;
+  fontWeight?: all | fontWeight;
+  fontOpticalSizing?: all | 'auto' | 'none';
+  fontPalette?: all | 'light' | 'dark' | (string & {});
+  fontVariationSettings?: all | (string & {});
+  gap?: all | gap;
+  glyphOrientationHorizontal?: all | glyphOrientationHorizontal;
+  glyphOrientationVertical?: all | glyphOrientationVertical;
+  grid?: all | grid;
+  gridArea?: all | gridArea;
+  gridAutoColumns?: all | gridAutoColumns;
+  gridAutoFlow?: all | gridAutoFlow;
+  gridAutoRows?: all | gridAutoRows;
+  gridColumn?: all | gridColumn;
+  gridColumnEnd?: all | gridColumnEnd;
+  gridColumnGap?: all | gridColumnGap;
+  gridColumnStart?: all | gridColumnStart;
+  gridGap?: all | gridGap;
+  gridRow?: all | gridRow;
+  gridRowEnd?: all | gridRowEnd;
+  gridRowGap?: all | gridRowGap;
+  gridRowStart?: all | gridRowStart;
+  gridTemplate?: all | gridTemplate;
+  gridTemplateAreas?: all | gridTemplateAreas;
+  gridTemplateColumns?: all | gridTemplateColumns;
+  gridTemplateRows?: all | gridTemplateRows;
+  hangingPunctuation?: all | (string & {});
+  hyphenateCharacter?: all | (string & {});
+  hyphenateLimitChars?: all | (string & {}) | number;
+  hyphens?: all | hyphens;
+  height?: all | number | (string & {});
+  imageOrientation?: all | imageOrientation;
+  imageRendering?: all | imageRendering;
+  imageResolution?: all | imageResolution;
+  imeMode?: all | imeMode;
+  initialLetter?: all | initialLetter;
+  initialLetterAlign?: all | initialLetterAlign;
+  inlineSize?: all | inlineSize;
+  interpolateSize?: all | interpolateSize;
+  inset?: all | number | (string & {});
+  insetBlock?: all | number | (string & {});
+  insetBlockEnd?: all | number | (string & {});
+  insetBlockStart?: all | number | (string & {});
+  insetInline?: all | number | (string & {});
+  insetInlineEnd?: all | number | (string & {});
+  insetInlineStart?: all | number | (string & {});
+  isolation?: all | isolation;
+  kerning?: all | kerning;
+  left?: all | number | (string & {});
+  letterSpacing?: all | letterSpacing;
+  lineBreak?: all | lineBreak;
+  lineHeight?: all | lineHeight;
+  lineHeightStep?: all | number | (string & {});
+  listStyle?: all | listStyle;
+  listStyleImage?: all | listStyleImage;
+  listStylePosition?: all | listStylePosition;
+  listStyleType?: all | listStyleType;
+  margin?: all | margin;
+  marginBlock?: all | marginBlockEnd;
+  marginBlockEnd?: all | marginBlockEnd;
+  marginBlockStart?: all | marginBlockStart;
+  marginBottom?: all | marginBottom;
+  marginInline?: all | marginInlineEnd;
+  marginInlineEnd?: all | marginInlineEnd;
+  marginInlineStart?: all | marginInlineStart;
+  marginLeft?: all | marginLeft;
+  marginRight?: all | marginRight;
+  marginTop?: all | marginTop;
+  marginTrim?:
+    | null
+    | 'none'
+    | 'block'
+    | 'block-start'
+    | 'block-end'
+    | 'inline'
+    | 'inline-start'
+    | 'inline-end';
+  marker?: all | marker;
+  markerEnd?: all | markerEnd;
+  markerMid?: all | markerMid;
+  markerOffset?: all | markerOffset;
+  markerStart?: all | markerStart;
+  mask?: all | mask;
+  maskClip?: all | maskClip;
+  maskComposite?: all | maskComposite;
+  maskImage?: all | maskImage;
+  maskMode?: all | maskMode;
+  maskOrigin?: all | maskOrigin;
+  maskPosition?: all | maskPosition;
+  maskRepeat?: all | maskRepeat;
+  maskSize?: all | maskSize;
+  maskType?: all | maskType;
+  maskBorder?: all | (string & {});
+  maskBorderMode?: all | 'alpha' | 'luminance';
+  maskBorderOutset?: all | (string & {}) | number;
+  maskBorderRepeat?: all | 'stretch' | 'repeat' | 'round' | 'space';
+  maskBorderSlice?: all | (string & {}) | number;
+  maskBorderSource?: all | (string & {});
+  maskBorderWidth?: all | (string & {}) | number;
+  maxBlockSize?: all | maxBlockSize;
+  maxHeight?: all | maxHeight;
+  maxInlineSize?: all | maxInlineSize;
+  maxWidth?: all | maxWidth;
+  minBlockSize?: all | minBlockSize;
+  minHeight?: all | minHeight;
+  minInlineSize?: all | minInlineSize;
+  minWidth?: all | minWidth;
+  mixBlendMode?: all | mixBlendMode;
+  motion?: all | motion;
+  motionOffset?: all | motionOffset;
+  motionPath?: all | motionPath;
+  motionRotation?: all | motionRotation;
+  MsOverflowStyle?: all | MsOverflowStyle;
+  objectFit?: all | objectFit;
+  objectPosition?: all | objectPosition;
+  offset?: all | (string & {});
+  offsetAnchor?: all | (string & {});
+  offsetDistance?: all | (string & {}) | number;
+  offsetPath?: all | (string & {});
+  offsetPosition?: all | (string & {});
+  offsetRotate?: all | (string & {});
+  opacity?: all | opacity;
+  order?: all | order;
+  orphans?: all | orphans;
+  outline?: all | outline;
+  outlineColor?: all | outlineColor;
+  outlineOffset?: all | outlineOffset;
+  outlineStyle?: all | outlineStyle;
+  outlineWidth?: all | outlineWidth;
+  overflow?: all | overflow;
+  overflowBlock?: all | overflowY;
+  overflowBlockX?: all | overflowX;
+  overflowX?: all | overflowX;
+  overflowY?: all | overflowY;
+  overflowAnchor?: all | overflowAnchor;
+  overflowClipMargin?: all | (string & {});
+  overflowWrap?: all | overflowWrap;
+  overscrollBehavior?: all | overscrollBehavior;
+  overscrollBehaviorBlock?: all | overscrollBehaviorY;
+  overscrollBehaviorY?: all | overscrollBehaviorY;
+  overscrollBehaviorInline?: all | overscrollBehaviorX;
+  overscrollBehaviorX?: all | overscrollBehaviorX;
+  padding?: all | padding;
+  paddingBlock?: all | paddingBlockEnd;
+  paddingBlockEnd?: all | paddingBlockEnd;
+  paddingBlockStart?: all | paddingBlockStart;
+  paddingInline?: all | paddingBlockEnd;
+  paddingInlineEnd?: all | paddingBlockEnd;
+  paddingInlineStart?: all | paddingBlockStart;
+  paddingBottom?: all | paddingBottom;
+  paddingLeft?: all | paddingLeft;
+  paddingRight?: all | paddingRight;
+  paddingTop?: all | paddingTop;
+  page?: all | (string & {});
+  pageBreakAfter?: all | pageBreakAfter;
+  pageBreakBefore?: all | pageBreakBefore;
+  pageBreakInside?: all | pageBreakInside;
+  paintOrder?:
+    | null
+    | 'normal'
+    | 'stroke'
+    | 'fill'
+    | 'markers'
+    | 'stroke fill'
+    | 'stroke markers'
+    | 'fill markers'
+    | 'stroke fill markers';
+  pause?: all | pause;
+  pauseAfter?: all | pauseAfter;
+  pauseBefore?: all | pauseBefore;
+  perspective?: all | perspective;
+  perspectiveOrigin?: all | perspectiveOrigin;
+  pointerEvents?: all | pointerEvents;
+  position?: all | position;
+  positionAnchor?: all | (string & {});
+  positionArea?: all | positionArea;
+  positionTry?: all | (string & {});
+  positionTryFallbacks?: all | (string & {});
+  positionTryOptions?: all | (string & {});
+  positionVisibility?: all | positionVisibility;
+  quotes?: all | quotes;
+  resize?: all | resize;
+  rest?: all | rest;
+  restAfter?: all | restAfter;
+  restBefore?: all | restBefore;
+  right?: all | number | (string & {});
+  rowGap?: all | rowGap;
+  rubyAlign?: all | rubyAlign;
+  rubyMerge?: all | rubyMerge;
+  rubyPosition?: all | rubyPosition;
+  mathDepth?: all | number | (string & {});
+  mathShift?: all | 'normal' | 'compact';
+  mathStyle?: all | 'normal' | 'compact';
+  scrollBehavior?: all | scrollBehavior;
+  scrollMargin?: all | number | (string & {});
+  scrollMarginTop?: all | number | (string & {});
+  scrollMarginRight?: all | number | (string & {});
+  scrollMarginBottom?: all | number | (string & {});
+  scrollMarginLeft?: all | number | (string & {});
+  scrollMarginBlock?: all | number | (string & {});
+  scrollMarginBlockEnd?: all | number | (string & {});
+  scrollMarginBlockStart?: all | number | (string & {});
+  scrollMarginInline?: all | number | (string & {});
+  scrollMarginInlineEnd?: all | number | (string & {});
+  scrollMarginInlineStart?: all | number | (string & {});
+  scrollPadding?: all | number | (string & {});
+  scrollPaddingTop?: all | number | (string & {});
+  scrollPaddingRight?: all | number | (string & {});
+  scrollPaddingBottom?: all | number | (string & {});
+  scrollPaddingLeft?: all | number | (string & {});
+  scrollPaddingBlock?: all | number | (string & {});
+  scrollPaddingBlockEnd?: all | number | (string & {});
+  scrollPaddingBlockStart?: all | number | (string & {});
+  scrollPaddingInline?: all | number | (string & {});
+  scrollPaddingInlineEnd?: all | number | (string & {});
+  scrollPaddingInlineStart?: all | number | (string & {});
+  scrollSnapAlign?: all | scrollSnapAlign;
+  scrollSnapStop?: all | 'normal' | 'always';
+  scrollSnapType?: all | scrollSnapType;
+  scrollTimeline?: all | (string & {});
+  scrollTimelineAxis?: all | 'block' | 'inline' | 'x' | 'y';
+  scrollTimelineName?: all | (string & {});
+  scrollbarColor?: all | color;
+  scrollbarGutter?: all | 'auto' | 'stable' | 'stable both-edges';
+  scrollbarWidth?: all | 'auto' | 'thin' | 'none';
+  shapeImageThreshold?: all | shapeImageThreshold;
+  shapeMargin?: all | shapeMargin;
+  shapeOutside?: all | shapeOutside;
+  shapeRendering?: all | shapeRendering;
+  speak?: all | speak;
+  speakAs?: all | speakAs;
+  src?: all | src;
+  start?: all | number | (string & {});
+  stroke?: all | stroke;
+  strokeDasharray?: all | strokeDasharray;
+  strokeDashoffset?: all | strokeDashoffset;
+  strokeLinecap?: all | strokeLinecap;
+  strokeLinejoin?: all | strokeLinejoin;
+  strokeMiterlimit?: all | strokeMiterlimit;
+  strokeOpacity?: all | strokeOpacity;
+  strokeWidth?: all | strokeWidth;
+  tabSize?: all | tabSize;
+  tableLayout?: all | tableLayout;
+  textAlign?: all | textAlign;
+  textAlignLast?: all | textAlignLast;
+  textAnchor?: all | textAnchor;
+  textCombineUpright?: all | textCombineUpright;
+  textDecoration?: all | textDecoration;
+  textDecorationColor?: all | textDecorationColor;
+  textDecorationLine?: all | textDecorationLine;
+  textDecorationSkip?: all | textDecorationSkip;
+  textDecorationSkipInk?: all | 'auto' | 'none' | 'all';
+  textDecorationStyle?: all | textDecorationStyle;
+  textDecorationThickness?: all | number | (string & {});
+  textEmphasis?: all | textEmphasis;
+  textEmphasisColor?: all | textEmphasisColor;
+  textEmphasisPosition?: all | textEmphasisPosition;
+  textEmphasisStyle?: all | textEmphasisStyle;
+  textIndent?: all | textIndent;
+  textJustify?:
+    | null
+    | 'none'
+    | 'auto'
+    | 'inter-word'
+    | 'inter-character'
+    | 'distribute';
+  textOrientation?: all | textOrientation;
+  textOverflow?: all | textOverflow;
+  textRendering?: all | textRendering;
+  textShadow?: all | OptionalArray<textShadow>;
+  textSizeAdjust?: all | textSizeAdjust;
+  textTransform?: all | textTransform;
+  textUnderlineOffset?: all | number | (string & {});
+  textUnderlinePosition?: all | textUnderlinePosition;
+  textWrap?: all | 'wrap' | 'nowrap' | 'balance' | 'pretty' | 'stable';
+  timelineScope?: all | (string & {});
+  top?: all | top;
+  touchAction?: all | touchAction;
+  transform?: all | transform;
+  transformBox?: all | transformBox;
+  transformOrigin?: all | transformOrigin;
+  transformStyle?: all | transformStyle;
+  rotate?: all | number | (string & {});
+  scale?: all | number | (string & {});
+  translate?: all | number | (string & {});
+  transition?: all | OptionalArray<transition>;
+  transitionDelay?: all | OptionalArray<transitionDelay>;
+  transitionDuration?: all | OptionalArray<transitionDuration>;
+  transitionProperty?: all | OptionalArray<transitionProperty>;
+  transitionTimingFunction?: all | OptionalArray<transitionTimingFunction>;
+  unicodeBidi?: all | unicodeBidi;
+  unicodeRange?: all | unicodeRange;
+  userSelect?: all | userSelect;
+  verticalAlign?: all | verticalAlign;
+  viewTimeline?: all | (string & {});
+  viewTimelineAxis?: all | 'block' | 'inline' | 'x' | 'y';
+  viewTimelineName?: all | (string & {});
+  viewTimelineInset?: all | number | (string & {});
+  viewTransitionName?: all | (string & {});
+  visibility?: all | visibility;
+  voiceBalance?: all | voiceBalance;
+  voiceDuration?: all | voiceDuration;
+  voiceFamily?: all | voiceFamily;
+  voicePitch?: all | voicePitch;
+  voiceRange?: all | voiceRange;
+  voiceRate?: all | voiceRate;
+  voiceStress?: all | voiceStress;
+  voiceVolume?: all | voiceVolume;
+  whiteSpace?: all | whiteSpace;
+  widows?: all | widows;
+  width?: all | width;
+  willChange?: all | willChange;
+  wordBreak?: all | wordBreak;
+  wordSpacing?: all | wordSpacing;
+  wordWrap?: all | wordWrap;
+  writingMode?: all | writingMode;
+  zIndex?: all | zIndex;
+  zoom?: all | 'normal' | number | (string & {});
+}>;

--- a/packages/typescript-tests/src/open-unions.ts
+++ b/packages/typescript-tests/src/open-unions.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import type { CSSProperties } from '@stylexjs/stylex';
+
+/* eslint-disable no-unused-vars */
+
+/**
+ * `(string & {})` OPEN UNIONS
+ *
+ * `StyleXCSSTypes.d.ts` uses `(string & {})` instead of a bare `string` so that
+ * literal members survive in the union (and keep their editor autocomplete)
+ * while arbitrary strings are still accepted. Flow cannot express this, which
+ * is why the TypeScript definitions are maintained separately rather than
+ * translated from the Flow types.
+ */
+
+// Arbitrary strings are still accepted -- the union is genuinely open.
+const arbitrary: CSSProperties = {
+  appearance: 'some-future-value',
+  filter: 'blur(2px) saturate(1.5)',
+  color: 'oklch(0.7 0.1 200)',
+  height: 'calc(100% - 10px)',
+};
+
+// `var()` references are accepted on open properties.
+const vars: CSSProperties = {
+  color: 'var(--my-color)',
+  filter: 'var(--my-filter)',
+};
+
+// `null` remains assignable. This is significant in StyleX: `null` is how a
+// property is unset, e.g. in a conditional style. `{}` in TypeScript excludes
+// `null`, so this asserts that the `string & {}` intersection did not leak into
+// the `null` member of the `all` type.
+const nulls: CSSProperties = {
+  appearance: null,
+  color: null,
+  filter: null,
+  height: null,
+  display: null,
+};
+
+// The global keywords from `all` survive alongside `(string & {})`.
+const globals: CSSProperties = {
+  color: 'inherit',
+  height: 'initial',
+  filter: 'unset',
+};
+
+// Literal members are preserved rather than being absorbed by `string`.
+// NOTE: do not use `NonNullable` to strip `null` here -- it is defined as
+// `T & {}` in TypeScript >=4.9, and that intersection distributes over the
+// union and flattens `'textfield' | (string & {})` back down to `string`,
+// which would make this assertion vacuously pass.
+type Strip<T> = T extends null | undefined ? never : T;
+type Appearance = Strip<CSSProperties['appearance']>;
+const literalsSurvive: Extract<Appearance, 'textfield'> = 'textfield';
+
+// ...and a literal that is NOT part of the union is still rejected, so the
+// open union has not silently become a plain `string`.
+// @ts-expect-error - 'textfeild' is a typo, not a member of the union.
+const typoRejected: Extract<Appearance, 'textfeild'> = 'textfeild';
+
+// A bare `string` type is NOT assignable to a *closed* union, proving the
+// distinction between open and closed properties is still enforced.
+declare const someString: string;
+// @ts-expect-error - `backfaceVisibility` is a closed union.
+const closedStillClosed: CSSProperties = { backfaceVisibility: someString };
+
+// `null` unsetting inside a real `stylex.create` call with conditions.
+const styles = stylex.create({
+  conditional: (isActive: boolean) => ({
+    color: isActive ? 'red' : null,
+    appearance: isActive ? 'none' : null,
+  }),
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8097,7 +8097,7 @@ css-select@^5.1.0:
     domutils "^3.0.1"
     nth-check "^2.0.1"
 
-css-tree@3.2.1:
+css-tree@3.2.1, css-tree@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-3.2.1.tgz#86cac7011561272b30e6b1e042ba6ce047aa7518"
   integrity sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==
@@ -17990,6 +17990,11 @@ web-ext@10.5.0:
     watchpack "2.5.2"
     yargs "17.7.2"
     zip-dir "2.0.0"
+
+web-features@3.37.0:
+  version "3.37.0"
+  resolved "https://registry.npmjs.org/web-features/-/web-features-3.37.0.tgz#cd3348a27e4b941849aeb0fe875e336f78d03ce8"
+  integrity sha512-47x5zchtpsvvH/EEQ0h3d3E9kZyFxFyk6LkmYHXDZjLF0RAa3OV2s8dMRqphp/PTxxrd/iZwz37dte6xWgV7mQ==
 
 webdriver-bidi-protocol@0.2.11:
   version "0.2.11"


### PR DESCRIPTION
## What changed / motivation ?

> **Stacked on #1877.** GitHub will not let a pull request from a fork target a branch on that fork, so this targets `main` and its diff therefore includes #1877's commit. Review the last commit only (`Test CSSProperties against the CSS grammar, Baseline, and Flow`); it will shrink to just that once #1877 merges.

Stacked on #1877, which made `StyleXCSSTypes.d.ts` a hand-maintained duplicate of the Flow types.

`CSSProperties` is 522 properties and roughly 2,500 keywords, all written by hand, and nothing checks it against CSS. At that size review cannot catch a keyword that is misspelled, one that was never in any spec, or one that is missing — and after #1877 there are two copies that can drift apart.

CSS is machine-readable where it matters: the value definition grammar states what each property accepts, and Baseline states what is safe to use. These tests ask those sources rather than asking a reviewer to know CSS, so the types become checkable instead of trusted.

Deliberately validating, not generating. The types stay hand-written and hand-editable; the tests only report where they disagree with CSS. Where they intentionally differ — browsers and specs disagree too — it goes in an allowlist **with a reason**. Today a missing keyword and a deliberate omission look identical; afterwards they do not. That turns out to be 38 decisions and 66 gaps, all currently indistinguishable from each other and from correct code.

### The six tests

1. The TypeScript definitions match the Flow types — nothing else stops them diverging.
2. Every property accepts the CSS-wide keywords (`initial`, `inherit`, `unset`, `revert`, `revert-layer`) — valid everywhere, in no grammar, so nothing else can check them.
3. Every keyword is real, per the grammar — typos and invented values.
4. Closed unions list every keyword the grammar has — the reverse of 3: values a user cannot write at all.
5. Properties whose grammar needs arbitrary strings accept them. Not "are the literals right?" but "should this be a union of literals at all?" Would have caught #1463.
6. Every Baseline-available property is typed.

### Built so an agent can close the loop

Each allowlist entry is work still to do, and each failure names the property, prints its grammar or Baseline status, and states the two valid fixes. Remove an entry, run the test, read the failure, make the change, re-run — no CSS knowledge required beyond the output.

That is deliberate, because what remains is bulk cleanup rather than design. I had a small model do three of them unattended from the test output alone and it got them right. #1881 is five worked examples; what makes them trustworthy is not care in writing them but that the tests check each against the grammar *and* confirm both files still agree.

## Linked PR/Issues

Stacked on #1877. Test 5 surfaces #1463, fixed in #1880.

## Additional Context

The allowlists are two different things, and it is worth separating them. Some entries are decisions that should stay, because specs and browsers disagree and StyleX sides with browsers. The rest are a to-do list.

**Deliberate deviations (38) — expected to stay:**

| | | |
| --- | --- | --- |
| `KEPT_KEYWORDS` | 19 | Keywords the spec dropped that browsers still ship. `marginTrim` is the clearest: the spec was rewritten to `none \| in-flow \| all`, but Safari ships the original `block`/`inline` |
| `NOT_TYPED` | 17 | SVG presentation attributes. StyleX types `fill`, `stroke` and `strokeWidth`, so excluding the rest is arbitrary — but `x`, `y`, `d` and `r` read oddly as style keys |
| `NOT_TYPED` | 1 | `all`, which resets every property at once and cannot work with styleq's key-based override model |
| `NO_GRAMMAR` | 1 | `WebkitBoxOrient`, which css-tree simply lacks but the `-webkit-line-clamp` idiom needs |

**Known gaps (66) — expected to reach zero:**

| | | |
| --- | --- | --- |
| `INCOMPLETE_UNIONS` | 32 | Closed unions missing keywords the grammar allows — `display` cannot take `flow` or `table-caption`, `overflow` cannot take `overlay` |
| `NO_GRAMMAR` | 15 | Properties in no current spec, to be deleted: abandoned drafts (`motion-*` became `offset-*`), `@font-face` descriptors that were never properties (`src`, `unicode-range`) |
| `CLOSED_DESPITE_GRAMMAR` | 13 | Types too narrow for their grammar. `colorScheme` and `fontStyle` accept neither strings nor numbers; the rest accept a bare number, so only `calc()`, `var()` and units are out of reach |
| `NOT_TYPED` | 6 | Baseline-available properties that should be typed — `whiteSpaceCollapse` is literally commented out in `StyleXCSSTypes.js` awaiting this |

`marginTrim` appears in both halves, which is honest: it keeps values the spec dropped *and* is missing values the spec added.

**Scoping test 4** is what makes it useful: restricted to closed unions it finds 125 real omissions across 32 properties, where unrestricted it demands over ten thousand additions, because shorthands like `background` transitively pull in every named colour.

**Two new devDependencies**, both test-only. `css-tree` supplies the grammar and its parser — a patched fork of `mdn-data`, and the same parser `csstype` uses. `web-features` supplies Baseline; `mdn-data`'s `status` field looks like it would do instead, but it describes the spec rather than browsers, calling `font-stretch` obsolete though every browser has supported it since 2020 while marking its replacement `font-width` experimental. It is pinned exactly so that a version bump lands in `package.json` rather than as a lockfile line inside Dependabot's weekly grouped PR — worth knowing, because when it moves, test 6 can legitimately fail: a property reaching Baseline is the news it exists to deliver.

**Why not codegen, or `csstype`.** Generating these types from the grammar was the first thing I tried; it worked, but produced a ~4,000-line diff, replaced a file people read with generated output, and put css-tree in the build path of a public API — with no existing codegen in the repo to follow. `csstype` is spec-current in ways that clash: it would break roughly 24 of the deviations above, and wrapping it for StyleX's semantics (`null` to unset, bare numbers meaning pixels, `theme`, comma-list arrays) is unpleasant in Flow. The dual Flow/TypeScript requirement is what makes most off-the-shelf options awkward.

**The omissions are not deliberate** — I checked whether StyleX prefixes or normalises values in a way that made them redundant, and it does not.

**Follow-ups.** No TSDoc, unlike csstype, though most of the data is available here. And `packages/@stylexjs/eslint-plugin/src/reference/cssProperties.js` is a second, independent encoding of this knowledge that could use the same treatment — worth knowing before leaning on it that its conversion misassigned values, so `stylex/valid-styles` currently accepts `zIndex: 'ideographic'` and `transform: 'border-box'`.

Each failure was verified by injecting it. The suite runs in ~60ms.

## Pre-flight checklist

- [x] I have read the contributing guidelines
      [Contribution Guidelines](https://github.com/facebook/stylex/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
